### PR TITLE
FileDownload widget: Allow callback to update filename

### DIFF
--- a/panel/tests/widgets/test_misc.py
+++ b/panel/tests/widgets/test_misc.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import, division, unicode_literals
 
-from io import BytesIO
+from io import BytesIO, StringIO
 from base64 import b64encode
 
 import numpy as np
@@ -49,6 +49,14 @@ def test_progress_bounds():
 
 
 def test_file_download_label():
+    file_download = FileDownload()
+
+    assert file_download.label == 'No file set'
+
+    file_download = FileDownload(StringIO("data"), filename="abc.py")
+
+    assert file_download.label == "Download abc.py"
+
     file_download = FileDownload(__file__)
 
     assert file_download.label == 'Download test_misc.py'
@@ -64,6 +72,38 @@ def test_file_download_label():
     file_download.filename = 'abc.py'
 
     assert file_download.label == 'Download abc.py'
+
+
+def test_file_download_file():
+    with pytest.raises(ValueError):
+        FileDownload(StringIO("data"))
+
+    with pytest.raises(ValueError):
+        FileDownload(embed=True)
+    
+    with pytest.raises(FileNotFoundError):
+        FileDownload("nofile", embed=True)
+
+    with pytest.raises(ValueError):
+        FileDownload(666, embed=True)
+    
+    file_download = FileDownload("nofile")
+    with pytest.raises(FileNotFoundError):
+        file_download._clicks += 1
+
+
+def test_file_download_callback():
+    file_download = FileDownload(callback=lambda: StringIO("data"), file="abc")
+
+    with pytest.raises(ValueError):
+        file_download._clicks += 1
+    
+    file_download = FileDownload(callback=lambda: StringIO("data"), filename="abc.py")
+    
+    assert file_download.data is None
+
+    file_download._clicks += 1
+    assert file_download.data is not None
 
 
 def test_file_download_data():

--- a/panel/tests/widgets/test_misc.py
+++ b/panel/tests/widgets/test_misc.py
@@ -105,6 +105,18 @@ def test_file_download_callback():
     file_download._clicks += 1
     assert file_download.data is not None
 
+    file_download.data = None
+
+    def cb():
+        file_download.filename = "cba.py"
+        return StringIO("data")
+
+    file_download.callback = cb
+    file_download._clicks += 1
+
+    assert file_download.data is not None
+    assert file_download.filename == "cba.py"
+    assert file_download.label == "Download cba.py"
 
 def test_file_download_data():
     file_download = FileDownload(__file__, embed=True)

--- a/panel/widgets/misc.py
+++ b/panel/widgets/misc.py
@@ -260,11 +260,11 @@ class FileDownload(Widget):
             return
 
         from ..param import ParamFunction
-        filename = self.filename
         if self.callback is None:
             fileobj = self.file
         else:
             fileobj = ParamFunction.eval(self.callback)
+        filename = self.filename
         if isinstance(fileobj, str):
             if not os.path.isfile(fileobj):
                 raise FileNotFoundError('File "%s" not found.' % fileobj)

--- a/panel/widgets/misc.py
+++ b/panel/widgets/misc.py
@@ -254,6 +254,9 @@ class FileDownload(Widget):
     @param.depends('_clicks', watch=True)
     def _transfer(self):
         if self.file is None and self.callback is None:
+            if self.embed:
+                raise ValueError('Must provide a file or a callback '
+                                  'if it is to be embeded')
             return
 
         from ..param import ParamFunction
@@ -262,7 +265,9 @@ class FileDownload(Widget):
             fileobj = self.file
         else:
             fileobj = ParamFunction.eval(self.callback)
-        if isinstance(fileobj, str) and os.path.isfile(fileobj):
+        if isinstance(fileobj, str):
+            if not os.path.isfile(fileobj):
+                raise FileNotFoundError('File "%s" not found.' % fileobj)
             with open(fileobj, 'rb') as f:
                 b64 = b64encode(f.read()).decode("utf-8")
             if filename is None:
@@ -276,7 +281,7 @@ class FileDownload(Widget):
                 raise ValueError('Must provide filename if file-like '
                                  'object is provided.')
         else:
-            raise ValueError('Cannot transfer unknown file type %s' %
+            raise ValueError('Cannot transfer unknown object of type %s' %
                              type(fileobj).__name__)
 
         ext = filename.split('.')[-1]

--- a/panel/widgets/misc.py
+++ b/panel/widgets/misc.py
@@ -256,7 +256,7 @@ class FileDownload(Widget):
         if self.file is None and self.callback is None:
             if self.embed:
                 raise ValueError('Must provide a file or a callback '
-                                  'if it is to be embeded')
+                                 'if it is to be embedded.')
             return
 
         from ..param import ParamFunction


### PR DESCRIPTION
Hi!

I've started to work on fixing #1236, to try to better understand the code I started with adding some more tests and error handling.

As I found a way to update the ``filename`` parameter from the callback as side-effect (this is what I intended to do in #1236), I've decided to submit this first batch of work as a PR.

I plan to submit another PR in the next days, trying to fix completely #1236.

(I was also hindered by these ``Model 'panel.models.widgets.FileDownload' does not exist`` errors while trying to launch a Bokeh server, error that is probably related to the recent problems around that, I'll try to update my setup and see how it goes).