### PR TITLE
Fix bug in closed Tabs handling

### DIFF
--- a/panel/layout/tabs.py
+++ b/panel/layout/tabs.py
@@ -75,7 +75,7 @@ class Tabs(NamedListPanel):
         if model:
             try:
                 inds = [old.index(tab) for tab in new]
-            except:
+            except Exception:
                 return old, None
             old = self.objects
             new = [old[i] for i in inds]

--- a/panel/layout/tabs.py
+++ b/panel/layout/tabs.py
@@ -73,7 +73,10 @@ class Tabs(NamedListPanel):
         """
         model, _ = self._models.get(ref)
         if model:
-            inds = [old.index(tab) for tab in new]
+            try:
+                inds = [old.index(tab) for tab in new]
+            except:
+                return old, None
             old = self.objects
             new = [old[i] for i in inds]
         return old, new
@@ -84,6 +87,8 @@ class Tabs(NamedListPanel):
             return
         if attr == 'tabs':
             old, new = self._process_close(ref, attr, old, new)
+            if new is None:
+                return
         super(Tabs, self)._comm_change(doc, ref, attr, old, new)
 
     def _server_change(self, doc, ref, attr, old, new):
@@ -92,6 +97,8 @@ class Tabs(NamedListPanel):
             return
         if attr == 'tabs':
             old, new = self._process_close(ref, attr, old, new)
+            if new is None:
+                return
         super(Tabs, self)._server_change(doc, ref, attr, old, new)
 
     def _update_active(self, *events):


### PR DESCRIPTION
The server seemingly sometimes sends messages that are misinterpreted as Tab close events, this ensures these events are ignored.