### PR TITLE
bump param dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -142,7 +142,7 @@ extras_require['all'] = sorted(set(sum(extras_require.values(), [])))
 # non-python dependencies). Note that setup_requires isn't used
 # because it doesn't work well with pip.
 extras_require['build'] = [
-    'param >=1.9.0',
+    'param >=1.9.2',
     'pyct >=0.4.4',
     'setuptools >=30.3.0',
     'bokeh >=1.4.0',


### PR DESCRIPTION
fix #1063

panel 0.8.0 uses CalendarDateRange from param, which was introduced in
param 1.9.2