### PR TITLE
Add Widget.from_param classmethod

### DIFF
--- a/examples/user_guide/Param.ipynb
+++ b/examples/user_guide/Param.ipynb
@@ -226,6 +226,22 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "However it is also possible to explicitly construct a widget from a parameter using the `.from_param` method, which makes it easy to override widget settings using keyword arguments:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pn.widgets.IntSlider.from_param(Example.param.unbounded_int, start=0, end=100)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Custom name\n",
     "\n",
     "By default, a param Pane has a title that is derived from the class name of its `Parameterized` object. Using the ``name`` keyword we can set any title to the pane, e.g. to improve the user interface."

--- a/panel/tests/widgets/test_base.py
+++ b/panel/tests/widgets/test_base.py
@@ -5,13 +5,16 @@ import pytest
 
 from panel.io import block_comm
 from panel.widgets import (
-    CompositeWidget, DataFrame, FileDownload, TextInput, ToggleGroup, Widget
+    CompositeWidget, DataFrame, FileDownload, FloatSlider, TextInput,
+    ToggleGroup, Widget
 )
 from panel.tests.util import check_layoutable_properties, py3_only
 
-all_widgets = [w for w in param.concrete_descendents(Widget).values()
-               if not w.__name__.startswith('_') and
-               not issubclass(w, (CompositeWidget, DataFrame, FileDownload, ToggleGroup))]
+all_widgets = [
+    w for w in param.concrete_descendents(Widget).values()
+    if not w.__name__.startswith('_') and
+    not issubclass(w, (CompositeWidget, DataFrame, FileDownload, ToggleGroup))
+]
 
 
 @py3_only
@@ -95,3 +98,56 @@ def test_widget_triggers_events(document, comm):
     assert event.attr == 'value'
     assert event.model is widget
     assert event.new == '123'
+
+
+def test_widget_from_param_cls():
+    class Test(param.Parameterized):
+
+        a = param.Parameter()
+
+    widget = TextInput.from_param(Test.param.a)
+    assert isinstance(widget, TextInput)
+    assert widget.name == 'A'
+
+    Test.a = 'abc'
+    assert widget.value == 'abc'
+
+    widget.value = 'def'
+    assert Test.a == 'def'
+
+
+def test_widget_from_param_instance():
+    class Test(param.Parameterized):
+
+        a = param.Parameter()
+
+    test = Test()
+    widget = TextInput.from_param(test.param.a)
+    assert isinstance(widget, TextInput)
+    assert widget.name == 'A'
+
+    test.a = 'abc'
+    assert widget.value == 'abc'
+
+    widget.value = 'def'
+    assert test.a == 'def'
+
+
+def test_widget_from_param_instance_with_kwargs():
+    class Test(param.Parameterized):
+
+        a = param.Number(default=3.14)
+
+    test = Test()
+    widget = FloatSlider.from_param(test.param.a, start=0.3, end=5.2)
+    assert isinstance(widget, FloatSlider)
+    assert widget.name == 'A'
+    assert widget.start == 0.3
+    assert widget.end == 5.2
+    assert widget.value == 3.14
+
+    test.a = 1.57
+    assert widget.value == 1.57
+
+    widget.value = 4.3
+    assert test.a == 4.3

--- a/panel/widgets/base.py
+++ b/panel/widgets/base.py
@@ -61,7 +61,7 @@ class Widget(Reactive):
         self.param.watch(self._update_widget, self._manual_params)
 
     @classmethod
-    def from_parameter(cls, parameter, **params):
+    def from_param(cls, parameter, **params):
         """
         Construct a widget from a Parameter and link the two
         bi-directionally.
@@ -78,7 +78,8 @@ class Widget(Reactive):
         Widget instance linked to the supplied parameter
         """
         from ..param import Param
-        return Param(parameter, widgets={parameter.name: dict(type=cls, **params)})
+        layout = Param(parameter, widgets={parameter.name: dict(type=cls, **params)})
+        return layout[0]
 
     def _manual_update(self, events, model, doc, root, parent, comm):
         """

--- a/panel/widgets/base.py
+++ b/panel/widgets/base.py
@@ -60,6 +60,26 @@ class Widget(Reactive):
         super(Widget, self).__init__(**params)
         self.param.watch(self._update_widget, self._manual_params)
 
+    @classmethod
+    def from_parameter(cls, parameter, **params):
+        """
+        Construct a widget from a Parameter and link the two
+        bi-directionally.
+        
+        Parameters
+        ----------
+        parameter: param.Parameter
+          A parameter to create the widget from.
+        params: dict
+          Keyword arguments to be passed to the widget constructor
+        
+        Returns
+        -------
+        Widget instance linked to the supplied parameter
+        """
+        from ..param import Param
+        return Param(parameter, widgets={parameter.name: dict(type=cls, **params)})
+
     def _manual_update(self, events, model, doc, root, parent, comm):
         """
         Method for handling any manual update events, i.e. events triggered


### PR DESCRIPTION
Simplifies the creation of a widget linked to and created from a particular parameter.

```python
import param

class A(param.Parameterized):
    
    value = param.Number()
    
a = A()

pn.widgets.FloatSlider.from_param(a.param.value, start=0, end=3.14)
```

@maximlt @MarcSkovMadsen Any thoughts on this? It's **a** solution to something I think you both brought up before. If you like the idea maybe we should also consider a shorter method name than `from_parameter`, suggestions welcome.