### PR TITLE
Fix param dependency update from #1064.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -90,7 +90,7 @@ except Exception:
 
 install_requires = [
     'bokeh >=1.4.0,<2.0',
-    'param >=1.9.0',
+    'param >=1.9.2',
     'pyviz_comms >=0.7.3',
     'markdown',
     'tqdm',


### PR DESCRIPTION
I guess this is what was intended (i.e. increasing the run time version rather than the build time one).

The build dep version could presumably be lower, but it probably doesn't matter too much.