### PR TITLE
Added try/except for retrieving library version

### DIFF
--- a/panel/__init__.py
+++ b/panel/__init__.py
@@ -18,6 +18,9 @@ from .pane import panel, Pane # noqa
 from .param import Param # noqa
 from .template import Template # noqa
 
-__version__ = str(_param.version.Version(
-    fpath=__file__, archive_commit="$Format:%h$", reponame="panel"))
+try:
+    __version__ = str(_param.version.Version(
+        fpath=__file__, archive_commit="$Format:%h$", reponame="panel"))
+except:
+    __version__ = "0.0.0+unknown"
 


### PR DESCRIPTION
In some weird environments, `param`'s way of retrieving version information has many bugs (since it opens a subprocess to call git, for instance, which gives problems when Python processes are created with systems such as Supervisor or Gunicorn). This commit adds the option for the library to keep on going, even if the version cannot be correctly retreived.

This is just the way it is also done in https://github.com/holoviz/param/blob/7d2d2a848dc79d9741709702f8b47f87497701b0/param/__init__.py#L46

BTW I have made basically the same PR in `pyviz_comms`, as I am facing the same problem using both libraries when the Panel server is launched from Gunicorn/Supervisor