### PR TITLE
Safe embed [doc-build]

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -107,4 +107,4 @@ html_context.update({
     )
 })
 
-nbbuild_patterns_to_take_along = ["simple.html"]
+nbbuild_patterns_to_take_along = ["simple.html", "*.json", "json_*"]

--- a/panel/config.py
+++ b/panel/config.py
@@ -69,6 +69,11 @@ class _config(param.Parameterized):
     raw_css = param.List(default=[], doc="""
         List of raw CSS strings to add to load.""")
 
+    safe_embed = param.Boolean(default=False, doc="""
+        Ensure all bokeh property changes trigger events which are
+        embedded. Useful when only partial updates are made in an
+        app, e.g. when working with HoloViews.""")
+
     sizing_mode = param.ObjectSelector(default=None, objects=[
         'fixed', 'stretch_width', 'stretch_height', 'stretch_both',
         'scale_width', 'scale_height', 'scale_both', None], doc="""

--- a/panel/io/embed.py
+++ b/panel/io/embed.py
@@ -13,10 +13,11 @@ from itertools import product
 
 from bokeh.models import CustomJS
 from param.parameterized import Watcher
-from tqdm import tqdm
 
 from .model import add_to_doc, diff
 from .state import state
+from tqdm import tqdm
+
 
 #---------------------------------------------------------------------
 # Private API
@@ -265,7 +266,6 @@ def embed_state(panel, model, doc, max_states=1000, max_opts=3,
                            'increase the max_states specified in the function '
                            'to remove this warning' %
                            len(cross_product))
-
 
     nested_dict = lambda: defaultdict(nested_dict)
     state_dict = nested_dict()

--- a/panel/io/notebook.py
+++ b/panel/io/notebook.py
@@ -271,8 +271,10 @@ def block_comm():
     Context manager to temporarily block comm push
     """
     state._hold = True
-    yield
-    state._hold = False
+    try:
+        yield
+    finally:
+        state._hold = False
 
 
 def load_notebook(inline=True, load_timeout=5000):

--- a/panel/pane/holoviews.py
+++ b/panel/pane/holoviews.py
@@ -215,43 +215,46 @@ class HoloViews(PaneBase):
         ref = root.ref['id']
         if self.object is None:
             model = _BkSpacer()
+            self._models[ref] = (model, parent)
+            return model
+
+        if self._restore_plot is not None:
+            plot = self._restore_plot
+            self._restore_plot = None
+        elif isinstance(self.object, Plot):
+            plot = self.object
         else:
-            if self._restore_plot is not None:
-                plot = self._restore_plot
-                self._restore_plot = None
-            elif isinstance(self.object, Plot):
-                plot = self.object
-            else:
-                plot = self._render(doc, comm, root)
-            plot.pane = self
-            backend = plot.renderer.backend
-            if hasattr(plot.renderer, 'get_plot_state'):
-                state = plot.renderer.get_plot_state(plot)
-            else:
-                # Compatibility with holoviews<1.13.0
-                state = plot.state
+            plot = self._render(doc, comm, root)
 
-            # Ensure rerender if content is responsive but layout is centered
-            if (backend == 'bokeh' and self.center and
-                state.sizing_mode not in ('fixed', None)
-                and not self._responsive_content):
-                self._responsive_content = True
-                self._update_layout()
-                self._restore_plot = plot
-                raise RerenderError()
-            else:
-                self._responsive_content = False
+        plot.pane = self
+        backend = plot.renderer.backend
+        if hasattr(plot.renderer, 'get_plot_state'):
+            state = plot.renderer.get_plot_state(plot)
+        else:
+            # Compatibility with holoviews<1.13.0
+            state = plot.state
 
-            kwargs = {p: v for p, v in self.param.get_param_values()
-                      if p in Layoutable.param and p != 'name'}
-            child_pane = self._panes.get(backend, Pane)(state, **kwargs)
-            self._update_plot(plot, child_pane)
-            model = child_pane._get_model(doc, root, parent, comm)
-            if ref in self._plots:
-                old_plot, old_pane = self._plots[ref]
-                old_plot.comm = None # Ensures comm does not get cleaned up
-                old_plot.cleanup()
-            self._plots[ref] = (plot, child_pane)
+        # Ensure rerender if content is responsive but layout is centered
+        if (backend == 'bokeh' and self.center and
+            state.sizing_mode not in ('fixed', None)
+            and not self._responsive_content):
+            self._responsive_content = True
+            self._update_layout()
+            self._restore_plot = plot
+            raise RerenderError()
+        else:
+            self._responsive_content = False
+
+        kwargs = {p: v for p, v in self.param.get_param_values()
+                  if p in Layoutable.param and p != 'name'}
+        child_pane = self._panes.get(backend, Pane)(state, **kwargs)
+        self._update_plot(plot, child_pane)
+        model = child_pane._get_model(doc, root, parent, comm)
+        if ref in self._plots:
+            old_plot, old_pane = self._plots[ref]
+            old_plot.comm = None # Ensures comm does not get cleaned up
+            old_plot.cleanup()
+        self._plots[ref] = (plot, child_pane)
         self._models[ref] = (model, parent)
         return model
 


### PR DESCRIPTION
Reverts https://github.com/holoviz/panel/pull/1021

Just to recap some of the conversation/explanation from that PR:

>Just to explain both the issues you are having with HoloViews and what this workaround is meant to achieve. Embedding in Panel (and previously the HoloMap support in HoloViews) work by collecting all the widgets in an app that have a discrete set of values and then taking their cross product to come up with the state space. The embedding code then iterates over that state space and records the events that are generated as each change is applied. This works well for simple cases but can exhibit issues with more complex cases when combined with HoloViews. Specifically HoloViews tries to compute the minimal set of events to go from one state to the next. Imagine you have states A, B and C, the embedding code will go from A->B and record the events, and then go from B->C and record the events. However, since it's computing minimal diffs the transition from C->B may not include all the events to fully restore the view to the original state A, because it has only recorded the diff to go from A->B and A and B may be more similar than C and A. This problem is particularly acute when we change column labels.

>The correct solution would be to ensure that during embedding HoloViews always includes all the events necessary to fully restore the state. An alternative solution would be to find a path through the state space that applies all the events to get to that state consecutively. Both are pretty difficult problems, particularly while also still minimizing the size of the resulting data. This PR is a total hammer to solve this problem, instead of saying "let's try to compute a minimal diff between A and B" it says, let's just embed the entire plot for each state change. This will result in much bigger file sizes and trigger a full rerender of the plot but it also guarantees all the state changes are recorded in full.

The new approach in this PR provides a context manager which simply short circuits bokeh's mechanism to see if some property has changed or not, always telling it that the property has changed and an event should be generated. This means that for each state change all properties that are altered will be recorded. This is still no 100% guarantee that all changes are captured since a user might have conditional logic but it should capture the vast majority of cases in HoloViews and using changes in HoloViews we can make sure that all necessary events are captured.