### PR TITLE
Improve the FileDownload widget

### DIFF
--- a/examples/reference/widgets/FileDownload.ipynb
+++ b/examples/reference/widgets/FileDownload.ipynb
@@ -14,7 +14,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The ``FileDownload`` widget allows downloading a file on the frontend by sending the file data to the browser either on initialization (if ``embed=True``) or when the button is clicked. If the button\n",
+    "The ``FileDownload`` widget allows downloading a file on the frontend by sending the file data to the browser either on initialization (if ``embed=True``) or when the button is clicked.\n",
     "\n",
     "For more information about listening to widget events and laying out widgets refer to the [widgets user guide](../../user_guide/Widgets.ipynb). Alternatively you can learn how to build GUIs by declaring parameters independently of any specific widgets in the [param user guide](../../user_guide/Param.ipynb). To express interactivity entirely using Javascript without the need for a Python server take a look at the [links user guide](../../user_guide/Param.ipynb).\n",
     "\n",
@@ -43,7 +43,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The `FileDownload` widget accepts a path to a file or a file-like object (with a `.read` method) if the latter is provided a `filename` must also be set. By default the file is only transferred to the browser after clicking the button is clicked (this requires a live-server or notebook kernel):"
+    "The `FileDownload` widget accepts a path to a file or a file-like object (with a `.read` method) if the latter is provided a `filename` must also be set. By default (`auto=True` and `embed=False`) the file is only transferred to the browser after the button is clicked (this requires a live-server or notebook kernel):"
    ]
   },
   {
@@ -61,7 +61,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The file data may also be embedded immediately using embed parameter, this allows using the widget even in a static export:"
+    "The file data may also be embedded immediately using `embed` parameter, this allows using the widget even in a static export:"
    ]
   },
   {
@@ -128,8 +128,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "years_options = list(autompg.yr.unique())\n",
     "years = pn.widgets.MultiChoice(\n",
-    "    name='Years', options=list(autompg.yr.unique()), margin=(0, 20, 0, 0)\n",
+    "    name='Years', options=years_options, value=[years_options[0]], margin=(0, 20, 0, 0)\n",
     ")\n",
     "mpg = pn.widgets.RangeSlider(\n",
     "    name='Mile per Gallon', start=autompg.mpg.min(), end=autompg.mpg.max()\n",

--- a/examples/user_guide/Widgets.ipynb
+++ b/examples/user_guide/Widgets.ipynb
@@ -216,6 +216,7 @@
     "\n",
     "* **[``Button``](../reference/widgets/Button.ipynb)**: Allows triggering events when the button is clicked.  Unlike other widgets, it does not have a ``value`` parameter.\n",
     "* **[``DataFrame``](../reference/widgets/DataFrame.ipynb)**: A widget that allows displaying and editing a Pandas DataFrame.\n",
+    "* **[``FileDownload``](../reference/widgets/FileDownload.ipynb)**: A button that allows downloading a file on the frontend by sending the file data to the browser.\n",
     "* **[``Progress``](../reference/widgets/Progress.ipynb)**: A Progress bar which allows updating current the progress towards some goal or indicate an ongoing process."
    ]
   }

--- a/panel/models/file_download.ts
+++ b/panel/models/file_download.ts
@@ -27,48 +27,142 @@ function dataURItoBlob(dataURI: string) {
 
 export class FileDownloadView extends InputWidgetView {
   model: FileDownload
-
   anchor_el: HTMLAnchorElement
+  _downloadable: boolean = false
+  _click_listener: any
+  _embed: boolean = false 
+  _prev_href: string | null = ""
+  _prev_download: string | null = ""
 
-  _initialized: boolean = false
+  initialize(): void {
+    super.initialize()
+    if ( this.model.data && this.model.filename ) {
+      this._embed = true
+    }
+  }
 
   connect_signals(): void {
     super.connect_signals()
-    this.connect(this.model.properties.button_type.change, () => this.render())
-    this.connect(this.model.properties.data.change, () => this.render())
-    this.connect(this.model.properties.filename.change, () => this.render())
+    this.connect(this.model.properties.button_type.change, () => this._update_button_style())
+    this.connect(this.model.properties.filename.change, () => this._update_download())
+    this.connect(this.model.properties._transfers.change, () => this._handle_click())
     this.connect(this.model.properties.label.change, () => this._update_label())
   }
-  
+
   render(): void {
     super.render()
+    // Create an anchor HTML element that is styled as a bokeh button.
+    // When its 'href' and 'download' attributes are set, it's a downloadable link:
+    // * A click triggers a download
+    // * A right click allows to "Save as" the file
+
+    // There are three main cases:
+    // 1. embed=True: The widget is a download link
+    // 2. auto=False: The widget is first a button and becomes a download link after the first click
+    // 3. auto=True: The widget is a button, i.e right click to "Save as..." won't work
     this.anchor_el = document.createElement('a')
-    this.anchor_el.classList.add(bk_btn)
-    this.anchor_el.classList.add(bk_btn_type(this.model.button_type))
-    this.anchor_el.textContent = this.model.label
-    if (this.model.data === null || this.model.filename === null) {
-      this.anchor_el.addEventListener("click", () => this.click())
-      this.group_el.appendChild(this.anchor_el)  
-      this._initialized = true
+    this._update_button_style()
+    this._update_label()
+
+    // Changing the disabled property calls render() so it needs to be handled here.
+    // This callback is inherited from ControlView in bokehjs.
+    if ( this.model.disabled ) {
+      this.anchor_el.setAttribute("disabled", "")
+      this._downloadable = false
+    } else {
+      this.anchor_el.removeAttribute("disabled")
+      // auto=False + toggle Disabled ==> Needs to reset the link as it was.
+      if ( this._prev_download ) {
+        this.anchor_el.download = this._prev_download
+      }
+      if ( this._prev_href ) {
+        this.anchor_el.href = this._prev_href
+      }
+      if ( this.anchor_el.download && this.anchor_el.download ) {
+        this._downloadable = true
+      }
+    }
+
+    // If embedded the button is just a download link.
+    // Otherwise clicks will be handled by the code itself, allowing for more interactivity.
+    if ( this._embed ) {
+      this._make_link_downloadable()
+    } else {
+      // Add a "click" listener, note that it's not going to
+      // handle right clicks (they won't increment 'clicks')
+      this._click_listener = this._increment_clicks.bind(this)
+      this.anchor_el.addEventListener("click", this._click_listener)
+    }
+    this.group_el.appendChild(this.anchor_el)
+  }
+
+  _increment_clicks() : void {
+    this.model.clicks = this.model.clicks + 1
+  }
+
+  _handle_click() : void {
+
+    // When auto=False the button becomes a link which no longer
+    // requires being updated.
+    if ( !this.model.auto && this._downloadable) {
       return
     }
-    const blob = dataURItoBlob(this.model.data)
-    const uriContent = (URL as any).createObjectURL(blob)
-    this.anchor_el.href = uriContent
-    this.anchor_el.download = this.model.filename
-    //this.group_el.classList.add(bk_btn_group)
-    this.group_el.appendChild(this.anchor_el)
-    if (this.model.auto && this._initialized)
+
+    this._make_link_downloadable()
+ 
+    if ( !this._embed && this.model.auto ) {
+      // Temporarily removing the event listener to emulate a click
+      // event on the anchor link which will trigger a download.
+      this.anchor_el.removeEventListener("click", this._click_listener)
       this.anchor_el.click()
-    this._initialized = true
+
+      // In this case #3 the widget is not a link so these attributes are removed.
+      this.anchor_el.removeAttribute("href")
+      this.anchor_el.removeAttribute("download")
+
+      this.anchor_el.addEventListener("click", this._click_listener)
+    }
+
+    // Store the current state for handling changes of the disabled property.
+    this._prev_href = this.anchor_el.getAttribute("href")
+    this._prev_download = this.anchor_el.getAttribute("download")
+  }
+
+  _make_link_downloadable() : void {
+    this._update_href()
+    this._update_download()
+    if ( this.anchor_el.download && this.anchor_el.href ){
+      this._downloadable = true
+    }
+  }
+
+  _update_href() : void {
+    if ( this.model.data ) {
+      const blob = dataURItoBlob(this.model.data)
+      this.anchor_el.href = (URL as any).createObjectURL(blob)
+    }
+  }
+
+  _update_download() : void {
+    if ( this.model.filename ) {
+      this.anchor_el.download = this.model.filename
+    }
   }
 
   _update_label(): void {
     this.anchor_el.textContent = this.model.label
   }
 
-  click(): void {
-    this.model.clicks = this.model.clicks + 1
+  _update_button_style(): void{
+    if ( !this.anchor_el.hasAttribute("class") ){ // When the widget is rendered.
+      this.anchor_el.classList.add(bk_btn)
+      this.anchor_el.classList.add(bk_btn_type(this.model.button_type))
+    } else {  // When the button type is changed.
+      const prev_button_type = this.anchor_el.classList.item(1)
+      if ( prev_button_type ) {
+        this.anchor_el.classList.replace(prev_button_type, bk_btn_type(this.model.button_type))
+      }
+    }
   }
 }
 

--- a/panel/models/file_download.ts
+++ b/panel/models/file_download.ts
@@ -82,6 +82,7 @@ export namespace FileDownload {
     data: p.Property<string | null>
     label: p.Property<string>
     filename: p.Property<string | null>
+    _transfers: p.Property<number>
   }
 }
 
@@ -106,6 +107,7 @@ export class FileDownload extends InputWidget {
       label:    [ p.String,  "Download"  ],
       filename: [ p.String,  null  ],
       button_type: [ p.ButtonType, "default" ], // TODO (bev)
+      _transfers: [ p.Number, 0    ],
     })
 
     this.override({

--- a/panel/models/widgets.py
+++ b/panel/models/widgets.py
@@ -122,4 +122,8 @@ class FileDownload(InputWidget):
 
     filename = String(help="""Filename to use on download""")
 
+    _transfers = Int(0, help="""
+    A private property to create and click the link.
+    """)
+
     title = Override(default='')

--- a/panel/tests/widgets/test_misc.py
+++ b/panel/tests/widgets/test_misc.py
@@ -136,6 +136,17 @@ def test_file_download_callback():
     assert file_download.filename == "cba.py"
     assert file_download.label == "Download cba.py"
 
+
+def test_file_download_transfers():
+    file_download = FileDownload(__file__, embed=True)
+    assert file_download._transfers == 1
+
+    file_download = FileDownload(__file__)
+    assert file_download._transfers == 0
+    file_download._clicks += 1
+    assert file_download._transfers == 1
+
+
 def test_file_download_data():
     file_download = FileDownload(__file__, embed=True)
 

--- a/panel/tests/widgets/test_misc.py
+++ b/panel/tests/widgets/test_misc.py
@@ -74,6 +74,24 @@ def test_file_download_label():
     assert file_download.label == 'Download abc.py'
 
 
+def test_file_download_filename(tmpdir):
+    file_download = FileDownload()
+
+    filepath = tmpdir.join("foo.txt")
+    filepath.write("content")
+    file_download.file = str(filepath)
+
+    assert file_download.filename == "foo.txt"
+
+    file_download._clicks += 1
+    file_download.file = __file__
+
+    assert file_download.filename == "test_misc.py"
+
+    file_download.file = StringIO("data")
+    assert file_download.filename == "test_misc.py"
+
+
 def test_file_download_file():
     with pytest.raises(ValueError):
         FileDownload(StringIO("data"))

--- a/panel/widgets/misc.py
+++ b/panel/widgets/misc.py
@@ -190,6 +190,8 @@ class FileDownload(Widget):
 
     _clicks = param.Integer(default=0)
 
+    _transfers = param.Integer(default=0)
+
     _mime_types = {
         'application': {
             'pdf': 'pdf', 'zip': 'zip'
@@ -305,3 +307,4 @@ class FileDownload(Widget):
 
         self.param.set_param(data=data, filename=filename)
         self._update_label()
+        self._transfers += 1

--- a/panel/widgets/misc.py
+++ b/panel/widgets/misc.py
@@ -230,6 +230,11 @@ class FileDownload(Widget):
     def _update_default(self):
         self._default_label = False
 
+    @param.depends('file', watch=True)
+    def _update_filename(self):
+        if isinstance(self.file, str):
+            self.filename = os.path.basename(self.file)
+
     @param.depends('auto', 'file', 'filename', watch=True)
     def _update_label(self):
         label = 'Download' if self._synced or self.auto else 'Transfer'


### PR DESCRIPTION
Fixes #1299 

The intent of this PR is to fix various bugs with the FileDownload widget. I had to clearly define the behaviour of the widget, that to me follows three cases:
1. embed=True --> The widget is a link that looks like a button (right click to "Save as..." is possible)
2. auto=False --> There are two steps, first the widget is a button, after it's clicked it's a link (right click possible)
3. auto=True --> The widget is a button (right click to "Save as..." isn't possible).

To get there I had to make the following changes:
* On the python side: the biggest change is the new ``_transfers`` model attribute. It took me a long time before I dared to touch the python side but I found out it was the only solution that worked and allowed to fix all the bugs. When the widget is a button, a click will increment ``_clicks`` in typescript which will be reflected in python and trigger ``_transfer()``. This method will increment ``_transfers``, this signal will be caught on the typescript side, where a link will be created and clicked to download the data.
* On the typescript side: I've opted for an approach that is in favour of rendering first the widget and then updating it (that is not completely true as disabling/enabling the widget actually renders it again because of an inherited callback). It's quite a change compared to the first implementation, I believe it was required to cover all the cases supposedly offered by the widget.

Example fixed:
![filedownload-fixed-example](https://user-images.githubusercontent.com/35924738/80433886-8dc53500-88f8-11ea-91e9-7827fededa22.gif)

Updating button type, disabled, filename fixed:
![filedownload-fixed-ui](https://user-images.githubusercontent.com/35924738/80433825-53f42e80-88f8-11ea-9b18-fc820e0891e8.gif)