### PR TITLE
Add test_deprecations to test suite.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@
 
 [tox]
 #          python version             test group                  extra envs  extra commands
-envlist = {py27,py36,py37}-{flakes,unit,unit_deploy,examples,all_recommended}-{default}-{dev,pkg}
+envlist = {py27,py36,py37,py38}-{flakes,unit,unit_deploy,examples,all_recommended,deprecation_check}-{default}-{dev,pkg}
 build = wheel
 
 [_flakes]
@@ -34,6 +34,11 @@ commands = {[_flakes]commands}
            {[_unit]commands}
            {[_examples]commands}
 
+[_deprecation_check]
+description = Unit tests, but DeprecationWarnings and FutureWarnings are errors
+deps = .[tests]
+# Not yet sure how people use these in reality vs what's in the docs (there's also PendingDeprecationWarning)
+commands = pytest panel -W error::DeprecationWarning -W error::FutureWarning
 
 [testenv]
 changedir = {envtmpdir}
@@ -43,12 +48,14 @@ commands = unit: {[_unit]commands}
            flakes: {[_flakes]commands}
            examples: {[_examples]commands}
            all_recommended: {[_all_recommended]commands}
+           deprecation_check: {[_deprecation_check]commands}
 
 deps = unit: {[_unit]deps}
        unit_deploy: {[_unit_deploy]deps}
        flakes: {[_flakes]deps}
        examples: {[_examples]deps}
        all_recommended: {[_all_recommended]deps}
+       deprecation_check: {[_deprecation_check]commands}
 
 [pytest]
 addopts = -v --pyargs --doctest-modules --doctest-ignore-import-errors

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@
 
 [tox]
 #          python version             test group                  extra envs  extra commands
-envlist = {py27,py36,py37,py38}-{flakes,unit,unit_deploy,examples,all_recommended,deprecation_check}-{default}-{dev,pkg}
+envlist = {py27,py36,py37,py38}-{flakes,unit,unit_deploy,examples,all_recommended,deprecations}-{default}-{dev,pkg}
 build = wheel
 
 [_flakes]
@@ -34,7 +34,7 @@ commands = {[_flakes]commands}
            {[_unit]commands}
            {[_examples]commands}
 
-[_deprecation_check]
+[_deprecations]
 description = Unit tests, but DeprecationWarnings and FutureWarnings are errors
 deps = .[tests]
 # Not yet sure how people use these in reality vs what's in the docs (there's also PendingDeprecationWarning)
@@ -48,14 +48,14 @@ commands = unit: {[_unit]commands}
            flakes: {[_flakes]commands}
            examples: {[_examples]commands}
            all_recommended: {[_all_recommended]commands}
-           deprecation_check: {[_deprecation_check]commands}
+           deprecations: {[_deprecations]commands}
 
 deps = unit: {[_unit]deps}
        unit_deploy: {[_unit_deploy]deps}
        flakes: {[_flakes]deps}
        examples: {[_examples]deps}
        all_recommended: {[_all_recommended]deps}
-       deprecation_check: {[_deprecation_check]commands}
+       deprecations: {[_deprecations]commands}
 
 [pytest]
 addopts = -v --pyargs --doctest-modules --doctest-ignore-import-errors


### PR DESCRIPTION
```
$ doit list
[...]
test_deprecations      Unit tests, but DeprecationWarnings and FutureWarnings are errors
[...]
```

```
$ doit test_deprecations
.  test_deprecations
=========================================================================== test session starts ===========================================================================
platform linux -- Python 3.7.3, pytest-5.3.2, py-1.8.0, pluggy-0.13.1 -- /home/sefkw/mc3/envs/miscdev37/bin/python
cachedir: .pytest_cache
metadata: {'Python': '3.7.3', 'Platform': 'Linux-5.3.0-7625-generic-x86_64-with-debian-buster-sid', 'Packages': {'pytest': '5.3.2', 'py': '1.8.0', 'pluggy': '0.13.1'}, 'Plugins': {'cov': '2.5.1', 'html': '2.0.0', 'metadata': '1.8.0', 'hypothesis': '3.56.10', 'nbval': '0.9.3', 'nbsmoke': '0.4.1'}}
rootdir: /home/sefkw/code/holoviz/panel, inifile: tox.ini
plugins: cov-2.5.1, html-2.0.0, metadata-1.8.0, hypothesis-3.56.10, nbval-0.9.3, nbsmoke-0.4.1
collecting ... collected 702 items / 3 errors / 2 skipped / 697 selected

================================================================================= ERRORS ==================================================================================
_______________________________________________________________ ERROR collecting panel/tests/test_links.py ________________________________________________________________
panel/tests/test_links.py:4: in <module>
    import holoviews as hv
../holoviews/holoviews/__init__.py:11: in <module>
    from . import util                                       # noqa (API import)
../holoviews/holoviews/util/__init__.py:15: in <module>
    from ..core import DynamicMap, HoloMap, Dimensioned, ViewableElement, StoreOptions, Store
../holoviews/holoviews/core/__init__.py:4: in <module>
    from .data import *            # noqa (API import)
../holoviews/holoviews/core/data/__init__.py:25: in <module>
    from .grid import GridInterface
../holoviews/holoviews/core/data/grid.py:5: in <module>
    from collections import OrderedDict, defaultdict, Iterable
<frozen importlib._bootstrap>:1032: in _handle_fromlist
    ???
../../../mc3/envs/miscdev37/lib/python3.7/collections/__init__.py:52: in __getattr__
    DeprecationWarning, stacklevel=2)
E   DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
_______________________________________________________________ ERROR collecting panel/tests/test_links.py ________________________________________________________________
panel/tests/test_links.py:4: in <module>
    import holoviews as hv
../holoviews/holoviews/__init__.py:11: in <module>
    from . import util                                       # noqa (API import)
../holoviews/holoviews/util/__init__.py:15: in <module>
    from ..core import DynamicMap, HoloMap, Dimensioned, ViewableElement, StoreOptions, Store
../holoviews/holoviews/core/__init__.py:4: in <module>
    from .data import *            # noqa (API import)
../holoviews/holoviews/core/data/__init__.py:25: in <module>
    from .grid import GridInterface
../holoviews/holoviews/core/data/grid.py:5: in <module>
    from collections import OrderedDict, defaultdict, Iterable
<frozen importlib._bootstrap>:1032: in _handle_fromlist
    ???
../../../mc3/envs/miscdev37/lib/python3.7/collections/__init__.py:52: in __getattr__
    DeprecationWarning, stacklevel=2)
E   DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
______________________________________________________________ ERROR collecting panel/tests/test_pipeline.py ______________________________________________________________
Using pytest.skip outside of a test is not allowed. To decorate a test function, use the @pytest.mark.skip or @pytest.mark.skipif decorators instead, and to skip a module use `pytestmark = pytest.mark.{skip,skipif}.
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! Interrupted: 3 errors during collection !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
====================================================================== 2 skipped, 3 errors in 3.38s =======================================================================
TaskFailed - taskid:test_deprecations
Command failed: 'pytest "panel" "-W" "error::DeprecationWarning" "-W" "error::FutureWarning"' returned 2
```

It's just adding warning filtering to pytest. Not sure what real usage of the various warnings (DeprecationWarning, FutureWarning, PendingDeprecationWarning) is like in the real world, but I have seen the first two lots of times I think.

Also: expand python versions available to tox to include 3.8 (no effect, except allowing people to test etc with 3.8).

Future work:
  * Probably would be more useful to have this in other holoviz libs than panel itself (e.g. can already see deprecation warnings here coming from holoviews, not from panel).
  * I would like to make travis check and report these periodically (i.e. not be part of regular builds, as they are ok to have and don't need to be fixed straight away). I'd also like to make them visible in a way that anyone other than Philipp :) can see them, as some are likely to be easy ways to contribute to maintenance. However, I can't remember how to use travis, and maybe would be better suited to a github action anyway...