### PR TITLE
Set sizing_mode behavior at panel extension load

### DIFF
--- a/panel/_styles/dataframe.css
+++ b/panel/_styles/dataframe.css
@@ -7,6 +7,7 @@ table.panel-df {
     color: black;
     font-size: 12px;
     table-layout: fixed;
+    width: 100%;
 }
 
 .panel-df tr, th, td {

--- a/panel/config.py
+++ b/panel/config.py
@@ -64,9 +64,9 @@ class _config(param.Parameterized):
     raw_css = param.List(default=[], doc="""
         List of raw CSS strings to add to the template.""")
 
-    sizing_mode = param.ObjectSelector(default='fixed', objects=[
+    sizing_mode = param.ObjectSelector(default=None, objects=[
         'fixed', 'stretch_width', 'stretch_height', 'stretch_both',
-        'scale_width', 'scale_height', 'scale_both'], doc="""
+        'scale_width', 'scale_height', 'scale_both', None], doc="""
         Specify the default sizing mode behavior of panels.""")
 
     _embed = param.Boolean(default=False, allow_None=True, doc="""

--- a/panel/config.py
+++ b/panel/config.py
@@ -64,6 +64,11 @@ class _config(param.Parameterized):
     raw_css = param.List(default=[], doc="""
         List of raw CSS strings to add to the template.""")
 
+    sizing_mode = param.ObjectSelector(default='fixed', objects=[
+        'fixed', 'stretch_width', 'stretch_height', 'stretch_both',
+        'scale_width', 'scale_height', 'scale_both'], doc="""
+        Specify the default sizing mode behavior of panels.""")
+
     _embed = param.Boolean(default=False, allow_None=True, doc="""
         Whether plot data will be embedded.""")
 

--- a/panel/viewable.py
+++ b/panel/viewable.py
@@ -184,12 +184,11 @@ class Layoutable(param.Parameterized):
     """)
 
     def __init__(self, **params):
-        
         if (params.get('width', None) is not None and
             params.get('height', None) is not None and
             'sizing_mode' not in params):
             params['sizing_mode'] = 'fixed'
-        else:
+        elif not self.param.sizing_mode.constant and not self.param.sizing_mode.readonly:
             params['sizing_mode'] = params.get('sizing_mode', config.sizing_mode)
         super(Layoutable, self).__init__(**params)
 

--- a/panel/viewable.py
+++ b/panel/viewable.py
@@ -184,10 +184,13 @@ class Layoutable(param.Parameterized):
     """)
 
     def __init__(self, **params):
+        
         if (params.get('width', None) is not None and
             params.get('height', None) is not None and
             'sizing_mode' not in params):
             params['sizing_mode'] = 'fixed'
+        else:
+            params['sizing_mode'] = params.get('sizing_mode', config.sizing_mode)
         super(Layoutable, self).__init__(**params)
 
 


### PR DESCRIPTION
This pr allow to set the default sizing_mode behavior when panel extension is loaded
It follows discussion https://github.com/holoviz/panel/issues/823
Howver, it does not fix the issue wich is specific to the pandas Dataframe

![image](https://user-images.githubusercontent.com/18531147/70260494-b3f30880-1790-11ea-95c1-eed00900b10b.png)
