### PR TITLE
Add ability to define explicit embed states

### DIFF
--- a/examples/user_guide/Deploy_and_Export.ipynb
+++ b/examples/user_guide/Deploy_and_Export.ipynb
@@ -441,17 +441,38 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If you try the widget above you will note that it only has 3 different states, 0, 5 and 10. This is because by default embed will try to limit the number of options of non-discrete or semi-discrete widgets to at most three values. This can be controlled using the `max_opts` argument to the embed method. The full set of options for the embed method include:\n",
+    "If you try the widget above you will note that it only has 3 different states, 0, 5 and 10. This is because by default embed will try to limit the number of options of non-discrete or semi-discrete widgets to at most three values. This can be controlled using the `max_opts` argument to the embed method or you can provide an explicit list of `states` to embed for each widget:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "row.embed(states={slider: list(range(0, 12, 2))})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    " The full set of options for the embed method include:\n",
     "\n",
-    "- **max_states**: The maximum number of states to embed\n",
+    "- **`max_states`**: The maximum number of states to embed\n",
     "\n",
-    "- **max_opts**: The maximum number of states for a single widget\n",
+    "- **`max_opts`**: The maximum number of states for a single widget\n",
     "\n",
-    "- **json** (default=True): Whether to export the data to json files\n",
+    "- **`states`** (default={}): A dictionary specifying the widget values to embed for each widget\n",
     "\n",
-    "- **save_path** (default='./'): The path to save json files to\n",
+    "- **`json`** (default=True): Whether to export the data to json files\n",
     "\n",
-    "- **load_path** (default=None):  The path or URL the json files will be loaded from (same as ``save_path`` if not specified)\n",
+    "- **`save_path`** (default='./'): The path to save json files to\n",
+    "\n",
+    "- **`load_path`** (default=None):  The path or URL the json files will be loaded from (same as ``save_path`` if not specified)\n",
+    "\n",
+    "* **`progress`** (default=False): Whether to report progress\n",
+    "\n",
     "\n",
     "As you might imagine if there are multiple widgets there can quickly be a combinatorial explosion of states so by default the output is limited to about 1000 states. For larger apps the states can also be exported to json files, e.g. if you want to serve the app on a website specify the ``save_path`` to declare where it will be stored and the ``load_path`` to declare where the JS code running on the website will look for the files."
    ]

--- a/panel/io/embed.py
+++ b/panel/io/embed.py
@@ -177,7 +177,7 @@ def links_to_jslinks(model, widget):
 
 def embed_state(panel, model, doc, max_states=1000, max_opts=3,
                 json=False, json_prefix='', save_path='./',
-                load_path=None, progress=True):
+                load_path=None, progress=True, states={}):
     """
     Embeds the state of the application on a State model which allows
     exporting a static version of an app. This works by finding all
@@ -200,12 +200,16 @@ def embed_state(panel, model, doc, max_states=1000, max_opts=3,
       The max number of ticks sampled in a continuous widget like a slider
     json: boolean (default=True)
       Whether to export the data to json files
+    json_prefix: str (default='')
+      Prefix for JSON filename
     save_path: str (default='./')
       The path to save json files to
     load_path: str (default=None)
       The path or URL the json files will be loaded from.
     progress: boolean (default=True)
       Whether to report progress
+    states: dict (default={})
+      A dictionary specifying the widget values to embed for each widget
     """
     from ..config import config
     from ..layout import Panel
@@ -236,6 +240,7 @@ def embed_state(panel, model, doc, max_states=1000, max_opts=3,
                if w not in Link.registry]
     state_model = State()
 
+
     widget_data, ignore = [], []
     for widget in widgets:
         if widget._param_pane is not None:
@@ -259,17 +264,18 @@ def embed_state(panel, model, doc, max_states=1000, max_opts=3,
             continue
 
         # Get data which will let us record the changes on widget events 
-        widget, w_model, vals, getter, on_change, js_getter = widget._get_embed_state(model, max_opts)
-        w_type = widget._widget_type
-        if isinstance(widget, DiscreteSlider):
-            w_model = widget._composite[1]._models[ref][0].select_one({'type': w_type})
+        w, w_model, vals, getter, on_change, js_getter = widget._get_embed_state(
+            model, states.get(widget), max_opts)
+        w_type = w._widget_type
+        if isinstance(w, DiscreteSlider):
+            w_model = w._composite[1]._models[ref][0].select_one({'type': w_type})
         else:
-            w_model = widget._models[ref][0]
+            w_model = w._models[ref][0]
             if not isinstance(w_model, w_type):
                 w_model = w_model.select_one({'type': w_type})
         js_callback = CustomJS(code=STATE_JS.format(
             id=state_model.ref['id'], js_getter=js_getter))
-        widget_data.append((widget, w_model, vals, getter, js_callback, on_change))
+        widget_data.append((w, w_model, vals, getter, js_callback, on_change))
 
     # Ensure we recording state for widgets which could be JS linked
     values = []

--- a/panel/io/notebook.py
+++ b/panel/io/notebook.py
@@ -259,7 +259,8 @@ def show_server(panel, notebook_url, port):
 
 
 def show_embed(panel, max_states=1000, max_opts=3, json=False,
-               save_path='./', load_path=None, progress=True):
+               json_prefix='', save_path='./', load_path=None,
+               progress=True, states={}):
     """
     Renders a static version of a panel in a notebook by evaluating
     the set of states defined by the widgets in the model. Note
@@ -274,12 +275,16 @@ def show_embed(panel, max_states=1000, max_opts=3, json=False,
       The maximum number of states for a single widget
     json: boolean (default=True)
       Whether to export the data to json files
+    json_prefix: str (default='')
+      Prefix for JSON filename
     save_path: str (default='./')
       The path to save json files to
     load_path: str (default=None)
       The path or URL the json files will be loaded from.
     progress: boolean (default=False)
       Whether to report progress
+    states: dict (default={})
+      A dictionary specifying the widget values to embed for each widget
     """
     from IPython.display import publish_display_data
     from ..config import config
@@ -289,7 +294,8 @@ def show_embed(panel, max_states=1000, max_opts=3, json=False,
     with config.set(embed=True):
         model = panel.get_root(doc, comm)
         embed_state(panel, model, doc, max_states, max_opts,
-                    json, save_path, load_path)
+                    json, json_prefix, save_path, load_path, progress,
+                    states)
     publish_display_data(*render_model(model))
 
 

--- a/panel/io/save.py
+++ b/panel/io/save.py
@@ -71,7 +71,7 @@ def save_png(model, filename, template=None, template_variables=None):
 def save(panel, filename, title=None, resources=None, template=None,
          template_variables=None, embed=False, max_states=1000,
          max_opts=3, embed_json=False, json_prefix='', save_path='./',
-         load_path=None, progress=True):
+         load_path=None, progress=True, embed_states={}):
     """
     Saves Panel objects to file.
 
@@ -105,6 +105,8 @@ def save(panel, filename, title=None, resources=None, template=None,
       The path or URL the json files will be loaded from.
     progress: boolean (default=True)
       Whether to report progress
+    embed_states: dict (default={})
+      A dictionary specifying the widget values to embed for each widget
     """
     from ..pane import PaneBase
     from ..template import Template
@@ -131,7 +133,7 @@ def save(panel, filename, title=None, resources=None, template=None,
             if embed:
                 embed_state(
                     panel, model, doc, max_states, max_opts, embed_json,
-                    json_prefix, save_path, load_path, progress
+                    json_prefix, save_path, load_path, progress, embed_states
                 )
             else:
                 add_to_doc(model, doc, True)

--- a/panel/tests/io/test_embed.py
+++ b/panel/tests/io/test_embed.py
@@ -117,7 +117,7 @@ def test_embed_float_slider_explicit_values(document, comm):
         assert event['new'] == '&lt;pre&gt;%s&lt;/pre&gt;' % states[k]
 
 
-def test_embed_select_str_link(document, comm):
+def test_embed_select_explicit_values(document, comm):
     select = Select(options=['A', 'B', 'C'])
     string = Str()
     def link(target, event):

--- a/panel/viewable.py
+++ b/panel/viewable.py
@@ -604,7 +604,7 @@ class Viewable(Renderable, Layoutable, ServableMixin):
         return show_server(self, notebook_url, port)
 
     def embed(self, max_states=1000, max_opts=3, json=False, json_prefix='',
-              save_path='./', load_path=None, progress=True, states={}):
+              save_path='./', load_path=None, progress=False, states={}):
         """
         Renders a static version of a panel in a notebook by evaluating
         the set of states defined by the widgets in the model. Note

--- a/panel/viewable.py
+++ b/panel/viewable.py
@@ -603,8 +603,8 @@ class Viewable(Renderable, Layoutable, ServableMixin):
         """
         return show_server(self, notebook_url, port)
 
-    def embed(self, max_states=1000, max_opts=3, json=False,
-              save_path='./', load_path=None, progress=True):
+    def embed(self, max_states=1000, max_opts=3, json=False, json_prefix='',
+              save_path='./', load_path=None, progress=True, states={}):
         """
         Renders a static version of a panel in a notebook by evaluating
         the set of states defined by the widgets in the model. Note
@@ -619,22 +619,26 @@ class Viewable(Renderable, Layoutable, ServableMixin):
           The maximum number of states for a single widget
         json: boolean (default=True)
           Whether to export the data to json files
+        json_prefix: str (default='')
+          Prefix for JSON filename
         save_path: str (default='./')
           The path to save json files to
         load_path: str (default=None)
           The path or URL the json files will be loaded from.
         progress: boolean (default=False)
           Whether to report progress
+        states: dict (default={})
+          A dictionary specifying the widget values to embed for each widget
         """
         show_embed(
-            self, max_states, max_opts, json, save_path,
-            load_path, progress
+            self, max_states, max_opts, json, json_prefix, save_path,
+            load_path, progress, states
         )
 
     def save(self, filename, title=None, resources=None, template=None,
              template_variables=None, embed=False, max_states=1000,
              max_opts=3, embed_json=False, json_prefix='', save_path='./',
-             load_path=None):
+             load_path=None, embed_states={}):
         """
         Saves Panel objects to file.
 
@@ -664,10 +668,13 @@ class Viewable(Renderable, Layoutable, ServableMixin):
            The path to save json files to
         load_path: str (default=None)
            The path or URL the json files will be loaded from.
+        embed_states: dict (default={})
+          A dictionary specifying the widget values to embed for each widget
         """
         return save(self, filename, title, resources, template,
                     template_variables, embed, max_states, max_opts,
-                    embed_json, json_prefix, save_path, load_path)
+                    embed_json, json_prefix, save_path, load_path,
+                    embed_states)
 
     def server_doc(self, doc=None, title=None, location=True):
         """

--- a/panel/widgets/base.py
+++ b/panel/widgets/base.py
@@ -105,7 +105,7 @@ class Widget(Reactive):
     def _filter_properties(self, properties):
         return [p for p in properties if p not in Layoutable.param]
 
-    def _get_embed_state(self, root, max_opts=3):
+    def _get_embed_state(self, root, values=None, max_opts=3):
         """
         Returns the bokeh model and a discrete set of value states
         for the widget.
@@ -114,6 +114,8 @@ class Widget(Reactive):
         ---------
         root: bokeh.model.Model
           The root model of the widget
+        values: list (optional)
+          An explicit list of value states to embed
         max_opts: int
           The maximum number of states the widget should return
 

--- a/panel/widgets/button.py
+++ b/panel/widgets/button.py
@@ -88,6 +88,6 @@ class Toggle(_ButtonBase):
 
     _widget_type = _BkToggle
 
-    def _get_embed_state(self, root, max_opts=3):
+    def _get_embed_state(self, root, values=None, max_opts=3):
         return (self, self._models[root.ref['id']][0], [False, True],
                 lambda x: x.active, 'active', 'cb_obj.active')

--- a/panel/widgets/input.py
+++ b/panel/widgets/input.py
@@ -381,7 +381,7 @@ class Checkbox(Widget):
             msg['labels'] = [msg.pop('labels')]
         return msg
 
-    def _get_embed_state(self, root, max_opts=3):
+    def _get_embed_state(self, root, values=None, max_opts=3):
         return (self, self._models[root.ref['id']][0], [False, True],
                 lambda x: str(0 in x.active).lower(), 'active',
                 "String(cb_obj.active.indexOf(0) >= 0)")

--- a/panel/widgets/player.py
+++ b/panel/widgets/player.py
@@ -59,8 +59,10 @@ class Player(PlayerBase):
             params['value'] = params['start']
         super(Player, self).__init__(**params)
 
-    def _get_embed_state(self, root, max_opts=3):
-        return (self, self._models[root.ref['id']][0], range(self.start, self.end, self.step),
+    def _get_embed_state(self, root, values=None, max_opts=3):
+        if values is None:
+            values = list(range(self.start, self.end, self.step))
+        return (self, self._models[root.ref['id']][0], values,
                 lambda x: x.value, 'value', 'cb_obj.value')
 
 

--- a/panel/widgets/select.py
+++ b/panel/widgets/select.py
@@ -159,17 +159,6 @@ class MultiSelect(_MultiSelectBase):
     _widget_type = _BkMultiSelect
 
 
-
-class MultiSelect(_MultiSelectBase):
-
-    size = param.Integer(default=4, doc="""
-        The number of items displayed at once (i.e. determines the
-        widget height).""")
-
-    _widget_type = _BkMultiSelect
-
-
-
 class MultiChoice(_MultiSelectBase):
 
     delete_button = param.Boolean(default=True, doc="""

--- a/panel/widgets/select.py
+++ b/panel/widgets/select.py
@@ -110,8 +110,14 @@ class Select(SelectBase):
         msg.pop('options', None)
         return msg
 
-    def _get_embed_state(self, root, max_opts=3):
-        return (self, self._models[root.ref['id']][0], self.values,
+    def _get_embed_state(self, root, values=None, max_opts=3):
+        if values is None:
+            values = self.values
+        elif any(v not in self.values for v in values):
+            raise ValueError("Supplied embed states were not found "
+                             "in the %s widgets values list." %
+                             type(self).__name__)
+        return (self, self._models[root.ref['id']][0], values,
                 lambda x: x.value, 'value', 'cb_obj.value')
 
 
@@ -151,6 +157,17 @@ class MultiSelect(_MultiSelectBase):
         widget height).""")
 
     _widget_type = _BkMultiSelect
+
+
+
+class MultiSelect(_MultiSelectBase):
+
+    size = param.Integer(default=4, doc="""
+        The number of items displayed at once (i.e. determines the
+        widget height).""")
+
+    _widget_type = _BkMultiSelect
+
 
 
 class MultiChoice(_MultiSelectBase):
@@ -231,8 +248,14 @@ class _RadioGroupBase(Select):
                 msg['value'] = list(self.values)[index]
         return msg
 
-    def _get_embed_state(self, root, max_opts=3):
-        return (self, self._models[root.ref['id']][0], self.values,
+    def _get_embed_state(self, root, values=None, max_opts=3):
+        if values is None:
+            values = self.values
+        elif any(v not in self.values for v in values):
+            raise ValueError("Supplied embed states were not found in "
+                             "the %s widgets values list." %
+                             type(self).__name__)
+        return (self, self._models[root.ref['id']][0], values,
                 lambda x: x.active, 'active', 'cb_obj.active')
 
 


### PR DESCRIPTION
Fixes https://github.com/holoviz/panel/issues/1198

Simple example:

```python
slider = pn.widgets.FloatSlider(name='A')

@pn.depends(slider)
def fn(value):
    return value + 1

pn.Row(slider, fn).embed(states={slider: [0.1, 0.7, 1]})
```

- [x] Add docs
- [x] Add tests