### PR TITLE
Add missing property in WidgetBox docs

### DIFF
--- a/examples/reference/layouts/WidgetBox.ipynb
+++ b/examples/reference/layouts/WidgetBox.ipynb
@@ -21,6 +21,7 @@
     "For layout and styling related parameters see the [customization user guide](../../user_guide/Customization.ipynb).\n",
     "\n",
     "* **``objects``** (list): The list of objects to display in the WidgetBox. Should not generally be modified directly except when replaced in its entirety.\n",
+    "* **``disabled``** (boolean, default=False): Allow to disable all the widgets displayed in the WidgetBox.\n",
     "\n",
     "___"
    ]


### PR DESCRIPTION
The ``disabled`` property added to the ``WidgetBox`` widget by https://github.com/holoviz/panel/pull/532 wasn't documented in the reference example, fixes that.