### PR TITLE
Allow recursive reactive updates

### DIFF
--- a/panel/pane/base.py
+++ b/panel/pane/base.py
@@ -21,8 +21,6 @@ from ..io import (
     init_doc, push, state, unlocked,
 )
 from ..layout.base import NamedListPanel, Panel, Row
-from ..io import push, state, unlocked
-from ..layout import Panel, Row
 from ..links import Link
 from ..models import ReactiveHTML as _BkReactiveHTML
 from ..reactive import Reactive
@@ -578,7 +576,7 @@ class ReplacementPane(PaneBase):
                 for i, (sub_old, sub_new) in enumerate(zip(old, new)):
                     if isinstance(new, NamedListPanel):
                         old._names[i] = new._names[i]
-                    recursive_update(new, i, sub_old, sub_new)
+                    cls._recursive_update(new, i, sub_old, sub_new)
                 ignored += ('objects',)
         pvals = dict(old.param.values())
         new_params = {}
@@ -617,10 +615,10 @@ class ReplacementPane(PaneBase):
         if type(old_object) is pane_type and ((not links and not custom_watchers and was_internal) or inplace):
             if isinstance(object, Panel) and len(old_object) == len(object):
                 for i, (old, new) in enumerate(zip(old_object, object)):
-                    recursive_update(old_object, i, old, new)
+                    cls._recursive_update(old_object, i, old, new)
             elif isinstance(object, Reactive):
-                pvals = dict(self._pane.get_param_values())
-                new_params = {k: v for k, v in object.get_param_values()
+                pvals = dict(old_object.param.values())
+                new_params = {k: v for k, v in object.param.values()
                               if k != 'name' and v is not pvals[k]}
                 old_object.param.update(**new_params)
             else:

--- a/panel/pane/base.py
+++ b/panel/pane/base.py
@@ -551,11 +551,23 @@ class ReplacementPane(PaneBase):
         self._pane.param.update({event.name: event.new for event in events})
 
     @classmethod
-    def _recursive_update(cls, layout, index, old, new):
+    def _recursive_update(cls, layout: Panel, index: int, old: Reactive, new: Reactive):
         """
         Recursively descends through Panel layouts and diffs their
         contents updating only changed parameters ensuring we don't
         have to trigger a full re-render of the entire component.
+
+        Arguments
+        ---------
+        layout: Panel
+          The layout the items are being updated or replaced on.
+        index: int
+          The index of the item being replaced.
+        old: Reactive
+          The Reactive component being updated or replaced.
+        new: Reactive
+          The new Reactive component that the old one is being updated
+          or replaced with.
         """
         ignored = ('name',)
         if type(old) is not type(new):

--- a/panel/pane/base.py
+++ b/panel/pane/base.py
@@ -618,7 +618,7 @@ class ReplacementPane(PaneBase):
                     cls._recursive_update(old_object, i, old, new)
             elif isinstance(object, Reactive):
                 pvals = dict(old_object.param.values())
-                new_params = {k: v for k, v in object.param.values()
+                new_params = {k: v for k, v in object.param.values().items()
                               if k != 'name' and v is not pvals[k]}
                 old_object.param.update(**new_params)
             else:
@@ -645,7 +645,7 @@ class ReplacementPane(PaneBase):
         kwargs = dict(self.param.values(), **self._kwargs)
         del kwargs['object']
         new_pane, internal = self._update_from_object(
-            new_object, self._pane, self._internal, self.inplace, **kwargs
+            new_object, self._pane, self._internal, **kwargs
         )
         if new_pane is None:
             return


### PR DESCRIPTION
Implements #878 

Recursive diffing means you can write apps like this and instead of replacing the components in the returned layout each time it will simply update them:

```python
slider = pn.widgets.IntSlider(name='Slider', start=0, end=10)

@pn.depends(slider)
def example(value):
    return pn.Row(slider, pn.widgets.Checkbox(value=bool(value%2)), value)

pn.panel(example)
```