### PR TITLE
Do not process events related to fake Template root

### DIFF
--- a/panel/io/state.py
+++ b/panel/io/state.py
@@ -42,6 +42,9 @@ class _state(param.Parameterized):
     # An index of all currently active views
     _views = {}
 
+    # For templates to keep reference to their main root
+    _fake_roots = []
+
     # An index of all currently active servers
     _servers = {}
 

--- a/panel/pane/base.py
+++ b/panel/pane/base.py
@@ -179,6 +179,8 @@ class PaneBase(Reactive):
 
     def _update_pane(self, *events):
         for ref, (_, parent) in self._models.items():
+            if ref not in state._views or ref in state._fake_roots:
+                continue
             viewable, root, doc, comm = state._views[ref]
             if comm or state._unblocked(doc):
                 with unlocked():

--- a/panel/template.py
+++ b/panel/template.py
@@ -128,6 +128,7 @@ class Template(param.Parameterized, ServableMixin):
             model.name = name
             model.tags = tags
             add_to_doc(model, doc, hold=bool(comm))
+        state._fake_roots.append(ref)
         state._views[ref] = (col, preprocess_root, doc, comm)
 
         col._preprocess(preprocess_root)

--- a/panel/widgets/base.py
+++ b/panel/widgets/base.py
@@ -68,6 +68,8 @@ class Widget(Reactive):
 
     def _update_widget(self, *events):
         for ref, (model, parent) in self._models.items():
+            if ref not in state._views or ref in state._fake_roots:
+                continue
             viewable, root, doc, comm = state._views[ref]
             if comm or state._unblocked(doc):
                 with unlocked():


### PR DESCRIPTION
Panel was built around the idea that everything has a single root model which contains all the other models. Templates came along and broke that assumption, because it allows you to insert multiple roots at different points of an Jinja template.

To deal with that we create a fake root model, which makes things like cross-root linking of axes and JS links across roots work. However the rest of the code was not aware this thing was a fake, so it was creating duplicate models for it and keeping them all updated. So bad news is, that’s a horrific bug, good news is everything that was using templates is about to get 2x faster.