### PR TITLE
Removed escape workaround for png exports of HTML models

### DIFF
--- a/panel/io/save.py
+++ b/panel/io/save.py
@@ -48,36 +48,6 @@ def save_png(model, filename):
     export_png(model, filename=filename, webdriver=webdriver)
 
 
-@contextmanager
-def swap_html_model():
-    """
-    Temporary fix to swap HTML model for Div model during png export
-    to avoid issues with DOMParser compatibility in PhantomJS.
-
-    Can be removed when switching to chromedriver.
-    """
-
-    from ..viewable import Viewable
-
-    state._html_escape = False
-    swapped = []
-    for viewable in param.concrete_descendents(Viewable).values():
-        model = getattr(viewable, '_bokeh_model', None)
-        try:
-            swap_model = issubclass(model, HTML)
-            assert swap_model
-        except Exception:
-            continue
-        else:
-            viewable._bokeh_model = Div
-            swapped.append(viewable)
-    try:
-        yield
-    finally:
-        state._html_escape = True
-        for viewable in swapped:
-            viewable._bokeh_model = HTML
-
 #---------------------------------------------------------------------
 # Public API
 #---------------------------------------------------------------------
@@ -130,8 +100,7 @@ def save(panel, filename, title=None, resources=None, template=None,
     doc = Document()
     comm = Comm()
     with config.set(embed=embed):
-        with swap_html_model():
-            model = panel.get_root(doc, comm)
+        model = panel.get_root(doc, comm)
         if embed:
             embed_state(
                 panel, model, doc, max_states, max_opts, embed_json,

--- a/panel/io/save.py
+++ b/panel/io/save.py
@@ -5,20 +5,15 @@ from __future__ import absolute_import, division, unicode_literals
 
 import io
 
-from contextlib import contextmanager
 from six import string_types
-
-import param
 
 from bokeh.document.document import Document
 from bokeh.embed import file_html
 from bokeh.io.export import export_png
-from bokeh.models import Div
 from bokeh.resources import CDN
 from pyviz_comms import Comm
 
 from ..config import config
-from ..models import HTML
 from .embed import embed_state
 from .model import add_to_doc
 from .state import state

--- a/panel/io/state.py
+++ b/panel/io/state.py
@@ -37,9 +37,6 @@ class _state(param.Parameterized):
     # Used to ensure that events are not scheduled from the wrong thread
     _thread_id = None
 
-    # Temporary flag to allow using Div model on static export
-    _html_escape = True
-
     _comm_manager = _CommManager
 
     # An index of all currently active views

--- a/panel/util.py
+++ b/panel/util.py
@@ -19,10 +19,7 @@ try:  # python >= 3.3
 except ImportError:
     from collections import MutableSequence, MutableMapping
 
-try:
-    from html import escape as _escape
-except Exception:
-    from xml.sax.saxutils import quoteattr
+from html import escape # noqa
 
 import param
 import numpy as np
@@ -31,28 +28,6 @@ datetime_types = (np.datetime64, dt.datetime, dt.date)
 
 if sys.version_info.major > 2:
     unicode = str
-
-
-html_escape_table = {
-    '"': "&quot;",
-    "'": "&#x27;"
-}
-
-
-def escape(string):
-    """
-    Temporary wrapper around HTML escaping to allow using Div model
-    during static png exports.
-    """
-    from .io import state
-
-    if state._html_escape:
-        if sys.version_info.major == 2:
-            return quoteattr(string, html_escape_table)[1:-1]
-        else:
-            return _escape(string)
-    else:
-        return string
 
 
 def isfile(path):


### PR DESCRIPTION
No longer needed and messed up HTML exports in certain scenarios.