### PR TITLE
Add support for VSCode

### DIFF
--- a/panel/config.py
+++ b/panel/config.py
@@ -80,7 +80,7 @@ class _config(param.Parameterized):
         Specify the default sizing mode behavior of panels.""")
 
     _comms = param.ObjectSelector(
-        default='default', objects=['default', 'ipywidgets'], doc="""
+        default='default', objects=['default', 'ipywidgets', 'vscode'], doc="""
         Whether to render output in Jupyter with the default Jupyter
         extension or use the jupyter_bokeh ipywidget model.""")
 


### PR DESCRIPTION
It seems like VSCode does not yet like `_repr_mimebundle_` so we add an explicit `pn.config.comms = 'vscode'` that adds special handling to display ipywidgets output in VSCode. In practice I suspect that VSCode will have to fix this issue soon because ipywidgets 8.0 (currently in alpha) switches from `_ipython_display_` to `_repr_mimebundle_`.

- [ ] Add docs