### PR TITLE
let FileInput widget set filename

### DIFF
--- a/panel/tests/widgets/test_input.py
+++ b/panel/tests/widgets/test_input.py
@@ -59,10 +59,11 @@ def test_file_input(document, comm):
 
     assert isinstance(widget, BkFileInput)
 
-    file_input._comm_change({'mime_type': 'text/plain', 'value': 'U29tZSB0ZXh0Cg=='})
+    file_input._comm_change({'mime_type': 'text/plain', 'value': 'U29tZSB0ZXh0Cg==', 'filename': 'testfile'})
     assert file_input.value == b'Some text\n'
     assert file_input.mime_type == 'text/plain'
     assert file_input.accept == '.txt'
+    assert file_input.filename == 'testfile'
 
 
 def test_literal_input(document, comm):

--- a/panel/widgets/input.py
+++ b/panel/widgets/input.py
@@ -72,7 +72,7 @@ class FileInput(Widget):
 
     def _filter_properties(self, properties):
         properties = super(FileInput, self)._filter_properties(properties)
-        return properties + ['value', 'mime_type']
+        return properties + ['value', 'mime_type', 'filename']
 
     def _process_property_change(self, msg):
         msg = super(FileInput, self)._process_property_change(msg)


### PR DESCRIPTION
fixes #955 

The value of the `filename` property of the `FileInput` always remained
`None` (also after uploading a file).

I could add a test [here](https://github.com/holoviz/panel/blob/master/panel/tests/widgets/test_input.py#L63), if you let me know what the filename I should be testing for here.