### PR TITLE
Unlock Document and dispatch events if we have lock

### DIFF
--- a/panel/io/__init__.py
+++ b/panel/io/__init__.py
@@ -7,5 +7,5 @@ from .embed import embed_state # noqa
 from .state import state # noqa
 from .model import add_to_doc, remove_root, diff # noqa
 from .resources import Resources # noqa
-from .server import get_server # noqa
+from .server import get_server, unlocked # noqa
 from .notebook import block_comm, ipywidget, load_notebook, push # noqa

--- a/panel/io/server.py
+++ b/panel/io/server.py
@@ -7,8 +7,10 @@ import signal
 import threading
 import uuid
 
+from contextlib import contextmanager
 from functools import partial
 
+from bokeh.document.events import ModelChangedEvent
 from bokeh.server.server import Server
 
 from .state import state
@@ -33,6 +35,39 @@ def _server_url(url, port):
 #---------------------------------------------------------------------
 # Public API
 #---------------------------------------------------------------------
+
+
+@contextmanager
+def unlocked():
+    """
+    Context manager which unlocks a Document and dispatches
+    ModelChangedEvents triggered in the context body to all sockets
+    on current sessions.
+    """
+    curdoc = state.curdoc
+    if curdoc is None or curdoc.session_context is None:
+        yield
+        return
+    connections = curdoc.session_context.session._subscribed_connections
+    curdoc.hold()
+    try:
+        yield
+        events = []
+        for conn in connections:
+            socket = conn._socket
+            for event in curdoc._held_events:
+                if isinstance(event, ModelChangedEvent):
+                    msg = conn.protocol.create('PATCH-DOC', [event])
+                    socket.write_message(msg.header_json, locked=False)
+                    socket.write_message(msg.metadata_json, locked=False)
+                    socket.write_message(msg.content_json, locked=False)
+                    msg.write_buffers(socket, locked=False)
+                elif event not in events:
+                    events.append(event)
+        curdoc._held_events = events
+    finally:
+        curdoc.unhold()
+
 
 def get_server(panel, port=0, websocket_origin=None, loop=None,
                show=False, start=False, **kwargs):

--- a/panel/io/server.py
+++ b/panel/io/server.py
@@ -61,7 +61,9 @@ def unlocked():
                     socket.write_message(msg.header_json, locked=False)
                     socket.write_message(msg.metadata_json, locked=False)
                     socket.write_message(msg.content_json, locked=False)
-                    msg.write_buffers(socket, locked=False)
+                    for header, payload in msg._buffers:
+                        socket.write_message(header, locked=False)
+                        socket.write_message(payload, binary=True, locked=False)
                 elif event not in events:
                     events.append(event)
         curdoc._held_events = events

--- a/panel/pane/base.py
+++ b/panel/pane/base.py
@@ -11,7 +11,7 @@ import param
 from bokeh.io import curdoc as _curdoc
 from bokeh.models.layouts import GridBox as _BkGridBox
 
-from ..io import push, state
+from ..io import push, state, unlocked
 from ..layout import Panel, Row
 from ..links import Link
 from ..viewable import Viewable, Reactive, Layoutable
@@ -139,7 +139,8 @@ class PaneBase(Reactive):
         for ref, (model, parent) in self._models.items():
             viewable, root, doc, comm = state._views[ref]
             if comm or state._unblocked(doc):
-                self._update_object(model, doc, root, parent, comm)
+                with unlocked():
+                    self._update_object(model, doc, root, parent, comm)
                 if comm and 'embedded' not in root.tags:
                     push(doc, comm)
             else:

--- a/panel/pane/holoviews.py
+++ b/panel/pane/holoviews.py
@@ -14,7 +14,7 @@ import param
 
 from bokeh.models import Spacer as _BkSpacer
 
-from ..io import state
+from ..io import state, unlocked
 from ..layout import Panel, Column, WidgetBox, HSpacer, VSpacer, Row
 from ..viewable import Viewable
 from ..widgets import Player
@@ -197,7 +197,8 @@ class HoloViews(PaneBase):
 
         if plot.backend == 'bokeh':
             if plot.comm or state._unblocked(plot.document):
-                plot.update(key)
+                with unlocked():
+                    plot.update(key)
                 if plot.comm and 'embedded' not in plot.root.tags:
                     plot.push()
             else:

--- a/panel/viewable.py
+++ b/panel/viewable.py
@@ -30,7 +30,7 @@ from .io.notebook import (
 )
 from .io.save import save
 from .io.state import state
-from .io.server import StoppableThread, get_server
+from .io.server import StoppableThread, get_server, unlocked
 from .util import param_reprs
 
 
@@ -647,7 +647,8 @@ class Reactive(Viewable):
                 viewable, root, doc, comm = state._views[ref]
 
                 if comm or state._unblocked(doc):
-                    self._update_model(events, msg, root, model, doc, comm)
+                    with unlocked():
+                        self._update_model(events, msg, root, model, doc, comm)
                     if comm and 'embedded' not in root.tags:
                         push(doc, comm)
                 else:

--- a/panel/widgets/base.py
+++ b/panel/widgets/base.py
@@ -9,7 +9,7 @@ from functools import partial
 
 import param
 
-from ..io import push, state
+from ..io import push, state, unlocked
 from ..viewable import Reactive, Layoutable
 
 
@@ -65,7 +65,8 @@ class Widget(Reactive):
         for ref, (model, parent) in self._models.items():
             viewable, root, doc, comm = state._views[ref]
             if comm or state._unblocked(doc):
-                self._manual_update(event, model, doc, root, parent, comm)
+                with unlocked():
+                    self._manual_update(event, model, doc, root, parent, comm)
                 if comm and 'embedded' not in root.tags:
                     push(doc, comm)
             else:


### PR DESCRIPTION
This PR ensures that when even on the server events are dispatched immediately. This is achieved by adding an `unlock` context manager which dispatches all ModelChangedEvents triggered in the context body to all sockets on current sessions. I have to do significantly more testing to figure out if this is actually safe.

Fixes https://github.com/holoviz/panel/issues/778