### PR TITLE
CLI fixups: fix handling of no args; restore pyct commands (were being ignored).

### DIFF
--- a/panel/cli.py
+++ b/panel/cli.py
@@ -67,21 +67,21 @@ def main(args=None):
     for cls in bokeh_commands:
         subs.add_parser(cls.name, help=cls.help)
 
+    if len(sys.argv) == 1:
+        all_commands = sorted([c.name for c in bokeh_commands] + pyct_commands)
+        die("ERROR: Must specify subcommand, one of: %s" % nice_join(all_commands))
+
     if sys.argv[1] in ('--help', '-h'):
         args = parser.parse_args(sys.argv[1:])
         args.invoke(args)
         sys.exit()
-
-    if len(sys.argv) == 1:
-        all_commands = sorted([c.name for c in bokeh_commands] + pyct_commands)
-        die("ERROR: Must specify subcommand, one of: %s" % nice_join(all_commands))
 
     if len(sys.argv) > 1 and any(sys.argv[1] == c.name for c in bokeh_commands):
         if sys.argv[1] == 'serve' and not any(arg.startswith('--index') for arg in sys.argv):
             sys.argv = sys.argv + ['--index=%s' % INDEX_HTML]
         sys.argv = transform_cmds(sys.argv)
         bokeh_entry_point()
-    elif sys.argv[0]in pyct_commands:
+    elif sys.argv[1] in pyct_commands:
         try:
             import pyct.cmd
         except ImportError:


### PR DESCRIPTION
Aside: I'd like to add at least a basic test of the cli (e.g. as is done for holoviz; https://github.com/holoviz/holoviz/blob/master/tox.ini#L36), but I think that should be part of a larger effort to get better at testing from the user's point of view. (E.g. does conda install panel currently work? And then does `panel install-examples` or whatever work? And then do the examples run? Etc. This topic is on the pyctdev "roadmap".)