### PR TITLE
Implemented __signature__ for Viewable objects

### DIFF
--- a/panel/__init__.py
+++ b/panel/__init__.py
@@ -10,13 +10,14 @@ from . import pipeline # noqa
 from . import widgets # noqa
 
 from .config import config, panel_extension as extension # noqa
+from .depends import depends # noqa
 from .interact import interact # noqa
 from .io import ipywidget, serve, state # noqa
 from .layout import Row, Column, WidgetBox, Tabs, Spacer, GridSpec, GridBox # noqa
 from .pane import panel, Pane # noqa
 from .param import Param # noqa
 from .template import Template # noqa
-from .depends import depends # noqa
 
 __version__ = str(_param.version.Version(
     fpath=__file__, archive_commit="$Format:%h$", reponame="panel"))
+

--- a/panel/config.py
+++ b/panel/config.py
@@ -57,7 +57,7 @@ class _config(param.Parameterized):
 
     apply_signatures = param.Boolean(default=True, doc="""
         Whether to set custom Signature which allows tab-completion
-        in some IDEs and environements.""")
+        in some IDEs and environments.""")
 
     css_files = param.List(default=_CSS_FILES, doc="""
         External CSS files to load.""")
@@ -318,10 +318,10 @@ class panel_extension(_pyviz_extension):
                 prefix = cls.__doc__.split('\n')[0]
                 cls.__doc__ = cls.__doc__.replace(prefix, '')
             sig = inspect.signature(cls.__init__)
-            sig_params = list(sig.parameters)
-            if not sig_params or 'params' != sig_params[-1]:
+            sig_params = list(sig.parameters.values())
+            if not sig_params or sig_params[-1] != Parameter('params', Parameter.VAR_KEYWORD):
                 continue
-            parameters = list(sig.parameters.values())[:-1]
+            parameters = sig_params[:-1]
 
             processed_kws, keyword_groups = set(), []
             for cls in reversed(cls.mro()):
@@ -336,7 +336,7 @@ class panel_extension(_pyviz_extension):
             parameters += [
                 Parameter(name, Parameter.KEYWORD_ONLY)
                 for kws in reversed(keyword_groups) for name in kws
-                if name not in sig_params
+                if name not in sig.parameters
             ]
             parameters.append(Parameter('kwargs', Parameter.VAR_KEYWORD))
             cls.__init__.__signature__ = Signature(

--- a/panel/pane/vtk/vtk.py
+++ b/panel/pane/vtk/vtk.py
@@ -44,8 +44,8 @@ class VTKVolume(PaneBase):
 
     _updates = True
 
-    def __init__(self, obj=None, **params):
-        super(VTKVolume, self).__init__(obj, **params)
+    def __init__(self, object=None, **params):
+        super(VTKVolume, self).__init__(object, **params)
         self._sub_spacing = self.spacing
 
     @classmethod
@@ -203,8 +203,8 @@ class VTK(PaneBase):
 
     _serializers = {}
 
-    def __init__(self, obj=None, **params):
-        super(VTK, self).__init__(obj, **params)
+    def __init__(self, object=None, **params):
+        super(VTK, self).__init__(object, **params)
         self._legend = None
         self._vtkjs = None
         if self.serialize_on_instantiation:

--- a/panel/tests/pane/test_base.py
+++ b/panel/tests/pane/test_base.py
@@ -7,7 +7,8 @@ import param
 from panel.interact import interactive
 from panel.pane import Pane, PaneBase, Bokeh, HoloViews
 from panel.param import ParamMethod
-from panel.tests.util import check_layoutable_properties
+from panel.tests.util import check_layoutable_properties, py3_only
+
 
 all_panes = [w for w in param.concrete_descendents(PaneBase).values()
              if not w.__name__.startswith('_') and not
@@ -41,3 +42,12 @@ def test_pane_clone(pane):
     assert ([(k, v) for k, v in sorted(p.param.get_param_values()) if k != 'name'] ==
             [(k, v) for k, v in sorted(clone.param.get_param_values()) if k != 'name'])
 
+
+@py3_only
+@pytest.mark.parametrize('pane', all_panes)
+def test_pane_signature(pane):
+    from inspect import Parameter, signature
+    parameters = signature(pane).parameters
+    assert len(parameters) == 2
+    assert 'object' in parameters
+    assert parameters['object'] == Parameter('object', Parameter.POSITIONAL_OR_KEYWORD, default=None)

--- a/panel/tests/test_layout.py
+++ b/panel/tests/test_layout.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 
+import param
 import pytest
 
 from bokeh.models import (
@@ -8,11 +9,26 @@ from bokeh.models import (
 )
 
 from panel.depends import depends
-from panel.layout import Column, Row, Tabs, Spacer, GridSpec, GridBox, WidgetBox
+from panel.layout import (
+    Column, ListPanel, Row, Tabs, Spacer, GridSpec, GridBox, WidgetBox
+)
 from panel.pane import Bokeh, Pane
 from panel.param import Param
 from panel.widgets import IntSlider
-from panel.tests.util import check_layoutable_properties
+from panel.tests.util import check_layoutable_properties, py3_only
+
+
+all_panels = [w for w in param.concrete_descendents(ListPanel).values()
+               if not w.__name__.startswith('_') and w is not Tabs]
+
+
+@py3_only
+@pytest.mark.parametrize('panel', all_panels)
+def test_widget_signature(panel):
+    from inspect import signature
+    parameters = signature(panel).parameters
+    assert len(parameters) == 2
+    assert 'objects' in parameters
 
 
 @pytest.fixture

--- a/panel/tests/test_viewable.py
+++ b/panel/tests/test_viewable.py
@@ -1,10 +1,18 @@
 from __future__ import absolute_import, division, unicode_literals
 
+import param
+import pytest
+
 from panel import config
+from panel.interact import interactive
 from panel.pane import Str
+from panel.viewable import Viewable
 
-from .util import jb_available
+from .util import jb_available, py3_only
 
+all_viewables = [w for w in param.concrete_descendents(Viewable).values()
+               if not w.__name__.startswith('_') and
+               not issubclass(w, interactive)]
 
 @jb_available
 def test_viewable_ipywidget():
@@ -12,3 +20,12 @@ def test_viewable_ipywidget():
     with config.set(comms='ipywidgets'):
         data, metadata = pane._repr_mimebundle_()
     assert 'application/vnd.jupyter.widget-view+json' in data
+
+
+@py3_only
+@pytest.mark.parametrize('viewable', all_viewables)
+def test_viewable_signature(viewable):
+    from inspect import Parameter, signature
+    parameters = signature(viewable).parameters
+    assert 'params' in parameters
+    assert parameters['params'] == Parameter('params', Parameter.VAR_KEYWORD)

--- a/panel/tests/util.py
+++ b/panel/tests/util.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import, division, unicode_literals
 
+import sys
+
 import numpy as np
 import pytest
 
@@ -33,6 +35,8 @@ try:
 except Exception:
     jupyter_bokeh = None
 jb_available = pytest.mark.skipif(jupyter_bokeh is None, reason="requires jupyter_bokeh")
+
+py3_only = pytest.mark.skipif(sys.version_info.major < 3, reason="requires Python 3")
 
 
 def mpl_figure():

--- a/panel/tests/widgets/test_base.py
+++ b/panel/tests/widgets/test_base.py
@@ -4,12 +4,20 @@ import param
 import pytest
 
 from panel.io import block_comm
-from panel.widgets import CompositeWidget, DataFrame, TextInput, Widget
-from panel.tests.util import check_layoutable_properties
+from panel.widgets import CompositeWidget, DataFrame, TextInput, ToggleGroup, Widget
+from panel.tests.util import check_layoutable_properties, py3_only
 
 all_widgets = [w for w in param.concrete_descendents(Widget).values()
                if not w.__name__.startswith('_') and
-               not issubclass(w, (CompositeWidget, DataFrame))]
+               not issubclass(w, (CompositeWidget, DataFrame, ToggleGroup))]
+
+
+@py3_only
+@pytest.mark.parametrize('widget', all_widgets)
+def test_widget_signature(widget):
+    from inspect import signature
+    parameters = signature(widget).parameters
+    assert len(parameters) == 1
 
 
 @pytest.mark.parametrize('widget', all_widgets)

--- a/panel/widgets/select.py
+++ b/panel/widgets/select.py
@@ -358,12 +358,12 @@ class CrossSelector(CompositeWidget, MultiSelect):
        preserve definition order after filtering. Disable to allow the
        order of selection to define the order of the selected list.""")
 
-    def __init__(self, *args, **kwargs):
-        super(CrossSelector, self).__init__(**kwargs)
+    def __init__(self, **params):
+        super(CrossSelector, self).__init__(**params)
         # Compute selected and unselected values
 
         labels, values = self.labels, self.values
-        selected = [labels[indexOf(v, values)] for v in kwargs.get('value', [])
+        selected = [labels[indexOf(v, values)] for v in params.get('value', [])
                     if isIn(v, values)]
         unselected = [k for k in labels if k not in selected]
         layout = dict(sizing_mode='stretch_both', background=self.background, margin=0)


### PR DESCRIPTION
Replaces the `param` docstring signature with a ``__signature__`` attribute, which should allow for tab-completion in newer versions of IPython. The new signature is applied on extension load as long as `pn.config.apply_signature` is set.

Additionally this enforces strict rules on what `Pane`, `Widget`, and `Panel` component signatures must look like during testing. This ensures no new components are added without considering how the signature code affects them.