### PR TITLE
Fix handling of the Toggle widget in a Param pane

### DIFF
--- a/panel/tests/test_param.py
+++ b/panel/tests/test_param.py
@@ -363,15 +363,21 @@ def test_list_selector_param(document, comm):
 
 def test_action_param(document, comm):
     class Test(param.Parameterized):
-        a = param.Action(lambda x: x.b.append(1))
-        b = param.List(default=[])
+        a = param.Action(lambda x: setattr(x, 'b', 2))
+        b = param.Number(default=1)
 
     test = Test()
     test_pane = Pane(test)
     model = test_pane.get_root(document, comm=comm)
 
-    slider = model.children[1]
-    assert isinstance(slider, Button)
+    button = model.children[1]
+    assert isinstance(button, Button)
+
+    # Check that the action is actually executed
+    pn_button = test_pane.layout[1]
+    pn_button.clicks = 1
+
+    assert test.b == 2
 
 
 def test_explicit_params(document, comm):


### PR DESCRIPTION
Fixes #1331 

The panel widget `Toggle` was not synced like the other widgets in a Param pane:
https://github.com/holoviz/panel/blob/b73ec774734ee7b88ebaf7749707309caeba66b2/panel/param.py#L378-L379
This special handling originated from #15 and was probably implemented this way because the widget that is created when one needs to expand a subparameter pane is a `Toggle`. I believe that now widgets created in a pane are given by `_ordered_params()` which do not expose that `Toggle` widget. So it's just fine to remove that special handling.

I also took advantage of this PR to fix a typo and improve the coverage of the param action test.