### PR TITLE
Improve error message for dataframe with duplicate column names

### DIFF
--- a/panel/tests/widgets/test_tables.py
+++ b/panel/tests/widgets/test_tables.py
@@ -129,6 +129,6 @@ def test_dataframe_duplicate_column_name(document, comm):
     
     df = pd.DataFrame([[1, 1], [2, 2]], columns=['a', 'b'])
     table = DataFrame(df)
-    model = table.get_root(document, comm)
+    table.get_root(document, comm)
     with pytest.raises(ValueError):
         table.value = table.value.rename(columns={'a': 'b'})

--- a/panel/tests/widgets/test_tables.py
+++ b/panel/tests/widgets/test_tables.py
@@ -115,3 +115,20 @@ def test_dataframe_process_data_event(dataframe):
     table._process_events({'data': {'int': {1: 3, 2: 4, 0: 1}}})
     df['int'] = [1, 3, 4]
     pd.testing.assert_frame_equal(table.value, df)
+
+
+def test_dataframe_duplicate_column_name(document, comm):
+    df = pd.DataFrame([[1, 1], [2, 2]], columns=['col', 'col'])
+    with pytest.raises(ValueError):
+        table = DataFrame(df)
+
+    df = pd.DataFrame([[1, 1], [2, 2]], columns=['a', 'b'])
+    table = DataFrame(df)
+    with pytest.raises(ValueError):
+        table.value = table.value.rename(columns={'a': 'b'})
+    
+    df = pd.DataFrame([[1, 1], [2, 2]], columns=['a', 'b'])
+    table = DataFrame(df)
+    model = table.get_root(document, comm)
+    with pytest.raises(ValueError):
+        table.value = table.value.rename(columns={'a': 'b'})

--- a/panel/widgets/tables.py
+++ b/panel/widgets/tables.py
@@ -47,7 +47,17 @@ class DataFrame(Widget):
 
     def __init__(self, value=None, **params):
         super(DataFrame, self).__init__(value=value, **params)
+        self.param.watch(self._validate, 'value')
+        self._validate(None)
         self._renamed_cols = {}
+
+    def _validate(self, event):
+        if self.value is None:
+            return
+        cols = self.value.columns
+        if len(cols) != len(cols.drop_duplicates()):
+            raise ValueError('Cannot display a pandas.DataFrame with '
+                             'duplicate column names.')
 
     def _get_columns(self):
         if self.value is None:
@@ -122,6 +132,7 @@ class DataFrame(Widget):
         return model
 
     def _manual_update(self, events, model, doc, root, parent, comm):
+        self._validate(None)
         for event in events:
             if event.name == 'value':
                 cds = model.source


### PR DESCRIPTION
Fixes #821 

I've had to validate the dataframe inside `_manual_update` because this method was called before the `_validate` callback I've added.