### PR TITLE
Ensure that ReplacementPane does not modify user objects

### DIFF
--- a/panel/pane/base.py
+++ b/panel/pane/base.py
@@ -334,8 +334,8 @@ class ReplacementPane(PaneBase):
                 for awatchers in pwatchers.values() for w in awatchers
             ]
             custom_watchers = not all(
-                'Reactive._link_params' in wfn or 'PaneBase._update_pane' in wfn
-                for wfn in watch_fns
+                'Reactive._link_params' in wfn or '._update_pane' in wfn or
+                'param_change' in wfn for wfn in watch_fns
             )
 
         if type(self._pane) is pane_type and not links and not custom_watchers and self._internal:

--- a/panel/tests/test_io.py
+++ b/panel/tests/test_io.py
@@ -78,7 +78,7 @@ def test_embed_checkbox(document, comm):
         assert event['kind'] == 'ModelChanged'
         assert event['attr'] == 'text'
         assert event['model'] == model.children[1].ref
-        assert event['new'] == '&lt;pre&gt;%s&lt;/pre&gt;' % k
+        assert event['new'] == '&lt;pre&gt;%s&lt;/pre&gt;' % k.title()
 
 
 def test_save_embed_bytesio():

--- a/panel/tests/test_param.py
+++ b/panel/tests/test_param.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 import os
 
 import param

--- a/panel/tests/test_param.py
+++ b/panel/tests/test_param.py
@@ -6,7 +6,7 @@ from bokeh.models import (
     Div, Slider, Select, RangeSlider, MultiSelect, Row as BkRow,
     CheckboxGroup, Toggle, Button, TextInput as BkTextInput,
     Tabs as BkTabs, Column as BkColumn, TextInput)
-from panel.pane import Pane, PaneBase, Matplotlib, Bokeh
+from panel.pane import Pane, PaneBase, Matplotlib, Bokeh, HTML
 from panel.layout import Tabs, Row
 from panel.param import Param, ParamMethod, ParamFunction, JSONInit
 from panel.widgets import LiteralInput
@@ -840,6 +840,37 @@ def test_param_function_pane(document, comm):
     pane._cleanup(row)
     assert pane._models == {}
     assert inner_pane._models == {}
+
+
+def test_param_function_pane_update(document, comm):
+    test = View()
+
+    objs = {
+        0: HTML("012"),
+        1: HTML("123")
+    }
+
+    @param.depends(test.param.a)
+    def view(a):
+        return objs[a]
+
+    pane = Pane(view)
+    inner_pane = pane._pane
+    assert inner_pane is not objs[0]
+    assert inner_pane.object is objs[0].object
+    assert pane._internal
+
+    test.a = 1
+
+    assert pane._pane is inner_pane
+    assert pane._internal
+
+    objs[0].param.watch(print, ['object'])
+
+    test.a = 0
+
+    assert pane._pane is not inner_pane
+    assert not pane._internal
 
 
 def test_get_param_method_pane_type():


### PR DESCRIPTION
Some of our "reactive" APIs like `interact` or `depends` use an internal optimization which tries to avoid replacing models entirely instead reusing them so they can be updated. The problem with that is that if a user supplies an object it will be reused in itself is problematic but also causes issues when that object is later reused (because no change will be detected). Therefore we have to be more careful about this optimization, the two cases we can use the optimization therefore are:

1) The object was created internally, i.e. the user has to reference to the object and therefore will never reuse it.
2) We can safely make a clone of the object (i.e. there are no custom watchers or links installed on the object)

Fixes https://github.com/holoviz/panel/issues/838
Fixes https://github.com/holoviz/panel/issues/853