### PR TITLE
Remove name property in docs of FileInput

### DIFF
--- a/examples/reference/widgets/FileInput.ipynb
+++ b/examples/reference/widgets/FileInput.ipynb
@@ -24,14 +24,10 @@
     "\n",
     "##### Core\n",
     "\n",
-    "* **``accept``** (str):  A list of file input filters that restrict what files the user can pick from.\n",
+    "* **``accept``** (str):  A list of file input filters that restrict what files the user can pick from\n",
     "* **``filename``** (str): The filename of the uploaded file\n",
     "* **``mime_type``** (str): The mime type of the uploaded file\n",
     "* **``value``** (bytes): A bytes object containing the file data\n",
-    "\n",
-    "##### Display\n",
-    "\n",
-    "* **``name``** (str): The title of the widget\n",
     "\n",
     "___"
    ]
@@ -100,7 +96,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "file_input = pn.widgets.FileInput(accept='.csv,.json', name='File Input')\n",
+    "file_input = pn.widgets.FileInput(accept='.csv,.json')\n",
     "\n",
     "file_input"
    ]


### PR DESCRIPTION
Fixes #519 

Remove from the reference docs of the `FileInput` widget any mention to the `name` parameter to make clear that it has no effect whatsoever on the display of the widget.