### PR TITLE
[DOC] remove pane affectation to display it

### DIFF
--- a/examples/reference/panes/VTKVolume.ipynb
+++ b/examples/reference/panes/VTKVolume.ipynb
@@ -89,7 +89,7 @@
     "data_matrix[25:55, 25:55, 25:55] = 100\n",
     "data_matrix[45:74, 45:74, 45:74] = 150\n",
     "\n",
-    "vol = pn.pane.VTKVolume(data_matrix, sizing_mode='stretch_width', height=400, spacing=(3,2,1), interpolation='nearest', edge_gradient=0, sampling=0)"
+    "pn.pane.VTKVolume(data_matrix, sizing_mode='stretch_width', height=400, spacing=(3,2,1), interpolation='nearest', edge_gradient=0, sampling=0)"
    ]
   },
   {


### PR DESCRIPTION
No display because affected to `vol`
![image](https://user-images.githubusercontent.com/18531147/73541955-f143e180-4433-11ea-9c64-11474d6e9e62.png)
