### PR TITLE
Made signature of show() match that of servable()

### DIFF
--- a/panel/viewable.py
+++ b/panel/viewable.py
@@ -243,8 +243,8 @@ class ServableMixin(object):
             self.server_doc(title=title)
         return self
 
-    def show(self, port=0, websocket_origin=None, threaded=False,
-             title=None, verbose=True, open=True, **kwargs):
+    def show(self, title=None, port=0, websocket_origin=None, threaded=False,
+             verbose=True, open=True, **kwargs):
         """
         Starts a Bokeh server and displays the Viewable in a new tab.
 


### PR DESCRIPTION
Right now, a notebook can have `.servable('Title')`, but it has to have `.show(title='Title')` with the keyword specified. I very often switch between .show and .servable when debugging, and this difference makes doing so awkward.  Note that if someone has previously used "port" as a positional argument, this change will not be backwards compatible. So I can understand if it's decided not to merge this, but I thought it was worth proposing before the number of Panel users got so high that this behavior could never be changed.