### PR TITLE
Do not link HoloViews axes with different types

### DIFF
--- a/panel/pane/holoviews.py
+++ b/panel/pane/holoviews.py
@@ -535,14 +535,16 @@ def link_axes(root_view, root_model):
 
             fig = p.state
             if fig.x_range.tags:
-                range_map[(fig.x_range.tags[0], plot.root.ref['id'])].append((fig, p, fig.x_range))
+                range_map[(fig.x_range.tags[0], plot.root.ref['id'])].append((fig, p, fig.xaxis[0], fig.x_range))
             if fig.y_range.tags:
-                range_map[(fig.y_range.tags[0], plot.root.ref['id'])].append((fig, p, fig.y_range))
+                range_map[(fig.y_range.tags[0], plot.root.ref['id'])].append((fig, p, fig.yaxis[0], fig.y_range))
 
     for (tag, _), axes in range_map.items():
-        fig, p, axis = axes[0]
-        for fig, p, _ in axes[1:]:
+        fig, p, ax, axis = axes[0]
+        for fig, p, pax, _ in axes[1:]:
             changed = []
+            if  type(ax) is not type(pax):
+                continue
             if tag in fig.x_range.tags and not axis is fig.x_range:
                 fig.x_range = axis
                 p.handles['x_range'] = axis


### PR DESCRIPTION
Ensures that HoloViews bokeh axes of different types (categorical, datetime, numeric) are not linked.