### PR TITLE
Developer instructions: fix pyctdev version specification.

### DIFF
--- a/doc/developer_guide/index.rst
+++ b/doc/developer_guide/index.rst
@@ -76,7 +76,7 @@ more consistent and general.
 
 .. code-block:: sh
 
-    conda install -c pyviz pyctdev>0.5.0
+    conda install -c pyviz "pyctdev>0.5.0"
     doit ecosystem_setup
 
 Once pyctdev is available and you are in the cloned panel repository you can


### PR DESCRIPTION
Without the quotes, the output of `conda install -c pyviz pyctdev` will presumably be ending up in the file `0.5.0`. E.g. see #741.

(Not sure why conda wouldn't just install the latest; I can't test that.)