### PR TITLE
Do not override widget class if already specified by user

### DIFF
--- a/panel/param.py
+++ b/panel/param.py
@@ -310,7 +310,9 @@ class Param(PaneBase):
         p_obj = self.object.param[p_name]
         kw_widget = {}
 
+        widget_class_overridden = True
         if self.widgets is None or p_name not in self.widgets:
+            widget_class_overridden = False
             widget_class = self.widget_type(p_obj)
         elif isinstance(self.widgets[p_name], dict):
             if 'type' in self.widgets[p_name]:
@@ -347,12 +349,14 @@ class Param(PaneBase):
             if bounds[1] is not None:
                 kw['end'] = bounds[1]
             if ('start' not in kw or 'end' not in kw):
-                if isinstance(p_obj, param.Number):
-                    widget_class = Spinner
-                    if isinstance(p_obj, param.Integer):
-                        kw['step'] = 1
-                elif not issubclass(widget_class, LiteralInput):
-                    widget_class = LiteralInput
+                # Do not change widget class if _mapping was overridden
+                if not widget_class_overridden:
+                    if isinstance(p_obj, param.Number):
+                        widget_class = Spinner
+                        if isinstance(p_obj, param.Integer):
+                            kw['step'] = 1
+                    elif not issubclass(widget_class, LiteralInput):
+                        widget_class = LiteralInput
             if hasattr(widget_class, 'step') and getattr(p_obj, 'step', None):
                 kw['step'] = p_obj.step
 


### PR DESCRIPTION
Following the discussions in #1128, I discovered that providing the `widgets` dict currently did not allow specifying it for `param.Number`:

```
import param 
import panel as pn
pn.extension()

class T(param.Parameterized):
    a = param.Number(default=None)
t = T(a=1e-3)
    
pn.Pane(t.param, widgets={
    'a': pn.widgets.LiteralInput()
}) # falls back to Spinner no matter what
```

The reason was that `param.Number` was handled as a special case and actually overriden once again if no `bounds` are provided.

This PR simply adds another quick check and forces panel to roll with the user-supplied `widgets`, if provided, even for `param.Number`.