### PR TITLE
Add support for serving static files

### DIFF
--- a/examples/user_guide/Deploy_and_Export.ipynb
+++ b/examples/user_guide/Deploy_and_Export.ipynb
@@ -191,7 +191,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Display in the Python REPL\n",
+    "### Display in the Python REPL\n",
     "\n",
     "Working from the command line will not automatically display rich representations inline as in a notebook, but you can still interact with your Panel components if you start a Bokeh server instance and open a separate browser window using the ``show`` method. The method has the following arguments:\n",
     "\n",
@@ -238,10 +238,14 @@
     ")\n",
     "```\n",
     "\n",
-    "The ``pn.serve`` function accepts the same arguments as the `show` method.\n",
-    "\n",
-    "\n",
-    "### Launching a server on the commandline\n",
+    "The ``pn.serve`` function accepts the same arguments as the `show` method."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Launching a server on the commandline\n",
     "\n",
     "Once the app is ready for deployment it can be served using the Bokeh server.  For a detailed breakdown of the design and functionality of Bokeh server, see the [Bokeh documentation](https://bokeh.pydata.org/en/latest/docs/user_guide/server.html). The most important thing to know is that Panel (and Bokeh) provide a CLI command to serve a Python script, app directory, or Jupyter notebook containing a Bokeh or Panel app. To launch a server using the CLI, simply run:\n",
     "\n",
@@ -298,6 +302,8 @@
     "                            Do not redirect to running app from root path\n",
     "      --num-procs N         Number of worker processes for an app. Using 0 will\n",
     "                            autodetect number of cores (defaults to 1)\n",
+    "      --static-dirs         Static directories to serve specified as key=value\n",
+    "                            pairs mapping from URL route to static file directory.\n",
     "      --websocket-max-message-size BYTES\n",
     "                            Set the Tornado websocket_max_message_size value\n",
     "                            (defaults to 20MB) NOTE: This setting has effect ONLY\n",
@@ -312,9 +318,31 @@
     "\n",
     "To turn a notebook into a deployable app simply append ``.servable()`` to one or more Panel objects, which will add the app to Bokeh's ``curdoc``, ensuring it can be discovered by Bokeh server on deployment. In this way it is trivial to build dashboards that can be used interactively in a notebook and then seamlessly deployed on Bokeh server.\n",
     "\n",
-    "When called on a notebook, `panel serve` first converts it to a python script using [`nbconvert.PythonExporter()`](https://nbconvert.readthedocs.io/en/stable/api/exporters.html), albeit with [IPython magics](https://ipython.readthedocs.io/en/stable/interactive/magics.html) stripped out. This means that non-code cells, such as raw cells, are entirely handled by `nbconvert` and [may modify the served app](https://nbsphinx.readthedocs.io/en/latest/raw-cells.html).\n",
+    "When called on a notebook, `panel serve` first converts it to a python script using [`nbconvert.PythonExporter()`](https://nbconvert.readthedocs.io/en/stable/api/exporters.html), albeit with [IPython magics](https://ipython.readthedocs.io/en/stable/interactive/magics.html) stripped out. This means that non-code cells, such as raw cells, are entirely handled by `nbconvert` and [may modify the served app](https://nbsphinx.readthedocs.io/en/latest/raw-cells.html)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Static file hosting\n",
     "\n",
-    "### Accessing session state\n",
+    "Whether you're launching your application using `panel serve` from the commandline or using `pn.serve` in a script you can also serve static files. When using `panel serve` you can use the `--static-dirs` argument to specify a list of static directories to serve along with their routes, e.g.:\n",
+    "\n",
+    "    panel serve some_script.py --static-dirs assets=./assets\n",
+    "    \n",
+    "This will serve the `./assets` directory on the servers `/assets` route. Note however that the `/static` route is reserved internally by Panel.\n",
+    "\n",
+    "Similarly when using `pn.serve` or `panel_obj.show` the static routes may be defined as a dictionary, e.g. the equivalent to the example would be:\n",
+    "\n",
+    "    pn.serve(panel_obj, static_dirs={'assets': './assets'})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Accessing session state\n",
     "\n",
     "Whenever a Panel app is being served the ``panel.state`` object exposes some of the internal Bokeh server components to a user.\n",
     "\n",
@@ -364,13 +392,8 @@
     "\n",
     "* **``href``** (string): The full url, e.g. 'https://panel.holoviz.org/user_guide/Interact.html:80?color=blue#interact'.\n",
     "* **``protocol``** (string): protocol part of the url, e.g. 'http:' or 'https:'\n",
-    "* **``port``** (string): port number, e.g. '80'"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
+    "* **``port``** (string): port number, e.g. '80'\n",
+    "\n",
     "#### pn.state.busy\n",
     "\n",
     "Often an application will have longer running callbacks which are being processed on the server, to give users some indication that the server is busy you may therefore have some way of indicating that busy state. The `pn.state.busy` parameter indicates whether a callback is being actively processed and may be linked to some visual indicator.\n",

--- a/panel/__main__.py
+++ b/panel/__main__.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, division, unicode_literals
 import sys
 
 def main():
-    from panel.cli import main as _main
+    from panel.command import main as _main
 
    # Main entry point (see setup.py)
     _main(sys.argv)

--- a/panel/command/__init__.py
+++ b/panel/command/__init__.py
@@ -7,11 +7,12 @@ import sys
 import argparse
 
 from bokeh.__main__ import main as bokeh_entry_point
+from bokeh.command.subcommands.serve import Serve as BkServe
 from bokeh.command.util import die
 from bokeh.util.string import nice_join
 
-from . import __version__
-from .io.server import INDEX_HTML
+from .. import __version__
+from .serve import Serve
 
 
 def transform_cmds(argv):
@@ -19,10 +20,11 @@ def transform_cmds(argv):
     Allows usage with anaconda-project by remapping the argv list provided
     into arguments accepted by Bokeh 0.12.7 or later.
     """
-    replacements = {'--anaconda-project-host':'--allow-websocket-origin',
-                    '--anaconda-project-port': '--port',
-                    '--anaconda-project-address': '--address'
-                     }
+    replacements = {
+        '--anaconda-project-host':'--allow-websocket-origin',
+        '--anaconda-project-port': '--port',
+        '--anaconda-project-address': '--address'
+    }
     transformed = []
     skip = False
     for arg in argv:
@@ -65,7 +67,12 @@ def main(args=None):
         subs.add_parser(cmd, help=fn.__doc__)
 
     for cls in bokeh_commands:
-        subs.add_parser(cls.name, help=cls.help)
+        if cls is BkServe:
+            subparser = subs.add_parser(Serve.name, help=Serve.help)
+            subcommand = Serve(parser=subparser)
+            subparser.set_defaults(invoke=subcommand.invoke)
+        else:
+            subs.add_parser(cls.name, help=cls.help)
 
     if len(sys.argv) == 1:
         all_commands = sorted([c.name for c in bokeh_commands] + pyct_commands)
@@ -77,10 +84,15 @@ def main(args=None):
         sys.exit()
 
     if len(sys.argv) > 1 and any(sys.argv[1] == c.name for c in bokeh_commands):
-        if sys.argv[1] == 'serve' and not any(arg.startswith('--index') for arg in sys.argv):
-            sys.argv = sys.argv + ['--index=%s' % INDEX_HTML]
         sys.argv = transform_cmds(sys.argv)
-        bokeh_entry_point()
+        if sys.argv[1] == 'serve':
+            args = parser.parse_args(sys.argv[1:])
+            try:
+                ret = args.invoke(args)
+            except Exception as e:
+                die("ERROR: " + str(e))
+        else:
+            bokeh_entry_point()
     elif sys.argv[1] in pyct_commands:
         try:
             import pyct.cmd
@@ -91,6 +103,13 @@ def main(args=None):
     else:
         parser.parse_args(sys.argv[1:])
         sys.exit(1)
+
+    if ret is False:
+        sys.exit(1)
+    elif ret is not True and isinstance(ret, int) and ret != 0:
+        sys.exit(ret)
+
+
 
 if __name__ == "__main__":
     main()

--- a/panel/command/__init__.py
+++ b/panel/command/__init__.py
@@ -92,7 +92,7 @@ def main(args=None):
             except Exception as e:
                 die("ERROR: " + str(e))
         else:
-            bokeh_entry_point()
+            ret = bokeh_entry_point()
     elif sys.argv[1] in pyct_commands:
         try:
             import pyct.cmd

--- a/panel/command/serve.py
+++ b/panel/command/serve.py
@@ -3,13 +3,9 @@ Subclasses the bokeh serve commandline handler to extend it in various
 ways.
 """
 
-from glob import glob
-
 from bokeh.command.subcommands.serve import Serve as _BkServe
 
 from ..io.server import INDEX_HTML, get_static_routes
-from ..util import bokeh_version
-
 
 def parse_var(s):
     """

--- a/panel/command/serve.py
+++ b/panel/command/serve.py
@@ -1,0 +1,65 @@
+"""
+Subclasses the bokeh serve commandline handler to extend it in various
+ways.
+"""
+
+from glob import glob
+
+from bokeh.command.subcommands.serve import Serve as _BkServe
+
+from ..io.server import INDEX_HTML, get_static_routes
+from ..util import bokeh_version
+
+
+def parse_var(s):
+    """
+    Parse a key, value pair, separated by '='
+    That's the reverse of ShellArgs.
+
+    On the command line (argparse) a declaration will typically look like:
+        foo=hello
+    or
+        foo="hello world"
+    """
+    items = s.split('=')
+    key = items[0].strip() # we remove blanks around keys, as is logical
+    if len(items) > 1:
+        # rejoin the rest:
+        value = '='.join(items[1:])
+    return (key, value)
+
+
+def parse_vars(items):
+    """
+    Parse a series of key-value pairs and return a dictionary
+    """
+    return dict((parse_var(item) for item in items))
+
+
+class Serve(_BkServe):
+
+    args = _BkServe.args + (
+        ('--static-dirs', dict(
+            metavar="KEY=VALUE",
+            nargs='+',
+            help=("Static directories to serve specified as key=value "
+                  "pairs mapping from URL route to static file directory.")
+        )),
+    )
+    
+    def customize_kwargs(self, args, server_kwargs):
+        '''Allows subclasses to customize ``server_kwargs``.
+
+        Should modify and return a copy of the ``server_kwargs`` dictionary.
+        '''
+        kwargs = dict(server_kwargs)
+        if 'index' not in kwargs:
+            kwargs['index'] = INDEX_HTML
+
+        # Handle tranquilized functions in the supplied functions
+        kwargs['extra_patterns'] = patterns = []
+
+        if args.static_dirs:
+            patterns += get_static_routes(parse_vars(args.static_dirs))
+
+        return kwargs

--- a/panel/io/server.py
+++ b/panel/io/server.py
@@ -181,11 +181,16 @@ def get_static_routes(static_dirs):
     """
     patterns = []
     for slug, path in static_dirs.items():
+        if not slug.startswith('/'):
+            slug = '/' + slug
+        if slug == '/static':
+            raise ValueError("Static file route may not use /static "
+                             "this is reserved for internal use.")
         path = os.path.abspath(path)
         if not os.path.isdir(path):
             raise ValueError("Cannot serve non-existent path %s" % path)
         patterns.append(
-            (r"/%s/(.*)" % slug, StaticFileHandler, {"path": path})
+            (r"%s/(.*)" % slug, StaticFileHandler, {"path": path})
         )
     return patterns
 

--- a/panel/tests/test_cli.py
+++ b/panel/tests/test_cli.py
@@ -1,4 +1,4 @@
-from panel.cli import transform_cmds
+from panel.command import transform_cmds
 
 def test_transformation():
     args = ['panel', 'serve', '.',

--- a/panel/tests/test_server.py
+++ b/panel/tests/test_server.py
@@ -4,13 +4,12 @@ import time
 import pytest
 import requests
 
-from bokeh.client import pull_session
 from tornado.ioloop import IOLoop
 
 from panel.io import state
 from panel.models import HTML as BkHTML
 from panel.pane import Markdown
-from panel.io.server import StoppableThread, get_server
+from panel.io.server import StoppableThread
 
 
 def test_get_server(html_server_session):

--- a/setup.py
+++ b/setup.py
@@ -89,7 +89,7 @@ except Exception:
 ########## dependencies ##########
 
 install_requires = [
-    'bokeh >=2.0.0',
+    'bokeh >=2.0.1',
     'param >=1.9.3',
     'pyviz_comms >=0.7.4',
     'markdown',
@@ -205,7 +205,7 @@ setup_args = dict(
     python_requires=">=3.6",
     entry_points={
         'console_scripts': [
-            'panel = panel.cli:main'
+            'panel = panel.command:main'
         ]},
     install_requires=install_requires,
     extras_require=extras_require,


### PR DESCRIPTION
This PR allows serving static files by providing a dictionary mapping from route to paths to `pn.serve` or `panel serve` on the command line.

On the commandline the syntax looks like this:

```bash
panel serve some_app.py --static-dirs custom_static="./examples"
``` 

while in Python it's specified as:

```python
pn.serve(some_pn_obj, static_dirs={'custom_static': './examples'})
```

In both cases all contents of './examples' will now be served on `http(s)://hostname/custom_static/` (note that the `/static` endpoint is reserved for bokeh's static files).

Implement https://github.com/holoviz/panel/issues/1118

- [x] Add docs
- [x] Add tests

Cc: @MarcSkovMadsen @lvankouwen Any chance you could give this a spin and see if it meets your requirements?