### PR TITLE
Respect write-locks in synchronous Websocket events

### DIFF
--- a/panel/io/server.py
+++ b/panel/io/server.py
@@ -77,8 +77,8 @@ def unlocked():
         for conn in connections:
             socket = conn._socket
             if hasattr(socket, 'write_lock') and socket.write_lock._block._value == 0:
-                state._locks.append(id(socket))
-            locked = id(socket) in state._locks
+                state._locks.add(socket)
+            locked = socket in state._locks
             for event in curdoc._held_events:
                 if (isinstance(event, ModelChangedEvent) and event not in old_events
                     and hasattr(socket, 'write_message') and not locked):

--- a/panel/io/state.py
+++ b/panel/io/state.py
@@ -5,6 +5,8 @@ from __future__ import absolute_import, division, unicode_literals
 
 import threading
 
+from weakref import WeakSet
+
 import param
 
 from bokeh.document import Document
@@ -49,9 +51,8 @@ class _state(param.Parameterized):
     # Jupyter display handles
     _handles = {}
 
-    # Stores list of Websocket socket ids which are locked
-    # Reset after every event
-    _locks = []
+    # Stores a set of locked Websockets, reset after every change event
+    _locks = WeakSet()
 
     def __repr__(self):
         server_info = []

--- a/panel/io/state.py
+++ b/panel/io/state.py
@@ -49,6 +49,10 @@ class _state(param.Parameterized):
     # Jupyter display handles
     _handles = {}
 
+    # Stores list of Websocket socket ids which are locked
+    # Reset after every event
+    _locks = []
+
     def __repr__(self):
         server_info = []
         for server, panel, docs in self._servers.values():

--- a/panel/viewable.py
+++ b/panel/viewable.py
@@ -772,7 +772,7 @@ class Reactive(Viewable):
             self._changing = {}
 
     def _server_change(self, doc, ref, attr, old, new):
-        state._locks = []
+        state._locks.clear()
         self._events.update({attr: new})
         if not self._processing:
             self._processing = True

--- a/panel/viewable.py
+++ b/panel/viewable.py
@@ -772,6 +772,7 @@ class Reactive(Viewable):
             self._changing = {}
 
     def _server_change(self, doc, ref, attr, old, new):
+        state._locks = []
         self._events.update({attr: new})
         if not self._processing:
             self._processing = True


### PR DESCRIPTION
As described in #1148 we override the bokeh Websocket handlers asynchronous locking mechanisms to allow synchronous functions to trigger updates on the frontend immediately instead of blocking until they finish, e.g.:

```python
import panel as pn
import time

button = pn.widgets.Button(name='Run')
progress = pn.widgets.Progress(value=0)

def update_progress(event):
    for i in range(100):
        time.sleep(0.01)
        progress.value = i

button.on_click(update_progress)

pn.Row(button, progress).show()
```

If we didn't do this, this example wouldn't update the progress bar until the callback finishes. However in implementing this we are not respecting the Websocket handlers write lock. This PR ensures checks whether a write lock is enabled and if so locks the synchronous events out. This ensures most computations where updates aren't triggered in very quick succession can synchronously trigger events but may result in unexpected behavior where a callback suddenly locks in the middle. However once the callback finishes it'll all be made consistent so I think this is a worthwhile tradeoff until we handle async callbacks correctly. 

Fixes https://github.com/holoviz/panel/issues/1148