### PR TITLE
Report what is missing from an installation using pytest

### DIFF
--- a/panel/tests/pane/test_base.py
+++ b/panel/tests/pane/test_base.py
@@ -9,7 +9,13 @@ from panel.pane import Pane, PaneBase, Bokeh, HoloViews
 from panel.param import ParamMethod
 from panel.tests.util import check_layoutable_properties
 
-all_panes = [w for w in param.concrete_descendents(PaneBase).values()
+def _maybe_skip(w):
+    requirements = { 'Plotly': 'plotly' }
+    req = requirements.get(w.__name__, None)
+    kw = {'marks': pytest.importorskip(req)} if req is not None else {}
+    return pytest.param(w,**kw)
+
+all_panes = [_maybe_skip(w) for w in param.concrete_descendents(PaneBase).values()
              if not w.__name__.startswith('_') and not
              issubclass(w, (Bokeh, HoloViews, ParamMethod, interactive))]
 

--- a/panel/tests/test_pipeline.py
+++ b/panel/tests/test_pipeline.py
@@ -1,7 +1,5 @@
-from distutils.version import LooseVersion
-
 import pytest
-import param
+param = pytest.importorskip("param", minversion="1.8.3")
 
 from panel.layout import Row, Column
 from panel.pane import HoloViews
@@ -9,14 +7,8 @@ from panel.param import ParamMethod
 from panel.pipeline import Pipeline, find_route
 from panel.widgets import Button, Select
 
-if LooseVersion(param.__version__) < '1.8.2':
-    pytest.skip("skipping if param version < 1.8.2", allow_module_level=True)
 
-try:
-    import holoviews as hv
-except:
-    pytest.skip('Pipeline requires HoloViews.')
-
+hv = pytest.importorskip("holoviews")
 
 class Stage1(param.Parameterized):
 

--- a/panel/tests/widgets/test_misc.py
+++ b/panel/tests/widgets/test_misc.py
@@ -6,7 +6,7 @@ from base64 import b64encode
 import pytest
 
 import numpy as np
-pytest.importorskip("scipy.io")#from scipy.io import wavfile
+pytest.importorskip("scipy.io")
 
 from panel.widgets import Audio
 

--- a/panel/tests/widgets/test_misc.py
+++ b/panel/tests/widgets/test_misc.py
@@ -3,8 +3,10 @@ from __future__ import absolute_import, division, unicode_literals
 from io import BytesIO
 from base64 import b64encode
 
+import pytest
+
 import numpy as np
-from scipy.io import wavfile
+pytest.importorskip("scipy.io")#from scipy.io import wavfile
 
 from panel.widgets import Audio
 
@@ -12,7 +14,7 @@ def test_audio_array(document, comm):
     data = np.random.randint(-100,100, 100).astype('int16')
     sample_rate = 10
     buffer = BytesIO()
-    wavfile.write(buffer, sample_rate, data)
+    scipy.io.wavfile.write(buffer, sample_rate, data)
     b64_encoded = b64encode(buffer.getvalue()).decode('utf-8')
 
     audio = Audio(name='Button', value=data, sample_rate=sample_rate)

--- a/panel/tests/widgets/test_misc.py
+++ b/panel/tests/widgets/test_misc.py
@@ -6,7 +6,7 @@ from base64 import b64encode
 import pytest
 
 import numpy as np
-scipy_io = pytest.importorskip("scipy.io")
+wavfile = pytest.importorskip("scipy.io.wavfile")
 
 from panel.widgets import Audio
 

--- a/panel/tests/widgets/test_misc.py
+++ b/panel/tests/widgets/test_misc.py
@@ -6,7 +6,7 @@ from base64 import b64encode
 import pytest
 
 import numpy as np
-pytest.importorskip("scipy.io")
+scipy_io = pytest.importorskip("scipy.io")
 
 from panel.widgets import Audio
 
@@ -14,7 +14,7 @@ def test_audio_array(document, comm):
     data = np.random.randint(-100,100, 100).astype('int16')
     sample_rate = 10
     buffer = BytesIO()
-    scipy.io.wavfile.write(buffer, sample_rate, data)
+    scipy_io.wavfile.write(buffer, sample_rate, data)
     b64_encoded = b64encode(buffer.getvalue()).decode('utf-8')
 
     audio = Audio(name='Button', value=data, sample_rate=sample_rate)

--- a/panel/tests/widgets/test_misc.py
+++ b/panel/tests/widgets/test_misc.py
@@ -14,7 +14,7 @@ def test_audio_array(document, comm):
     data = np.random.randint(-100,100, 100).astype('int16')
     sample_rate = 10
     buffer = BytesIO()
-    scipy_io.wavfile.write(buffer, sample_rate, data)
+    wavfile.write(buffer, sample_rate, data)
     b64_encoded = b64encode(buffer.getvalue()).decode('utf-8')
 
     audio = Audio(name='Button', value=data, sample_rate=sample_rate)

--- a/panel/tests/widgets/test_tables.py
+++ b/panel/tests/widgets/test_tables.py
@@ -1,9 +1,7 @@
 from __future__ import absolute_import, division, unicode_literals
+import pytest
 
-try:
-    import pandas as pd
-except ImportError:
-    pass
+pd = pytest.importorskip("pandas")
 
 from bokeh.models.widgets.tables import (
     NumberFormatter, IntEditor, NumberEditor, StringFormatter,

--- a/setup.py
+++ b/setup.py
@@ -103,8 +103,6 @@ _recommended = [
 
 extras_require = {
     'tests': [
-        'coveralls',
-        'nose',
         'flake8',
         'parameterized',
         'pytest',


### PR DESCRIPTION
I'm interested in making it possible to tell what features a given installation of panel is missing because of missing (or bad) dependencies. 

This could be useful for panel packagers (and hence users of that package). And it could apply to other holoviz projects, too - but I wanted to experiment with the idea somewhere.

To try this out, I wanted to install panel with only the minimum dependencies, and then check what features were unavailable. However, there were errors when I ran the test suite with only the minimum dependencies installed. So, in this PR I have done something quickly to get the tests to pass when only the minimum dependencies are installed. 

1. Presumably I'll need to rework some of the changes to fit how skipping is generally done in panel? Should I try to clean up the existing skipping to be more consistent? I didn't look very carefully at the test suite overall, so I'm not sure. Please take a look at these changes and see what you think.
2. The output of `pytest -rs` (below) shows one way a packager could learn what optional features are missing - sort of. It seems like a useful start, although a shorter 'feature matrix' would be nice (although even just grouping the reasons might be nice). (Also, this neglects the js side of things.)


#### install minimal deps

install `bokeh param pyviz_comms markdown pyct`

(info from `setup.py`)

plus install minimal test deps: `pytest`

#### run test suite to learn about skips

```
$ pytest -rs panel
=========================================================================== test session starts ===========================================================================
platform linux -- Python 3.7.5, pytest-5.3.0, py-1.8.0, pluggy-0.13.1 -- /home/sefkw/mc3/envs/panelt/bin/python
cachedir: .pytest_cache
rootdir: /home/sefkw/code/pyviz/panel, inifile: tox.ini
collected 516 items / 2 errors / 8 skipped / 506 selected                                                                                                                 

================================================================================= ERRORS ==================================================================================
______________________________________________________________ ERROR collecting panel/tests/test_pipeline.py ______________________________________________________________
Using pytest.skip outside of a test is not allowed. To decorate a test function, use the @pytest.mark.skip or @pytest.mark.skipif decorators instead, and to skip a module use `pytestmark = pytest.mark.{skip,skipif}.
____________________________________________________________ ERROR collecting panel/tests/widgets/test_misc.py ____________________________________________________________
ImportError while importing test module '/home/sefkw/code/pyviz/panel/panel/tests/widgets/test_misc.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
panel/tests/widgets/test_misc.py:7: in <module>
    from scipy.io import wavfile
E   ModuleNotFoundError: No module named 'scipy'
========================================================================= short test summary info =========================================================================
SKIPPED [1] /home/sefkw/mc3/envs/panelt/lib/python3.7/site-packages/_pytest/doctest.py:455: unable to import module local('/home/sefkw/code/pyviz/panel/panel/examples/apps/django2/project/urls.py')
SKIPPED [1] /home/sefkw/mc3/envs/panelt/lib/python3.7/site-packages/_pytest/doctest.py:455: unable to import module local('/home/sefkw/code/pyviz/panel/panel/examples/apps/django2/project/wsgi.py')
SKIPPED [1] /home/sefkw/mc3/envs/panelt/lib/python3.7/site-packages/_pytest/doctest.py:455: unable to import module local('/home/sefkw/code/pyviz/panel/panel/examples/apps/django2/sliders/apps.py')
SKIPPED [1] /home/sefkw/mc3/envs/panelt/lib/python3.7/site-packages/_pytest/doctest.py:455: unable to import module local('/home/sefkw/code/pyviz/panel/panel/examples/apps/django2/sliders/urls.py')
SKIPPED [1] /home/sefkw/mc3/envs/panelt/lib/python3.7/site-packages/_pytest/doctest.py:455: unable to import module local('/home/sefkw/code/pyviz/panel/panel/examples/apps/django2/sliders/views.py')
SKIPPED [1] /home/sefkw/mc3/envs/panelt/lib/python3.7/site-packages/_pytest/doctest.py:455: unable to import module local('/home/sefkw/code/pyviz/panel/panel/pane/vtk/vtkjs_serializer.py')
SKIPPED [1] /home/sefkw/code/pyviz/panel/panel/tests/test_pipeline.py:18: Pipeline requires HoloViews.
SKIPPED [1] /home/sefkw/mc3/envs/panelt/lib/python3.7/site-packages/_pytest/doctest.py:455: unable to import module local('/home/sefkw/code/pyviz/panel/panel/tests/widgets/test_misc.py')
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! Interrupted: 2 errors during collection !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
====================================================================== 8 skipped, 2 errors in 4.91s =======================================================================
```

(although I did `pytest -rs panel`, `pytest panel` fails in the same way)

#### after changes in this PR, see what gets skipped

(see "short test summary info" near the bottom)

```
$ pytest -rs panel
=============================== test session starts ================================
platform linux -- Python 3.7.5, pytest-5.3.0, py-1.8.0, pluggy-0.13.1 -- /home/sefkw/mc3/envs/panelt/bin/python
cachedir: .pytest_cache
rootdir: /home/sefkw/code/pyviz/panel, inifile: tox.ini
collected 467 items / 14 skipped / 453 selected                                    

panel/tests/test_cli.py::test_transformation PASSED                          [  0%]
panel/tests/test_docs.py::test_layouts_are_in_reference_gallery PASSED       [  0%]
panel/tests/test_docs.py::test_widgets_are_in_reference_gallery PASSED       [  0%]
panel/tests/test_docs.py::test_panes_are_in_reference_gallery PASSED         [  0%]
panel/tests/test_interact.py::test_interact_title PASSED                     [  1%]
panel/tests/test_interact.py::test_boolean_interact PASSED                   [  1%]
panel/tests/test_interact.py::test_string_interact PASSED                    [  1%]
panel/tests/test_interact.py::test_integer_interact PASSED                   [  1%]
panel/tests/test_interact.py::test_tuple_int_range_with_step_interact PASSED [  1%]
panel/tests/test_interact.py::test_tuple_int_range_interact PASSED           [  2%]
panel/tests/test_interact.py::test_tuple_float_range_interact PASSED         [  2%]
panel/tests/test_interact.py::test_tuple_float_range_interact_with_default PASSED [  2%]
panel/tests/test_interact.py::test_tuple_range_interact_with_default_of_different_type PASSED [  2%]
panel/tests/test_interact.py::test_tuple_range_interact_with_step_and_value PASSED [  2%]
panel/tests/test_interact.py::test_tuple_float_range_interact_with_step_and_value PASSED [  3%]
panel/tests/test_interact.py::test_tuple_range_interact_with_no_step_and_value PASSED [  3%]
panel/tests/test_interact.py::test_numeric_list_interact PASSED              [  3%]
panel/tests/test_interact.py::test_string_list_interact PASSED               [  3%]
panel/tests/test_interact.py::test_manual_interact PASSED                    [  4%]
panel/tests/test_interact.py::test_interact_updates_panel PASSED             [  4%]
panel/tests/test_interact.py::test_interact_replaces_panel PASSED            [  4%]
panel/tests/test_interact.py::test_interact_replaces_model PASSED            [  4%]
panel/tests/test_io.py::test_embed_discrete PASSED                           [  4%]
panel/tests/test_io.py::test_embed_continuous PASSED                         [  5%]
panel/tests/test_io.py::test_embed_checkbox PASSED                           [  5%]
panel/tests/test_io.py::test_save_embed_bytesio PASSED                       [  5%]
panel/tests/test_io.py::test_save_embed PASSED                               [  5%]
panel/tests/test_io.py::test_save_embed_json PASSED                          [  5%]
panel/tests/test_io.py::test_ipywidget SKIPPED                               [  6%]
panel/tests/test_layout.py::test_layout_properties[Column] PASSED            [  6%]
panel/tests/test_layout.py::test_layout_properties[Row] PASSED               [  6%]
panel/tests/test_layout.py::test_layout_properties[Tabs] PASSED              [  6%]
panel/tests/test_layout.py::test_layout_properties[Spacer] PASSED            [  7%]
panel/tests/test_layout.py::test_layout_model_cache_cleanup[Column] PASSED   [  7%]
panel/tests/test_layout.py::test_layout_model_cache_cleanup[Row] PASSED      [  7%]
panel/tests/test_layout.py::test_layout_model_cache_cleanup[Tabs] PASSED     [  7%]
panel/tests/test_layout.py::test_layout_model_cache_cleanup[Spacer] PASSED   [  7%]
panel/tests/test_layout.py::test_layout_constructor[Column] PASSED           [  8%]
panel/tests/test_layout.py::test_layout_constructor[Row] PASSED              [  8%]
panel/tests/test_layout.py::test_layout_getitem[Column] PASSED               [  8%]
panel/tests/test_layout.py::test_layout_getitem[Row] PASSED                  [  8%]
panel/tests/test_layout.py::test_layout_repr[Column] PASSED                  [  8%]
panel/tests/test_layout.py::test_layout_repr[Row] PASSED                     [  9%]
panel/tests/test_layout.py::test_layout_select_by_type[Column] PASSED        [  9%]
panel/tests/test_layout.py::test_layout_select_by_type[Row] PASSED           [  9%]
panel/tests/test_layout.py::test_layout_select_by_function[Column] PASSED    [  9%]
panel/tests/test_layout.py::test_layout_select_by_function[Row] PASSED       [ 10%]
panel/tests/test_layout.py::test_layoutget_root[Column-Column] PASSED        [ 10%]
panel/tests/test_layout.py::test_layoutget_root[Row-Row] PASSED              [ 10%]
panel/tests/test_layout.py::test_layout_reverse[Column] PASSED               [ 10%]
panel/tests/test_layout.py::test_layout_reverse[Row] PASSED                  [ 10%]
panel/tests/test_layout.py::test_layout_append[Column] PASSED                [ 11%]
panel/tests/test_layout.py::test_layout_append[Row] PASSED                   [ 11%]
panel/tests/test_layout.py::test_layout_extend[Column] PASSED                [ 11%]
panel/tests/test_layout.py::test_layout_extend[Row] PASSED                   [ 11%]
panel/tests/test_layout.py::test_layout_insert[Column] PASSED                [ 11%]
panel/tests/test_layout.py::test_layout_insert[Row] PASSED                   [ 12%]
panel/tests/test_layout.py::test_layout_setitem[Column] PASSED               [ 12%]
panel/tests/test_layout.py::test_layout_setitem[Row] PASSED                  [ 12%]
panel/tests/test_layout.py::test_layout_setitem_out_of_bounds[Column] PASSED [ 12%]
panel/tests/test_layout.py::test_layout_setitem_out_of_bounds[Row] PASSED    [ 13%]
panel/tests/test_layout.py::test_layout_setitem_replace_all[Column] PASSED   [ 13%]
panel/tests/test_layout.py::test_layout_setitem_replace_all[Row] PASSED      [ 13%]
panel/tests/test_layout.py::test_layout_setitem_replace_all_error[Column] PASSED [ 13%]
panel/tests/test_layout.py::test_layout_setitem_replace_all_error[Row] PASSED [ 13%]
panel/tests/test_layout.py::test_layout_setitem_replace_slice[Column] PASSED [ 14%]
panel/tests/test_layout.py::test_layout_setitem_replace_slice[Row] PASSED    [ 14%]
panel/tests/test_layout.py::test_layout_setitem_replace_slice_error[Column] PASSED [ 14%]
panel/tests/test_layout.py::test_layout_setitem_replace_slice_error[Row] PASSED [ 14%]
panel/tests/test_layout.py::test_layout_setitem_replace_slice_out_of_bounds[Column] PASSED [ 14%]
panel/tests/test_layout.py::test_layout_setitem_replace_slice_out_of_bounds[Row] PASSED [ 15%]
panel/tests/test_layout.py::test_layout_pop[Column] PASSED                   [ 15%]
panel/tests/test_layout.py::test_layout_pop[Row] PASSED                      [ 15%]
panel/tests/test_layout.py::test_layout_remove[Column] PASSED                [ 15%]
panel/tests/test_layout.py::test_layout_remove[Row] PASSED                   [ 16%]
panel/tests/test_layout.py::test_layout_clear[Column] PASSED                 [ 16%]
panel/tests/test_layout.py::test_layout_clear[Row] PASSED                    [ 16%]
panel/tests/test_layout.py::test_layout_clone_args[Column] PASSED            [ 16%]
panel/tests/test_layout.py::test_layout_clone_args[Row] PASSED               [ 16%]
panel/tests/test_layout.py::test_layout_clone_kwargs[Column] PASSED          [ 17%]
panel/tests/test_layout.py::test_layout_clone_kwargs[Row] PASSED             [ 17%]
panel/tests/test_layout.py::test_tabs_basic_constructor PASSED               [ 17%]
panel/tests/test_layout.py::test_tabs_constructor PASSED                     [ 17%]
panel/tests/test_layout.py::test_tabs_implicit_constructor PASSED            [ 17%]
panel/tests/test_layout.py::test_tabs_constructor_with_named_objects PASSED  [ 18%]
panel/tests/test_layout.py::test_tabs_set_panes PASSED                       [ 18%]
panel/tests/test_layout.py::test_tabs_reverse PASSED                         [ 18%]
panel/tests/test_layout.py::test_tabs_append PASSED                          [ 18%]
panel/tests/test_layout.py::test_empty_tabs_append PASSED                    [ 19%]
panel/tests/test_layout.py::test_tabs_append_uses_object_name PASSED         [ 19%]
panel/tests/test_layout.py::test_tabs_append_with_tuple_and_unnamed_contents PASSED [ 19%]
panel/tests/test_layout.py::test_tabs_append_with_tuple_and_named_contents PASSED [ 19%]
panel/tests/test_layout.py::test_tabs_extend PASSED                          [ 19%]
panel/tests/test_layout.py::test_tabs_extend_uses_object_name PASSED         [ 20%]
panel/tests/test_layout.py::test_tabs_extend_with_tuple_and_unnamed_contents PASSED [ 20%]
panel/tests/test_layout.py::test_tabs_extend_with_tuple_and_named_contents PASSED [ 20%]
panel/tests/test_layout.py::test_tabs_insert PASSED                          [ 20%]
panel/tests/test_layout.py::test_tabs_insert_uses_object_name PASSED         [ 20%]
panel/tests/test_layout.py::test_tabs_insert_with_tuple_and_unnamed_contents PASSED [ 21%]
panel/tests/test_layout.py::test_tabs_insert_with_tuple_and_named_contents PASSED [ 21%]
panel/tests/test_layout.py::test_tabs_setitem PASSED                         [ 21%]
panel/tests/test_layout.py::test_tabs_clone PASSED                           [ 21%]
panel/tests/test_layout.py::test_tabs_clone_args PASSED                      [ 22%]
panel/tests/test_layout.py::test_tabs_clone_kwargs PASSED                    [ 22%]
panel/tests/test_layout.py::test_tabs_setitem_out_of_bounds PASSED           [ 22%]
panel/tests/test_layout.py::test_tabs_setitem_replace_all PASSED             [ 22%]
panel/tests/test_layout.py::test_tabs_setitem_replace_all_error PASSED       [ 22%]
panel/tests/test_layout.py::test_tabs_setitem_replace_slice PASSED           [ 23%]
panel/tests/test_layout.py::test_tabs_setitem_replace_slice_error PASSED     [ 23%]
panel/tests/test_layout.py::test_tabs_setitem_replace_slice_out_of_bounds PASSED [ 23%]
panel/tests/test_layout.py::test_tabs_pop PASSED                             [ 23%]
panel/tests/test_layout.py::test_tabs_remove PASSED                          [ 23%]
panel/tests/test_layout.py::test_tabs_clear PASSED                           [ 24%]
panel/tests/test_layout.py::test_spacer PASSED                               [ 24%]
panel/tests/test_layout.py::test_spacer_clone PASSED                         [ 24%]
panel/tests/test_layout.py::test_layout_with_param_setitem PASSED            [ 24%]
panel/tests/test_layout.py::test_gridspec_integer_setitem PASSED             [ 25%]
panel/tests/test_layout.py::test_gridspec_clone PASSED                       [ 25%]
panel/tests/test_layout.py::test_gridspec_slice_setitem PASSED               [ 25%]
panel/tests/test_layout.py::test_gridspec_setitem_int_overlap PASSED         [ 25%]
panel/tests/test_layout.py::test_gridspec_setitem_slice_overlap PASSED       [ 25%]
panel/tests/test_layout.py::test_gridspec_setitem_cell_override PASSED       [ 26%]
panel/tests/test_layout.py::test_gridspec_setitem_span_override PASSED       [ 26%]
panel/tests/test_layout.py::test_gridspec_fixed_with_int_setitem PASSED      [ 26%]
panel/tests/test_layout.py::test_gridspec_fixed_with_slice_setitem PASSED    [ 26%]
panel/tests/test_layout.py::test_gridspec_fixed_with_upper_partial_slice_setitem PASSED [ 26%]
panel/tests/test_layout.py::test_gridspec_fixed_with_lower_partial_slice_setitem PASSED [ 27%]
panel/tests/test_layout.py::test_gridspec_fixed_with_empty_slice_setitem PASSED [ 27%]
panel/tests/test_layout.py::test_gridspec_stretch_with_int_setitem PASSED    [ 27%]
panel/tests/test_layout.py::test_gridspec_stretch_with_slice_setitem PASSED  [ 27%]
panel/tests/test_layout.py::test_widgetbox PASSED                            [ 28%]
panel/tests/test_layout.py::test_gridbox_ncols PASSED                        [ 28%]
panel/tests/test_layout.py::test_gridbox_nrows PASSED                        [ 28%]
panel/tests/test_links.py::test_widget_link_bidirectional PASSED             [ 28%]
panel/tests/test_links.py::test_pnwidget_hvplot_links SKIPPED                [ 28%]
panel/tests/test_links.py::test_bkwidget_hvplot_links SKIPPED                [ 29%]
panel/tests/test_links.py::test_bkwidget_bkplot_links PASSED                 [ 29%]
panel/tests/test_links.py::test_widget_bkplot_link PASSED                    [ 29%]
panel/tests/test_links.py::test_widget_jscallback PASSED                     [ 29%]
panel/tests/test_links.py::test_widget_jscallback_args_scalar PASSED         [ 29%]
panel/tests/test_links.py::test_widget_jscallback_args_model PASSED          [ 30%]
panel/tests/test_links.py::test_hvplot_jscallback SKIPPED                    [ 30%]
panel/tests/test_links.py::test_link_with_customcode SKIPPED                 [ 30%]
panel/tests/test_models.py::test_models_encoding PASSED                      [ 30%]
panel/tests/test_param.py::test_instantiate_from_class PASSED                [ 31%]
panel/tests/test_param.py::test_instantiate_from_parameter PASSED            [ 31%]
panel/tests/test_param.py::test_instantiate_from_parameters PASSED           [ 31%]
panel/tests/test_param.py::test_instantiate_from_instance PASSED             [ 31%]
panel/tests/test_param.py::test_instantiate_from_parameter_on_instance PASSED [ 31%]
panel/tests/test_param.py::test_instantiate_from_parameters_on_instance PASSED [ 32%]
panel/tests/test_param.py::test_param_pane_repr PASSED                       [ 32%]
panel/tests/test_param.py::test_param_pane_repr_with_params PASSED           [ 32%]
panel/tests/test_param.py::test_get_root PASSED                              [ 32%]
panel/tests/test_param.py::test_single_param PASSED                          [ 32%]
panel/tests/test_param.py::test_get_root_tabs PASSED                         [ 33%]
panel/tests/test_param.py::test_number_param PASSED                          [ 33%]
panel/tests/test_param.py::test_boolean_param PASSED                         [ 33%]
panel/tests/test_param.py::test_range_param PASSED                           [ 33%]
panel/tests/test_param.py::test_integer_param PASSED                         [ 34%]
panel/tests/test_param.py::test_object_selector_param PASSED                 [ 34%]
panel/tests/test_param.py::test_list_selector_param PASSED                   [ 34%]
panel/tests/test_param.py::test_action_param PASSED                          [ 34%]
panel/tests/test_param.py::test_explicit_params PASSED                       [ 34%]
panel/tests/test_param.py::test_param_precedence PASSED                      [ 35%]
panel/tests/test_param.py::test_param_label PASSED                           [ 35%]
panel/tests/test_param.py::test_param_precedence_ordering PASSED             [ 35%]
panel/tests/test_param.py::test_param_step PASSED                            [ 35%]
panel/tests/test_param.py::test_replace_param_object PASSED                  [ 35%]
panel/tests/test_param.py::test_set_parameters PASSED                        [ 36%]
panel/tests/test_param.py::test_set_display_threshold PASSED                 [ 36%]
panel/tests/test_param.py::test_set_widgets PASSED                           [ 36%]
panel/tests/test_param.py::test_set_show_name PASSED                         [ 36%]
panel/tests/test_param.py::test_set_show_labels PASSED                       [ 37%]
panel/tests/test_param.py::test_expand_param_subobject PASSED                [ 37%]
panel/tests/test_param.py::test_switch_param_subobject PASSED                [ 37%]
panel/tests/test_param.py::test_expand_param_subobject_into_row PASSED       [ 37%]
panel/tests/test_param.py::test_expand_param_subobject_expand PASSED         [ 37%]
panel/tests/test_param.py::test_param_subobject_expand_no_toggle PASSED      [ 38%]
panel/tests/test_param.py::test_expand_param_subobject_tabs PASSED           [ 38%]
panel/tests/test_param.py::test_get_param_function_pane_type PASSED          [ 38%]
panel/tests/test_param.py::test_param_function_pane PASSED                   [ 38%]
panel/tests/test_param.py::test_get_param_method_pane_type PASSED            [ 38%]
panel/tests/test_param.py::test_param_method_pane PASSED                     [ 39%]
panel/tests/test_param.py::test_param_method_pane_subobject PASSED           [ 39%]
panel/tests/test_param.py::test_param_method_pane_mpl SKIPPED                [ 39%]
panel/tests/test_param.py::test_param_method_pane_changing_type SKIPPED      [ 39%]
panel/tests/test_param.py::test_jsoninit_class_from_env_var PASSED           [ 40%]
panel/tests/test_param.py::test_jsoninit_instance_from_env_var PASSED        [ 40%]
panel/tests/test_reactive.py::test_link PASSED                               [ 40%]
panel/tests/test_reactive.py::test_param_rename PASSED                       [ 40%]
panel/tests/test_reactive.py::test_link_properties_nb PASSED                 [ 40%]
panel/tests/test_reactive.py::test_link_properties_server PASSED             [ 41%]
panel/tests/test_server.py::test_get_server PASSED                           [ 41%]
panel/tests/test_server.py::test_server_update PASSED                        [ 41%]
panel/tests/test_server.py::test_server_change_io_state PASSED               [ 41%]
panel/tests/test_server.py::test_show_server_info PASSED                     [ 41%]
panel/tests/test_server.py::test_kill_all_servers PASSED                     [ 42%]
panel/tests/test_util.py::test_get_method_owner_class PASSED                 [ 42%]
panel/tests/test_util.py::test_get_method_owner_instance PASSED              [ 42%]
panel/tests/test_util.py::test_render_mimebundle PASSED                      [ 42%]
panel/tests/test_util.py::test_abbreviated_repr_dict PASSED                  [ 43%]
panel/tests/test_util.py::test_abbreviated_repr_list PASSED                  [ 43%]
panel/tests/test_util.py::test_abbreviated_repr_ordereddict PASSED           [ 43%]
panel/tests/test_viewable.py::test_viewable_ipywidget SKIPPED                [ 43%]
panel/tests/pane/test_ace.py::test_ace_pane PASSED                           [ 43%]
panel/tests/pane/test_equation.py::test_latex_pane PASSED                    [ 44%]
panel/tests/pane/test_equation.py::test_latex_mathjax_pane PASSED            [ 44%]
panel/tests/pane/test_holoviews.py::test_get_holoviews_pane_type SKIPPED     [ 44%]
panel/tests/pane/test_holoviews.py::test_holoviews_pane_mpl_renderer SKIPPED [ 44%]
panel/tests/pane/test_holoviews.py::test_holoviews_pane_switch_backend SKIPPED [ 44%]
panel/tests/pane/test_holoviews.py::test_holoviews_pane_bokeh_renderer SKIPPED [ 45%]
panel/tests/pane/test_holoviews.py::test_holoviews_pane_initialize_empty SKIPPED [ 45%]
panel/tests/pane/test_holoviews.py::test_holoviews_widgets_from_dynamicmap SKIPPED [ 45%]
panel/tests/pane/test_holoviews.py::test_holoviews_with_widgets SKIPPED      [ 45%]
panel/tests/pane/test_holoviews.py::test_holoviews_updates_widgets SKIPPED   [ 46%]
panel/tests/pane/test_holoviews.py::test_holoviews_widgets_update_plot SKIPPED [ 46%]
panel/tests/pane/test_holoviews.py::test_holoviews_with_widgets_not_shown SKIPPED [ 46%]
panel/tests/pane/test_holoviews.py::test_holoviews_layouts SKIPPED           [ 46%]
panel/tests/pane/test_holoviews.py::test_holoviews_widgets_from_holomap SKIPPED [ 46%]
panel/tests/pane/test_holoviews.py::test_holoviews_date_slider_widgets_from_holomap SKIPPED [ 47%]
panel/tests/pane/test_holoviews.py::test_holoviews_widgets_explicit_widget_type_override SKIPPED [ 47%]
panel/tests/pane/test_holoviews.py::test_holoviews_widgets_invalid_widget_type_override SKIPPED [ 47%]
panel/tests/pane/test_holoviews.py::test_holoviews_widgets_explicit_widget_instance_override SKIPPED [ 47%]
panel/tests/pane/test_holoviews.py::test_holoviews_linked_axes SKIPPED       [ 47%]
panel/tests/pane/test_holoviews.py::test_holoviews_linked_x_axis SKIPPED     [ 48%]
panel/tests/pane/test_holoviews.py::test_holoviews_axiswise_not_linked_axes SKIPPED [ 48%]
panel/tests/pane/test_holoviews.py::test_holoviews_shared_axes_opt_not_linked_axes SKIPPED [ 48%]
panel/tests/pane/test_holoviews.py::test_holoviews_not_linked_axes SKIPPED   [ 48%]
panel/tests/pane/test_holoviews.py::test_holoviews_link_across_panes SKIPPED [ 49%]
panel/tests/pane/test_holoviews.py::test_holoviews_link_after_adding_item SKIPPED [ 49%]
panel/tests/pane/test_holoviews.py::test_holoviews_link_within_pane SKIPPED  [ 49%]
panel/tests/pane/test_image.py::test_svg_pane PASSED                         [ 49%]
panel/tests/pane/test_image.py::test_imgshape PASSED                         [ 49%]
panel/tests/pane/test_image.py::test_load_from_byteio PASSED                 [ 50%]
panel/tests/pane/test_image.py::test_load_from_stringio PASSED               [ 50%]
panel/tests/pane/test_image.py::test_loading_a_image_from_url PASSED         [ 50%]
panel/tests/pane/test_markup.py::test_get_markdown_pane_type PASSED          [ 50%]
panel/tests/pane/test_markup.py::test_get_dataframe_pane_type SKIPPED        [ 50%]
panel/tests/pane/test_markup.py::test_get_series_pane_type SKIPPED           [ 51%]
panel/tests/pane/test_markup.py::test_get_streamz_dataframe_pane_type SKIPPED [ 51%]
panel/tests/pane/test_markup.py::test_get_streamz_dataframes_pane_type SKIPPED [ 51%]
panel/tests/pane/test_markup.py::test_get_streamz_series_pane_type SKIPPED   [ 51%]
panel/tests/pane/test_markup.py::test_get_streamz_seriess_pane_type SKIPPED  [ 52%]
panel/tests/pane/test_markup.py::test_markdown_pane PASSED                   [ 52%]
panel/tests/pane/test_markup.py::test_html_pane PASSED                       [ 52%]
panel/tests/pane/test_markup.py::test_dataframe_pane_pandas SKIPPED          [ 52%]
panel/tests/pane/test_markup.py::test_dataframe_pane_streamz SKIPPED         [ 52%]
panel/tests/pane/test_markup.py::test_string_pane PASSED                     [ 53%]
panel/tests/pane/test_plot.py::test_get_bokeh_pane_type PASSED               [ 53%]
panel/tests/pane/test_plot.py::test_bokeh_pane PASSED                        [ 53%]
panel/tests/pane/test_plot.py::test_get_matplotlib_pane_type SKIPPED         [ 53%]
panel/tests/pane/test_plot.py::test_matplotlib_pane SKIPPED                  [ 53%]
panel/tests/pane/test_plotly.py::test_get_plotly_pane_type_from_figure SKIPPED [ 54%]
panel/tests/pane/test_plotly.py::test_get_plotly_pane_type_from_traces SKIPPED [ 54%]
panel/tests/pane/test_plotly.py::test_get_plotly_pane_type_from_trace SKIPPED [ 54%]
panel/tests/pane/test_plotly.py::test_plotly_pane_single_trace SKIPPED       [ 54%]
panel/tests/pane/test_plotly.py::test_plotly_pane_datetime_list_transform SKIPPED [ 55%]
panel/tests/pane/test_plotly.py::test_plotly_pane_datetime_array_transform SKIPPED [ 55%]
panel/tests/pane/test_plotly.py::test_plotly_pane_datetime64_list_transform SKIPPED [ 55%]
panel/tests/pane/test_plotly.py::test_plotly_pane_datetime64_array_transform SKIPPED [ 55%]
panel/tests/pane/test_plotly.py::test_plotly_pane_numpy_to_cds_traces SKIPPED [ 55%]
panel/tests/pane/test_vega.py::test_get_vega_pane_type_from_dict PASSED      [ 56%]
panel/tests/pane/test_vega.py::test_vega_pane PASSED                         [ 56%]
panel/tests/pane/test_vega.py::test_vega_pane_inline PASSED                  [ 56%]
panel/tests/pane/test_vega.py::test_get_vega_pane_type_from_altair SKIPPED   [ 56%]
panel/tests/pane/test_vega.py::test_altair_pane SKIPPED                      [ 56%]
panel/tests/pane/test_vtk.py::test_get_vtk_pane_type_from_url PASSED         [ 57%]
panel/tests/pane/test_vtk.py::test_get_vtk_pane_type_from_file PASSED        [ 57%]
panel/tests/pane/test_vtk.py::test_get_vtk_pane_type_from_render_window SKIPPED [ 57%]
panel/tests/pane/test_vtk.py::test_vtk_pane_from_url PASSED                  [ 57%]
panel/tests/pane/test_vtk.py::test_vtk_data_array_dump SKIPPED               [ 58%]
panel/tests/widgets/test_base.py::test_widget_layout_properties[TextInput] PASSED [ 58%]
panel/tests/widgets/test_base.py::test_widget_layout_properties[PasswordInput] PASSED [ 58%]
panel/tests/widgets/test_base.py::test_widget_layout_properties[TextAreaInput] PASSED [ 58%]
panel/tests/widgets/test_base.py::test_widget_layout_properties[FileInput] PASSED [ 58%]
panel/tests/widgets/test_base.py::test_widget_layout_properties[StaticText] PASSED [ 59%]
panel/tests/widgets/test_base.py::test_widget_layout_properties[DatePicker] PASSED [ 59%]
panel/tests/widgets/test_base.py::test_widget_layout_properties[ColorPicker] PASSED [ 59%]
panel/tests/widgets/test_base.py::test_widget_layout_properties[Spinner] PASSED [ 59%]
panel/tests/widgets/test_base.py::test_widget_layout_properties[LiteralInput] PASSED [ 59%]
panel/tests/widgets/test_base.py::test_widget_layout_properties[Checkbox] PASSED [ 60%]
panel/tests/widgets/test_base.py::test_widget_layout_properties[VideoStream] PASSED [ 60%]
panel/tests/widgets/test_base.py::test_widget_layout_properties[Progress] PASSED [ 60%]
panel/tests/widgets/test_base.py::test_widget_layout_properties[AutocompleteInput] PASSED [ 60%]
panel/tests/widgets/test_base.py::test_widget_layout_properties[Button] PASSED [ 61%]
panel/tests/widgets/test_base.py::test_widget_layout_properties[Toggle] PASSED [ 61%]
panel/tests/widgets/test_base.py::test_widget_layout_properties[RadioButtonGroup] PASSED [ 61%]
panel/tests/widgets/test_base.py::test_widget_layout_properties[CheckButtonGroup] PASSED [ 61%]
panel/tests/widgets/test_base.py::test_widget_layout_properties[DatetimeInput] PASSED [ 61%]
panel/tests/widgets/test_base.py::test_widget_layout_properties[Audio] PASSED [ 62%]
panel/tests/widgets/test_base.py::test_widget_layout_properties[Select] PASSED [ 62%]
panel/tests/widgets/test_base.py::test_widget_layout_properties[DiscretePlayer] PASSED [ 62%]
panel/tests/widgets/test_base.py::test_widget_layout_properties[Player] PASSED [ 62%]
panel/tests/widgets/test_base.py::test_widget_layout_properties[DateSlider] PASSED [ 62%]
panel/tests/widgets/test_base.py::test_widget_layout_properties[RangeSlider] PASSED [ 63%]
panel/tests/widgets/test_base.py::test_widget_layout_properties[DateRangeSlider] PASSED [ 63%]
panel/tests/widgets/test_base.py::test_widget_layout_properties[MultiSelect] PASSED [ 63%]
panel/tests/widgets/test_base.py::test_widget_layout_properties[ToggleGroup] PASSED [ 63%]
panel/tests/widgets/test_base.py::test_widget_layout_properties[FloatSlider] PASSED [ 64%]
panel/tests/widgets/test_base.py::test_widget_layout_properties[IntSlider] PASSED [ 64%]
panel/tests/widgets/test_base.py::test_widget_layout_properties[IntRangeSlider] PASSED [ 64%]
panel/tests/widgets/test_base.py::test_widget_layout_properties[RadioBoxGroup] PASSED [ 64%]
panel/tests/widgets/test_base.py::test_widget_layout_properties[CheckBoxGroup] PASSED [ 64%]
panel/tests/widgets/test_base.py::test_widget_disabled_properties[TextInput] PASSED [ 65%]
panel/tests/widgets/test_base.py::test_widget_disabled_properties[PasswordInput] PASSED [ 65%]
panel/tests/widgets/test_base.py::test_widget_disabled_properties[TextAreaInput] PASSED [ 65%]
panel/tests/widgets/test_base.py::test_widget_disabled_properties[FileInput] PASSED [ 65%]
panel/tests/widgets/test_base.py::test_widget_disabled_properties[StaticText] PASSED [ 65%]
panel/tests/widgets/test_base.py::test_widget_disabled_properties[DatePicker] PASSED [ 66%]
panel/tests/widgets/test_base.py::test_widget_disabled_properties[ColorPicker] PASSED [ 66%]
panel/tests/widgets/test_base.py::test_widget_disabled_properties[Spinner] PASSED [ 66%]
panel/tests/widgets/test_base.py::test_widget_disabled_properties[LiteralInput] PASSED [ 66%]
panel/tests/widgets/test_base.py::test_widget_disabled_properties[Checkbox] PASSED [ 67%]
panel/tests/widgets/test_base.py::test_widget_disabled_properties[VideoStream] PASSED [ 67%]
panel/tests/widgets/test_base.py::test_widget_disabled_properties[Progress] PASSED [ 67%]
panel/tests/widgets/test_base.py::test_widget_disabled_properties[AutocompleteInput] PASSED [ 67%]
panel/tests/widgets/test_base.py::test_widget_disabled_properties[Button] PASSED [ 67%]
panel/tests/widgets/test_base.py::test_widget_disabled_properties[Toggle] PASSED [ 68%]
panel/tests/widgets/test_base.py::test_widget_disabled_properties[RadioButtonGroup] PASSED [ 68%]
panel/tests/widgets/test_base.py::test_widget_disabled_properties[CheckButtonGroup] PASSED [ 68%]
panel/tests/widgets/test_base.py::test_widget_disabled_properties[DatetimeInput] PASSED [ 68%]
panel/tests/widgets/test_base.py::test_widget_disabled_properties[Audio] PASSED [ 68%]
panel/tests/widgets/test_base.py::test_widget_disabled_properties[Select] PASSED [ 69%]
panel/tests/widgets/test_base.py::test_widget_disabled_properties[DiscretePlayer] PASSED [ 69%]
panel/tests/widgets/test_base.py::test_widget_disabled_properties[Player] PASSED [ 69%]
panel/tests/widgets/test_base.py::test_widget_disabled_properties[DateSlider] PASSED [ 69%]
panel/tests/widgets/test_base.py::test_widget_disabled_properties[RangeSlider] PASSED [ 70%]
panel/tests/widgets/test_base.py::test_widget_disabled_properties[DateRangeSlider] PASSED [ 70%]
panel/tests/widgets/test_base.py::test_widget_disabled_properties[MultiSelect] PASSED [ 70%]
panel/tests/widgets/test_base.py::test_widget_disabled_properties[ToggleGroup] PASSED [ 70%]
panel/tests/widgets/test_base.py::test_widget_disabled_properties[FloatSlider] PASSED [ 70%]
panel/tests/widgets/test_base.py::test_widget_disabled_properties[IntSlider] PASSED [ 71%]
panel/tests/widgets/test_base.py::test_widget_disabled_properties[IntRangeSlider] PASSED [ 71%]
panel/tests/widgets/test_base.py::test_widget_disabled_properties[RadioBoxGroup] PASSED [ 71%]
panel/tests/widgets/test_base.py::test_widget_disabled_properties[CheckBoxGroup] PASSED [ 71%]
panel/tests/widgets/test_base.py::test_widget_clone[TextInput] PASSED        [ 71%]
panel/tests/widgets/test_base.py::test_widget_clone[PasswordInput] PASSED    [ 72%]
panel/tests/widgets/test_base.py::test_widget_clone[TextAreaInput] PASSED    [ 72%]
panel/tests/widgets/test_base.py::test_widget_clone[FileInput] PASSED        [ 72%]
panel/tests/widgets/test_base.py::test_widget_clone[StaticText] PASSED       [ 72%]
panel/tests/widgets/test_base.py::test_widget_clone[DatePicker] PASSED       [ 73%]
panel/tests/widgets/test_base.py::test_widget_clone[ColorPicker] PASSED      [ 73%]
panel/tests/widgets/test_base.py::test_widget_clone[Spinner] PASSED          [ 73%]
panel/tests/widgets/test_base.py::test_widget_clone[LiteralInput] PASSED     [ 73%]
panel/tests/widgets/test_base.py::test_widget_clone[Checkbox] PASSED         [ 73%]
panel/tests/widgets/test_base.py::test_widget_clone[VideoStream] PASSED      [ 74%]
panel/tests/widgets/test_base.py::test_widget_clone[Progress] PASSED         [ 74%]
panel/tests/widgets/test_base.py::test_widget_clone[AutocompleteInput] PASSED [ 74%]
panel/tests/widgets/test_base.py::test_widget_clone[Button] PASSED           [ 74%]
panel/tests/widgets/test_base.py::test_widget_clone[Toggle] PASSED           [ 74%]
panel/tests/widgets/test_base.py::test_widget_clone[RadioButtonGroup] PASSED [ 75%]
panel/tests/widgets/test_base.py::test_widget_clone[CheckButtonGroup] PASSED [ 75%]
panel/tests/widgets/test_base.py::test_widget_clone[DatetimeInput] PASSED    [ 75%]
panel/tests/widgets/test_base.py::test_widget_clone[Audio] PASSED            [ 75%]
panel/tests/widgets/test_base.py::test_widget_clone[Select] PASSED           [ 76%]
panel/tests/widgets/test_base.py::test_widget_clone[DiscretePlayer] PASSED   [ 76%]
panel/tests/widgets/test_base.py::test_widget_clone[Player] PASSED           [ 76%]
panel/tests/widgets/test_base.py::test_widget_clone[DateSlider] PASSED       [ 76%]
panel/tests/widgets/test_base.py::test_widget_clone[RangeSlider] PASSED      [ 76%]
panel/tests/widgets/test_base.py::test_widget_clone[DateRangeSlider] PASSED  [ 77%]
panel/tests/widgets/test_base.py::test_widget_clone[MultiSelect] PASSED      [ 77%]
panel/tests/widgets/test_base.py::test_widget_clone[ToggleGroup] PASSED      [ 77%]
panel/tests/widgets/test_base.py::test_widget_clone[FloatSlider] PASSED      [ 77%]
panel/tests/widgets/test_base.py::test_widget_clone[IntSlider] PASSED        [ 77%]
panel/tests/widgets/test_base.py::test_widget_clone[IntRangeSlider] PASSED   [ 78%]
panel/tests/widgets/test_base.py::test_widget_clone[RadioBoxGroup] PASSED    [ 78%]
panel/tests/widgets/test_base.py::test_widget_clone[CheckBoxGroup] PASSED    [ 78%]
panel/tests/widgets/test_base.py::test_widget_clone_override[TextInput] PASSED [ 78%]
panel/tests/widgets/test_base.py::test_widget_clone_override[PasswordInput] PASSED [ 79%]
panel/tests/widgets/test_base.py::test_widget_clone_override[TextAreaInput] PASSED [ 79%]
panel/tests/widgets/test_base.py::test_widget_clone_override[FileInput] PASSED [ 79%]
panel/tests/widgets/test_base.py::test_widget_clone_override[StaticText] PASSED [ 79%]
panel/tests/widgets/test_base.py::test_widget_clone_override[DatePicker] PASSED [ 79%]
panel/tests/widgets/test_base.py::test_widget_clone_override[ColorPicker] PASSED [ 80%]
panel/tests/widgets/test_base.py::test_widget_clone_override[Spinner] PASSED [ 80%]
panel/tests/widgets/test_base.py::test_widget_clone_override[LiteralInput] PASSED [ 80%]
panel/tests/widgets/test_base.py::test_widget_clone_override[Checkbox] PASSED [ 80%]
panel/tests/widgets/test_base.py::test_widget_clone_override[VideoStream] PASSED [ 80%]
panel/tests/widgets/test_base.py::test_widget_clone_override[Progress] PASSED [ 81%]
panel/tests/widgets/test_base.py::test_widget_clone_override[AutocompleteInput] PASSED [ 81%]
panel/tests/widgets/test_base.py::test_widget_clone_override[Button] PASSED  [ 81%]
panel/tests/widgets/test_base.py::test_widget_clone_override[Toggle] PASSED  [ 81%]
panel/tests/widgets/test_base.py::test_widget_clone_override[RadioButtonGroup] PASSED [ 82%]
panel/tests/widgets/test_base.py::test_widget_clone_override[CheckButtonGroup] PASSED [ 82%]
panel/tests/widgets/test_base.py::test_widget_clone_override[DatetimeInput] PASSED [ 82%]
panel/tests/widgets/test_base.py::test_widget_clone_override[Audio] PASSED   [ 82%]
panel/tests/widgets/test_base.py::test_widget_clone_override[Select] PASSED  [ 82%]
panel/tests/widgets/test_base.py::test_widget_clone_override[DiscretePlayer] PASSED [ 83%]
panel/tests/widgets/test_base.py::test_widget_clone_override[Player] PASSED  [ 83%]
panel/tests/widgets/test_base.py::test_widget_clone_override[DateSlider] PASSED [ 83%]
panel/tests/widgets/test_base.py::test_widget_clone_override[RangeSlider] PASSED [ 83%]
panel/tests/widgets/test_base.py::test_widget_clone_override[DateRangeSlider] PASSED [ 83%]
panel/tests/widgets/test_base.py::test_widget_clone_override[MultiSelect] PASSED [ 84%]
panel/tests/widgets/test_base.py::test_widget_clone_override[ToggleGroup] PASSED [ 84%]
panel/tests/widgets/test_base.py::test_widget_clone_override[FloatSlider] PASSED [ 84%]
panel/tests/widgets/test_base.py::test_widget_clone_override[IntSlider] PASSED [ 84%]
panel/tests/widgets/test_base.py::test_widget_clone_override[IntRangeSlider] PASSED [ 85%]
panel/tests/widgets/test_base.py::test_widget_clone_override[RadioBoxGroup] PASSED [ 85%]
panel/tests/widgets/test_base.py::test_widget_clone_override[CheckBoxGroup] PASSED [ 85%]
panel/tests/widgets/test_base.py::test_widget_model_cache_cleanup[TextInput] PASSED [ 85%]
panel/tests/widgets/test_base.py::test_widget_model_cache_cleanup[PasswordInput] PASSED [ 85%]
panel/tests/widgets/test_base.py::test_widget_model_cache_cleanup[TextAreaInput] PASSED [ 86%]
panel/tests/widgets/test_base.py::test_widget_model_cache_cleanup[FileInput] PASSED [ 86%]
panel/tests/widgets/test_base.py::test_widget_model_cache_cleanup[StaticText] PASSED [ 86%]
panel/tests/widgets/test_base.py::test_widget_model_cache_cleanup[DatePicker] PASSED [ 86%]
panel/tests/widgets/test_base.py::test_widget_model_cache_cleanup[ColorPicker] PASSED [ 86%]
panel/tests/widgets/test_base.py::test_widget_model_cache_cleanup[Spinner] PASSED [ 87%]
panel/tests/widgets/test_base.py::test_widget_model_cache_cleanup[LiteralInput] PASSED [ 87%]
panel/tests/widgets/test_base.py::test_widget_model_cache_cleanup[Checkbox] PASSED [ 87%]
panel/tests/widgets/test_base.py::test_widget_model_cache_cleanup[VideoStream] PASSED [ 87%]
panel/tests/widgets/test_base.py::test_widget_model_cache_cleanup[Progress] PASSED [ 88%]
panel/tests/widgets/test_base.py::test_widget_model_cache_cleanup[AutocompleteInput] PASSED [ 88%]
panel/tests/widgets/test_base.py::test_widget_model_cache_cleanup[Button] PASSED [ 88%]
panel/tests/widgets/test_base.py::test_widget_model_cache_cleanup[Toggle] PASSED [ 88%]
panel/tests/widgets/test_base.py::test_widget_model_cache_cleanup[RadioButtonGroup] PASSED [ 88%]
panel/tests/widgets/test_base.py::test_widget_model_cache_cleanup[CheckButtonGroup] PASSED [ 89%]
panel/tests/widgets/test_base.py::test_widget_model_cache_cleanup[DatetimeInput] PASSED [ 89%]
panel/tests/widgets/test_base.py::test_widget_model_cache_cleanup[Audio] PASSED [ 89%]
panel/tests/widgets/test_base.py::test_widget_model_cache_cleanup[Select] PASSED [ 89%]
panel/tests/widgets/test_base.py::test_widget_model_cache_cleanup[DiscretePlayer] PASSED [ 89%]
panel/tests/widgets/test_base.py::test_widget_model_cache_cleanup[Player] PASSED [ 90%]
panel/tests/widgets/test_base.py::test_widget_model_cache_cleanup[DateSlider] PASSED [ 90%]
panel/tests/widgets/test_base.py::test_widget_model_cache_cleanup[RangeSlider] PASSED [ 90%]
panel/tests/widgets/test_base.py::test_widget_model_cache_cleanup[DateRangeSlider] PASSED [ 90%]
panel/tests/widgets/test_base.py::test_widget_model_cache_cleanup[MultiSelect] PASSED [ 91%]
panel/tests/widgets/test_base.py::test_widget_model_cache_cleanup[ToggleGroup] PASSED [ 91%]
panel/tests/widgets/test_base.py::test_widget_model_cache_cleanup[FloatSlider] PASSED [ 91%]
panel/tests/widgets/test_base.py::test_widget_model_cache_cleanup[IntSlider] PASSED [ 91%]
panel/tests/widgets/test_base.py::test_widget_model_cache_cleanup[IntRangeSlider] PASSED [ 91%]
panel/tests/widgets/test_base.py::test_widget_model_cache_cleanup[RadioBoxGroup] PASSED [ 92%]
panel/tests/widgets/test_base.py::test_widget_model_cache_cleanup[CheckBoxGroup] PASSED [ 92%]
panel/tests/widgets/test_base.py::test_widget_triggers_events PASSED         [ 92%]
panel/tests/widgets/test_button.py::test_button PASSED                       [ 92%]
panel/tests/widgets/test_button.py::test_toggle PASSED                       [ 92%]
panel/tests/widgets/test_input.py::test_checkbox PASSED                      [ 93%]
panel/tests/widgets/test_input.py::test_date_picker PASSED                   [ 93%]
panel/tests/widgets/test_input.py::test_file_input PASSED                    [ 93%]
panel/tests/widgets/test_input.py::test_literal_input PASSED                 [ 93%]
panel/tests/widgets/test_input.py::test_static_text PASSED                   [ 94%]
panel/tests/widgets/test_input.py::test_text_input PASSED                    [ 94%]
panel/tests/widgets/test_input.py::test_datetime_input PASSED                [ 94%]
panel/tests/widgets/test_player.py::test_discrete_player PASSED              [ 94%]
panel/tests/widgets/test_select.py::test_select_list_constructor PASSED      [ 94%]
panel/tests/widgets/test_select.py::test_select_float_option_with_equality PASSED [ 95%]
panel/tests/widgets/test_select.py::test_select_text_option_with_equality PASSED [ 95%]
panel/tests/widgets/test_select.py::test_select PASSED                       [ 95%]
panel/tests/widgets/test_select.py::test_select_change_options PASSED        [ 95%]
panel/tests/widgets/test_select.py::test_select_non_hashable_options PASSED  [ 95%]
panel/tests/widgets/test_select.py::test_select_mutables PASSED              [ 96%]
panel/tests/widgets/test_select.py::test_select_change_options_on_watch PASSED [ 96%]
panel/tests/widgets/test_select.py::test_multi_select PASSED                 [ 96%]
panel/tests/widgets/test_select.py::test_multi_select_change_options PASSED  [ 96%]
panel/tests/widgets/test_select.py::test_toggle_group_error_init PASSED      [ 97%]
panel/tests/widgets/test_select.py::test_toggle_group_check PASSED           [ 97%]
panel/tests/widgets/test_select.py::test_toggle_group_radio PASSED           [ 97%]
panel/tests/widgets/test_select.py::test_cross_select_constructor PASSED     [ 97%]
panel/tests/widgets/test_select.py::test_cross_select_move_selected_to_unselected PASSED [ 97%]
panel/tests/widgets/test_select.py::test_cross_select_move_unselected_to_selected PASSED [ 98%]
panel/tests/widgets/test_select.py::test_cross_select_move_unselected_to_selected_not_definition_order PASSED [ 98%]
panel/tests/widgets/test_slider.py::test_float_slider PASSED                 [ 98%]
panel/tests/widgets/test_slider.py::test_int_slider PASSED                   [ 98%]
panel/tests/widgets/test_slider.py::test_range_slider PASSED                 [ 98%]
panel/tests/widgets/test_slider.py::test_date_slider PASSED                  [ 99%]
panel/tests/widgets/test_slider.py::test_date_range_slider PASSED            [ 99%]
panel/tests/widgets/test_slider.py::test_discrete_slider PASSED              [ 99%]
panel/tests/widgets/test_slider.py::test_discrete_date_slider PASSED         [ 99%]
panel/tests/widgets/test_slider.py::test_discrete_slider_options_dict PASSED [100%]

============================= short test summary info ==============================
SKIPPED [1] /home/sefkw/mc3/envs/panelt/lib/python3.7/site-packages/_pytest/doctest.py:455: unable to import module local('/home/sefkw/code/pyviz/panel/panel/examples/apps/django2/project/urls.py')
SKIPPED [1] /home/sefkw/mc3/envs/panelt/lib/python3.7/site-packages/_pytest/doctest.py:455: unable to import module local('/home/sefkw/code/pyviz/panel/panel/examples/apps/django2/project/wsgi.py')
SKIPPED [1] /home/sefkw/mc3/envs/panelt/lib/python3.7/site-packages/_pytest/doctest.py:455: unable to import module local('/home/sefkw/code/pyviz/panel/panel/examples/apps/django2/sliders/apps.py')
SKIPPED [1] /home/sefkw/mc3/envs/panelt/lib/python3.7/site-packages/_pytest/doctest.py:455: unable to import module local('/home/sefkw/code/pyviz/panel/panel/examples/apps/django2/sliders/urls.py')
SKIPPED [1] /home/sefkw/mc3/envs/panelt/lib/python3.7/site-packages/_pytest/doctest.py:455: unable to import module local('/home/sefkw/code/pyviz/panel/panel/examples/apps/django2/sliders/views.py')
SKIPPED [1] /home/sefkw/mc3/envs/panelt/lib/python3.7/site-packages/_pytest/doctest.py:455: unable to import module local('/home/sefkw/code/pyviz/panel/panel/pane/vtk/vtkjs_serializer.py')
SKIPPED [2] /home/sefkw/code/pyviz/panel/panel/tests/test_pipeline.py:11: could not import 'holoviews': No module named 'holoviews'
SKIPPED [2] /home/sefkw/code/pyviz/panel/panel/tests/pane/test_base.py:15: could not import 'plotly': No module named 'plotly'
SKIPPED [2] /home/sefkw/code/pyviz/panel/panel/tests/widgets/test_misc.py:9: could not import 'scipy.io': No module named 'scipy'
SKIPPED [2] /home/sefkw/code/pyviz/panel/panel/tests/widgets/test_tables.py:4: could not import 'pandas': No module named 'pandas'
SKIPPED [1] panel/tests/test_io.py:135: requires jupyter_bokeh
SKIPPED [1] panel/tests/test_links.py:37: requires holoviews
SKIPPED [1] panel/tests/test_links.py:66: requires holoviews
SKIPPED [1] panel/tests/test_links.py:177: requires holoviews
SKIPPED [1] panel/tests/test_links.py:193: requires holoviews
SKIPPED [1] panel/tests/test_param.py:911: requires matplotlib
SKIPPED [1] panel/tests/test_param.py:940: requires matplotlib
SKIPPED [1] panel/tests/test_viewable.py:9: requires jupyter_bokeh
SKIPPED [1] panel/tests/pane/test_holoviews.py:26: requires holoviews
SKIPPED [1] panel/tests/pane/test_holoviews.py:32: requires holoviews
SKIPPED [1] panel/tests/pane/test_holoviews.py:58: requires holoviews
SKIPPED [1] panel/tests/pane/test_holoviews.py:84: requires holoviews
SKIPPED [1] panel/tests/pane/test_holoviews.py:116: requires holoviews
SKIPPED [1] panel/tests/pane/test_holoviews.py:134: requires holoviews
SKIPPED [1] panel/tests/pane/test_holoviews.py:186: requires holoviews
SKIPPED [1] panel/tests/pane/test_holoviews.py:206: requires holoviews
SKIPPED [1] panel/tests/pane/test_holoviews.py:222: requires holoviews
SKIPPED [1] panel/tests/pane/test_holoviews.py:236: requires holoviews
SKIPPED [1] panel/tests/pane/test_holoviews.py:257: requires holoviews
SKIPPED [1] panel/tests/pane/test_holoviews.py:333: requires holoviews
SKIPPED [1] panel/tests/pane/test_holoviews.py:350: requires holoviews
SKIPPED [1] panel/tests/pane/test_holoviews.py:365: requires holoviews
SKIPPED [1] panel/tests/pane/test_holoviews.py:377: requires holoviews
SKIPPED [1] panel/tests/pane/test_holoviews.py:385: requires holoviews
SKIPPED [1] panel/tests/pane/test_holoviews.py:395: requires holoviews
SKIPPED [1] panel/tests/pane/test_holoviews.py:412: requires holoviews
SKIPPED [1] panel/tests/pane/test_holoviews.py:427: requires holoviews
SKIPPED [1] panel/tests/pane/test_holoviews.py:442: requires holoviews
SKIPPED [1] panel/tests/pane/test_holoviews.py:457: requires holoviews
SKIPPED [1] panel/tests/pane/test_holoviews.py:475: requires holoviews
SKIPPED [1] panel/tests/pane/test_holoviews.py:499: requires holoviews
SKIPPED [1] panel/tests/pane/test_holoviews.py:527: requires holoviews
SKIPPED [1] panel/tests/pane/test_markup.py:10: requires pandas
SKIPPED [1] panel/tests/pane/test_markup.py:16: requires pandas
SKIPPED [1] panel/tests/pane/test_markup.py:22: requires streamz
SKIPPED [1] panel/tests/pane/test_markup.py:28: requires streamz
SKIPPED [1] panel/tests/pane/test_markup.py:34: requires streamz
SKIPPED [1] panel/tests/pane/test_markup.py:40: requires streamz
SKIPPED [1] panel/tests/pane/test_markup.py:83: requires pandas
SKIPPED [1] panel/tests/pane/test_markup.py:105: requires streamz
SKIPPED [1] panel/tests/pane/test_plot.py:39: requires matplotlib
SKIPPED [1] panel/tests/pane/test_plot.py:44: requires matplotlib
SKIPPED [1] panel/tests/pane/test_plotly.py:22: requires plotly
SKIPPED [1] panel/tests/pane/test_plotly.py:29: requires plotly
SKIPPED [1] panel/tests/pane/test_plotly.py:35: requires plotly
SKIPPED [1] panel/tests/pane/test_plotly.py:41: requires plotly
SKIPPED [1] panel/tests/pane/test_plotly.py:75: requires plotly
SKIPPED [1] panel/tests/pane/test_plotly.py:87: requires plotly
SKIPPED [1] panel/tests/pane/test_plotly.py:99: requires plotly
SKIPPED [1] panel/tests/pane/test_plotly.py:111: requires plotly
SKIPPED [1] panel/tests/pane/test_plotly.py:123: requires plotly
SKIPPED [1] panel/tests/pane/test_vega.py:133: requires altair
SKIPPED [1] panel/tests/pane/test_vega.py:138: requires altair
SKIPPED [1] panel/tests/pane/test_vtk.py:42: requires vtk
SKIPPED [1] panel/tests/pane/test_vtk.py:60: requires vtk
========================= 412 passed, 69 skipped in 9.24s ==========================
```

 