### PR TITLE
Add a name parameter to the Param pane

### DIFF
--- a/examples/reference/panes/Param.ipynb
+++ b/examples/reference/panes/Param.ipynb
@@ -20,19 +20,20 @@
     "\n",
     "#### Parameters:\n",
     "\n",
-    "The basic parameters are\n",
+    "The basic parameters are:\n",
     "\n",
     "* **`object`** (param.parameterized.Parameters): The `param` attribute of a `param.Parameterized` Class\n",
-    "* **`parameters`** (None or List[str]): A list identifying the subset of parameters to include in the Pane.\n",
+    "* **`parameters`** (List[str]): A list identifying the subset of parameters to include in the Pane.\n",
     "* **`widgets`** (Dict): A Dictionary specifying which parameters and widgets to use for a given parameter. You can also specify widget attributes.\n",
     "\n",
-    "The more advanced parameters give you more control and they are\n",
+    "The more advanced parameters which give you more control are:\n",
     " \n",
-    "* **`default_layout`** (ClassSelector): A layout like Column, Row etc or a Custom GridBox.\n",
+    "* **`default_layout`** (ClassSelector): A layout like Column, Row, etc. or a Custom GridBox.\n",
     "* **`display_threshold`** (float): Parameters with precedence below this value are not displayed.\n",
     "* **`expand`** (bool): Whether parameterized subobjects are expanded or collapsed on instantiation.\n",
     "* **`expand_button`** (bool): Whether to add buttons to expand and collapse sub-objects.\n",
     "* **`expand_layout`** (layout): Layout to expand sub-objects into.\n",
+    "* **`name`** (str): The title of the pane.\n",
     "* **`show_labels`** (bool): Whether or not to show labels\n",
     "* **`show_name`** (bool): Whether or not to show the name of the Parameterized Class \n",
     "\n",
@@ -46,9 +47,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Lets build a model of a cycling Athlete and his PowerCurve. \n",
+    "Let's build a model of a cycling Athlete and her PowerCurve. \n",
     "\n",
-    "The PowerCurve is a recording of his maximum power output in Watt per kg for fixed durations of time."
+    "The PowerCurve is a recording of her maximum power output in Watt per kg for fixed durations of time."
    ]
   },
   {
@@ -113,7 +114,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The `pn.Param` can be used to view and edit the models.\n",
+    "The `pn.Param` pane can be used to view and edit the models.\n",
     "\n",
     "Try clicking the `...` button. This will expand the PowerCurve if running in an interactive notebook."
    ]
@@ -131,7 +132,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The default Name and Birthday widgets are slow to use. So lets change them to a `DatePicker` and a `LiteralInput` for ints."
+    "The default Name and Birthday widgets are slow to use. So let's change them to a `DatePicker` and a `LiteralInput`."
    ]
   },
   {
@@ -147,7 +148,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Lets expand the power curve by default:"
+    "Let's expand the power curve by default:"
    ]
   },
   {
@@ -168,7 +169,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now lets try to display the Name and Birthday only and in a Row."
+    "Now let's try to display the Name and Birthday only and in a Row."
    ]
   },
   {
@@ -191,7 +192,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Lets customize the view of the `Athlete` some more"
+    "Let's customize the view of the `Athlete` some more."
    ]
   },
   {
@@ -218,7 +219,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Lets take a look at the PowerCurve"
+    "Let's take a look at the PowerCurve."
    ]
   },
   {
@@ -234,7 +235,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The PowerCurve layout is not that tidy. Lets change the layout to two columns."
+    "The PowerCurve layout is not that tidy. Let's change the layout to two columns."
    ]
   },
   {
@@ -267,7 +268,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Lets put a plot of the PowerCurve in the mix"
+    "Let's put a plot of the PowerCurve in the mix."
    ]
   },
   {
@@ -306,7 +307,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "And finally. Lets put the things together"
+    "And finally, let's put things together."
    ]
   },
   {

--- a/examples/user_guide/Param.ipynb
+++ b/examples/user_guide/Param.ipynb
@@ -226,6 +226,24 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## Custom name\n",
+    "\n",
+    "By default, a param Pane has a title that is derived from the class name of its `Parameterized` object. Using the ``name`` keyword we can set any title to the pane, e.g. to improve the user interface."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pn.Param(CustomExample.param, name=\"Custom Name\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Parameter dependencies\n",
     "\n",
     "Declaring parameters is usually only the beginning of a workflow. In most applications these parameters are then tied to some computation. To express the relationship between a computation and the parameters it depends on, the ``param.depends`` decorator may be used on Parameterized methods. This decorator provides a hint to Panel and other Param-based libraries (e.g. HoloViews) that the method should be re-evaluated when a parameter changes.\n",

--- a/panel/param.py
+++ b/panel/param.py
@@ -209,7 +209,7 @@ class Param(PaneBase):
         for event in sorted(events, key=lambda x: x.name):
             if event.name == 'object':
                 if isinstance(event.new, param.parameterized.Parameters):
-                    self.object = object.cls if object.self is None else object.self
+                    self.object = self.object.cls if self.object.self is None else self.object.self
                     return
                 if event.new is None:
                     parameters = None

--- a/panel/param.py
+++ b/panel/param.py
@@ -94,6 +94,9 @@ class Param(PaneBase):
         usually to update the default Parameter values of the
         underlying parameterized object.""")
 
+    name = param.String(default='', doc="""
+        Title of the pane.""")
+
     parameters = param.List(default=[], doc="""
         If set this serves as a whitelist of parameters to display on
         the supplied Parameterized object.""")
@@ -151,6 +154,8 @@ class Param(PaneBase):
             object = object.cls if object.self is None else object.self
         if 'parameters' not in params and object is not None:
             params['parameters'] = [p for p in object.param if p != 'name']
+        if object and 'name' not in params:
+            params['name'] = param_name(object.name)
         super(Param, self).__init__(object, **params)
         self._updating = []
 
@@ -172,7 +177,7 @@ class Param(PaneBase):
                              'type or instance, found %s type.' %
                              type(layout).__name__)
         self.param.watch(self._update_widgets, [
-            'object', 'parameters', 'display_threshold', 'expand_button',
+            'object', 'parameters', 'name', 'display_threshold', 'expand_button',
             'expand', 'expand_layout', 'widgets', 'show_labels', 'show_name'])
         self._update_widgets()
 
@@ -201,7 +206,7 @@ class Param(PaneBase):
     #----------------------------------------------------------------
 
     def _synced_params(self):
-        ignored_params = ['name', 'default_layout']
+        ignored_params = ['default_layout']
         return [p for p in Layoutable.param if p not in ignored_params]
 
     def _update_widgets(self, *events):
@@ -215,6 +220,7 @@ class Param(PaneBase):
                     parameters = []
                 else:
                     parameters = [p for p in event.new.param if p != 'name']
+                    self.name = param_name(event.new.name)
             if event.name == 'parameters':
                 parameters = [] if event.new == [] else event.new
 
@@ -491,8 +497,7 @@ class Param(PaneBase):
         if self.expand_layout is Tabs:
             widgets = []
         elif self.show_name:
-            name = param_name(self.object.name)
-            widgets = [('_title', StaticText(value='<b>{0}</b>'.format(name)))]
+            widgets = [('_title', StaticText(value='<b>{0}</b>'.format(self.name)))]
         else:
             widgets = []
         widgets += [(pname, self.widget(pname)) for pname in self._ordered_params]

--- a/panel/param.py
+++ b/panel/param.py
@@ -209,14 +209,14 @@ class Param(PaneBase):
         for event in sorted(events, key=lambda x: x.name):
             if event.name == 'object':
                 if isinstance(event.new, param.parameterized.Parameters):
-                    self.object = self.object.cls if self.object.self is None else self.object.self
+                    self.object = event.new.cls if event.new.self is None else event.new.self
                     return
                 if event.new is None:
-                    parameters = None
+                    parameters = []
                 else:
                     parameters = [p for p in event.new.param if p != 'name']
             if event.name == 'parameters':
-                parameters = None if event.new == [] else event.new
+                parameters = [] if event.new == [] else event.new
 
         if parameters != [] and parameters != self.parameters:
             self.parameters = parameters

--- a/panel/tests/test_param.py
+++ b/panel/tests/test_param.py
@@ -482,6 +482,11 @@ def test_replace_param_object(document, comm):
     assert widget.start == 0
     assert widget.end == 10
 
+    # Check when object is None
+    pane.object = None
+
+    assert len(model.children) == 0
+
 
 def test_set_parameters(document, comm):
     class Test(param.Parameterized):

--- a/panel/tests/test_param.py
+++ b/panel/tests/test_param.py
@@ -85,6 +85,10 @@ def test_param_pane_repr_with_params(document, comm):
 
     assert repr(Pane(Test(), parameters=['a'])) == "Param(Test, parameters=['a'])"
 
+    # With a defined name.
+    test_pane = Pane(Test(), parameters=['a'], name='Another')
+    assert repr(test_pane) == "Param(Test, name='Another', parameters=['a'])"
+
 
 def test_get_root(document, comm):
 
@@ -486,6 +490,32 @@ def test_replace_param_object(document, comm):
     pane.object = None
 
     assert len(model.children) == 0
+
+
+def test_set_name(document, comm):
+    class Test(param.Parameterized):
+        a = param.Number(bounds=(0, 10))
+        b = param.String(default='A')
+
+    pane = Param(Test(), name='First')
+
+    model = pane.get_root(document, comm=comm)
+
+    assert len(model.children) == 3
+    title, slider, text = model.children
+    assert isinstance(title, Div)
+    # Check setting name displays in as a title
+    assert title.text == '<b>First</b>'
+    assert isinstance(slider, Slider)
+    assert isinstance(text, TextInput)
+
+    pane.name = 'Second'
+
+    assert len(model.children) == 3
+    title, _, _ = model.children
+    assert isinstance(title, Div)
+    # Check the title updates with name
+    assert title.text == '<b>Second</b>'
 
 
 def test_set_parameters(document, comm):

--- a/panel/tests/test_param.py
+++ b/panel/tests/test_param.py
@@ -469,6 +469,19 @@ def test_replace_param_object(document, comm):
     assert widget.start == 0
     assert widget.end == 10
 
+    # Check when object is from parameters
+    pane.object = Test().param
+
+    assert len(model.children) == 2
+    title, widget = model.children
+
+    assert isinstance(title, Div)
+    assert title.text == '<b>Test</b>'
+
+    assert isinstance(widget, Slider)
+    assert widget.start == 0
+    assert widget.end == 10
+
 
 def test_set_parameters(document, comm):
     class Test(param.Parameterized):


### PR DESCRIPTION
Fixes #1332 

I also fixed two non related bugs occurring when `.object` would be updated with `None` or with parameters `.param`.

![image](https://user-images.githubusercontent.com/35924738/81749756-84b59580-94ac-11ea-81e8-32b0f9e6bc7f.png)
