### PR TITLE
Ensure JS dependencies are skipped if already satisfied

### DIFF
--- a/panel/_templates/autoload_panel_js.js
+++ b/panel/_templates/autoload_panel_js.js
@@ -92,8 +92,18 @@ calls it with the rendered model.
         run_callbacks();
       })
     } else {
+      var skip = [];
+      {%- for lib, urls in skip_imports.items() %}
+      if (window['{{ lib }}'] !== undefined) {
+        var urls = {{ urls }};
+        for (var i = 0; i < urls.length; i++) {
+          skip.push(urls[i])
+        }
+      }
+      {%- endfor %}
       for (var i = 0; i < js_urls.length; i++) {
         var url = js_urls[i];
+        if (skip.indexOf(url) >= 0) { continue }
         var element = document.createElement('script');
         element.onload = on_load;
         element.onerror = on_error;

--- a/panel/compiler.py
+++ b/panel/compiler.py
@@ -27,7 +27,11 @@ def require_components():
         conf = {'paths': {name: js[:-3]}, 'exports': {name: export}}
         js_requires.append(conf)
 
+    skip_import = {}
     for model in js_requires:
+        if hasattr(model, '__js_skip__'):
+            skip_import.update(model.__js_skip__)
+
         if not (hasattr(model, '__js_require__') or isinstance(model, dict)):
             continue
         if isinstance(model, dict):
@@ -46,4 +50,4 @@ def require_components():
             if e not in requirements:
                 requirements.append(e)
                 exports.append(value)
-    return configs, requirements, exports
+    return configs, requirements, exports, skip_import

--- a/panel/io/notebook.py
+++ b/panel/io/notebook.py
@@ -142,14 +142,15 @@ def push(doc, comm, binary=True):
 AUTOLOAD_NB_JS = _env.get_template("autoload_panel_js.js")
 NB_TEMPLATE_BASE = _env.get_template('nb_template.html')
 
-def _autoload_js(bundle, configs, requirements, exports, load_timeout=5000):
+def _autoload_js(bundle, configs, requirements, exports, skip_imports, load_timeout=5000):
     return AUTOLOAD_NB_JS.render(
         bundle    = bundle,
         force     = True,
         timeout   = load_timeout,
         configs   = configs,
         requirements = requirements,
-        exports   = exports
+        exports   = exports,
+        skip_imports = skip_imports
     )
 
 
@@ -279,9 +280,9 @@ def load_notebook(inline=True, load_timeout=5000):
 
     resources = INLINE if inline else CDN
     bundle = bundle_for_objs_and_resources(None, resources)
-    configs, requirements, exports = require_components()
+    configs, requirements, exports, skip_imports = require_components()
 
-    bokeh_js = _autoload_js(bundle, configs, requirements, exports, load_timeout)
+    bokeh_js = _autoload_js(bundle, configs, requirements, exports, skip_imports, load_timeout)
     publish_display_data({
         'application/javascript': bokeh_js,
         LOAD_MIME: bokeh_js,

--- a/panel/models/ace.py
+++ b/panel/models/ace.py
@@ -20,6 +20,8 @@ class AcePlot(HTMLBox):
         'https://cdnjs.cloudflare.com/ajax/libs/ace/1.4.3/ext-language_tools.js'
     ]
 
+    __js_skip__ = {'ace': __javascript__}
+
     __js_require__ = {
         'paths': {
             'ace': 'https://cdnjs.cloudflare.com/ajax/libs/ace/1.4.3/ace',

--- a/panel/models/deckgl.py
+++ b/panel/models/deckgl.py
@@ -28,7 +28,7 @@ class DeckGLPlot(HTMLBox):
                       "https://cdn.jsdelivr.net/npm/mapbox-gl@1.6.1",
     ]
 
-    __js_skip__ = {'deck': __javascript__[:-1], 'mapboxgl': __javascript__[:-1:]}
+    __js_skip__ = {'deck': __javascript__[:-1], 'mapboxgl': __javascript__[-1:]}
 
     __js_require__ = {
         'paths': OrderedDict([
@@ -44,4 +44,3 @@ class DeckGLPlot(HTMLBox):
 
     height = Override(default=400)
     width = Override(default=600)
-

--- a/panel/models/deckgl.py
+++ b/panel/models/deckgl.py
@@ -22,10 +22,13 @@ class DeckGLPlot(HTMLBox):
 
     __javascript__ = ["https://cdn.jsdelivr.net/npm/deck.gl@8.1.0-alpha.1/dist.min.js",
                       "https://cdn.jsdelivr.net/npm/@deck.gl/json@8.1.0-alpha.1/dist/dist.dev.js",
-                      "https://cdn.jsdelivr.net/npm/mapbox-gl@1.6.1",
                       "https://cdn.jsdelivr.net/npm/@loaders.gl/csv@2.0.2/dist/dist.min.js",
                       "https://cdn.jsdelivr.net/npm/@loaders.gl/json@2.0.2/dist/dist.min.js",
-                      "https://cdn.jsdelivr.net/npm/@loaders.gl/3d-tiles@2.0.2/dist/dist.min.js"]
+                      "https://cdn.jsdelivr.net/npm/@loaders.gl/3d-tiles@2.0.2/dist/dist.min.js",
+                      "https://cdn.jsdelivr.net/npm/mapbox-gl@1.6.1",
+    ]
+
+    __js_skip__ = {'deck': __javascript__[:-1], 'mapboxgl': __javascript__[:-1:]}
 
     __js_require__ = {
         'paths': OrderedDict([

--- a/panel/models/katex.py
+++ b/panel/models/katex.py
@@ -12,6 +12,8 @@ class KaTeX(Markup):
     __javascript__ = ["https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.6.0/katex.min.js",
                       "https://cdn.jsdelivr.net/npm/katex@0.10.1/dist/contrib/auto-render.min.js"]
 
+    __js_skip__ = {'katex': __javascript__[:1], 'renderMathInElement': __javascript__[1:]}
+
     __js_require__ = {'paths': {'katex': 'https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.6.0/katex.min',
                                 'autoLoad': 'https://cdn.jsdelivr.net/npm/katex@0.10.1/dist/contrib/auto-render.min'},
                       'exports': {'katex': 'katex', 'autoLoad': 'renderMathInElement'}}

--- a/panel/models/mathjax.py
+++ b/panel/models/mathjax.py
@@ -11,6 +11,8 @@ class MathJax(Markup):
 
     __javascript__ = ["https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/latest.js?config=TeX-MML-AM_CHTML"]
 
+    __js_skip__ = {'MathJax': __javascript__}
+
     __js_require__ = {
         'paths': {
             'mathjax': "//cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=TeX-AMS_HTML"

--- a/panel/models/plotly.py
+++ b/panel/models/plotly.py
@@ -13,6 +13,8 @@ class PlotlyPlot(LayoutDOM):
 
     __javascript__ = ['https://cdn.plot.ly/plotly-latest.min.js']
 
+    __js_skip__ = {'Plotly': __javascript__}
+
     __js_require__ = {'paths': {'plotly': 'https://cdn.plot.ly/plotly-latest.min'},
                       'exports': {'plotly': 'Plotly'}}
 

--- a/panel/models/vega.py
+++ b/panel/models/vega.py
@@ -15,6 +15,12 @@ class VegaPlot(LayoutDOM):
                       'https://cdn.jsdelivr.net/npm/vega-lite@4',
                       'https://cdn.jsdelivr.net/npm/vega-embed@6']
 
+    __js_skip__ = {
+        'vega': __javascript__[:1],
+        'vegaLite': __javascript__[1:2],
+        'vegaEmbed': __javascript__[2:]
+    }
+
     __js_require__ = {
         'baseUrl': 'https://cdn.jsdelivr.net/npm/',
         'paths': {

--- a/panel/models/vtk.py
+++ b/panel/models/vtk.py
@@ -41,6 +41,8 @@ class VTKPlot(HTMLBox):
 
     __javascript__ = [vtk_cdn]
 
+    __js_skip__ = {'vtk': [vtk_cdn]}
+
     __js_require__ = {"paths": {"vtk": vtk_cdn[:-3]},
                       "shim": {"vtk": {"exports": "vtk"}}}
 
@@ -69,6 +71,8 @@ class VTKVolumePlot(HTMLBox):
     """
 
     __javascript__ = [vtk_cdn]
+
+    __js_skip__ = {'vtk': [vtk_cdn]}
 
     __js_require__ = {"paths": {"vtk": vtk_cdn[:-3]},
                       "shim": {"vtk": {"exports": "vtk"}}}


### PR DESCRIPTION
This adds a mechanism by which the dynamic loading code can check if a Javascript component has already been loaded and will then avoid loading it again. This avoids issues in JupyterLab where loading the same module twice can have side-effects, specifically the DeckGL dependency has issues when loaded twice as it seems to unload the JSON loader dependency causing certain examples two fail if two JupyterLab tabs are both running DeckGL examples.