### PR TITLE
Fix is_number util function

### DIFF
--- a/panel/util.py
+++ b/panel/util.py
@@ -260,11 +260,7 @@ def value_as_date(value):
 
 
 def is_number(s):
-    try:
-        float(s)
-        return True
-    except ValueError:
-        return False
+    return isinstance(s, numbers.Number)
 
 
 def parse_query(query):


### PR DESCRIPTION
The current `is_number` function does not really do what it says on the tin:

```
from panel.util import is_number

# Works:

is_number(1.23) # True

# Does not work:

# is_number(1+1j) # throws TypeError
# is_number({}) # ditto

is_number('123') # Returns True which may be desired (?) but is not intuitive
```

I have not checked in detail every use of `is_number` in the code base so far, but I'm tentatively submitting this PR which should work for python 3.