### PR TITLE
Allow re-rendering in the middle of render

### DIFF
--- a/panel/pane/__init__.py
+++ b/panel/pane/__init__.py
@@ -7,7 +7,6 @@ images, equations etc.
 """
 from __future__ import absolute_import, division, unicode_literals
 
-from ..viewable import Viewable
 from .ace import Ace # noqa
 from .base import PaneBase, Pane, panel # noqa
 from .equation import LaTeX # noqa

--- a/panel/pane/__init__.py
+++ b/panel/pane/__init__.py
@@ -9,7 +9,7 @@ from __future__ import absolute_import, division, unicode_literals
 
 from ..viewable import Viewable
 from .ace import Ace # noqa
-from .base import PaneBase, Pane # noqa
+from .base import PaneBase, Pane, panel # noqa
 from .equation import LaTeX # noqa
 from .holoviews import HoloViews # noqa
 from .image import GIF, JPG, PNG, SVG # noqa
@@ -20,30 +20,3 @@ from .plot import Bokeh, Matplotlib, RGGPlot, YT # noqa
 from .streamz import Streamz # noqa
 from .vega import Vega # noqa
 from .vtk import VTK, VTKVolume # noqa
-
-
-def panel(obj, **kwargs):
-    """
-    Creates a panel from any supplied object by wrapping it in a pane
-    and returning a corresponding Panel.
-
-    Arguments
-    ---------
-    obj: object
-       Any object to be turned into a Panel
-    **kwargs: dict
-       Any keyword arguments to be passed to the applicable Pane
-
-    Returns
-    -------
-    layout: Viewable
-       A Viewable representation of the input object
-    """
-    if isinstance(obj, Viewable):
-        return obj
-    if kwargs.get('name', False) is None:
-        kwargs.pop('name')
-    pane = PaneBase.get_pane_type(obj)(obj, **kwargs)
-    if len(pane.layout) == 1 and pane._unpack:
-        return pane.layout[0]
-    return pane.layout

--- a/panel/pane/base.py
+++ b/panel/pane/base.py
@@ -27,6 +27,39 @@ def Pane(obj, **kwargs):
     return PaneBase.get_pane_type(obj)(obj, **kwargs)
 
 
+def panel(obj, **kwargs):
+    """
+    Creates a panel from any supplied object by wrapping it in a pane
+    and returning a corresponding Panel.
+
+    Arguments
+    ---------
+    obj: object
+       Any object to be turned into a Panel
+    **kwargs: dict
+       Any keyword arguments to be passed to the applicable Pane
+
+    Returns
+    -------
+    layout: Viewable
+       A Viewable representation of the input object
+    """
+    if isinstance(obj, Viewable):
+        return obj
+    if kwargs.get('name', False) is None:
+        kwargs.pop('name')
+    pane = PaneBase.get_pane_type(obj)(obj, **kwargs)
+    if len(pane.layout) == 1 and pane._unpack:
+        return pane.layout[0]
+    return pane.layout
+
+
+class RerenderError(RuntimeError):
+    """
+    Error raised when a pane requests re-rendering during initial render.
+    """
+
+
 class PaneBase(Reactive):
     """
     PaneBase is the abstract baseclass for all atomic displayable units

--- a/panel/pane/holoviews.py
+++ b/panel/pane/holoviews.py
@@ -88,9 +88,6 @@ class HoloViews(PaneBase):
 
     @param.depends('center', 'widget_location', watch=True)
     def _update_layout(self):
-        from holoviews.core import DynamicMap, Store
-        from holoviews.plotting.util import initialize_dynamic
-
         loc = self.widget_location
         if not len(self.widget_box):
             widgets = []

--- a/panel/pane/holoviews.py
+++ b/panel/pane/holoviews.py
@@ -18,7 +18,7 @@ from ..io import state, unlocked
 from ..layout import Column, WidgetBox, HSpacer, VSpacer, Row
 from ..viewable import Layoutable, Viewable
 from ..widgets import Player
-from .base import PaneBase, Pane
+from .base import PaneBase, Pane, RerenderError
 from .plot import Bokeh, Matplotlib
 from .plotly import Plotly
 
@@ -77,6 +77,8 @@ class HoloViews(PaneBase):
     def __init__(self, object=None, **params):
         super(HoloViews, self).__init__(object, **params)
         self._initialized = False
+        self._responsive_content = False
+        self._restore_plot = None
         self.widget_box = self.widget_layout()
         self._widget_container = []
         self._update_widgets()
@@ -105,22 +107,7 @@ class HoloViews(PaneBase):
         elif loc in ('left_bottom', 'right_bottom'):
             widgets = Column(VSpacer(), self.widget_box)
 
-        # Do not center if content is responsive
-        backend = self.backend or Store.current_backend
-        if self.object is None:
-            opts = {}
-        else:
-            initialize_dynamic(self.object)
-            obj = self.object.last if isinstance(self.object, DynamicMap) else self.object
-            try:
-                opts = Store.lookup_options(backend, obj, 'plot').kwargs
-            except:
-                opts = {}
-        responsive_modes = ('stretch_width', 'stretch_both', 'scale_width', 'scale_both')
-        center = self.center
-        if ((opts.get('responsive') and not (opts.get('width') or opts.get('frame_width'))) or
-             opts.get('sizing_mode') in responsive_modes):
-            center = False
+        center = self.center and not self._responsive_content
 
         self._widget_container = widgets
         if not widgets:
@@ -229,7 +216,10 @@ class HoloViews(PaneBase):
         if self.object is None:
             model = _BkSpacer()
         else:
-            if isinstance(self.object, Plot):
+            if self._restore_plot is not None:
+                plot = self._restore_plot
+                self._restore_plot = None
+            elif isinstance(self.object, Plot):
                 plot = self.object
             else:
                 plot = self._render(doc, comm, root)
@@ -240,6 +230,17 @@ class HoloViews(PaneBase):
             else:
                 # Compatibility with holoviews<1.13.0
                 state = plot.state
+
+            # Ensure rerender if content is responsive but layout is centered
+            if (self.center and state.sizing_mode not in ('fixed', None)
+                and not self._responsive_content):
+                self._responsive_content = True
+                self._update_layout()
+                self._restore_plot = plot
+                raise RerenderError()
+            else:
+                self._responsive_content = False
+
             kwargs = {p: v for p, v in self.get_param_values()
                       if p in Layoutable.param and p != 'name'}
             child_pane = self._panes.get(backend, Pane)(state, **kwargs)


### PR DESCRIPTION
The HoloViews pane has a center option which controls whether the contents are centered. The problem with it is that it shouldn't center if the contents are responsive because that ends up leaving gaps. Previously I had a bunch of logic which tried to determine centering from the options set on the HoloViews element. That logic is brittle and potentially expensive because it has to pre-evaluate any dynamic content. Instead of doing that this PR introduces the capability to restart rendering in the middle of an ongoing render.

When a `RerenderError` is raised the layout will catch that error and restart the rendering pipeline. In doing so it will reuse any components in the layout that have already been rendered and clean up any components which have been dropped.  This allows the HoloViews pane to uncenter the contents when it discovers that the content it is displaying is meant to be responsive.