### PR TITLE
Allow serving Flask apps

### DIFF
--- a/doc/releases.rst
+++ b/doc/releases.rst
@@ -6,11 +6,12 @@ Version 0.9.4
 
 Date: 2020-04-01
 
-This is a minor release fixing an issue with recent versions of Tornado. It also fixes issue with the packages built on the PyViz conda channel.
+This is a minor release fixing a number of regressions and compatibility issues which continue to crop up due to the upgrade to Bokeh 2.0 Additionally this release completely overhauls how communication in notebook environments are handled, eliminating the need to register custom callbacks with inlined JS callbacks to sync properties. Many thanks to the contributors to this release including @hyamanieu, @maximlt, @mattpap and the maintainer @philippjfr.
 
 Enhancements:
 
 - Switch to using CommManager in notebook hugely simplifying comms in notebooks and reducing the amount of inlined Javascript (`#1171 <https://github.com/holoviz/panel/pull/1171>`_)
+- Add ability to serve Flask apps directly using pn.serve (`#1215 <https://github.com/holoviz/panel/pull/1215>`_) 
 
 Bug fixes:
 

--- a/panel/io/server.py
+++ b/panel/io/server.py
@@ -5,6 +5,7 @@ from __future__ import absolute_import, division, unicode_literals
 
 import os
 import signal
+import sys
 import threading
 import uuid
 
@@ -15,6 +16,8 @@ from types import FunctionType
 from bokeh.document.events import ModelChangedEvent
 from bokeh.server.server import Server
 from tornado.websocket import WebSocketHandler
+from tornado.web import RequestHandler
+from tornado.wsgi import WSGIContainer
 
 from .state import state
 
@@ -46,7 +49,7 @@ def _eval_panel(panel, server_id, title, doc):
     if isinstance(panel, Template):
         return panel._modify_doc(server_id, title, doc)
     return as_panel(panel)._modify_doc(server_id, title, doc)
-    
+
 #---------------------------------------------------------------------
 # Public API
 #---------------------------------------------------------------------
@@ -138,6 +141,23 @@ def serve(panels, port=0, websocket_origin=None, loop=None, show=True,
                       title, verbose, **kwargs)
 
 
+class ProxyFallbackHandler(RequestHandler):
+    """A `RequestHandler` that wraps another HTTP server callback and
+    proxies the subpath.
+    """
+
+    def initialize(self, fallback, proxy=None):
+        self.fallback = fallback
+        self.proxy = proxy
+
+    def prepare(self):
+        if self.proxy:
+            self.request.path = self.request.path.replace(self.proxy, '')
+        self.fallback(self.request)
+        self._finished = True
+        self.on_finish()
+
+
 def get_server(panel, port=0, websocket_origin=None, loop=None,
                show=False, start=False, title=None, verbose=False, **kwargs):
     """
@@ -179,10 +199,23 @@ def get_server(panel, port=0, websocket_origin=None, loop=None,
     from tornado.ioloop import IOLoop
 
     server_id = kwargs.pop('server_id', uuid.uuid4().hex)
+    kwargs['extra_patterns'] = extra_patterns = kwargs.get('extra_patterns', [])
     if isinstance(panel, dict):
-        apps = {slug if slug.startswith('/') else '/'+slug:
-                partial(_eval_panel, p, server_id, title)
-                for slug, p in panel.items()}
+        apps = {}
+        for slug, app in panel.items():
+            slug = slug if slug.startswith('/') else '/'+slug
+            if 'flask' in sys.modules:
+                from flask import Flask
+                if isinstance(app, Flask):
+                    wsgi = WSGIContainer(app)
+                    if slug == '/':
+                        raise ValueError('Flask apps must be served on a subpath.')
+                    if not slug.endswith('/'):
+                        slug += '/'
+                    extra_patterns.append(('^'+slug+'.*', ProxyFallbackHandler,
+                                           dict(fallback=wsgi, proxy=slug)))
+                    continue
+            apps[slug] = partial(_eval_panel, app, server_id, title)
     else:
         apps = {'/': partial(_eval_panel, panel, server_id, title)}
 


### PR DESCRIPTION
Allows serving flask app using pn.serve, e.g.:

```python
import panel as pn
from flask import Flask

flask_app = Flask(__name__)

@flask_app.route('/app')
def hello_world():
    return 'Hello, World!'

def panel_app():
    return "# This Panel app runs alongside flask, access the flask app at [here](./flask/app)"

pn.serve({'/flask': flask_app, 'panel': panel_app}, port=5001)
```

This will serve the panel app on `localhost:5001/panel` and the flask app on `localhost:5001/flask/app`.