### PR TITLE
Fixed handling of state._views for Templates

### DIFF
--- a/panel/template.py
+++ b/panel/template.py
@@ -136,17 +136,18 @@ class Template(param.Parameterized):
             else:
                 model = obj._get_model(doc, root, root, comm)
             for sub in obj.select(Viewable):
-                sub._models[ref] = sub._models.pop(root.ref['id'])
+                sub._models[ref] = sub._models.get(root.ref['id'])
+            obj._documents[doc] = root
+            doc.on_session_destroyed(obj._server_destroy)
             col.append(obj)
             model.name = name
             model.tags = tags
-            if hasattr(doc, 'on_session_destroyed'):
-                doc.on_session_destroyed(obj._server_destroy)
-                obj._documents[doc] = model
             add_to_doc(model, doc, hold=bool(comm))
         state._views[ref] = (col, preprocess_root, doc, comm)
 
         col._preprocess(preprocess_root)
+        col._documents[doc] = preprocess_root
+        doc.on_session_destroyed(col._server_destroy)
 
         if notebook:
             doc.template = self.nb_template

--- a/panel/template.py
+++ b/panel/template.py
@@ -122,7 +122,8 @@ class Template(param.Parameterized):
             doc.title = title
 
         root = None
-        preprocess_root = _BkRow()
+        col = Column()
+        preprocess_root = col.get_root(doc, comm)
         ref = preprocess_root.ref['id']
         for name, (obj, tags) in self._render_items.items():
             if root is None:
@@ -142,6 +143,7 @@ class Template(param.Parameterized):
                 doc.on_session_destroyed(obj._server_destroy)
                 obj._documents[doc] = model
             add_to_doc(model, doc, hold=bool(comm))
+        state._views[ref] = (col, preprocess_root, doc, comm)
 
         for (obj, _) in self._render_items.values():
             obj._preprocess(preprocess_root)

--- a/panel/template.py
+++ b/panel/template.py
@@ -10,7 +10,6 @@ import param
 
 from bokeh.document.document import Document as _Document
 from bokeh.io import curdoc as _curdoc
-from bokeh.models import Row as _BkRow
 from jinja2.environment import Template as _Template
 from six import string_types
 from pyviz_comms import JupyterCommManager as _JupyterCommManager


### PR DESCRIPTION
In order for pre-processing to work correctly on Templates we need to create a fake root that is shared by all sub-objects. Previously this fake root was not added to the `state._views` which is a global index of all roots, which ends up causing issues when updating a root.

Cc: @dharhas this should fix the issues you've been seeing