### PR TITLE
Add CommManager model to handle notebook comms

### DIFF
--- a/panel/_templates/nb_template.html
+++ b/panel/_templates/nb_template.html
@@ -21,7 +21,6 @@ that accepts these same parameters.
   {% block preamble %}{% endblock %}
   {% block resources %}
     {% block js_resources %}
-      {{ bokeh_js | indent(8) if bokeh_js }}
     {% endblock %}
   {% endblock %}
 {% endblock %}

--- a/panel/io/model.py
+++ b/panel/io/model.py
@@ -72,7 +72,10 @@ def hold(doc, policy='combine'):
             doc.hold(policy)
         yield
     finally:
-        doc._hold = held
+        if held:
+            doc._hold = held
+        else:
+            doc.unhold()
 
 
 _DEFAULT_IGNORED_REPR = frozenset(['children', 'text', 'name', 'toolbar', 'renderers', 'below', 'center', 'left', 'right'])

--- a/panel/io/model.py
+++ b/panel/io/model.py
@@ -4,6 +4,7 @@ Utilities for manipulating bokeh models.
 from __future__ import absolute_import, division, unicode_literals
 
 import textwrap
+from contextlib import contextmanager
 
 from bokeh.document import Document
 from bokeh.document.events import ColumnDataChangedEvent
@@ -60,6 +61,18 @@ def add_to_doc(obj, doc, hold=False):
     doc.add_root(obj)
     if doc._hold is None and hold:
         doc.hold()
+
+@contextmanager
+def hold(doc, policy='combine'):
+    held = doc._hold
+    try:
+        if policy is None:
+            doc.unhold()
+        else:
+            doc.hold(policy)
+        yield
+    finally:
+        doc._hold = held
 
 
 _DEFAULT_IGNORED_REPR = frozenset(['children', 'text', 'name', 'toolbar', 'renderers', 'below', 'center', 'left', 'right'])

--- a/panel/io/notebook.py
+++ b/panel/io/notebook.py
@@ -35,7 +35,6 @@ except Exception:
     from html import escape
 
 from ..compiler import require_components
-from ..models.comm_manager import CommManager
 from .embed import embed_state
 from .model import add_to_doc, diff
 from .resources import _env
@@ -107,8 +106,7 @@ def html_for_render_items(docs_json, render_items, template=None, template_varia
     elif isinstance(template, string_types):
         template = _env.from_string("{% extends base %}\n" + template)
 
-    html = template.render(context)
-    return html
+    return template.render(context)
 
 
 def render_template(document, comm=None, manager=None):
@@ -157,9 +155,8 @@ def render_mimebundle(model, doc, comm, manager=None):
     if not isinstance(model, LayoutDOM):
         raise ValueError('Can only render bokeh LayoutDOM models')
     add_to_doc(model, doc, True)
-    if manager is None:
-        manager = CommManager(plot_id=model.ref['id'], comm_id=comm.id)
-    doc.add_root(manager)
+    if manager is not None:
+        doc.add_root(manager)
     return render_model(model, comm)
 
 

--- a/panel/io/state.py
+++ b/panel/io/state.py
@@ -42,6 +42,9 @@ class _state(param.Parameterized):
 
     _comm_manager = _CommManager
 
+    # CommManager models
+    _managers = {}
+
     # An index of all currently active views
     _views = {}
 

--- a/panel/io/state.py
+++ b/panel/io/state.py
@@ -42,9 +42,6 @@ class _state(param.Parameterized):
 
     _comm_manager = _CommManager
 
-    # CommManager models
-    _managers = {}
-
     # An index of all currently active views
     _views = {}
 

--- a/panel/layout.py
+++ b/panel/layout.py
@@ -18,6 +18,7 @@ from bokeh.models import (
 )
 from bokeh.models.widgets import Tabs as BkTabs, Panel as BkPanel
 
+from .io.model import hold
 from .util import param_name, param_reprs
 from .viewable import Layoutable, Reactive
 

--- a/panel/layout.py
+++ b/panel/layout.py
@@ -512,7 +512,7 @@ class GridBox(ListPanel):
 
         with hold(doc):
             msg = {k: v for k, v in msg.items() if k not in ('nrows', 'ncols')}
-            super(GridBox, self)._update_model(events, msg, root, model, doc, comm)
+            super(Panel, self)._update_model(events, msg, root, model, doc, comm)
             ref = root.ref['id']
             if ref in state._views:
                 state._views[ref][0]._preprocess(root)

--- a/panel/models/comm_manager.py
+++ b/panel/models/comm_manager.py
@@ -1,5 +1,6 @@
 from bokeh.models import Model
-from bokeh.core.properties import String
+from bokeh.core.properties import String, Int
+from bokeh.protocol import Protocol
 
 
 class CommManager(Model):
@@ -7,3 +8,18 @@ class CommManager(Model):
     plot_id = String()
 
     comm_id = String()
+
+    client_comm_id = String()
+
+    debounce = Int(50)
+
+    timeout = Int(5000)
+
+    def __init__(self, **properties):
+        super().__init__(**properties)
+        self._protocol = Protocol()
+
+    def assemble(self, msg):
+        header = msg['header']
+        cls = self._protocol._messages[header['msgtype']]
+        return cls(header, msg['metadata'], msg['content'])

--- a/panel/models/comm_manager.py
+++ b/panel/models/comm_manager.py
@@ -1,0 +1,9 @@
+from bokeh.models import Model
+from bokeh.core.properties import String
+
+
+class CommManager(Model):
+
+    plot_id = String()
+
+    comm_id = String()

--- a/panel/models/comm_manager.ts
+++ b/panel/models/comm_manager.ts
@@ -59,17 +59,17 @@ export class CommManager extends Model {
     if (((window as any).PyViz == undefined) || ((window as any).PyViz.comm_manager == undefined))
       return
 
-	const receiver = (this._receiver as any)
-	let events = [];
-	if (receiver._partial && receiver._partial.content && receiver._partial.content.events)
-	  events = receiver._partial.content.events;
+    const receiver = (this._receiver as any)
+    let events = [];
+    if (receiver._partial && receiver._partial.content && receiver._partial.content.events)
+      events = receiver._partial.content.events;
 
-	for (const event of events) {
-	  if ((event.kind === 'ModelChanged') && (event.attr === event_name) &&
-		  (data.id === event.model.id) &&
-		  (JSON.stringify(data[(event_name as string)]) === JSON.stringify(event.new)))
-		return
-	}
+    for (const event of events) {
+      if ((event.kind === 'ModelChanged') && (event.attr === event_name) &&
+          (data.id === event.model.id) &&
+          (JSON.stringify(data[(event_name as string)]) === JSON.stringify(event.new)))
+        return
+    }
 
     if (!(comm_id in this._comms)) {
       const comm = (window as any).PyViz.comm_manager.get_client_comm(this.plot_id, comm_id, (msg: any) => this.on_ack(msg));
@@ -79,7 +79,7 @@ export class CommManager extends Model {
       this._comm_status[comm_id] = {event_buffer: [], blocked: false, time: Date.now()}
     }
 
-	const comm_status = this._comm_status[comm_id]
+    const comm_status = this._comm_status[comm_id]
     if (event_name === undefined)
       event_name = Object.keys(data).join(',') // we are a widget not an event... fake a key.
     data['comm_id'] = comm_id;
@@ -90,19 +90,19 @@ export class CommManager extends Model {
       setTimeout(() => this.process_events(comm_id), 50);
       comm_status.blocked = true;
       comm_status.time = Date.now()+50;
-	}
-	}
+    }
+  }
 
   process_events(comm_id: string) {
-	const comm = this._comms[comm_id]
+    const comm = this._comms[comm_id]
     const comm_status = this._comm_status[comm_id]
-	// Iterates over event queue and sends events via Comm
-	const events = unique_events(comm_status.event_buffer);
-	for (let i=0; i<events.length; i++) {
+    // Iterates over event queue and sends events via Comm
+    const events = unique_events(comm_status.event_buffer);
+    for (let i=0; i<events.length; i++) {
       const data = events[i];
       comm.send(data);
-	}
-	comm_status.event_buffer = [];
+    }
+    comm_status.event_buffer = [];
   }
 
   on_ack(msg: any) {
@@ -123,7 +123,6 @@ export class CommManager extends Model {
     else if (metadata.msg_type == "Error")
       console.log("Python failed with the following traceback:", metadata.traceback)
   }
-
 
   msg_handler(msg: any) {
     const metadata = msg.metadata

--- a/panel/models/comm_manager.ts
+++ b/panel/models/comm_manager.ts
@@ -1,0 +1,78 @@
+import * as p from "@bokehjs/core/properties"
+import {View} from "@bokehjs/core/view"
+import {Model} from "@bokehjs/model"
+import {Receiver} from "@bokehjs/protocol/receiver"
+
+export class CommManagerView extends View {
+  model: CommManager
+
+  renderTo(): void {
+  }
+}
+
+export namespace CommManager {
+  export type Attrs = p.AttrsOf<Props>
+
+  export type Props = Model.Props & {
+    plot_id: p.Property<string | null>
+    comm_id: p.Property<string | null>
+  }
+}
+
+export interface CommManager extends CommManager.Attrs {}
+
+export class CommManager extends Model {
+  properties: CommManager.Props
+  _receiver: Receiver
+
+  constructor(attrs?: Partial<CommManager.Attrs>) {
+    super(attrs)
+    this._receiver = new Receiver()
+    if (((window as any).PyViz == undefined) || (!(window as any).PyViz.comm_manager))
+      console.log("Could not find comm manager")
+    else
+      (window as any).PyViz.comm_manager.register_target(this.plot_id, this.comm_id, (msg: any) => this.msg_handler(msg))
+  }
+
+  msg_handler(msg: any) {
+    const metadata = msg.metadata
+    const buffers = msg.buffers
+    const content = msg.content.data
+    const plot_id = this.plot_id
+    console.log("NEW MSG")
+    if ((metadata.msg_type == "Ready")) {
+      if (metadata.content)
+        console.log("Python callback returned following output:", metadata.content)
+      else if (metadata.msg_type == "Error")
+        console.log("Python failed with the following traceback:", metadata.traceback)
+    } else if (plot_id != null) {
+      if ((plot_id in (window as any).PyViz.plot_index) && ((window as any).PyViz.plot_index[plot_id] != null))
+        var plot = (window as any).PyViz.plot_index[plot_id]
+      else if (((window as any).Bokeh !== undefined) && (plot_id in (window as any).Bokeh.index))
+        var plot = (window as any).Bokeh.index[plot_id]
+
+      if (plot == null)
+        return
+
+      if ((buffers != undefined) && (buffers.length > 0))
+        this._receiver.consume(buffers[0].buffer)
+      else
+        this._receiver.consume(content)
+
+      const comm_msg = this._receiver.message
+      if ((comm_msg != null) && (Object.keys(comm_msg.content).length > 0) && this.document != null)
+        this.document.apply_json_patch(comm_msg.content, comm_msg.buffers)
+    }
+  }
+
+  static __module__ = "panel.models.comm_manager"
+
+  static init_CommManager(): void {
+    this.prototype.default_view = CommManagerView
+
+    this.define<CommManager.Props>({
+      plot_id: [ p.String, null ],
+      comm_id: [ p.String, null ],
+    })
+  }
+}

--- a/panel/models/comm_manager.ts
+++ b/panel/models/comm_manager.ts
@@ -3,6 +3,23 @@ import {View} from "@bokehjs/core/view"
 import {Model} from "@bokehjs/model"
 import {Receiver} from "@bokehjs/protocol/receiver"
 
+function unique_events(events: any[]) {
+  // Processes the event queue ignoring duplicate events
+  // of the same type
+  const unique = [];
+  const unique_events = [];
+  for (let i=0; i<events.length; i++) {
+    const _tmpevent = events[i];
+    const event = _tmpevent[0];
+    const data = _tmpevent[1];
+    if (unique_events.indexOf(event)===-1) {
+      unique.unshift(data);
+      unique_events.push(event);
+    }
+  }
+  return unique;
+}
+
 export class CommManagerView extends View {
   model: CommManager
 
@@ -24,22 +41,95 @@ export interface CommManager extends CommManager.Attrs {}
 export class CommManager extends Model {
   properties: CommManager.Props
   _receiver: Receiver
+  _comm_status: any
+  _comms: any
 
   constructor(attrs?: Partial<CommManager.Attrs>) {
     super(attrs)
     this._receiver = new Receiver()
+    this._comm_status = {}
+    this._comms = {}
     if (((window as any).PyViz == undefined) || (!(window as any).PyViz.comm_manager))
       console.log("Could not find comm manager")
     else
       (window as any).PyViz.comm_manager.register_target(this.plot_id, this.comm_id, (msg: any) => this.msg_handler(msg))
   }
 
+  send(comm_id: string, data: any, event_name?: string) {
+    if (((window as any).PyViz == undefined) || ((window as any).PyViz.comm_manager == undefined))
+      return
+
+	const receiver = (this._receiver as any)
+	let events = [];
+	if (receiver._partial && receiver._partial.content && receiver._partial.content.events)
+	  events = receiver._partial.content.events;
+
+	for (const event of events) {
+	  if ((event.kind === 'ModelChanged') && (event.attr === event_name) &&
+		  (data.id === event.model.id) &&
+		  (JSON.stringify(data[(event_name as string)]) === JSON.stringify(event.new)))
+		return
+	}
+
+    if (!(comm_id in this._comms)) {
+      const comm = (window as any).PyViz.comm_manager.get_client_comm(this.plot_id, comm_id, (msg: any) => this.on_ack(msg));
+      if (comm == null)
+        return
+      this._comms[comm_id] = comm
+      this._comm_status[comm_id] = {event_buffer: [], blocked: false, time: Date.now()}
+    }
+
+	const comm_status = this._comm_status[comm_id]
+    if (event_name === undefined)
+      event_name = Object.keys(data).join(',') // we are a widget not an event... fake a key.
+    data['comm_id'] = comm_id;
+    var timeout = comm_status.time + 5000;
+
+    comm_status.event_buffer.unshift([event_name, data]);
+    if ((!comm_status.blocked || (Date.now() > timeout))) {
+      setTimeout(() => this.process_events(comm_id), 50);
+      comm_status.blocked = true;
+      comm_status.time = Date.now()+50;
+	}
+	}
+
+  process_events(comm_id: string) {
+	const comm = this._comms[comm_id]
+    const comm_status = this._comm_status[comm_id]
+	// Iterates over event queue and sends events via Comm
+	const events = unique_events(comm_status.event_buffer);
+	for (let i=0; i<events.length; i++) {
+      const data = events[i];
+      comm.send(data);
+	}
+	comm_status.event_buffer = [];
+  }
+
+  on_ack(msg: any) {
+    // Receives acknowledgement from Python, processing event
+    // and unblocking Comm if event queue empty
+    const metadata = msg.metadata;
+    const comm_id = metadata.comm_id
+    const comm_status = this._comm_status[comm_id]
+    if (comm_status.event_buffer.length) {
+      this.process_events(comm_id)
+      comm_status.blocked = true
+      comm_status.time = Date.now()+50
+    } else
+      comm_status.blocked = false;
+    comm_status.event_buffer = [];
+    if ((metadata.msg_type == "Ready") && metadata.content)
+      console.log("Python callback returned following output:", metadata.content)
+    else if (metadata.msg_type == "Error")
+      console.log("Python failed with the following traceback:", metadata.traceback)
+  }
+
+
   msg_handler(msg: any) {
     const metadata = msg.metadata
     const buffers = msg.buffers
     const content = msg.content.data
     const plot_id = this.plot_id
-    console.log("NEW MSG")
     if ((metadata.msg_type == "Ready")) {
       if (metadata.content)
         console.log("Python callback returned following output:", metadata.content)

--- a/panel/models/comm_manager.ts
+++ b/panel/models/comm_manager.ts
@@ -1,24 +1,9 @@
 import * as p from "@bokehjs/core/properties"
+import {DocumentChangedEvent, ModelChangedEvent} from "@bokehjs/document"
 import {View} from "@bokehjs/core/view"
 import {Model} from "@bokehjs/model"
+import {Message} from "@bokehjs/protocol/message"
 import {Receiver} from "@bokehjs/protocol/receiver"
-
-function unique_events(events: any[]) {
-  // Processes the event queue ignoring duplicate events
-  // of the same type
-  const unique = [];
-  const unique_events = [];
-  for (let i=0; i<events.length; i++) {
-    const _tmpevent = events[i];
-    const event = _tmpevent[0];
-    const data = _tmpevent[1];
-    if (unique_events.indexOf(event)===-1) {
-      unique.unshift(data);
-      unique_events.push(event);
-    }
-  }
-  return unique;
-}
 
 export class CommManagerView extends View {
   model: CommManager
@@ -33,6 +18,9 @@ export namespace CommManager {
   export type Props = Model.Props & {
     plot_id: p.Property<string | null>
     comm_id: p.Property<string | null>
+    client_comm_id: p.Property<string | null>
+    timeout: p.Property<number>
+    debounce: p.Property<number>
   }
 }
 
@@ -40,84 +28,73 @@ export interface CommManager extends CommManager.Attrs {}
 
 export class CommManager extends Model {
   properties: CommManager.Props
+  ns: any
   _receiver: Receiver
-  _comm_status: any
-  _comms: any
+  _client_comm: any
+  _event_buffer: DocumentChangedEvent[]
+  _timeout: number
+  _blocked: boolean
 
   constructor(attrs?: Partial<CommManager.Attrs>) {
     super(attrs)
     this._receiver = new Receiver()
-    this._comm_status = {}
-    this._comms = {}
+    this._event_buffer = []
+    this._blocked = false
+    this._timeout = Date.now()
     if (((window as any).PyViz == undefined) || (!(window as any).PyViz.comm_manager))
-      console.log("Could not find comm manager")
-    else
-      (window as any).PyViz.comm_manager.register_target(this.plot_id, this.comm_id, (msg: any) => this.msg_handler(msg))
+      console.log("Could not find comm manager on window.PyViz, ensure the extension is loaded.")
+    else {
+      this.ns = (window as any).PyViz
+      this.ns.comm_manager.register_target(this.plot_id, this.comm_id, (msg: any) => this.msg_handler(msg))
+      this._client_comm = this.ns.comm_manager.get_client_comm(this.plot_id, this.client_comm_id, (msg: any) => this.on_ack(msg));
+    }
   }
 
-  send(comm_id: string, data: any, event_name?: string) {
-    if (((window as any).PyViz == undefined) || ((window as any).PyViz.comm_manager == undefined))
+  protected _document_listener: (event: DocumentChangedEvent) => void = (event) => this._document_changed(event)
+
+  protected _doc_attached(): void {
+    super._doc_attached()
+	if (this.document != null)
+      this.document.on_change(this._document_listener)
+  }
+
+  protected _document_changed(event: DocumentChangedEvent): void {
+    // Filter out events that were initiated by the ClientSession itself
+    if ((event as any).setter_id === this.id) // XXX: not all document events define this
       return
 
-    const receiver = (this._receiver as any)
-    let events = [];
-    if (receiver._partial && receiver._partial.content && receiver._partial.content.events)
-      events = receiver._partial.content.events;
+    // Filter out changes to attributes that aren't server-visible
+    if (event instanceof ModelChangedEvent && !(event.attr in event.model.serializable_attributes()))
+      return
 
-    for (const event of events) {
-      if ((event.kind === 'ModelChanged') && (event.attr === event_name) &&
-          (data.id === event.model.id) &&
-          (JSON.stringify(data[(event_name as string)]) === JSON.stringify(event.new)))
-        return
-    }
-
-    if (!(comm_id in this._comms)) {
-      const comm = (window as any).PyViz.comm_manager.get_client_comm(this.plot_id, comm_id, (msg: any) => this.on_ack(msg));
-      if (comm == null)
-        return
-      this._comms[comm_id] = comm
-      this._comm_status[comm_id] = {event_buffer: [], blocked: false, time: Date.now()}
-    }
-
-    const comm_status = this._comm_status[comm_id]
-    if (event_name === undefined)
-      event_name = Object.keys(data).join(',') // we are a widget not an event... fake a key.
-    data['comm_id'] = comm_id;
-    var timeout = comm_status.time + 5000;
-
-    comm_status.event_buffer.unshift([event_name, data]);
-    if ((!comm_status.blocked || (Date.now() > timeout))) {
-      setTimeout(() => this.process_events(comm_id), 50);
-      comm_status.blocked = true;
-      comm_status.time = Date.now()+50;
+    this._event_buffer.unshift(event);
+    if ((!this._blocked || (Date.now() > this._timeout))) {
+      setTimeout(() => this.process_events(), this.debounce);
+      this._blocked = true;
+      this._timeout = Date.now()+this.timeout;
     }
   }
 
-  process_events(comm_id: string) {
-    const comm = this._comms[comm_id]
-    const comm_status = this._comm_status[comm_id]
+  process_events() {
     // Iterates over event queue and sends events via Comm
-    const events = unique_events(comm_status.event_buffer);
-    for (let i=0; i<events.length; i++) {
-      const data = events[i];
-      comm.send(data);
-    }
-    comm_status.event_buffer = [];
+    if (this.document == null)
+      return
+	const message = Message.create('PATCH-DOC', {}, this.document.create_json_patch(this._event_buffer))
+    this._client_comm.send(message)
+    this._event_buffer = [];
   }
 
   on_ack(msg: any) {
     // Receives acknowledgement from Python, processing event
     // and unblocking Comm if event queue empty
     const metadata = msg.metadata;
-    const comm_id = metadata.comm_id
-    const comm_status = this._comm_status[comm_id]
-    if (comm_status.event_buffer.length) {
-      this.process_events(comm_id)
-      comm_status.blocked = true
-      comm_status.time = Date.now()+50
+    if (this._event_buffer.length) {
+      this.process_events()
+      this._blocked = true
+      this._timeout = Date.now()+this.timeout
     } else
-      comm_status.blocked = false;
-    comm_status.event_buffer = [];
+      this._blocked = false;
+    this._event_buffer = [];
     if ((metadata.msg_type == "Ready") && metadata.content)
       console.log("Python callback returned following output:", metadata.content)
     else if (metadata.msg_type == "Error")
@@ -135,10 +112,11 @@ export class CommManager extends Model {
       else if (metadata.msg_type == "Error")
         console.log("Python failed with the following traceback:", metadata.traceback)
     } else if (plot_id != null) {
-      if ((plot_id in (window as any).PyViz.plot_index) && ((window as any).PyViz.plot_index[plot_id] != null))
-        var plot = (window as any).PyViz.plot_index[plot_id]
+      let plot = null
+      if ((plot_id in this.ns.plot_index) && (this.ns.plot_index[plot_id] != null))
+        plot = this.ns.plot_index[plot_id]
       else if (((window as any).Bokeh !== undefined) && (plot_id in (window as any).Bokeh.index))
-        var plot = (window as any).Bokeh.index[plot_id]
+        plot = (window as any).Bokeh.index[plot_id]
 
       if (plot == null)
         return
@@ -150,7 +128,7 @@ export class CommManager extends Model {
 
       const comm_msg = this._receiver.message
       if ((comm_msg != null) && (Object.keys(comm_msg.content).length > 0) && this.document != null)
-        this.document.apply_json_patch(comm_msg.content, comm_msg.buffers)
+        this.document.apply_json_patch(comm_msg.content, comm_msg.buffers, this.id)
     }
   }
 
@@ -162,6 +140,9 @@ export class CommManager extends Model {
     this.define<CommManager.Props>({
       plot_id: [ p.String, null ],
       comm_id: [ p.String, null ],
+      client_comm_id: [ p.String, null],
+      timeout: [ p.Number, 5000 ],
+      debounce: [ p.Number, 50],
     })
   }
 }

--- a/panel/models/index.ts
+++ b/panel/models/index.ts
@@ -1,5 +1,6 @@
 export {AcePlot} from "./ace"
 export {Audio} from "./audio"
+export {CommManager} from "./comm_manager"
 export {DeckGLPlot} from "./deckgl"
 export {HTML} from "./html"
 export {JSON} from "./json"

--- a/panel/tests/test_layout.py
+++ b/panel/tests/test_layout.py
@@ -502,9 +502,10 @@ def test_empty_tabs_append(document, comm):
 
 def test_tabs_close_tab_in_notebook(document, comm, tabs):
     model = tabs.get_root(document, comm=comm)
+    old_tabs = list(model.tabs)
     _, div2 = tabs
 
-    tabs._comm_change({'tabs': [model.tabs[1].ref['id']]}, model.ref['id'])
+    tabs._comm_change(document, model.ref['id'], 'tabs', old_tabs, [model.tabs[1]])
 
     assert len(tabs.objects) == 1
     assert tabs.objects[0] is div2

--- a/panel/tests/test_reactive.py
+++ b/panel/tests/test_reactive.py
@@ -53,11 +53,13 @@ def test_link_properties_nb(document, comm):
 
     # Link property and check bokeh js property callback is defined
     obj._link_props(div, ['text'], document, div, comm)
-    assert 'change:text' in div.js_property_callbacks
+    assert 'text' in div._callbacks
 
-    # Assert CustomJS callback contains root id
-    customjs = div.js_property_callbacks['change:text'][0]
-    assert div.ref['id'] in customjs.code
+    # Assert callback is set up correctly
+    cb = div._callbacks['text'][0]
+    assert isinstance(cb, partial)
+    assert cb.args == (document, div.ref['id'])
+    assert cb.func == obj._comm_change
 
 
 def test_link_properties_server(document):

--- a/panel/tests/widgets/test_ace.py
+++ b/panel/tests/widgets/test_ace.py
@@ -12,5 +12,5 @@ def test_ace(document, comm):
     assert ace.language == "python"
 
     # Try changes
-    ace._comm_change({"value": "Hi there!"})
+    ace._process_events({"value": "Hi there!"})
     assert ace.value == "Hi there!"

--- a/panel/tests/widgets/test_base.py
+++ b/panel/tests/widgets/test_base.py
@@ -84,7 +84,6 @@ def test_widget_triggers_events(document, comm):
     document.hold()
 
     # Simulate client side change
-    widget.value = '123'
     document._held_events = document._held_events[:-1]
 
     # Set new value

--- a/panel/tests/widgets/test_button.py
+++ b/panel/tests/widgets/test_button.py
@@ -11,7 +11,7 @@ def test_button(document, comm):
     assert isinstance(widget, button._widget_type)
     assert widget.label == 'Button'
 
-    button._comm_change({'clicks': 1})
+    button._process_events({'clicks': 1})
     assert button.clicks == 1
 
 
@@ -25,7 +25,7 @@ def test_toggle(document, comm):
     assert widget.label == 'Toggle'
 
     widget.active = False
-    toggle._comm_change({'active': widget.active})
+    toggle._process_events({'active': widget.active})
     assert toggle.value == False
 
     toggle.value = True

--- a/panel/tests/widgets/test_input.py
+++ b/panel/tests/widgets/test_input.py
@@ -19,7 +19,7 @@ def test_checkbox(document, comm):
     assert widget.active == [0]
 
     widget.active = []
-    checkbox._comm_change({'active': []})
+    checkbox._process_events({'active': []})
     assert checkbox.value == False
 
     checkbox.value = True
@@ -39,13 +39,13 @@ def test_date_picker(document, comm):
     assert widget.max_date == '2018-09-10'
 
     widget.value = '2018-09-03'
-    date_picker._comm_change({'value': '2018-09-03'})
+    date_picker._process_events({'value': '2018-09-03'})
     assert date_picker.value == date(2018, 9, 3)
 
-    date_picker._comm_change({'value': date(2018, 9, 5)})
+    date_picker._process_events({'value': date(2018, 9, 5)})
     assert date_picker.value == date(2018, 9, 5)
 
-    date_picker._comm_change({'value': date(2018, 9, 6)})
+    date_picker._process_events({'value': date(2018, 9, 6)})
     assert date_picker.value == date(2018, 9, 6)
 
     date_picker.value = date(2018, 9, 4)
@@ -59,7 +59,7 @@ def test_file_input(document, comm):
 
     assert isinstance(widget, BkFileInput)
 
-    file_input._comm_change({'mime_type': 'text/plain', 'value': 'U29tZSB0ZXh0Cg==', 'filename': 'testfile'})
+    file_input._process_events({'mime_type': 'text/plain', 'value': 'U29tZSB0ZXh0Cg==', 'filename': 'testfile'})
     assert file_input.value == b'Some text\n'
     assert file_input.mime_type == 'text/plain'
     assert file_input.accept == '.txt'
@@ -76,19 +76,19 @@ def test_literal_input(document, comm):
     assert widget.title == 'Literal'
     assert widget.value == '{}'
 
-    literal._comm_change({'value': "{'key': (0, 2)}"})
+    literal._process_events({'value': "{'key': (0, 2)}"})
     assert literal.value == {'key': (0, 2)}
     assert widget.title == 'Literal'
 
-    literal._comm_change({'value': "(0, 2)"})
+    literal._process_events({'value': "(0, 2)"})
     assert literal.value == {'key': (0, 2)}
     assert widget.title == 'Literal (wrong type)'
 
-    literal._comm_change({'value': "invalid"})
+    literal._process_events({'value': "invalid"})
     assert literal.value == {'key': (0, 2)}
     assert widget.title == 'Literal (invalid)'
 
-    literal._comm_change({'value': "{'key': (0, 3)}"})
+    literal._process_events({'value': "{'key': (0, 3)}"})
     assert literal.value == {'key': (0, 3)}
     assert widget.title == 'Literal'
 
@@ -122,7 +122,7 @@ def test_text_input(document, comm):
     assert widget.value == 'ABC'
     assert widget.title == 'Text:'
 
-    text._comm_change({'value': 'CBA'})
+    text._process_events({'value': 'CBA'})
     assert text.value == 'CBA'
 
     text.value = 'A'
@@ -140,19 +140,19 @@ def test_datetime_input(document, comm):
     assert widget.title == 'Datetime'
     assert widget.value == '2018-01-01 00:00:00'
 
-    dt_input._comm_change({'value': '2018-01-01 00:00:01'})
+    dt_input._process_events({'value': '2018-01-01 00:00:01'})
     assert dt_input.value == datetime(2018, 1, 1, 0, 0, 1)
     assert widget.title == 'Datetime'
 
-    dt_input._comm_change({'value': '2018-01-01 00:00:01a'})
+    dt_input._process_events({'value': '2018-01-01 00:00:01a'})
     assert dt_input.value == datetime(2018, 1, 1, 0, 0, 1)
     assert widget.title == 'Datetime (invalid)'
 
-    dt_input._comm_change({'value': '2018-01-11 00:00:00'})
+    dt_input._process_events({'value': '2018-01-11 00:00:00'})
     assert dt_input.value == datetime(2018, 1, 1, 0, 0, 1)
     assert widget.title == 'Datetime (out of bounds)'
 
-    dt_input._comm_change({'value': '2018-01-02 00:00:01'})
+    dt_input._process_events({'value': '2018-01-02 00:00:01'})
     assert dt_input.value == datetime(2018, 1, 2, 0, 0, 1)
     assert widget.title == 'Datetime'
 

--- a/panel/tests/widgets/test_player.py
+++ b/panel/tests/widgets/test_player.py
@@ -17,7 +17,7 @@ def test_discrete_player(document, comm):
     assert widget.step == 1
 
     widget.value = 2
-    discrete_player._comm_change({'value': 2})
+    discrete_player._process_events({'value': 2})
     assert discrete_player.value == 10
 
     discrete_player.value = 100

--- a/panel/tests/widgets/test_select.py
+++ b/panel/tests/widgets/test_select.py
@@ -51,7 +51,7 @@ def test_select(document, comm):
     assert widget.value == as_unicode(opts['1'])
     assert widget.options == [(as_unicode(v),k) for k,v in opts.items()]
 
-    select._comm_change({'value': as_unicode(opts['A'])})
+    select._process_events({'value': as_unicode(opts['A'])})
     assert select.value == opts['A']
 
     widget.value = as_unicode(opts['1'])
@@ -105,11 +105,11 @@ def test_select_mutables(document, comm):
     assert widget.options == [(as_unicode(v),k) for k,v in opts.items()]
 
     widget.value = as_unicode(opts['B'])
-    select._comm_change({'value': as_unicode(opts['A'])})
+    select._process_events({'value': as_unicode(opts['A'])})
     assert select.value == opts['A']
 
     widget.value = as_unicode(opts['B'])
-    select._comm_change({'value': as_unicode(opts['B'])})
+    select._process_events({'value': as_unicode(opts['B'])})
     assert select.value == opts['B']
 
     select.value = opts['A']
@@ -144,11 +144,11 @@ def test_multi_select(document, comm):
     assert widget.options == ['A', '1', 'C']
 
     widget.value = ['1']
-    select._comm_change({'value': ['1']})
+    select._process_events({'value': ['1']})
     assert select.value == [1]
 
     widget.value = ['A', 'C']
-    select._comm_change({'value': ['A', 'C']})
+    select._process_events({'value': ['A', 'C']})
     assert select.value == ['A', object]
 
     select.value = [object, 'A']
@@ -167,11 +167,11 @@ def test_multi_choice(document, comm):
     assert widget.options == ['A', '1', 'C']
 
     widget.value = ['1']
-    choice._comm_change({'value': ['1']})
+    choice._process_events({'value': ['1']})
     assert choice.value == [1]
 
     widget.value = ['A', 'C']
-    choice._comm_change({'value': ['A', 'C']})
+    choice._process_events({'value': ['A', 'C']})
     assert choice.value == ['A', object]
 
     choice.value = [object, 'A']
@@ -230,18 +230,18 @@ def test_toggle_group_check(document, comm):
         assert widget.labels == ['A', '1', 'C']
 
         widget.active = [2]
-        select._comm_change({'active': [2]})
+        select._process_events({'active': [2]})
         assert select.value == [object]
 
         widget.active = [0, 2]
-        select._comm_change({'active': [0, 2]})
+        select._process_events({'active': [0, 2]})
         assert select.value == ['A', object]
 
         select.value = [object, 'A']
         assert widget.active == [2, 0]
 
         widget.active = []
-        select._comm_change({'active': []})
+        select._process_events({'active': []})
         assert select.value == []
 
 
@@ -259,7 +259,7 @@ def test_toggle_group_radio(document, comm):
         assert widget.labels == ['A', '1', 'C']
 
         widget.active = 2
-        select._comm_change({'active': 2})
+        select._process_events({'active': 2})
         assert select.value == object
 
         select.value = 'A'

--- a/panel/tests/widgets/test_slider.py
+++ b/panel/tests/widgets/test_slider.py
@@ -22,7 +22,7 @@ def test_float_slider(document, comm):
     assert widget.end == 0.5
     assert widget.value == 0.4
 
-    slider._comm_change({'value': 0.2})
+    slider._process_events({'value': 0.2})
     assert slider.value == 0.2
 
     slider.value = 0.3
@@ -41,7 +41,7 @@ def test_int_slider(document, comm):
     assert widget.end == 3
     assert widget.value == 1
 
-    slider._comm_change({'value': 2})
+    slider._process_events({'value': 2})
     assert slider.value == 2
 
     slider.value = 0
@@ -66,7 +66,7 @@ def test_range_slider(document, comm):
     assert widget.end == 3
     assert widget.value == (0, 3)
 
-    slider._comm_change({'value': (0, 2)})
+    slider._process_events({'value': (0, 2)})
     assert slider.value == (0, 2)
 
     slider.value = (0, 1)
@@ -88,11 +88,11 @@ def test_date_slider(document, comm):
 
     epoch = datetime(1970, 1, 1)
     widget.value = (datetime(2018, 9, 3)-epoch).total_seconds()*1000
-    date_slider._comm_change({'value': widget.value})
+    date_slider._process_events({'value': widget.value})
     assert date_slider.value == date(2018, 9, 3)
 
     # Test raw timestamp value:
-    date_slider._comm_change({'value': (datetime(2018, 9, 4)-epoch).total_seconds()*1000.0})
+    date_slider._process_events({'value': (datetime(2018, 9, 4)-epoch).total_seconds()*1000.0})
     assert date_slider.value == date(2018, 9, 4)
 
     date_slider.value = date(2018, 9, 6)
@@ -115,7 +115,7 @@ def test_date_range_slider(document, comm):
     epoch = datetime(1970, 1, 1)
     widget.value = ((datetime(2018, 9, 3)-epoch).total_seconds()*1000,
                     (datetime(2018, 9, 6)-epoch).total_seconds()*1000)
-    date_slider._comm_change({'value': widget.value})
+    date_slider._process_events({'value': widget.value})
     assert date_slider.value == (datetime(2018, 9, 3), datetime(2018, 9, 6))
 
     date_slider.value = (datetime(2018, 9, 4), datetime(2018, 9, 6))
@@ -140,7 +140,7 @@ def test_discrete_slider(document, comm):
     assert label.text == 'DiscreteSlider: <b>1</b>'
 
     widget.value = 2
-    discrete_slider._slider._comm_change({'value': 2})
+    discrete_slider._slider._process_events({'value': 2})
     assert discrete_slider.value == 10
 
     discrete_slider.value = 100
@@ -167,7 +167,7 @@ def test_discrete_date_slider(document, comm):
     assert label.text == 'DiscreteSlider: <b>2016-01-02</b>'
 
     widget.value = 2
-    discrete_slider._slider._comm_change({'value': 2})
+    discrete_slider._slider._process_events({'value': 2})
     assert discrete_slider.value == dates['2016-01-03']
 
     discrete_slider.value = dates['2016-01-01']
@@ -192,7 +192,7 @@ def test_discrete_slider_options_dict(document, comm):
     assert label.text == 'DiscreteSlider: <b>1</b>'
 
     widget.value = 2
-    discrete_slider._slider._comm_change({'value': 2})
+    discrete_slider._slider._process_events({'value': 2})
     assert discrete_slider.value == 10
 
     discrete_slider.value = 100

--- a/panel/viewable.py
+++ b/panel/viewable.py
@@ -7,7 +7,6 @@ from __future__ import absolute_import, division, unicode_literals
 
 import difflib
 import logging
-import re
 import sys
 import threading
 import traceback
@@ -20,7 +19,6 @@ import param
 
 from bokeh.document.document import Document as _Document
 from bokeh.io import curdoc as _curdoc
-from bokeh.models import CustomJS
 from pyviz_comms import JupyterCommManager
 
 from .callbacks import PeriodicCallback
@@ -753,6 +751,7 @@ class Reactive(Viewable):
                 if comm and 'embedded' not in root.tags:
                     push(doc, comm)
             else:
+                cb = partial(self._update_model, events, msg, root, model, doc, comm)
                 doc.add_next_tick_callback(cb)
 
     def _link_params(self):

--- a/panel/widgets/button.py
+++ b/panel/widgets/button.py
@@ -10,9 +10,6 @@ import param
 
 from bokeh.models import Button as _BkButton, Toggle as _BkToggle
 
-from ..config import config
-from ..io.notebook import get_comm_customjs
-from ..io.state import state
 from .base import Widget
 
 
@@ -34,27 +31,10 @@ class Button(_ButtonBase):
 
     _widget_type = _BkButton
 
-    def _link_clicks(self, model, doc, root, comm=None):
-        ref = root.ref['id']
-        if comm is None:
-            model.on_click(partial(self._server_click, doc, ref))
-        elif config.embed:
-            pass
-        else:
-            on_msg = partial(self._comm_change, ref=ref)
-            client_comm = state._comm_manager.get_client_comm(
-                on_msg=on_msg, on_error=partial(self._on_error, ref),
-                on_stdout=partial(self._on_stdout, ref)
-            )
-            customjs = get_comm_customjs(
-                'clicks', client_comm, ref, "value = 1;",
-                self._timeout, self._debounce
-            )
-            model.js_on_click(customjs)
-
     def _get_model(self, doc, root=None, parent=None, comm=None):
         model = super(Button, self)._get_model(doc, root, parent, comm)
-        self._link_clicks(model, doc, root or model, comm)
+        ref = (root or model).ref['id']
+        model.on_click(partial(self._server_click, doc, ref))
         return model
 
     def _server_click(self, doc, ref, event):


### PR DESCRIPTION
In the past to make communication work in notebook backends we had to attach callbacks to all bokeh properties we wanted to monitor. This was extremely inefficient because each of these callbacks is ~100 lines of JS code and a large app might have hundreds or even thousands of properties. In this PR we introduce a CommManager model, this model is added to the `Document.roots` when rendering in a notebook and registers a Document.on_change callback which will dispatch **all** the protocol messages that bokeh supports to Python. This means that it will behave identically to the server, simplifying codepaths and ensuring that bokeh models stay synced at all times.

Benefits:

- We support all bokeh protocol messages
- Simplifies codepaths (no more difference between comm and server codepaths)
- Much smaller Javascript output