### PR TITLE
Add pydeck

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -123,3 +123,4 @@ package-lock.json
 .vscode/
 .vscode/panel.code-workspace
 0.5.0
+discover/.generated_defaults/

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,125 @@
-.vscode/settings.json
-.vscode/panel.code-workspace
-__pycache__/dodo.cpython-37.pyc
-__pycache__/setup.cpython-37.pyc
-0.5.0
-panel/.version
-.doit.db
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+pip-wheel-metadata/
+.version
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# dotenv
+.env
+
+# virtualenv
+.venv
+venv/
+ENV/
+
+# OSX
+.DS_STORE
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
 .mypy_cache/
+
+# nbsite
+# these files normally shouldn't be checked in as they should be
+# dynamically built from notebooks
+doc/**/*.rst
+doc/**/*.ipynb
+doc/**/*.json
+# this dir contains the whole website and should not be checked in on master
+builtdocs/
+.doit.db
+
+# bokeh model cache
+panel/models/*.json
+node_modules
+package-lock.json
+
+.vscode/
+.vscode/panel.code-workspace
+0.5.0

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+.vscode/settings.json
+.vscode/panel.code-workspace
+__pycache__/dodo.cpython-37.pyc
+__pycache__/setup.cpython-37.pyc
+0.5.0
+panel/.version
+.doit.db
+.mypy_cache/

--- a/examples/reference/panes/Plotly.ipynb
+++ b/examples/reference/panes/Plotly.ipynb
@@ -156,9 +156,22 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
    "name": "python",
-   "pygments_lexer": "ipython3"
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
   }
  },
  "nbformat": 4,

--- a/examples/reference/panes/PyDeck.ipynb
+++ b/examples/reference/panes/PyDeck.ipynb
@@ -1,0 +1,206 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import panel as pn\n",
+    "import pydeck as pdk\n",
+    "pn.extension('pydeck')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[Deck.gl](https://deck.gl/#/) is an awesome WebGL-powered framework for visual exploratory data\n",
+    "analysis of large datasets.\n",
+    "\n",
+    "The [`PyDeck`](https://deckgl.readthedocs.io/en/latest/) *package* provides Python bindings. Please follow the [installation instructions](https://github.com/uber/deck.gl/blob/master/bindings/pydeck/README.md) closely to get it working in this Jupyter Notebook.\n",
+    "\n",
+    "The `PyDeck` *pane* renders `PyDeck` plots inside a panel.\n",
+    "\n",
+    "#### Parameters:\n",
+    "\n",
+    "For layout and styling related parameters see the [customization user guide](../../user_guide/Customization.ipynb).\n",
+    "\n",
+    "* **``object``** (object): The PyDeck object being displayed\n",
+    "\n",
+    "___"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In order to use Deck.gl you need a MAP BOX Key which you can acquire for free for limited use at\n",
+    "[mapbox.com](https://account.mapbox.com/access-tokens/)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "MAPBOX_KEY = (\n",
+    "    \"pk.eyJ1IjoibWFyY3Nrb3ZtYWRzZW4iLCJhIjoiY2s1anMzcG5rMDYzazNvcm10NTFybTE4cSJ9.\"\n",
+    "    \"TV1XBgaMfR-iTLvAXM_Iew\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You also need some data in the form of an url or a DataFrame. Here we use an url."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "UK_ACCIDENTS_DATA = (\n",
+    "    \"https://raw.githubusercontent.com/uber-common/\"\n",
+    "    \"deck.gl-data/master/examples/3d-heatmap/heatmap-data.csv\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Lets define a `Deck`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def uk_accidents_deck() -> pdk.Deck:\n",
+    "    \"\"\"The UK Accidents Deck\n",
+    "\n",
+    "    See [PyDec Docs](https://deckgl.readthedocs.io/en/latest/layer.html)\n",
+    "\n",
+    "    Returns:\n",
+    "        pdk.Deck: The UK Accidents Deck\n",
+    "    \"\"\"\n",
+    "    # 2014 location of car accidents in the UK\n",
+    "\n",
+    "    # Define a layer to display on a map\n",
+    "    layer = pdk.Layer(\n",
+    "        \"HexagonLayer\",\n",
+    "        UK_ACCIDENTS_DATA,\n",
+    "        get_position=[\"lng\", \"lat\",],\n",
+    "        auto_highlight=True,\n",
+    "        elevation_scale=50,\n",
+    "        pickable=True,\n",
+    "        elevation_range=[0, 3000,],\n",
+    "        extruded=True,\n",
+    "        coverage=1,\n",
+    "    )\n",
+    "\n",
+    "    # Set the viewport location\n",
+    "    view_state = pdk.ViewState(\n",
+    "        longitude=-1.415,\n",
+    "        latitude=52.2323,\n",
+    "        zoom=6,\n",
+    "        min_zoom=5,\n",
+    "        max_zoom=15,\n",
+    "        pitch=40.5,\n",
+    "        bearing=-27.36,\n",
+    "    )\n",
+    "\n",
+    "    # Combined all of it and render a viewport\n",
+    "    return pdk.Deck(layers=[layer], initial_view_state=view_state, mapbox_key=MAPBOX_KEY,)\n",
+    "deck = uk_accidents_deck()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The `deck` can be used in a notebook without Panel as it is already connected to an ipywidget"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "deck.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "But you can use the `PyDeck` *pane* to work more efficiently with the deck in your Panel app."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
+    "# Does not work as it shows nothing\n",
+    "pn.pane.PyDeck(deck)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# But it works using Bokeh\n",
+    "pn.pane.PyDeck(deck).show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "panel_dev",
+   "language": "python",
+   "name": "panel_dev"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/panel/config.py
+++ b/panel/config.py
@@ -87,7 +87,7 @@ class _config(param.Parameterized):
     _comms = param.ObjectSelector(
         default='default', objects=['default', 'ipywidgets'], doc="""
         Whether to render output in Jupyter with the default Jupyter
-        extension or use the jupyter_bokeh ipywidget model.""") 
+        extension or use the jupyter_bokeh ipywidget model.""")
 
     _inline = param.Boolean(default=True, allow_None=True, doc="""
         Whether to inline JS and CSS resources.
@@ -137,7 +137,7 @@ class _config(param.Parameterized):
     def comms(self, value):
         validate_config(self, '_comms', value)
         self._comms_ = value
-        
+
     @property
     def embed_json(self):
         if self._embed_json_ is not None:
@@ -219,6 +219,7 @@ class panel_extension(_pyviz_extension):
     _imports = {'katex': 'panel.models.katex',
                 'mathjax': 'panel.models.mathjax',
                 'plotly': 'panel.models.plotly',
+                'pydeck': 'panel.models.pydeck',
                 'vega': 'panel.models.vega',
                 'vtk': 'panel.models.vtk',
                 'ace': 'panel.models.ace'}

--- a/panel/models/pydeck.py
+++ b/panel/models/pydeck.py
@@ -1,0 +1,28 @@
+"""Defines a custom PyDeckPlot to render PyDeck Plots
+
+[Deck.gl](https://deck.gl/#/) is an awesome WebGL-powered framework for visual exploratory data
+analysis of large datasets.
+
+And now PyDeck provides Python bindings. See
+
+- [PyDeck Docs](https://deckgl.readthedocs.io/en/latest/)
+- [PyDeck Repo](https://github.com/uber/deck.gl/tree/master/bindings/pydeck)
+"""
+from bokeh.core.properties import Dict, String, List, Any, Instance, Enum, Int, Bool
+from bokeh.models import LayoutDOM, ColumnDataSource
+
+
+class PyDeckPlot(LayoutDOM):
+    """A Bokeh model that wraps around a PyDeck plot and renders it inside a HTMLBox"""
+
+    json_input = String()
+    mapbox_api_key = String()
+    tooltip = Bool()  # Or Dict(String, Any)
+
+    # description = String()
+    # initial_view_state = Dict(String, Any)
+    # layers = List(Dict(String, Any))
+    # map_style = String()
+    # mapbox_key = String()
+    # selected_data = List(Dict(String, Any))
+    # views = List(Dict(String, Any))

--- a/panel/models/pydeck.py
+++ b/panel/models/pydeck.py
@@ -8,12 +8,17 @@ And now PyDeck provides Python bindings. See
 - [PyDeck Docs](https://deckgl.readthedocs.io/en/latest/)
 - [PyDeck Repo](https://github.com/uber/deck.gl/tree/master/bindings/pydeck)
 """
-from bokeh.core.properties import Dict, String, List, Any, Instance, Enum, Int, Bool
+from bokeh.core.properties import Dict, String, List, Any, Instance, Enum, Int, Bool, JSON
 from bokeh.models import HTMLBox
 import pathlib
 
 PYDECK_TS = pathlib.Path(__file__).parent / "pydeck.ts"
 PYDECK_TS_STR = str(PYDECK_TS.resolve())
+
+DECK_GL_PANEL_EXPRESS_JS = (
+    "https://cdn.jsdelivr.net/npm/@deck.gl/jupyter-widget@^8.0.0/dist/index.js"
+)
+MAPBOX_GL_JS = "https://api.tiles.mapbox.com/mapbox-gl-js/v0.50.0/mapbox-gl.js"
 
 
 class PyDeckPlot(HTMLBox):
@@ -21,7 +26,9 @@ class PyDeckPlot(HTMLBox):
 
     __implementation__ = PYDECK_TS_STR
 
-    json_input = String()
+    __javascript__ = [DECK_GL_PANEL_EXPRESS_JS, MAPBOX_GL_JS]
+
+    json_input = JSON()
     mapbox_api_key = String()
     tooltip = Bool()  # Or Dict(String, Any)
 

--- a/panel/models/pydeck.py
+++ b/panel/models/pydeck.py
@@ -9,11 +9,17 @@ And now PyDeck provides Python bindings. See
 - [PyDeck Repo](https://github.com/uber/deck.gl/tree/master/bindings/pydeck)
 """
 from bokeh.core.properties import Dict, String, List, Any, Instance, Enum, Int, Bool
-from bokeh.models import LayoutDOM, ColumnDataSource
+from bokeh.models import HTMLBox
+import pathlib
+
+PYDECK_TS = pathlib.Path(__file__).parent / "pydeck.ts"
+PYDECK_TS_STR = str(PYDECK_TS.resolve())
 
 
-class PyDeckPlot(LayoutDOM):
+class PyDeckPlot(HTMLBox):
     """A Bokeh model that wraps around a PyDeck plot and renders it inside a HTMLBox"""
+
+    __implementation__ = PYDECK_TS_STR
 
     json_input = String()
     mapbox_api_key = String()

--- a/panel/models/pydeck.py
+++ b/panel/models/pydeck.py
@@ -31,6 +31,7 @@ class PyDeckPlot(HTMLBox):
     json_input = JSON()
     mapbox_api_key = String()
     tooltip = Bool()  # Or Dict(String, Any)
+    _render_count = Int()
 
     # description = String()
     # initial_view_state = Dict(String, Any)

--- a/panel/models/pydeck.ts
+++ b/panel/models/pydeck.ts
@@ -1,0 +1,66 @@
+import { HTMLBox, HTMLBoxView } from "models/layouts/html_box"
+
+import { div } from "core/dom"
+import * as p from "core/properties"
+
+export class PyDeckPlotView extends HTMLBoxView {
+    model: PyDeckPlot
+
+    connect_signals(): void {
+        console.log("connect_signals")
+        super.connect_signals()
+
+        this.connect(this.model.properties.json_input.change, () => {
+            this.render();
+        })
+
+        this.connect(this.model.properties.mapbox_api_key.change, () => {
+            this.render();
+        })
+
+        this.connect(this.model.properties.tooltip.change, () => {
+            this.render();
+        })
+    }
+
+    render(): void {
+        super.render()
+
+        this.el.appendChild(div({
+            style: {
+                padding: '2px',
+                color: '#b88d8e',
+                backgroundColor: '#2a3153',
+            },
+        }, `${this.model.json_input}: ${this.model.mapbox_api_key} ${this.model.tooltip}`))
+    }
+}
+
+export namespace PyDeckPlot {
+    export type Attrs = p.AttrsOf<Props>
+    export type Props = HTMLBox.Props & {
+        json_input: p.Property<string>
+        mapbox_api_key: p.Property<string>
+        tooltip: p.Property<boolean>
+    }
+}
+
+export interface PyDeckPlot extends PyDeckPlot.Attrs { }
+
+export class PyDeckPlot extends HTMLBox {
+    properties: PyDeckPlot.Props
+
+    constructor(attrs?: Partial<PyDeckPlot.Attrs>) {
+        super(attrs)
+    }
+
+    static init_PyDeckPlot(): void {
+        this.prototype.default_view = PyDeckPlotView;
+
+        this.define<PyDeckPlot.Props>({
+            json_input: [p.String],
+            mapbox_api_key: [p.String],
+            tooltip: [p.Boolean]
+        })
+    }
+}

--- a/panel/models/pydeck.ts
+++ b/panel/models/pydeck.ts
@@ -23,6 +23,8 @@ export class PyDeckPlotView extends HTMLBoxView {
         this.connect(this.model.properties.tooltip.change, () => {
             this.render();
         })
+
+        this.connect(this.model.properties._render_count.change, this.render);
     }
 
     render(): void {
@@ -30,7 +32,7 @@ export class PyDeckPlotView extends HTMLBoxView {
 
         if (!(window as any).createDeck) { return }
 
-        const container = this.el.appendChild(div({ class: "deck_gl", style: { height: "400px", width: "800px" } }));
+        const container = this.el.appendChild(div({ class: "deckgl", style: { height: "400px", width: "800px" } }));
 
         const jsonInput = JSON.parse(this.model.json_input);
         const MAPBOX_API_KEY = this.model.mapbox_api_key;
@@ -51,6 +53,7 @@ export namespace PyDeckPlot {
         json_input: p.Property<string>
         mapbox_api_key: p.Property<string>
         tooltip: p.Property<boolean>
+        _render_count: p.Property<number>
     }
 }
 
@@ -69,7 +72,8 @@ export class PyDeckPlot extends HTMLBox {
         this.define<PyDeckPlot.Props>({
             json_input: [p.String],
             mapbox_api_key: [p.String],
-            tooltip: [p.Boolean]
+            tooltip: [p.Boolean],
+            _render_count: [p.Number, 0],
         })
     }
 }

--- a/panel/models/pydeck.ts
+++ b/panel/models/pydeck.ts
@@ -3,6 +3,8 @@ import { HTMLBox, HTMLBoxView } from "models/layouts/html_box"
 import { div } from "core/dom"
 import * as p from "core/properties"
 
+const createDeck = (window as any).createDeck;
+
 export class PyDeckPlotView extends HTMLBoxView {
     model: PyDeckPlot
 
@@ -26,13 +28,20 @@ export class PyDeckPlotView extends HTMLBoxView {
     render(): void {
         super.render()
 
-        this.el.appendChild(div({
-            style: {
-                padding: '2px',
-                color: '#b88d8e',
-                backgroundColor: '#2a3153',
-            },
-        }, `${this.model.json_input}: ${this.model.mapbox_api_key} ${this.model.tooltip}`))
+        if (!(window as any).createDeck) { return }
+
+        const container = this.el.appendChild(div({ class: "deck_gl", style: { height: "400px", width: "800px" } }));
+
+        const jsonInput = JSON.parse(this.model.json_input);
+        const MAPBOX_API_KEY = this.model.mapbox_api_key;
+        const tooltip = this.model.tooltip;
+
+        createDeck({
+            mapboxApiKey: MAPBOX_API_KEY,
+            container: container,
+            jsonInput,
+            tooltip
+        });
     }
 }
 

--- a/panel/pane/__init__.py
+++ b/panel/pane/__init__.py
@@ -8,18 +8,19 @@ images, equations etc.
 from __future__ import absolute_import, division, unicode_literals
 
 from ..viewable import Viewable
-from .ace import Ace # noqa
-from .base import PaneBase, Pane # noqa
-from .equation import LaTeX # noqa
-from .holoviews import HoloViews # noqa
-from .image import GIF, JPG, PNG, SVG # noqa
-from .markup import DataFrame, HTML, Markdown, Str # noqa
-from .media import Audio, Video # noqa
-from .plotly import Plotly # noqa
-from .plot import Bokeh, Matplotlib, RGGPlot, YT # noqa
-from .streamz import Streamz # noqa
-from .vega import Vega # noqa
-from .vtk import VTK, VTKVolume # noqa
+from .ace import Ace  # noqa
+from .base import PaneBase, Pane  # noqa
+from .equation import LaTeX  # noqa
+from .holoviews import HoloViews  # noqa
+from .image import GIF, JPG, PNG, SVG  # noqa
+from .markup import DataFrame, HTML, Markdown, Str  # noqa
+from .media import Audio, Video  # noqa
+from .plotly import Plotly  # noqa
+from .plot import Bokeh, Matplotlib, RGGPlot, YT  # noqa
+from .pydeck import PyDeck
+from .streamz import Streamz  # noqa
+from .vega import Vega  # noqa
+from .vtk import VTK, VTKVolume  # noqa
 
 
 def panel(obj, **kwargs):
@@ -41,8 +42,8 @@ def panel(obj, **kwargs):
     """
     if isinstance(obj, Viewable):
         return obj
-    if kwargs.get('name', False) is None:
-        kwargs.pop('name')
+    if kwargs.get("name", False) is None:
+        kwargs.pop("name")
     pane = PaneBase.get_pane_type(obj)(obj, **kwargs)
     if len(pane.layout) == 1 and pane._unpack:
         return pane.layout[0]

--- a/panel/pane/pydeck.py
+++ b/panel/pane/pydeck.py
@@ -1,0 +1,30 @@
+"""
+Defines a PyDeck Pane which renders a PyDeck plot using a PyDeckPlot
+bokeh model.
+
+For now I've just experimented a bit.
+
+There is a simple implementation of an app using PyDeck in the gallery at
+[awesome-streamlit.org](https://awesome-streamlit.org).
+
+See
+
+- [pydeck implementation](https://github.com/MarcSkovMadsen/awesome-panel/blob/master/package/awesome_panel/express/pane/pydeck.py)
+- [test_pydeck app](https://github.com/MarcSkovMadsen/awesome-panel/blob/master/src/pages/gallery/awesome_panel_express_tests/test_pydeck.py)
+- [test_pydeck test](https://github.com/MarcSkovMadsen/awesome-panel/blob/master/package/tests/test_pydeck.py)
+
+It's based on the following resources
+
+- [PyDeck Github](https://github.com/uber/deck.gl/tree/master/bindings/pydeck)
+- [PyDeck Docs](https://deckgl.readthedocs.io/en/latest/)
+- [PyDeck Deck Implementation](https://github.com/uber/deck.gl/blob/master/bindings/pydeck/pydeck/bindings/deck.py)
+- [PyDeck render_json_to_html Implementation](https://github.com/uber/deck.gl/blob/master/bindings/pydeck/pydeck/io/html.py)
+
+When I move on I believe I can find inspiration in
+
+- The Panel implementation of the Plotly Pane and Plotly Bokeh Model
+- [Extending Bokeh](https://docs.bokeh.org/en/latest/docs/user_guide/extensions.html)
+- [PyDeck Jupyter Implementation](https://github.com/uber/deck.gl/blob/master/bindings/pydeck/pydeck/widget/widget.py)
+
+There is a feature request for this at [Github 957](https://github.com/holoviz/panel/issues/957)
+"""

--- a/panel/tests/models/test_pydeck.py
+++ b/panel/tests/models/test_pydeck.py
@@ -1,0 +1,76 @@
+"""In this module we test the PyDeck Bokeh Model"""
+
+import pytest
+from panel.models.pydeck import PyDeckPlot
+
+# from pydeck import pdk
+
+# pylint: disable=line-too-long
+@pytest.fixture
+def json_input() -> str:
+    return '{"initialViewState": {"bearing": -27.36, "latitude": 52.2323, "longitude": -1.415, "maxZoom": 15, "minZoom": 5, "pitch": 40.5, "zoom": 6}, "layers": [{"@@type": "HexagonLayer", "autoHighlight": true, "coverage": 1, "data": "https://raw.githubusercontent.com/uber-common/deck.gl-data/master/examples/3d-heatmap/heatmap-data.csv", "elevationRange": [0, 3000], "elevationScale": 50, "extruded": true, "getPosition": "@@=[lng, lat]", "id": "18a4e022-062c-428f-877f-c8c089472297", "pickable": true}], "mapStyle": "mapbox://styles/mapbox/dark-v9", "views": [{"@@type": "MapView", "controller": true}]}'
+
+
+# pylint: enable=line-too-long
+
+
+@pytest.fixture
+def mapbox_api_key() -> str:
+    return (
+        "pk.eyJ1IjoibWFyY3Nrb3ZtYWRzZW4iLCJhIjoiY2s1anMzcG5rMDYzazNvcm10NTFybTE4cSJ9."
+        "TV1XBgaMfR-iTLvAXM_Iew"
+    )
+
+
+@pytest.fixture
+def tooltip() -> bool:
+    return True
+
+
+# @pytest.fixture
+# def uk_accidents_deck() -> pdk.Deck:
+#     """The UK Accidents Deck
+
+#     See [PyDec Docs](https://deckgl.readthedocs.io/en/latest/layer.html)
+
+#     Returns:
+#         pdk.Deck: The UK Accidents Deck
+#     """
+#     # 2014 location of car accidents in the UK
+
+#     # Define a layer to display on a map
+#     layer = pdk.Layer(
+#         "HexagonLayer",
+#         UK_ACCIDENTS_DATA,
+#         get_position=["lng", "lat",],
+#         auto_highlight=True,
+#         elevation_scale=50,
+#         pickable=True,
+#         elevation_range=[0, 3000,],
+#         extruded=True,
+#         coverage=1,
+#     )
+
+#     # Set the viewport location
+#     view_state = pdk.ViewState(
+#         longitude=-1.415,
+#         latitude=52.2323,
+#         zoom=6,
+#         min_zoom=5,
+#         max_zoom=15,
+#         pitch=40.5,
+#         bearing=-27.36,
+#     )
+
+#     # Combined all of it and render a viewport
+#     return pdk.Deck(layers=[layer], initial_view_state=view_state, mapbox_key=MAPBOX_KEY,)
+
+
+def test_constructor(json_input, mapbox_api_key, tooltip):
+    # When
+    actual = PyDeckPlot(json_input=json_input, mapbox_api_key=mapbox_api_key, tooltip=tooltip,)
+    breakpoint()
+    # Then
+    assert actual.json_input == json_input
+    assert actual.mapbox_api_key == mapbox_api_key
+    assert actual.tooltip == tooltip

--- a/panel/tests/models/test_pydeck.py
+++ b/panel/tests/models/test_pydeck.py
@@ -69,7 +69,6 @@ def tooltip() -> bool:
 def test_constructor(json_input, mapbox_api_key, tooltip):
     # When
     actual = PyDeckPlot(json_input=json_input, mapbox_api_key=mapbox_api_key, tooltip=tooltip,)
-    breakpoint()
     # Then
     assert actual.json_input == json_input
     assert actual.mapbox_api_key == mapbox_api_key

--- a/panel/tests/models/test_pydeck.py
+++ b/panel/tests/models/test_pydeck.py
@@ -27,45 +27,6 @@ def tooltip() -> bool:
     return True
 
 
-# @pytest.fixture
-# def uk_accidents_deck() -> pdk.Deck:
-#     """The UK Accidents Deck
-
-#     See [PyDec Docs](https://deckgl.readthedocs.io/en/latest/layer.html)
-
-#     Returns:
-#         pdk.Deck: The UK Accidents Deck
-#     """
-#     # 2014 location of car accidents in the UK
-
-#     # Define a layer to display on a map
-#     layer = pdk.Layer(
-#         "HexagonLayer",
-#         UK_ACCIDENTS_DATA,
-#         get_position=["lng", "lat",],
-#         auto_highlight=True,
-#         elevation_scale=50,
-#         pickable=True,
-#         elevation_range=[0, 3000,],
-#         extruded=True,
-#         coverage=1,
-#     )
-
-#     # Set the viewport location
-#     view_state = pdk.ViewState(
-#         longitude=-1.415,
-#         latitude=52.2323,
-#         zoom=6,
-#         min_zoom=5,
-#         max_zoom=15,
-#         pitch=40.5,
-#         bearing=-27.36,
-#     )
-
-#     # Combined all of it and render a viewport
-#     return pdk.Deck(layers=[layer], initial_view_state=view_state, mapbox_key=MAPBOX_KEY,)
-
-
 def test_constructor(json_input, mapbox_api_key, tooltip):
     # When
     actual = PyDeckPlot(json_input=json_input, mapbox_api_key=mapbox_api_key, tooltip=tooltip,)

--- a/panel/tests/models/test_pydeck_manual.py
+++ b/panel/tests/models/test_pydeck_manual.py
@@ -1,0 +1,88 @@
+"""In this module we test the PyDeck Bokeh Model
+
+These test can be run partically via pytest and partially by running
+`panel serve` on this file and manually verifying the results
+"""
+import panel as pn
+import pydeck as pdk
+from panel.models.pydeck import PyDeckPlot
+from panel.tests.utils import TestApp
+
+UK_ACCIDENTS_DATA = (
+    "https://raw.githubusercontent.com/uber-common/"
+    "deck.gl-data/master/examples/3d-heatmap/heatmap-data.csv"
+)
+
+MAPBOX_KEY = (
+    "pk.eyJ1IjoibWFyY3Nrb3ZtYWRzZW4iLCJhIjoiY2s1anMzcG5rMDYzazNvcm10NTFybTE4cSJ9."
+    "TV1XBgaMfR-iTLvAXM_Iew"
+)
+
+
+def uk_accidents_deck() -> pdk.Deck:
+    """The UK Accidents Deck
+
+    See [PyDec Docs](https://deckgl.readthedocs.io/en/latest/layer.html)
+
+    Returns:
+        pdk.Deck: The UK Accidents Deck
+    """
+    # 2014 location of car accidents in the UK
+
+    # Define a layer to display on a map
+    layer = pdk.Layer(
+        "HexagonLayer",
+        UK_ACCIDENTS_DATA,
+        get_position=["lng", "lat",],
+        auto_highlight=True,
+        elevation_scale=50,
+        pickable=True,
+        elevation_range=[0, 3000,],
+        extruded=True,
+        coverage=1,
+    )
+
+    # Set the viewport location
+    view_state = pdk.ViewState(
+        longitude=-1.415,
+        latitude=52.2323,
+        zoom=6,
+        min_zoom=5,
+        max_zoom=15,
+        pitch=40.5,
+        bearing=-27.36,
+    )
+
+    # Combined all of it and render a viewport
+    return pdk.Deck(layers=[layer], initial_view_state=view_state, mapbox_key=MAPBOX_KEY,)
+
+
+def test_basic():
+    """A basic test. We test that
+
+    - json_input
+    - mapbox_api_key
+    - tooltip
+
+    is shown"""
+    deck = uk_accidents_deck()
+    plot = PyDeckPlot(
+        json_input=deck.to_json(), mapbox_api_key=deck.mapbox_key, tooltip=deck.deck_widget.tooltip,
+    )
+
+    return TestApp(test_basic, pn.pane.Bokeh(plot))
+
+
+def view() -> pn.Column:
+    """Wraps all tests in a Column
+
+    Returns:
+        pn.Column -- A Column containing all the tests
+    """
+    return pn.Column(__doc__, test_basic,)
+
+
+if __name__.startswith("bk"):
+    pn.extension()
+
+    view().servable("test_pydeck_manual")

--- a/panel/tests/pane/test_pydeck.py
+++ b/panel/tests/pane/test_pydeck.py
@@ -1,0 +1,43 @@
+import pytest
+
+try:
+    import pydeck
+except:
+    pydeck = None
+pydeck_available = pytest.mark.skipif(pydeck is None, reason="requires pydeck")
+
+from panel.models.pydeck import PyDeckPlot
+from panel.pane import Pane, PaneBase, PyDeck
+
+
+@pydeck_available
+def test_get_pydeck_pane_type_from_deck():
+    deck = pydeck.Deck()
+    assert PaneBase.get_pane_type(deck) is PyDeck
+
+
+@pydeck_available
+def test_pydeck_pane_deck(document, comm):
+    deck = pydeck.Deck(tooltip=True)
+    pane = Pane(deck)
+
+    # Create pane
+    model = pane.get_root(document, comm=comm)
+    assert isinstance(model, PyDeckPlot)
+    assert pane._models[model.ref["id"]][0] is model
+    assert model.json_input == deck.to_json()
+    assert model.mapbox_api_key == deck.mapbox_key
+    assert model.tooltip == deck.deck_widget.tooltip
+
+    # Replace Pane.object
+    new_deck = pydeck.Deck(tooltip=False)
+    pane.object = new_deck
+
+    assert pane._models[model.ref["id"]][0] is model
+    assert model.json_input == new_deck.to_json()
+    assert model.mapbox_api_key == new_deck.mapbox_key
+    assert model.tooltip == new_deck.deck_widget.tooltip
+
+    # Cleanup
+    pane._cleanup(model)
+    assert pane._models == {}

--- a/panel/tests/utils.py
+++ b/panel/tests/utils.py
@@ -1,0 +1,35 @@
+"""Functionality to speed up developing tests of Panel apps"""
+from typing import Callable
+
+from panel.layout import Column
+from panel.pane import Markdown
+
+
+class TestApp(Column):
+    """Creates a Test App from the name and docstring of the test function"""
+
+    __test__ = False  # We don't wan't pytest to collect this
+
+    def __init__(self, test_func: Callable, *args, **kwargs):
+        """## Creates a Test App from the name and docstring of the test function
+
+        Displays
+        - __name__
+        - __doc__
+
+        Has sizing_mode="stretch_width" unless otherwise specified
+
+        Arguments:
+            test_func {Callable} -- The function to create an app from.
+        """
+        text_str = test_func.__name__.replace("_", " ",).capitalize()
+        text_str = "# " + text_str
+
+        if test_func.__doc__:
+            text_str += "\n\n" + test_func.__doc__
+        text = Markdown(text_str)
+
+        if "sizing_mode" not in kwargs and "width" not in kwargs and "height" not in kwargs:
+            kwargs["sizing_mode"] = "stretch_width"
+
+        super().__init__(text, *args, **kwargs)

--- a/setup.py
+++ b/setup.py
@@ -114,6 +114,7 @@ extras_require = {
         # For examples
         'hvplot',
         'plotly',
+        'pydeck',
         'altair',
         'streamz',
         'vega_datasets',


### PR DESCRIPTION
Defines a PyDeck Pane which renders a PyDeck plot using a PyDeckPlot
bokeh model.

For now I've just experimented a bit.

There is a simple implementation of an app using PyDeck in the gallery at
[awesome-streamlit.org](https://awesome-streamlit.org).

![image](https://user-images.githubusercontent.com/42288570/72674947-9f877880-3a7d-11ea-86a8-0b35275eb8bf.png)

See

- [pydeck implementation](https://github.com/MarcSkovMadsen/awesome-panel/blob/master/package/awesome_panel/express/pane/pydeck.py)
- [test_pydeck app](https://github.com/MarcSkovMadsen/awesome-panel/blob/master/src/pages/gallery/awesome_panel_express_tests/test_pydeck.py)
- [test_pydeck test](https://github.com/MarcSkovMadsen/awesome-panel/blob/master/package/tests/test_pydeck.py)

It's based on the following resources

- [PyDeck Github](https://github.com/uber/deck.gl/tree/master/bindings/pydeck)
- [PyDeck Docs](https://deckgl.readthedocs.io/en/latest/)
- [PyDeck Deck Implementation](https://github.com/uber/deck.gl/blob/master/bindings/pydeck/pydeck/bindings/deck.py)
- [PyDeck render_json_to_html Implementation](https://github.com/uber/deck.gl/blob/master/bindings/pydeck/pydeck/io/html.py)

When I move on I believe I can find inspiration in

- The Panel implementation of the Plotly Pane and Plotly Bokeh Model
- [Extending Bokeh](https://docs.bokeh.org/en/latest/docs/user_guide/extensions.html)
- [PyDeck Jupyter Implementation](https://github.com/uber/deck.gl/blob/master/bindings/pydeck/pydeck/widget/widget.py)

There is a feature request for this at [Github 957](https://github.com/holoviz/panel/issues/957)