### PR TITLE
Fixes for specifying requirejs dependencies

### DIFF
--- a/panel/models/ace.py
+++ b/panel/models/ace.py
@@ -16,17 +16,19 @@ class AcePlot(HTMLBox):
     """
 
     __javascript__ = [
-        'https://cdnjs.cloudflare.com/ajax/libs/ace/1.4.3/ace.js',
-        'https://cdnjs.cloudflare.com/ajax/libs/ace/1.4.3/ext-language_tools.js'
+        'https://cdnjs.cloudflare.com/ajax/libs/ace/1.4.7/ace.js',
+        'https://cdnjs.cloudflare.com/ajax/libs/ace/1.4.7/ext-language_tools.js'
     ]
 
     __js_skip__ = {'ace': __javascript__}
 
     __js_require__ = {
         'paths': {
-            'ace': 'https://cdnjs.cloudflare.com/ajax/libs/ace/1.4.3/ace',
-            'ace_lang_tools': 'https://cdnjs.cloudflare.com/ajax/libs/ace/1.4.3/ext-language_tools'},
-        'exports': {'ace': 'ace'}
+            ('ace', ('ace/ace', 'ace/ext-language_tools')): '//cdnjs.cloudflare.com/ajax/libs/ace/1.4.7'},
+        'exports': {'ace': 'ace'},
+        'shim': {
+            'ace/ext-language_tools': { 'deps': ["ace/ace"] }
+        }
     }
 
     code = String()

--- a/panel/models/vtk.py
+++ b/panel/models/vtk.py
@@ -43,8 +43,13 @@ class VTKPlot(HTMLBox):
 
     __js_skip__ = {'vtk': [vtk_cdn]}
 
-    __js_require__ = {"paths": {"vtk": vtk_cdn[:-3]},
-                      "shim": {"vtk": {"exports": "vtk"}}}
+    __js_require__ = {
+        "paths": {"vtk": vtk_cdn[:-3]},
+        "exports": {"vtk": None},
+        "shim": {
+            "vtk": {"exports": "vtk"}
+        }
+    }
 
     append = Bool(default=False)
 
@@ -64,6 +69,7 @@ class VTKPlot(HTMLBox):
 
     width = Override(default=300)
 
+
 class VTKVolumePlot(HTMLBox):
     """
     A Bokeh model that wraps around a vtk-js library and renders it inside
@@ -74,8 +80,13 @@ class VTKVolumePlot(HTMLBox):
 
     __js_skip__ = {'vtk': [vtk_cdn]}
 
-    __js_require__ = {"paths": {"vtk": vtk_cdn[:-3]},
-                      "shim": {"vtk": {"exports": "vtk"}}}
+    __js_require__ = {
+        "paths": {"vtk": vtk_cdn[:-3]},
+        "exports": {"vtk": None},
+        "shim": {
+            "vtk": {"exports": "vtk"}
+        }
+    }
 
     actor = Any(readonly=True)
 


### PR DESCRIPTION
The requirejs dependency specification was not sufficient to correctly express Ace dependencies resulting in breakage in the classic notebook.