### PR TITLE
Fixed HoloViews axis linking across Template roots

### DIFF
--- a/panel/io/server.py
+++ b/panel/io/server.py
@@ -37,9 +37,12 @@ def _server_url(url, port):
         return 'http://%s:%d%s' % (url.split(':')[0], port, "/")
 
 def _eval_panel(panel, server_id, title, doc):
+    from ..template import Template
     from ..pane import panel as as_panel
 
-    if isinstance(panel, FunctionType):
+    if isinstance(panel, Template):
+        return panel._modify_doc(server_id, title, doc)
+    elif isinstance(panel, FunctionType):
         panel = panel()
     return as_panel(panel)._modify_doc(server_id, title, doc)
     

--- a/panel/pane/holoviews.py
+++ b/panel/pane/holoviews.py
@@ -535,11 +535,11 @@ def link_axes(root_view, root_model):
 
             fig = p.state
             if fig.x_range.tags:
-                range_map[(fig.x_range.tags[0], plot.root.ref['id'])].append((fig, p, fig.xaxis[0], fig.x_range))
+                range_map[fig.x_range.tags[0]].append((fig, p, fig.xaxis[0], fig.x_range))
             if fig.y_range.tags:
-                range_map[(fig.y_range.tags[0], plot.root.ref['id'])].append((fig, p, fig.yaxis[0], fig.y_range))
+                range_map[fig.y_range.tags[0]].append((fig, p, fig.yaxis[0], fig.y_range))
 
-    for (tag, _), axes in range_map.items():
+    for (tag), axes in range_map.items():
         fig, p, ax, axis = axes[0]
         for fig, p, pax, _ in axes[1:]:
             changed = []

--- a/panel/template.py
+++ b/panel/template.py
@@ -19,7 +19,7 @@ from .io.model import add_to_doc
 from .io.notebook import render_template
 from .io.state import state
 from .layout import Column
-from .pane import panel as _panel, HTML, Str
+from .pane import panel as _panel, HTML, Str, HoloViews
 from .viewable import ServableMixin, Viewable
 from .widgets import Button
 
@@ -113,11 +113,13 @@ class Template(param.Parameterized, ServableMixin):
         ref = preprocess_root.ref['id']
         for name, (obj, tags) in self._render_items.items():
             model = obj.get_root(doc, comm)
+            doc.on_session_destroyed(obj._server_destroy)
             for sub in obj.select(Viewable):
                 sub._models[ref] = sub._models.get(model.ref['id'])
+                if isinstance(sub, HoloViews):
+                    sub._plots[ref] = sub._plots.get(model.ref['id'])
+            col.objects.append(obj)
             obj._documents[doc] = model
-            doc.on_session_destroyed(obj._server_destroy)
-            col.append(obj)
             model.name = name
             model.tags = tags
             add_to_doc(model, doc, hold=bool(comm))

--- a/panel/tests/test_template.py
+++ b/panel/tests/test_template.py
@@ -44,8 +44,8 @@ def test_template_links_axes(document, comm):
     (_, (m1, _)) = list(p1._models.items())[0]
     (_, (m2, _)) = list(p2._models.items())[0]
     (_, (m3, _)) = list(p3._models.items())[0]
-    assert m1.x_range is not m2.x_range
-    assert m1.y_range is not m2.y_range
+    assert m1.x_range is m2.x_range
+    assert m1.y_range is m2.y_range
     assert m2.x_range is m3.x_range
     assert m2.y_range is m3.y_range
 


### PR DESCRIPTION
In https://github.com/holoviz/panel/pull/826 I made some fixes to root handling but because I did some confusing things with a shared root a) plots were rendered too many times and b) you could not link axes across roots.

@timothydmorton @dharhas This one is worth testing on the LSST dashboard. I'm not sure you need to be able to link axes across multiple roots but if you wanted to you can do it again. It should also speed things up a little bit since it no longer renders plots multiple times.