### PR TITLE
Retrieve vtk slices on python side

### DIFF
--- a/panel/models/vtk.py
+++ b/panel/models/vtk.py
@@ -4,10 +4,36 @@ Defines custom VTKPlot bokeh model to render VTK objects.
 """
 from bokeh.core.properties import (String, Bool, Dict, Any, Override,
                                    Instance, Int, Float, PositiveInt, Enum)
+from bokeh.core.has_props import abstract
 from bokeh.core.enums import enumeration
 from bokeh.models import HTMLBox, Model
 
 vtk_cdn = "https://unpkg.com/vtk.js"
+
+@abstract
+class AbstractVTKPlot(HTMLBox):
+    """
+    Abstract Bokeh model for vtk plots that wraps around a vtk-js library and
+    renders it inside a Bokeh plot.
+    """
+
+    __javascript__ = [vtk_cdn]
+
+    __js_skip__ = {'vtk': [vtk_cdn]}
+
+    __js_require__ = {
+        "paths": {"vtk": vtk_cdn[:-3]},
+        "exports": {"vtk": None},
+        "shim": {
+            "vtk": {"exports": "vtk"}
+        }
+    }
+
+    renderer_el = Any(readonly=True)
+
+    height = Override(default=300)
+
+    width = Override(default=300)
 
 
 class VTKAxes(Model):
@@ -34,25 +60,12 @@ class VTKAxes(Model):
     fontsize = PositiveInt(default=12)
 
 
-class VTKPlot(HTMLBox):
+
+class VTKPlot(AbstractVTKPlot):
     """
-    A Bokeh model that wraps around a vtk-js library and renders it inside
-    a Bokeh plot.
+    Bokeh model dedicated to plot a vtk render window with only 3D geometry objects
+    (Volumes are not suported)
     """
-
-    __javascript__ = [vtk_cdn]
-
-    __js_skip__ = {'vtk': [vtk_cdn]}
-
-    __js_require__ = {
-        "paths": {"vtk": vtk_cdn[:-3]},
-        "exports": {"vtk": None},
-        "shim": {
-            "vtk": {"exports": "vtk"}
-        }
-    }
-
-    append = Bool(default=False)
 
     data = String(help="""The serialized vtk.js data""")
 
@@ -60,34 +73,16 @@ class VTKPlot(HTMLBox):
 
     axes = Instance(VTKAxes)
 
-    enable_keybindings = Bool(default=False)
-
     orientation_widget = Bool(default=False)
 
-    renderer_el = Any(readonly=True)
-
-    height = Override(default=300)
-
-    width = Override(default=300)
+    enable_keybindings = Bool(default=False)
 
 
-class VTKVolumePlot(HTMLBox):
+class VTKVolumePlot(AbstractVTKPlot):
     """
-    A Bokeh model that wraps around a vtk-js library and renders it inside
-    a Bokeh plot.
+    Bokeh model dedicated to plot a volumetric object with the help of vtk-js
+    (3D geometry objects are not suported)
     """
-
-    __javascript__ = [vtk_cdn]
-
-    __js_skip__ = {'vtk': [vtk_cdn]}
-
-    __js_require__ = {
-        "paths": {"vtk": vtk_cdn[:-3]},
-        "exports": {"vtk": None},
-        "shim": {
-            "vtk": {"exports": "vtk"}
-        }
-    }
 
     data = Dict(String, Any)
 
@@ -122,7 +117,3 @@ class VTKVolumePlot(HTMLBox):
     render_background = String(default='#52576e')
 
     interpolation = Enum(enumeration('fast_linear','linear','nearest'))
-
-    height = Override(default=300)
-
-    width = Override(default=300)

--- a/panel/models/vtk.py
+++ b/panel/models/vtk.py
@@ -31,6 +31,8 @@ class AbstractVTKPlot(HTMLBox):
 
     renderer_el = Any(readonly=True)
 
+    orientation_widget = Bool(default=False)
+
     height = Override(default=300)
 
     width = Override(default=300)
@@ -72,8 +74,6 @@ class VTKPlot(AbstractVTKPlot):
     camera = Dict(String, Any)
 
     axes = Instance(VTKAxes)
-
-    orientation_widget = Bool(default=False)
 
     enable_keybindings = Bool(default=False)
 

--- a/panel/models/vtk.py
+++ b/panel/models/vtk.py
@@ -117,3 +117,7 @@ class VTKVolumePlot(AbstractVTKPlot):
     render_background = String(default='#52576e')
 
     interpolation = Enum(enumeration('fast_linear','linear','nearest'))
+
+    slices_data_i = Dict(String, Any)
+    slices_data_j = Dict(String, Any)
+    slices_data_k = Dict(String, Any)

--- a/panel/models/vtk.py
+++ b/panel/models/vtk.py
@@ -33,6 +33,8 @@ class AbstractVTKPlot(HTMLBox):
 
     orientation_widget = Bool(default=False)
 
+    camera = Dict(String, Any)
+
     height = Override(default=300)
 
     width = Override(default=300)
@@ -70,8 +72,6 @@ class VTKPlot(AbstractVTKPlot):
     """
 
     data = String(help="""The serialized vtk.js data""")
-
-    camera = Dict(String, Any)
 
     axes = Instance(VTKAxes)
 

--- a/panel/models/vtk/vtk.ts
+++ b/panel/models/vtk/vtk.ts
@@ -1,21 +1,18 @@
 import * as p from "@bokehjs/core/properties"
 
 import {canvas} from "@bokehjs/core/dom"
-import {clone} from "@bokehjs/core/util/object"
 
 import {VTKAxes} from "./vtkaxes"
 import {AbstractVTKView, AbstractVTKPlot} from "./vtk_layout"
-import {majorAxis, vtk, vtkns} from "./vtk_utils"
+import {vtk, vtkns} from "./vtk_utils"
 
 export class VTKPlotView extends AbstractVTKView {
   model: VTKPlot
-  protected _setting: boolean = false
   protected _axes: any
   protected _axes_initialized: boolean = false
 
   connect_signals(): void {
     super.connect_signals()
-    this.connect(this.model.properties.camera.change, () => this._set_camera_state())
     this.connect(this.model.properties.axes.change, () => {
       this._delete_axes()
       if(this.model.axes)
@@ -44,7 +41,6 @@ export class VTKPlotView extends AbstractVTKView {
     this._axes = null
     this._axes_initialized = false
     this._plot()
-    this._vtk_renwin.getRenderer().getActiveCamera().onModified(() => this._get_camera_state())
   }
 
   after_layout(): void {
@@ -52,69 +48,6 @@ export class VTKPlotView extends AbstractVTKView {
       this._render_axes_canvas()
       this._axes_initialized = true
     }
-  }
-
-  _create_orientation_widget(): void {
-    const axes = vtkns.AxesActor.newInstance()
-
-    // add orientation widget
-    const orientationWidget = vtkns.OrientationMarkerWidget.newInstance({
-      actor: axes,
-      interactor: this._vtk_renwin.getInteractor(),
-    })
-    orientationWidget.setEnabled(true)
-    orientationWidget.setViewportCorner(
-      vtkns.OrientationMarkerWidget.Corners.BOTTOM_RIGHT
-    )
-    orientationWidget.setViewportSize(0.15)
-    orientationWidget.setMinPixelSize(100)
-    orientationWidget.setMaxPixelSize(300)
-
-    this._orientationWidget = orientationWidget
-
-    const widgetManager = vtkns.WidgetManager.newInstance()
-    widgetManager.setRenderer(orientationWidget.getRenderer())
-
-    const widget = vtkns.InteractiveOrientationWidget.newInstance()
-    widget.placeWidget(axes.getBounds());
-    widget.setBounds(axes.getBounds());
-    widget.setPlaceFactor(1);
-
-    const vw = widgetManager.addWidget(widget)
-    this._widgetManager = widgetManager
-
-    // Manage user interaction
-    vw.onOrientationChange(({direction} : any) => {
-      const camera = this._vtk_renwin.getRenderer().getActiveCamera()
-      const focalPoint = camera.getFocalPoint()
-      const position = camera.getPosition()
-      const viewUp = camera.getViewUp()
-
-      const distance = Math.sqrt(
-        Math.pow(position[0]-focalPoint[0],2) +
-        Math.pow(position[1]-focalPoint[1],2) +
-        Math.pow(position[2]-focalPoint[2],2)
-      )
-
-      camera.setPosition(
-        focalPoint[0] + direction[0] * distance,
-        focalPoint[1] + direction[1] * distance,
-        focalPoint[2] + direction[2] * distance
-      )
-
-      if (direction[0])
-        camera.setViewUp(majorAxis(viewUp, 1, 2))
-      if (direction[1])
-        camera.setViewUp(majorAxis(viewUp, 0, 2))
-      if (direction[2])
-        camera.setViewUp(majorAxis(viewUp, 0, 1))
-
-      this._orientationWidget.updateMarkerOrientation()
-      this._vtk_renwin.getRenderer().resetCameraClippingRange()
-      this._vtk_renwin.getRenderWindow().render()
-    })
-
-    this._orientation_widget_visbility(this.model.orientation_widget)
   }
 
   _render_axes_canvas(): void {
@@ -141,45 +74,6 @@ export class VTKPlotView extends AbstractVTKView {
       axes_canvas.setAttribute('width', width.toFixed())
       axes_canvas.setAttribute('height', height.toFixed())
     })
-  }
-
-  _orientation_widget_visbility(visbility: boolean): void {
-    this._orientationWidget.setEnabled(visbility)
-    if(visbility)
-      this._widgetManager.enablePicking()
-    else
-      this._widgetManager.disablePicking()
-    this._orientationWidget.updateMarkerOrientation()
-    this._vtk_renwin.getRenderWindow().render()
-  }
-
-  _get_camera_state(): void {
-    if (!this._setting) {
-      this._setting = true;
-      const state = clone(this._vtk_renwin.getRenderer().getActiveCamera().get());
-      delete state.classHierarchy;
-      delete state.vtkObject;
-      delete state.vtkCamera;
-      delete state.viewPlaneNormal;
-      this.model.camera = state;
-      this._setting = false;
-    }
-  }
-
-  _set_camera_state(): void {
-    if (!this._setting) {
-      this._setting = true;
-      try {
-        this._vtk_renwin.getRenderer().getActiveCamera().set(this.model.camera);
-      } finally {
-        this._setting = false;
-      }
-      if (this._orientationWidget != null){
-        this._orientationWidget.updateMarkerOrientation()
-      }
-      this._vtk_renwin.getRenderer().resetCameraClippingRange()
-      this._vtk_renwin.getRenderWindow().render()
-    }
   }
 
   _delete_axes(): void{
@@ -220,7 +114,7 @@ export class VTKPlotView extends AbstractVTKView {
         const fn = vtk.macro.debounce(() => {
           if (this._axes == null && this.model.axes)
             this._set_axes()
-          this._set_camera_state()
+          this.model.properties.camera.change.emit()
         }, 100)
         sceneImporter.setUrl('index.json')
         sceneImporter.onReady(fn)
@@ -233,7 +127,6 @@ export namespace VTKPlot {
   export type Attrs = p.AttrsOf<Props>
   export type Props = AbstractVTKPlot.Props & {
     axes: p.Property<VTKAxes>
-    camera: p.Property<any>
     enable_keybindings: p.Property<boolean>
   }
 }
@@ -248,7 +141,6 @@ export class VTKPlot extends AbstractVTKPlot {
 
   constructor(attrs?: Partial<VTKPlot.Attrs>) {
     super(attrs)
-    this.renderer_el = null
     this.outline = vtkns.OutlineFilter.newInstance() //use to display bouding box of a selected actor
     const mapper = vtkns.Mapper.newInstance()
     mapper.setInputConnection(this.outline.getOutputPort())
@@ -256,25 +148,13 @@ export class VTKPlot extends AbstractVTKPlot {
     this.outline_actor.setMapper(mapper)
   }
 
-  getActors() : [any] {
-    return this.renderer_el.getRenderer().getActors()
-  }
-
-  static __module__ = "panel.models.vtk"
-
   static init_VTKPlot(): void {
     this.prototype.default_view = VTKPlotView
 
     this.define<VTKPlot.Props>({
-      axes:               [ p.Instance       ],
-      camera:             [ p.Any            ],
       data:               [ p.String         ],
+      axes:               [ p.Instance       ],
       enable_keybindings: [ p.Boolean, false ],
     })
-
-    this.override({
-      height: 300,
-      width: 300
-    });
   }
 }

--- a/panel/models/vtk/vtk_layout.ts
+++ b/panel/models/vtk/vtk_layout.ts
@@ -1,14 +1,105 @@
-import {PanelHTMLBoxView, set_size} from "../layout"
+import * as p from "@bokehjs/core/properties"
+
 import {div} from "@bokehjs/core/dom"
+import {HTMLBox} from "@bokehjs/models/layouts/html_box"
 
-import  {vtkns} from "./vtk_utils"
+import {PanelHTMLBoxView, set_size} from "../layout"
 
-export class VTKHTMLBoxView extends PanelHTMLBoxView{
+import  {vtkns, VolumeType, majorAxis} from "./vtk_utils"
+
+export abstract class AbstractVTKView extends PanelHTMLBoxView{
+  model: AbstractVTKPlot
   protected _vtk_container: HTMLDivElement
   protected _vtk_renwin: any
+  protected _orientationWidget: any
+  protected _widgetManager: any
+
+  connect_signals(): void {
+    super.connect_signals()
+    this.connect(this.model.properties.data.change, () => {
+      this.invalidate_render()
+    })
+    this.connect(this.model.properties.orientation_widget.change, () => {
+      this._orientation_widget_visbility(this.model.orientation_widget)
+    })
+  }
+
+  _orientation_widget_visbility(visbility: boolean): void {
+    this._orientationWidget.setEnabled(visbility)
+    if(visbility)
+      this._widgetManager.enablePicking()
+    else
+      this._widgetManager.disablePicking()
+    this._orientationWidget.updateMarkerOrientation()
+    this._vtk_renwin.getRenderWindow().render()
+  }
+
+  _create_orientation_widget(): void {
+    const axes = vtkns.AxesActor.newInstance()
+
+    // add orientation widget
+    const orientationWidget = vtkns.OrientationMarkerWidget.newInstance({
+      actor: axes,
+      interactor: this._vtk_renwin.getInteractor(),
+    })
+    orientationWidget.setEnabled(true)
+    orientationWidget.setViewportCorner(
+      vtkns.OrientationMarkerWidget.Corners.BOTTOM_RIGHT
+    )
+    orientationWidget.setViewportSize(0.15)
+    orientationWidget.setMinPixelSize(100)
+    orientationWidget.setMaxPixelSize(300)
+
+    this._orientationWidget = orientationWidget
+
+    const widgetManager = vtkns.WidgetManager.newInstance()
+    widgetManager.setRenderer(orientationWidget.getRenderer())
+
+    const widget = vtkns.InteractiveOrientationWidget.newInstance()
+    widget.placeWidget(axes.getBounds());
+    widget.setBounds(axes.getBounds());
+    widget.setPlaceFactor(1);
+
+    const vw = widgetManager.addWidget(widget)
+    this._widgetManager = widgetManager
+
+    // Manage user interaction
+    vw.onOrientationChange(({direction} : any) => {
+      const camera = this._vtk_renwin.getRenderer().getActiveCamera()
+      const focalPoint = camera.getFocalPoint()
+      const position = camera.getPosition()
+      const viewUp = camera.getViewUp()
+
+      const distance = Math.sqrt(
+        Math.pow(position[0]-focalPoint[0],2) +
+        Math.pow(position[1]-focalPoint[1],2) +
+        Math.pow(position[2]-focalPoint[2],2)
+      )
+
+      camera.setPosition(
+        focalPoint[0] + direction[0] * distance,
+        focalPoint[1] + direction[1] * distance,
+        focalPoint[2] + direction[2] * distance
+      )
+
+      if (direction[0])
+        camera.setViewUp(majorAxis(viewUp, 1, 2))
+      if (direction[1])
+        camera.setViewUp(majorAxis(viewUp, 0, 2))
+      if (direction[2])
+        camera.setViewUp(majorAxis(viewUp, 0, 1))
+
+      this._orientationWidget.updateMarkerOrientation()
+      this._vtk_renwin.getRenderer().resetCameraClippingRange()
+      this._vtk_renwin.getRenderWindow().render()
+    })
+
+    this._orientation_widget_visbility(this.model.orientation_widget)
+  }
 
   render(): void {
     super.render()
+    this._orientationWidget = null
     this._vtk_container = div()
     set_size(this._vtk_container, this.model)
     this.el.appendChild(this._vtk_container)
@@ -17,6 +108,8 @@ export class VTKHTMLBoxView extends PanelHTMLBoxView{
       container: this._vtk_container
     })
     this._remove_default_key_binding()
+    this._create_orientation_widget()
+    this.model.renderer_el = this._vtk_renwin
   }
 
   after_layout(): void {
@@ -31,3 +124,36 @@ export class VTKHTMLBoxView extends PanelHTMLBoxView{
     document.querySelector('body')!.removeEventListener('keyup',interactor.handleKeyUp)
   }
 }
+
+export namespace AbstractVTKPlot {
+  export type Attrs = p.AttrsOf<Props>
+  export type Props = HTMLBox.Props & {
+    data: p.Property<string|VolumeType>
+    orientation_widget: p.Property<boolean>
+  }
+}
+
+export interface AbstractVTKPlot extends AbstractVTKPlot.Attrs {}
+
+export abstract class AbstractVTKPlot extends HTMLBox {
+  properties: AbstractVTKPlot.Props
+  renderer_el: any
+
+  static __module__ = "panel.models.vtk"
+
+  constructor(attrs?: Partial<AbstractVTKPlot.Attrs>) {
+    super(attrs)
+  }
+
+  static init_AbstractVTKPlot(): void{
+    this.define<AbstractVTKPlot.Props>({
+      orientation_widget: [ p.Boolean, false ],
+    })
+
+    this.override({
+      height: 300,
+      width: 300
+    });
+  }
+}
+

--- a/panel/models/vtk/vtk_layout.ts
+++ b/panel/models/vtk/vtk_layout.ts
@@ -188,7 +188,7 @@ export abstract class AbstractVTKPlot extends HTMLBox {
   static init_AbstractVTKPlot(): void{
     this.define<AbstractVTKPlot.Props>({
       orientation_widget: [ p.Boolean, false ],
-      camera:             [ p.Any            ],
+      camera:             [ p.Instance       ],
     })
 
     this.override({

--- a/panel/models/vtk/vtk_utils.ts
+++ b/panel/models/vtk/vtk_utils.ts
@@ -1,5 +1,6 @@
 import {ARRAY_TYPES, DType} from "@bokehjs/core/util/serialization"
 
+
 export const vtk = (window as any).vtk
 
 export const vtkns: any = {}
@@ -31,9 +32,87 @@ if (vtk) {
   vtkns['ColorTransferFunction'] = vtk.Rendering.Core.vtkColorTransferFunction
   vtkns['PiecewiseFunction'] = vtk.Common.DataModel.vtkPiecewiseFunction
   vtkns['BoundingBox'] = vtk.Common.DataModel.vtkBoundingBox
+  vtkns['ScalarToRGBA'] = vtk.Filters.General.vtkScalarToRGBA
+
+  const customSliceFilter = vtk.macro.newInstance((publicAPI: any, model: any, initialValues: any = {}) => {
+    Object.assign(model, {sliceMode: 'i', sliceIndex: 0}, initialValues);
+    vtk.macro.obj(publicAPI, model) // make it an object
+    vtk.macro.algo(publicAPI, model, 1, 1) // mixin algorithm code 1 in, 1 out
+    vtk.macro.setGet(publicAPI, model, ['sliceIndex', 'sliceMode', 'lookupTable', 'piecewiseFunction']);
+    publicAPI.requestData = (inData: any[], outData: any[]) => {
+      // implement requestData
+      const input = inData[0];
+      const scalars = input.getPointData().getScalars()
+
+      const datasetDefinition = input.get('extent', 'spacing', 'origin', 'direction')
+      const numberOfComponents = scalars.getNumberOfComponents()
+      if (numberOfComponents != 1)
+        throw('Invalid input, number of components must be 1')
+
+      const slice = model.sliceIndex
+      const {extent} = datasetDefinition
+      const shape = [extent[1]-extent[0]+1, extent[3]-extent[2]+1, extent[5]-extent[4]+1]
+      let sliceRawArray: number[] //Todo replace by a typed array
+      if (model.sliceMode == 'i') {
+        datasetDefinition.extent = [slice, slice, ...extent.slice(2,6)]
+        const sliceSize = shape[1] * shape[2]
+        sliceRawArray = new Array(sliceSize)
+        const offset = slice
+        let count = 0, index = offset
+        while (count < sliceSize){
+          sliceRawArray[count] = scalars.getData()[index]
+          index += shape[2]
+          count++
+        }
+      } else if (model.sliceMode == 'j') {
+        datasetDefinition.extent = [...extent.slice(0,2), slice, slice, ...extent.slice(4,6)]
+        const sliceSize = shape[0] * shape[2]
+        sliceRawArray = new Array(sliceSize)
+        const offset = slice * shape[0]
+        let count = 0
+        let index = offset
+        while (count < sliceSize){
+            for(let i=0; i<shape[0]; i++){
+              sliceRawArray[count] = scalars.getData()[index + i]
+              count++
+            }
+            index += shape[0] * shape[1]
+        }
+      } else {
+        datasetDefinition.extent = [...extent.slice(0,4), slice, slice]
+        const sliceSize = shape[0] * shape[1]
+        const offset = sliceSize * slice
+        sliceRawArray = scalars.getData().slice(offset, offset + sliceSize)
+      }
+
+      const rgba = [0, 0, 0, 0]
+      const rgbaArray = new Uint8Array(sliceRawArray.length * 4)
+      let offset = 0
+      for (let idx = 0; idx < sliceRawArray.length; idx++) {
+        const x = sliceRawArray[idx]
+        model.lookupTable.getColor(x, rgba)
+        // rgba[3] = model.piecewiseFunction.getValue(x) if we want to use transparency
+        rgba[3] = 1
+        rgbaArray[offset++] = 255 * rgba[0]
+        rgbaArray[offset++] = 255 * rgba[1]
+        rgbaArray[offset++] = 255 * rgba[2]
+        rgbaArray[offset++] = 255 * rgba[3]
+      }
+
+      const colorArray = vtkns.DataArray.newInstance({
+        name: 'rgba',
+        numberOfComponents: 4,
+        values: rgbaArray,
+      })
+      const output = vtkns.ImageData.newInstance(datasetDefinition)
+      output.getPointData().setScalars(colorArray)
+      outData[0] = output
+    }
+  })
+  vtkns['CustomSliceFilter'] = customSliceFilter
 }
 
-export type VolumeType = {
+export declare type VolumeType = {
   buffer: string
   dims: number[]
   dtype: DType
@@ -42,47 +121,49 @@ export type VolumeType = {
   extent: number[] | null
 }
 
+
 export function hexToRGB(color: string): number[] {
   return [parseInt(color.slice(1,3),16)/255,
-          parseInt(color.slice(3,5),16)/255,
-          parseInt(color.slice(5,7),16)/255]
-}
-
-function utf8ToAB(utf8_str: string): ArrayBuffer {
-  var buf = new ArrayBuffer(utf8_str.length) // 2 bytes for each char
-  var bufView = new Uint8Array(buf)
-  for (var i=0, strLen=utf8_str.length; i<strLen; i++) {
-    bufView[i] = utf8_str.charCodeAt(i)
+    parseInt(color.slice(3,5),16)/255,
+    parseInt(color.slice(5,7),16)/255]
   }
-  return buf
-}
-
-export function data2VTKImageData(data: VolumeType): any{
-  const source = vtkns.ImageData.newInstance({
-    spacing: data.spacing
-  })
-  source.setDimensions(data.dims)
-  source.setOrigin(data.origin != null ? data.origin : data.dims.map((v: number) => v/2))
-  const dataArray = vtkns.DataArray.newInstance({
-    name: "scalars",
-    numberOfComponents: 1,
-    values: new ARRAY_TYPES[data.dtype as DType](utf8ToAB(atob(data.buffer)))
-  })
-  source.getPointData().setScalars(dataArray)
-  return source
-}
 
 
-export function majorAxis(vec3: number[], idxA: number, idxB: number): number[] {
-  const axis = [0, 0, 0]
-  const idx = Math.abs(vec3[idxA]) > Math.abs(vec3[idxB]) ? idxA : idxB
-  const value = vec3[idx] > 0 ? 1 : -1
-  axis[idx] = value
-  return axis
-}
+  function utf8ToAB(utf8_str: string): ArrayBuffer {
+    var buf = new ArrayBuffer(utf8_str.length) // 2 bytes for each char
+    var bufView = new Uint8Array(buf)
+    for (var i=0, strLen=utf8_str.length; i<strLen; i++) {
+      bufView[i] = utf8_str.charCodeAt(i)
+    }
+    return buf
+  }
 
-export function cartesian_product(...arrays: any){
-  return arrays.reduce((acc: any, curr: any) =>
-  acc.flatMap((c: any) => curr.map((n: any) => [].concat(c, n)))
-  );
-}
+  export function data2VTKImageData(data: VolumeType): any{
+    const source = vtkns.ImageData.newInstance({
+      spacing: data.spacing
+    })
+    source.setDimensions(data.dims)
+    source.setOrigin(data.origin != null ? data.origin : data.dims.map((v: number) => v/2))
+    const dataArray = vtkns.DataArray.newInstance({
+      name: "scalars",
+      numberOfComponents: 1,
+      values: new ARRAY_TYPES[data.dtype as DType](utf8ToAB(atob(data.buffer)))
+    })
+    source.getPointData().setScalars(dataArray)
+    return source
+  }
+
+
+  export function majorAxis(vec3: number[], idxA: number, idxB: number): number[] {
+    const axis = [0, 0, 0]
+    const idx = Math.abs(vec3[idxA]) > Math.abs(vec3[idxB]) ? idxA : idxB
+    const value = vec3[idx] > 0 ? 1 : -1
+    axis[idx] = value
+    return axis
+  }
+
+  export function cartesian_product(...arrays: any){
+    return arrays.reduce((acc: any, curr: any) =>
+    acc.flatMap((c: any) => curr.map((n: any) => [].concat(c, n)))
+    );
+  }

--- a/panel/models/vtk/vtkvolume.ts
+++ b/panel/models/vtk/vtkvolume.ts
@@ -325,8 +325,6 @@ export class VTKVolumePlot extends AbstractVTKPlot {
     super(attrs)
   }
 
-  static __module__ = "panel.models.vtk"
-
   static init_VTKVolumePlot(): void {
     this.prototype.default_view = VTKVolumePlotView
 
@@ -349,10 +347,5 @@ export class VTKVolumePlot extends AbstractVTKPlot {
       render_background: [ p.String,      '#52576e' ],
       interpolation:     [ p.Any,      'fast_linear'],
     })
-
-    this.override({
-      height: 300,
-      width: 300
-    });
   }
 }

--- a/panel/models/vtk/vtkvolume.ts
+++ b/panel/models/vtk/vtkvolume.ts
@@ -149,6 +149,7 @@ export class VTKVolumePlotView extends AbstractVTKView {
     this._vtk_renwin.getRenderer().setBackground(...hexToRGB(this.model.render_background))
     this._set_interpolation(this.model.interpolation)
     this._vtk_renwin.getRenderer().resetCamera()
+    setInterval(() => this._update_slices_data(), 100) // all 100 ms
   }
 
   _connect_controls(): void{
@@ -157,35 +158,35 @@ export class VTKVolumePlotView extends AbstractVTKView {
       this.model.colormap = this.colormap_slector.value
     })
     if (!this.model.colormap)
-      this.model.colormap = this.colormap_slector.value
+    this.model.colormap = this.colormap_slector.value
     else
-      this.model.properties.colormap.change.emit()
+    this.model.properties.colormap.change.emit()
 
-      // Shadow selector
+    // Shadow selector
     this.shadow_selector.addEventListener('change', () => {
       this.model.shadow = !!Number(this.shadow_selector.value)
     })
     if (this.model.shadow = !!Number(this.shadow_selector.value))
-      this.model.properties.shadow.change.emit()
+    this.model.properties.shadow.change.emit()
 
 
     // Sampling slider
     this.sampling_slider.addEventListener('input', () => {
       const js_sampling_value = Number(this.sampling_slider.value)
       if (Math.abs(this.model.sampling-js_sampling_value) >= 5e-3)
-        this.model.sampling = js_sampling_value
+      this.model.sampling = js_sampling_value
     })
     if (Math.abs(this.model.sampling-Number(this.shadow_selector.value)) >= 5e-3)
-      this.model.properties.sampling.change.emit()
+    this.model.properties.sampling.change.emit()
 
     // Edge Gradient slider
     this.edge_gradient_slider.addEventListener('input', () => {
       const js_edge_gradient_value = Number(this.edge_gradient_slider.value)
       if (Math.abs(this.model.edge_gradient-js_edge_gradient_value) >= 5e-3)
-        this.model.edge_gradient = js_edge_gradient_value
+      this.model.edge_gradient = js_edge_gradient_value
     })
     if (Math.abs(this.model.edge_gradient-Number(this.edge_gradient_slider.value)) >= 5e-3)
-      this.model.properties.edge_gradient.change.emit()
+    this.model.properties.edge_gradient.change.emit()
   }
 
   _plot_volume(): void {
@@ -203,8 +204,8 @@ export class VTKVolumePlotView extends AbstractVTKView {
     const lookupTable = vtkns.ColorTransferFunction.newInstance()
     const piecewiseFunction =vtkns.PiecewiseFunction.newInstance()
     const sampleDistance = 0.7 * Math.sqrt(source.getSpacing()
-                                                 .map((v: number) => v * v)
-                                                 .reduce((a: number, b: number) => a + b, 0));
+    .map((v: number) => v * v)
+    .reduce((a: number, b: number) => a + b, 0));
     mapper.setSampleDistance(sampleDistance);
 
     actor.getProperty().setRGBTransferFunction(0, lookupTable);
@@ -215,164 +216,184 @@ export class VTKVolumePlotView extends AbstractVTKView {
     // For better looking volume rendering
     // - distance in world coordinates a scalar opacity of 1.0
     actor
-      .getProperty()
-      .setScalarOpacityUnitDistance(
-        0,
-        vtkns.BoundingBox.getDiagonalLength(source.getBounds()) /
-          Math.max(...source.getDimensions())
+    .getProperty()
+    .setScalarOpacityUnitDistance(
+      0,
+      vtkns.BoundingBox.getDiagonalLength(source.getBounds()) /
+      Math.max(...source.getDimensions())
       );
-    // - control how we emphasize surface boundaries
-    //  => max should be around the average gradient magnitude for the
-    //     volume or maybe average plus one std dev of the gradient magnitude
-    //     (adjusted for spacing, this is a world coordinate gradient, not a
-    //     pixel gradient)
-    //  => max hack: (dataRange[1] - dataRange[0]) * 0.05
-    actor.getProperty().setGradientOpacityMinimumValue(0, 0);
-    actor
+      // - control how we emphasize surface boundaries
+      //  => max should be around the average gradient magnitude for the
+      //     volume or maybe average plus one std dev of the gradient magnitude
+      //     (adjusted for spacing, this is a world coordinate gradient, not a
+      //     pixel gradient)
+      //  => max hack: (dataRange[1] - dataRange[0]) * 0.05
+      actor.getProperty().setGradientOpacityMinimumValue(0, 0);
+      actor
       .getProperty()
       .setGradientOpacityMaximumValue(0, (dataRange[1] - dataRange[0]) * 0.05);
-    // - Use shading based on gradient
-    actor.getProperty().setShade(this.model.shadow);
-    actor.getProperty().setUseGradientOpacity(0, true);
-    // - generic good default
-    actor.getProperty().setGradientOpacityMinimumOpacity(0, 0.0);
-    actor.getProperty().setGradientOpacityMaximumOpacity(0, 1.0);
-    actor.getProperty().setAmbient(this.model.ambient);
-    actor.getProperty().setDiffuse(this.model.diffuse);
-    actor.getProperty().setSpecular(this.model.specular);
-    actor.getProperty().setSpecularPower(this.model.specular_power);
+      // - Use shading based on gradient
+      actor.getProperty().setShade(this.model.shadow);
+      actor.getProperty().setUseGradientOpacity(0, true);
+      // - generic good default
+      actor.getProperty().setGradientOpacityMinimumOpacity(0, 0.0);
+      actor.getProperty().setGradientOpacityMaximumOpacity(0, 1.0);
+      actor.getProperty().setAmbient(this.model.ambient);
+      actor.getProperty().setDiffuse(this.model.diffuse);
+      actor.getProperty().setSpecular(this.model.specular);
+      actor.getProperty().setSpecularPower(this.model.specular_power);
 
-    this._vtk_renwin.getRenderer().addVolume(actor)
-    this._controllerWidget.setupContent(this._vtk_renwin.getRenderWindow(), actor, true)
-  }
+      this._vtk_renwin.getRenderer().addVolume(actor)
+      this._controllerWidget.setupContent(this._vtk_renwin.getRenderWindow(), actor, true)
+    }
 
-  _plot_slices(): void {
-    const source = this._vtk_image_data
-    const image_actor_i = vtkns.ImageSlice.newInstance()
-    const image_actor_j = vtkns.ImageSlice.newInstance()
-    const image_actor_k = vtkns.ImageSlice.newInstance()
+    _plot_slices(): void {
+      const source = this._vtk_image_data
+      const image_actor_i = vtkns.ImageSlice.newInstance()
+      const image_actor_j = vtkns.ImageSlice.newInstance()
+      const image_actor_k = vtkns.ImageSlice.newInstance()
 
-    const image_mapper_i = vtkns.ImageMapper.newInstance()
-    const image_mapper_j = vtkns.ImageMapper.newInstance()
-    const image_mapper_k = vtkns.ImageMapper.newInstance()
+      const image_mapper_i = vtkns.ImageMapper.newInstance()
+      const image_mapper_j = vtkns.ImageMapper.newInstance()
+      const image_mapper_k = vtkns.ImageMapper.newInstance()
 
-    image_mapper_i.setInputData(source)
-    image_mapper_i.setISlice(this.model.slice_i)
-    image_actor_i.setMapper(image_mapper_i)
+      image_mapper_i.setInputData(source)
+      image_mapper_i.setISlice(this.model.slice_i)
+      image_actor_i.setMapper(image_mapper_i)
 
-    image_mapper_j.setInputData(source)
-    image_mapper_j.setJSlice(this.model.slice_j)
-    image_actor_j.setMapper(image_mapper_j)
+      image_mapper_j.setInputData(source)
+      image_mapper_j.setJSlice(this.model.slice_j)
+      image_actor_j.setMapper(image_mapper_j)
 
-    image_mapper_k.setInputData(source)
-    image_mapper_k.setKSlice(this.model.slice_k)
-    image_actor_k.setMapper(image_mapper_k)
+      image_mapper_k.setInputData(source)
+      image_mapper_k.setKSlice(this.model.slice_k)
+      image_actor_k.setMapper(image_mapper_k)
 
-    // set_color and opacity
-    const piecewiseFunction = vtkns.PiecewiseFunction.newInstance()
-    piecewiseFunction.removeAllPoints()
-    piecewiseFunction.addPoint(0, 1)
-    const lookupTable = this.volume.getProperty().getRGBTransferFunction(0)
-    const property = image_actor_i.getProperty()
-    image_actor_j.setProperty(property)
-    image_actor_k.setProperty(property)
+      // set_color and opacity
+      const piecewiseFunction = vtkns.PiecewiseFunction.newInstance()
+      piecewiseFunction.removeAllPoints()
+      piecewiseFunction.addPoint(0, 1)
+      const lookupTable = this.volume.getProperty().getRGBTransferFunction(0)
+      const property = image_actor_i.getProperty()
+      image_actor_j.setProperty(property)
+      image_actor_k.setProperty(property)
 
-    property.setRGBTransferFunction(lookupTable)
-    property.setScalarOpacity(piecewiseFunction)
+      property.setRGBTransferFunction(lookupTable)
+      property.setScalarOpacity(piecewiseFunction)
 
-    const renderer = this._vtk_renwin.getRenderer()
-    renderer.addActor(image_actor_i)
-    renderer.addActor(image_actor_j)
-    renderer.addActor(image_actor_k)
+      const renderer = this._vtk_renwin.getRenderer()
+      renderer.addActor(image_actor_i)
+      renderer.addActor(image_actor_j)
+      renderer.addActor(image_actor_k)
 
 
-    const export_slice_i = vtkns['CustomSliceFilter']({sliceMode: 'i', sliceIndex: this.model.slice_i})
-    export_slice_i.setLookupTable(lookupTable)
-    export_slice_i.setPiecewiseFunction(piecewiseFunction)
-    export_slice_i.setInputData(source)
-    lookupTable.onModified(() => export_slice_i.modified())
+      const export_slice_i = vtkns['CustomSliceFilter']({sliceMode: 'i', sliceIndex: this.model.slice_i})
+      export_slice_i.setLookupTable(lookupTable)
+      export_slice_i.setPiecewiseFunction(piecewiseFunction)
+      export_slice_i.setInputData(source)
+      lookupTable.onModified(() => export_slice_i.modified())
 
-    const export_slice_j = vtkns['CustomSliceFilter']({sliceMode: 'j', sliceIndex: this.model.slice_j})
-    export_slice_j.setLookupTable(lookupTable)
-    export_slice_j.setPiecewiseFunction(piecewiseFunction)
-    export_slice_j.setInputData(source)
-    lookupTable.onModified(() => export_slice_j.modified())
+      const export_slice_j = vtkns['CustomSliceFilter']({sliceMode: 'j', sliceIndex: this.model.slice_j})
+      export_slice_j.setLookupTable(lookupTable)
+      export_slice_j.setPiecewiseFunction(piecewiseFunction)
+      export_slice_j.setInputData(source)
+      lookupTable.onModified(() => export_slice_j.modified())
 
-    const export_slice_k = vtkns['CustomSliceFilter']({sliceMode: 'k', sliceIndex: this.model.slice_k})
-    export_slice_k.setLookupTable(lookupTable)
-    export_slice_k.setPiecewiseFunction(piecewiseFunction)
-    export_slice_k.setInputData(source)
-    lookupTable.onModified(() => export_slice_k.modified())
+      const export_slice_k = vtkns['CustomSliceFilter']({sliceMode: 'k', sliceIndex: this.model.slice_k})
+      export_slice_k.setLookupTable(lookupTable)
+      export_slice_k.setPiecewiseFunction(piecewiseFunction)
+      export_slice_k.setInputData(source)
+      lookupTable.onModified(() => export_slice_k.modified())
 
-    this._export_filters = [export_slice_i, export_slice_j, export_slice_k]
-    this.model.export_filters = this._export_filters
+      this._export_filters = [export_slice_i, export_slice_j, export_slice_k]
+      this.model.export_filters = this._export_filters
+    }
 
-  }
+    _get_slice_data(name: string, data:any): any {
+      const {extent, spacing} = data.get('extent', 'spacing')
+      const values = data.getPointData().getScalars().getData()
+      return {name, extent, spacing, values}
+    }
 
-  _set_volume_visbility(visibility: boolean): void {
-    this.volume.setVisibility(visibility)
-  }
+    _update_slices_data(){
+      if (this._export_filters[0].shouldUpdate())
+      this.model.slices_data_i = this._get_slice_data('i', this._export_filters[0].getOutputData())
+      if (this._export_filters[1].shouldUpdate())
+      this.model.slices_data_j = this._get_slice_data('j', this._export_filters[1].getOutputData())
+      if (this._export_filters[2].shouldUpdate())
+      this.model.slices_data_k = this._get_slice_data('k', this._export_filters[2].getOutputData())
+    }
 
-  _set_slices_visbility(visibility: boolean): void {
-    this._vtk_renwin.getRenderer().getActors().slice(0,3).map(
-      (actor: any) => actor.setVisibility(visibility)
-    )
-  }
-}
+    _set_volume_visbility(visibility: boolean): void {
+      this.volume.setVisibility(visibility)
+    }
 
-export namespace VTKVolumePlot {
-  export type Attrs = p.AttrsOf<Props>
-  export type Props = AbstractVTKPlot.Props & {
-    shadow: p.Property<boolean>,
-    sampling: p.Property<number>,
-    edge_gradient: p.Property<number>,
-    colormap: p.Property<string>,
-    rescale: p.Property<boolean>,
-    ambient: p.Property<number>,
-    diffuse: p.Property<number>,
-    specular: p.Property<number>,
-    specular_power: p.Property<number>,
-    slice_i: p.Property<number>,
-    slice_j: p.Property<number>,
-    slice_k: p.Property<number>,
-    display_volume: p.Property<boolean>,
-    display_slices: p.Property<boolean>,
-    render_background: p.Property<string>
-    interpolation: p.Property<InterpolationType>
-  }
-}
+    _set_slices_visbility(visibility: boolean): void {
+      this._vtk_renwin.getRenderer().getActors().slice(0,3).map(
+        (actor: any) => actor.setVisibility(visibility)
+        )
+      }
+    }
 
-export interface VTKVolumePlot extends VTKVolumePlot.Attrs {}
+    export namespace VTKVolumePlot {
+      export type Attrs = p.AttrsOf<Props>
+      export type Props = AbstractVTKPlot.Props & {
+        shadow: p.Property<boolean>,
+        sampling: p.Property<number>,
+        edge_gradient: p.Property<number>,
+        colormap: p.Property<string>,
+        rescale: p.Property<boolean>,
+        ambient: p.Property<number>,
+        diffuse: p.Property<number>,
+        specular: p.Property<number>,
+        specular_power: p.Property<number>,
+        slice_i: p.Property<number>,
+        slice_j: p.Property<number>,
+        slice_k: p.Property<number>,
+        display_volume: p.Property<boolean>,
+        display_slices: p.Property<boolean>,
+        render_background: p.Property<string>,
+        interpolation: p.Property<InterpolationType>,
+        slices_data_i: p.Property<any>,
+        slices_data_j: p.Property<any>,
+        slices_data_k: p.Property<any>,
+      }
+    }
 
-export class VTKVolumePlot extends AbstractVTKPlot {
-  properties: VTKVolumePlot.Props
-  export_filters: any[]
+    export interface VTKVolumePlot extends VTKVolumePlot.Attrs {}
 
-  constructor(attrs?: Partial<VTKVolumePlot.Attrs>) {
-    super(attrs)
-  }
+    export class VTKVolumePlot extends AbstractVTKPlot {
+      properties: VTKVolumePlot.Props
+      export_filters: any[]
 
-  static init_VTKVolumePlot(): void {
-    this.prototype.default_view = VTKVolumePlotView
+      constructor(attrs?: Partial<VTKVolumePlot.Attrs>) {
+        super(attrs)
+      }
 
-    this.define<VTKVolumePlot.Props>({
-      data:              [ p.Instance               ],
-      shadow:            [ p.Boolean,          true ],
-      sampling:          [ p.Number,            0.4 ],
-      edge_gradient:     [ p.Number,            0.2 ],
-      colormap:          [ p.String                 ],
-      rescale:           [ p.Boolean,         false ],
-      ambient:           [ p.Number,            0.2 ],
-      diffuse:           [ p.Number,            0.7 ],
-      specular:          [ p.Number,            0.3 ],
-      specular_power:    [ p.Number,            8.0 ],
-      slice_i:           [ p.Int,               0   ],
-      slice_j:           [ p.Int,               0   ],
-      slice_k:           [ p.Int,               0   ],
-      display_volume:    [ p.Boolean,          true ],
-      display_slices:    [ p.Boolean,         false ],
-      render_background: [ p.String,      '#52576e' ],
-      interpolation:     [ p.Any,      'fast_linear'],
-    })
-  }
-}
+      static init_VTKVolumePlot(): void {
+        this.prototype.default_view = VTKVolumePlotView
+
+        this.define<VTKVolumePlot.Props>({
+          data:              [ p.Instance               ],
+          shadow:            [ p.Boolean,          true ],
+          sampling:          [ p.Number,            0.4 ],
+          edge_gradient:     [ p.Number,            0.2 ],
+          colormap:          [ p.String                 ],
+          rescale:           [ p.Boolean,         false ],
+          ambient:           [ p.Number,            0.2 ],
+          diffuse:           [ p.Number,            0.7 ],
+          specular:          [ p.Number,            0.3 ],
+          specular_power:    [ p.Number,            8.0 ],
+          slice_i:           [ p.Int,               0   ],
+          slice_j:           [ p.Int,               0   ],
+          slice_k:           [ p.Int,               0   ],
+          display_volume:    [ p.Boolean,          true ],
+          display_slices:    [ p.Boolean,         false ],
+          render_background: [ p.String,      '#52576e' ],
+          interpolation:     [ p.Any,      'fast_linear'],
+          slices_data_i:     [ p.Instance               ],
+          slices_data_j:     [ p.Instance               ],
+          slices_data_k:     [ p.Instance               ],
+        })
+      }
+    }

--- a/panel/models/vtk/vtkvolume.ts
+++ b/panel/models/vtk/vtkvolume.ts
@@ -1,20 +1,17 @@
 import * as p from "@bokehjs/core/properties"
-import {HTMLBox} from "@bokehjs/models/layouts/html_box"
-import {VTKHTMLBoxView} from "./vtk_layout"
+
+import {AbstractVTKPlot, AbstractVTKView} from "./vtk_layout"
 import {VolumeType, vtkns, data2VTKImageData, hexToRGB} from "./vtk_utils"
 
 
 declare type InterpolationType = 'fast_linear' | 'linear' | 'nearest'
-export class VTKVolumePlotView extends VTKHTMLBoxView {
+export class VTKVolumePlotView extends AbstractVTKView {
   model: VTKVolumePlot
   protected _controllerWidget: any
   protected _vtk_image_data: any
 
   connect_signals(): void {
     super.connect_signals()
-    this.connect(this.model.properties.data.change, () => {
-      this.invalidate_render()
-    })
     this.connect(this.model.properties.colormap.change, () => {
       this.colormap_slector.value = this.model.colormap
       const event = new Event('change');
@@ -136,7 +133,7 @@ export class VTKVolumePlotView extends VTKHTMLBoxView {
       size: [400, 150],
       rescaleColorMap: this.model.rescale,
     })
-    this._vtk_image_data = data2VTKImageData(this.model.data)
+    this._vtk_image_data = data2VTKImageData((this.model.data as VolumeType))
     this._controllerWidget.setContainer(this.el)
     this._vtk_renwin.getRenderWindow().getInteractor()
     this._vtk_renwin.getRenderWindow().getInteractor().setDesiredUpdateRate(45)
@@ -299,8 +296,7 @@ export class VTKVolumePlotView extends VTKHTMLBoxView {
 
 export namespace VTKVolumePlot {
   export type Attrs = p.AttrsOf<Props>
-  export type Props = HTMLBox.Props & {
-    data: p.Property<VolumeType>,
+  export type Props = AbstractVTKPlot.Props & {
     shadow: p.Property<boolean>,
     sampling: p.Property<number>,
     edge_gradient: p.Property<number>,
@@ -322,7 +318,7 @@ export namespace VTKVolumePlot {
 
 export interface VTKVolumePlot extends VTKVolumePlot.Attrs {}
 
-export class VTKVolumePlot extends HTMLBox {
+export class VTKVolumePlot extends AbstractVTKPlot {
   properties: VTKVolumePlot.Props
 
   constructor(attrs?: Partial<VTKVolumePlot.Attrs>) {

--- a/panel/pane/vtk/vtk.py
+++ b/panel/pane/vtk/vtk.py
@@ -119,6 +119,8 @@ class VTKVolume(PaneBase):
         Activate/Deactivate the orientation widget display.
     """)
 
+    camera = param.Dict(doc="State of the rendered VTK camera.")
+
     _serializers = {}
 
     _rename = {'max_data_size': None, 'spacing': None, 'origin': None}
@@ -170,7 +172,7 @@ class VTKVolume(PaneBase):
                               **props)
         if root is None:
             root = model
-        self._link_props(model, ['colormap', 'orientation_widget'], doc, root, comm)
+        self._link_props(model, ['colormap', 'orientation_widget', 'camera'], doc, root, comm)
         self._models[root.ref['id']] = (model, parent)
         return model
 

--- a/panel/pane/vtk/vtk.py
+++ b/panel/pane/vtk/vtk.py
@@ -115,6 +115,10 @@ class VTKVolume(PaneBase):
         Postition of each slice can be controlled using slice_(i,j,k) parameters
     """)
 
+    orientation_widget = param.Boolean(default=False, doc="""
+        Activate/Deactivate the orientation widget display.
+    """)
+
     _serializers = {}
 
     _rename = {'max_data_size': None, 'spacing': None, 'origin': None}
@@ -166,7 +170,7 @@ class VTKVolume(PaneBase):
                               **props)
         if root is None:
             root = model
-        self._link_props(model, ['colormap'], doc, root, comm)
+        self._link_props(model, ['colormap', 'orientation_widget'], doc, root, comm)
         self._models[root.ref['id']] = (model, parent)
         return model
 

--- a/panel/pane/vtk/vtk.py
+++ b/panel/pane/vtk/vtk.py
@@ -121,6 +121,10 @@ class VTKVolume(PaneBase):
 
     camera = param.Dict(doc="State of the rendered VTK camera.")
 
+    slices_data_i = param.Dict()
+    slices_data_j = param.Dict()
+    slices_data_k = param.Dict()
+
     _serializers = {}
 
     _rename = {'max_data_size': None, 'spacing': None, 'origin': None}
@@ -172,7 +176,16 @@ class VTKVolume(PaneBase):
                               **props)
         if root is None:
             root = model
-        self._link_props(model, ['colormap', 'orientation_widget', 'camera'], doc, root, comm)
+        self._link_props(model,
+                         [
+                            'colormap',
+                            'orientation_widget',
+                            'camera',
+                            'slices_data_i',
+                            'slices_data_j',
+                            'slices_data_k'
+                         ],
+                         doc, root, comm)
         self._models[root.ref['id']] = (model, parent)
         return model
 


### PR DESCRIPTION
This PR allow to get on the python side the slices computed by vtk.js in a vtkvolume
```python
import panel as pn
pn.extension('vtk')
import holoviews as hv
hv.extension('bokeh')
import numpy as np

data_matrix = np.zeros([75, 75, 75], dtype=np.uint8)
data_matrix[0:35, 0:35, 0:35] = 50
data_matrix[25:55, 25:55, 25:55] = 100
data_matrix[45:74, 45:74, 45:74] = 150

vol = pn.pane.VTKVolume(data_matrix, sizing_mode='stretch_width', height=400, spacing=(3,2,1),
                        interpolation='nearest', edge_gradient=0, sampling=0, display_slices=True,
                        display_volume=False, rescale=True, orientation_widget=True)
btn = pn.widgets.Button(name='debug')
btn.jscallback(args={'vtkpan':vol}, clicks="debugger")

@pn.depends(vol.param.slices_data_i, vol.param.slices_data_j, vol.param.slices_data_k)
def plot_rgb(data_i, data_j, data_k):
    if data_i and data_j and data_k:
        image_i = hv.RGB(np.array(list(data_i['values'].values()), dtype=np.uint8).reshape(75,75,4)[:,:,:3])
        image_j = hv.RGB(np.array(list(data_j['values'].values()), dtype=np.uint8).reshape(75,75,4)[:,:,:3])
        image_k = hv.RGB(np.array(list(data_k['values'].values()), dtype=np.uint8).reshape(75,75,4)[:,:,:3])
        return image_i + image_j + image_k
    else:
        return hv.RGB([]) + hv.RGB([]) + hv.RGB([])

pn.Column(pn.Row(pn.Column(btn, vol.controls(jslink=False, parameters=['slice_i', 'slice_j', 'slice_k'])), vol), plot_rgb)
```

![ezgif com-video-to-gif](https://user-images.githubusercontent.com/18531147/73765952-9b45a580-4775-11ea-88df-fae67940cf8d.gif)


However I need help concerning the way to communicate through bokeh api