### PR TITLE
Show should allow a kwarg for title

### DIFF
--- a/panel/base.py
+++ b/panel/base.py
@@ -1,0 +1,74 @@
+from __future__ import absolute_import, division, unicode_literals
+
+from bokeh.io import curdoc as _curdoc
+
+from .io.server import StoppableThread, get_server
+
+
+class ServableMixin(object):
+
+    def _get_server(self, port=0, websocket_origin=None, loop=None,
+                   show=False, start=False, **kwargs):
+        return get_server(self, port, websocket_origin, loop, show,
+                          start, **kwargs)
+
+    #----------------------------------------------------------------
+    # Public API
+    #----------------------------------------------------------------
+
+    def servable(self, title=None):
+        """
+        Serves the object if in a `panel serve` context and returns
+        the Panel object to allow it to display itself in a notebook
+        context.
+
+        Arguments
+        ---------
+        title : str
+          A string title to give the Document (if served as an app)
+
+        Returns
+        -------
+        The Panel object itself
+        """
+        if _curdoc().session_context:
+            self.server_doc(title=title)
+        return self
+
+    def show(self, port=0, websocket_origin=None, threaded=False, title=None):
+        """
+        Starts a Bokeh server and displays the Viewable in a new tab
+
+        Arguments
+        ---------
+        port: int (optional, default=0)
+          Allows specifying a specific port
+        websocket_origin: str or list(str) (optional)
+          A list of hosts that can connect to the websocket.
+
+          This is typically required when embedding a server app in
+          an external web site.
+
+          If None, "localhost" is used.
+        threaded: boolean (optional, default=False)
+          Whether to launch the Server on a separate thread, allowing
+          interactive use.
+
+        Returns
+        -------
+        server: bokeh.server.Server or threading.Thread
+          Returns the Bokeh server instance or the thread the server
+          was launched on (if threaded=True)
+        """
+        if threaded:
+            from tornado.ioloop import IOLoop
+            loop = IOLoop()
+            server = StoppableThread(
+                target=self._get_server, io_loop=loop,
+                args=(port, websocket_origin, loop, True, True))
+            server.start()
+        else:
+            self.server_doc(title=title)
+            server = self._get_server(port, websocket_origin, show=True, start=True)
+
+        return server

--- a/panel/viewable.py
+++ b/panel/viewable.py
@@ -27,8 +27,8 @@ from .io.notebook import (get_comm_customjs, push, render_mimebundle,
                           render_model, show_embed, show_server)
 from .io.save import save
 from .io.state import state
-from .io.server import StoppableThread, get_server
 from .util import param_reprs
+from .base import ServableMixin
 
 
 class Layoutable(param.Parameterized):
@@ -188,7 +188,7 @@ class Layoutable(param.Parameterized):
         super(Layoutable, self).__init__(**params)
 
 
-class Viewable(Layoutable):
+class Viewable(Layoutable, ServableMixin):
     """
     Viewable is the baseclass all objects in the panel library are
     built on. It defines the interface for declaring any object that
@@ -310,11 +310,6 @@ class Viewable(Layoutable):
         if server_id:
             state._servers[server_id][2].append(doc)
         return self.server_doc(doc)
-
-    def _get_server(self, port=0, websocket_origin=None, loop=None,
-                   show=False, start=False, **kwargs):
-        return get_server(self, port, websocket_origin, loop, show,
-                          start, **kwargs)
 
     #----------------------------------------------------------------
     # Public API
@@ -480,63 +475,6 @@ class Viewable(Layoutable):
             self._documents[doc] = model
         add_to_doc(model, doc)
         return doc
-
-    def servable(self, title=None):
-        """
-        Serves the object if in a `panel serve` context and returns
-        the panel object to allow it to display itself in a notebook
-        context.
-
-        Arguments
-        ---------
-        title : str
-          A string title to give the Document (if served as an app)
-
-        Returns
-        -------
-        The Panel object itself
-        """
-        if _curdoc().session_context:
-            self.server_doc(title=title)
-        return self
-
-    def show(self, port=0, websocket_origin=None, threaded=False):
-        """
-        Starts a bokeh server and displays the Viewable in a new tab
-
-        Arguments
-        ---------
-        port: int (optional, default=0)
-          Allows specifying a specific port
-        websocket_origin: str or list(str) (optional)
-          A list of hosts that can connect to the websocket.
-
-          This is typically required when embedding a server app in
-          an external web site.
-
-          If None, "localhost" is used.
-        threaded: boolean (optional, default=False)
-          Whether to launch the Server on a separate thread, allowing
-          interactive use.
-
-        Returns
-        -------
-        server: bokeh.server.Server or threading.Thread
-          Returns the bokeh server instance or the thread the server
-          was launched on (if threaded=True)
-        """
-        if threaded:
-            from tornado.ioloop import IOLoop
-            loop = IOLoop()
-            server = StoppableThread(
-                target=self._get_server, io_loop=loop,
-                args=(port, websocket_origin, loop, True, True))
-            server.start()
-        else:
-            server = self._get_server(port, websocket_origin, show=True, start=True)
-
-        return server
-
 
 
 class Reactive(Viewable):


### PR DESCRIPTION
This doesn't work yet, but I think show should be extended to accept any argument to `panel serve`. It seems that this is how `.show()` works in bokeh.