### PR TITLE
Updates to About page

### DIFF
--- a/doc/about.rst
+++ b/doc/about.rst
@@ -5,6 +5,6 @@ Panel is completely open source, available under a BSD license freely for both c
 
 Panel is part of the `HoloViz <https://holoviz.org>`_ family of tools. The `holoviz.org <https://holoviz.org>`_ website shows how to use Panel together with other libraries to solve complex problems, with detailed tutorials and examples. You can see a variety of projects using Panel at `examples.pyviz.org <https://examples.pyviz.org>`_, and you can compare Panel to other available tools at `pyviz.org <https://pyviz.org>`_.
 
-If you have any questions or usage issues visit the `Panel Discourse <https://discourse.holoviz.org/c/panel/`_ site. If you are interested in contributing to Panel development to help address some of the `open issues <https://github.com/holoviz/panel/issues>`_, see our `developer instructions <https://pyviz-dev.github.io/panel/developer_guide/index.html>`_ to set up your development environment.
+If you have any questions or usage issues visit the `Panel Discourse <https://discourse.holoviz.org/c/panel/>`_ site. If you are interested in contributing to Panel development to help address some of the `open issues <https://github.com/holoviz/panel/issues>`_, see our `developer instructions <https://pyviz-dev.github.io/panel/developer_guide/index.html>`_ to set up your development environment.
 
 If you like Panel and have built something you want to share, tweet a link or screenshot of your latest creation at @Panel_org, along with any other library you used (@HoloViews, @Datashader, @BokehPlots, @Matplotlib, etc.). Thanks!

--- a/doc/about.rst
+++ b/doc/about.rst
@@ -3,9 +3,9 @@ About
 
 Panel is completely open source, available under a BSD license freely for both commercial and non-commercial use.
 
-Panel is part of the `HoloViz <https://holoviz.org>`_ family of tools. The `holoviz.org <https://holoviz.org>`_ website shows how to use Panel together with other libraries to solve complex problems, with detailed tutorials and examples. Example projects using Panel are at
+Panel is part of the `HoloViz <https://holoviz.org>`_ family of tools. The `holoviz.org <https://holoviz.org>`_ website shows how to use Panel together with other libraries to solve complex problems, with detailed tutorials and examples. You can see a variety of projects using Panel at
 `examples.pyviz.org <https://examples.pyviz.org>`_, and you can compare Panel to other available tools at `pyviz.org <https://pyviz.org>`_.
 
-If you have any questions or usage issues visit the `HoloViz Discourse <https://discourse.holoviz.org/c/panel/`_. If you are interested in contributing to Panel development to help address some of the `open issues <https://github.com/holoviz/panel/issues>`_, see our `developer instructions <https://pyviz-dev.github.io/panel/developer_guide/index.html>`_ to set up your development environment.
+If you have any questions or usage issues visit the `Panel Discourse <https://discourse.holoviz.org/c/panel/`_ site. If you are interested in contributing to Panel development to help address some of the `open issues <https://github.com/holoviz/panel/issues>`_, see our `developer instructions <https://pyviz-dev.github.io/panel/developer_guide/index.html>`_ to set up your development environment.
 
 If you like Panel and have built something you want to share, tweet a link or screenshot of your latest creation at @Panel_org, along with any other library you used (@HoloViews, @Datashader, @BokehPlots, @Matplotlib, etc.). Thanks!

--- a/doc/about.rst
+++ b/doc/about.rst
@@ -1,8 +1,5 @@
-About Panel
-===========
+About
+=====
 
-Panel is completely open source, available under a BSD license freely for both commercial and non-commercial use. Panel is part of the HoloViz ecosystem and works well with all the HoloViz tools.
-
-Panel was originally developed with the support of `Anaconda Inc. <https://anaconda.com>`_, and is now maintained by Anaconda developers and community contributors.
-
-If you are interested in contributing to Panel development, you can see our list of open issues that you could help address, including possible larger wishlist items. And if you are lucky enough to be in a position to fund our developers to work on documentation, features, or bug fixes, please contact sales@anaconda.com.
+Panel is part of the `HoloViz <https://holoviz.org>`_ family of tools. The `holoviz.org <https://holoviz.org>`_ website shows how to use Panel together with other libraries to solve complex problems, with detailed tutorials and examples. Example projects using Panel are at
+`examples.pyviz.org <https://examples.pyviz.org>`_, and you can compare Panel to other available tools at `pyviz.org <https://pyviz.org>`_.

--- a/doc/about.rst
+++ b/doc/about.rst
@@ -1,10 +1,9 @@
 About
 =====
 
-Panel is completely open source, available under a BSD license freely for both commercial and non-commercial use.
+Panel is completely open source, available under a BSD license freely for both commercial and non-commercial use. Panel was originally developed with the support of `Anaconda Inc. <https://anaconda.com>`_, and is now maintained by Anaconda developers and community contributors.
 
-Panel is part of the `HoloViz <https://holoviz.org>`_ family of tools. The `holoviz.org <https://holoviz.org>`_ website shows how to use Panel together with other libraries to solve complex problems, with detailed tutorials and examples. You can see a variety of projects using Panel at
-`examples.pyviz.org <https://examples.pyviz.org>`_, and you can compare Panel to other available tools at `pyviz.org <https://pyviz.org>`_.
+Panel is part of the `HoloViz <https://holoviz.org>`_ family of tools. The `holoviz.org <https://holoviz.org>`_ website shows how to use Panel together with other libraries to solve complex problems, with detailed tutorials and examples. You can see a variety of projects using Panel at `examples.pyviz.org <https://examples.pyviz.org>`_, and you can compare Panel to other available tools at `pyviz.org <https://pyviz.org>`_.
 
 If you have any questions or usage issues visit the `Panel Discourse <https://discourse.holoviz.org/c/panel/`_ site. If you are interested in contributing to Panel development to help address some of the `open issues <https://github.com/holoviz/panel/issues>`_, see our `developer instructions <https://pyviz-dev.github.io/panel/developer_guide/index.html>`_ to set up your development environment.
 

--- a/doc/about.rst
+++ b/doc/about.rst
@@ -1,5 +1,11 @@
 About
 =====
 
+Panel is completely open source, available under a BSD license freely for both commercial and non-commercial use.
+
 Panel is part of the `HoloViz <https://holoviz.org>`_ family of tools. The `holoviz.org <https://holoviz.org>`_ website shows how to use Panel together with other libraries to solve complex problems, with detailed tutorials and examples. Example projects using Panel are at
 `examples.pyviz.org <https://examples.pyviz.org>`_, and you can compare Panel to other available tools at `pyviz.org <https://pyviz.org>`_.
+
+If you have any questions or usage issues visit the `HoloViz Discourse <https://discourse.holoviz.org/c/panel/`_. If you are interested in contributing to Panel development to help address some of the `open issues <https://github.com/holoviz/panel/issues>`_, see our `developer instructions <https://pyviz-dev.github.io/panel/developer_guide/index.html>`_ to set up your development environment.
+
+If you like Panel and have built something you want to share, tweet a link or screenshot of your latest creation at @Panel_org, along with any other library you used (@HoloViews, @Datashader, @BokehPlots, @Matplotlib, etc.). Thanks!

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -80,17 +80,6 @@ And then you can launch Jupyter to explore them yourself using either Jupyter No
   jupyter notebook
   jupyter lab
 
-
-HoloViz
--------
-
-Panel is part of the HoloViz family of tools.  The `HoloViz website
-<https://holoviz.org>`_ shows how to use Panel together with other
-libraries to solve complex problems, with detailed tutorials and
-examples. For a list of examples building on this set of tools
-(including Panel) see `examples.pyviz.org
-<https://examples.pyviz.org/>`_.
-
 .. |CondaPyViz| image:: https://img.shields.io/conda/v/pyviz/panel.svg
 .. _CondaPyViz: https://anaconda.org/pyviz/panel
 


### PR DESCRIPTION

Changes:

- [x] Remove About section from homepage.
- [x] Use consistent About blurb on About page.

I'm fine with leaving out mention of Anaconda as that can be found on holoviz.org. @jbednar One thing I do like that I have removed is this sentence:

> Panel is completely open source, available under a BSD license freely for both commercial and non-commercial use.

It is nice to start with a general description of what the library is. I would be in favor of adding a sentence like this to all the About pages for all the HoloViz libraries. What do you think?