### PR TITLE
Include panel/index.ts in package data

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,6 +3,7 @@ include LICENSE.txt
 include panel/.version
 include panel/*.json
 include panel/assets/*.gif
+include panel/index.ts
 include panel/models/*.ts
 include panel/models/vtk/*.ts
 include panel/_templates/*.js


### PR DESCRIPTION
This should fix the conda-forge package. Looking at the history of `MANIFEST.in`, this should have failed before, so something else must have changed as well, either in panel or on conda-forge.

fixes #1233 