### PR TITLE
rename widget-box -> panel-widget-box

### DIFF
--- a/examples/gallery/demos/VTKSlicer.ipynb
+++ b/examples/gallery/demos/VTKSlicer.ipynb
@@ -156,7 +156,7 @@
     "    pn.Column(dataset_selection, toggle_parallel_proj, *volume_controls[1:], sizing_mode='fixed'),\n",
     "    pn.Param(smoother, parameters=['smooth_level', 'order']),\n",
     "    pn.layout.VSpacer(),\n",
-    "    css_classes=['widget-box', 'custom-wbox'], sizing_mode='stretch_height'\n",
+    "    css_classes=['panel-widget-box', 'custom-wbox'], sizing_mode='stretch_height'\n",
     ")"
    ]
   },

--- a/examples/gallery/dynamic/dynamic_ui.ipynb
+++ b/examples/gallery/dynamic/dynamic_ui.ipynb
@@ -33,7 +33,7 @@
     "    pn.widgets.RangeSlider,\n",
     "    pn.widgets.Spinner,\n",
     "    pn.widgets.TextInput,\n",
-    "], css_classes=['widget-box'])\n",
+    "], css_classes=['panel-widget-box'])\n",
     "\n",
     "row = pn.Row(selector, pn.widgets.ColorPicker(), pn.pane.Str())\n",
     "\n",

--- a/examples/user_guide/Customization.ipynb
+++ b/examples/user_guide/Customization.ipynb
@@ -28,7 +28,7 @@
     "\n",
     "The ``css_classes`` parameter allows associating a Panel component with one or more CSS classes. CSS styles can be embedded in raw form or by referencing an external .css file by providing each to the panel extension using the ``raw_css`` and ``css_files`` arguments; both should be supplied as lists. Outside the notebook or if we want to add some CSS in an external module or library, we can simply append to the ``pn.config.raw_css`` and ``pn.config.js_files`` config parameters.\n",
     "\n",
-    "To demonstrate this usage, let us define a CSS class called ``widget-box`` which we will give a background and a nice border:"
+    "To demonstrate this usage, let us define a CSS class called ``panel-widget-box`` which we will give a background and a nice border:"
    ]
   },
   {
@@ -38,7 +38,7 @@
    "outputs": [],
    "source": [
     "css = '''\n",
-    ".widget-box {\n",
+    ".panel-widget-box {\n",
     "  background: #f0f0f0;\n",
     "  border-radius: 5px;\n",
     "  border: 1px black solid;\n",
@@ -65,7 +65,7 @@
     "    pn.widgets.FloatSlider(name='Number', margin=(10, 5, 5, 10)),\n",
     "    pn.widgets.Select(name='Fruit', options=['Apple', 'Orange', 'Pear'], margin=(0, 5, 5, 10)),\n",
     "    pn.widgets.Button(name='Run', margin=(5, 10, 10, 10)),\n",
-    "css_classes=['widget-box'])"
+    "css_classes=['panel-widget-box'])"
    ]
   },
   {

--- a/panel/_styles/widgets.css
+++ b/panel/_styles/widgets.css
@@ -1,4 +1,4 @@
-.widget-box {
+.panel-widget-box {
 	min-height: 20px;
 	background-color: #f5f5f5;
 	border: 1px solid #e3e3e3 !important;

--- a/panel/layout/base.py
+++ b/panel/layout/base.py
@@ -648,7 +648,7 @@ class WidgetBox(ListPanel):
     Vertical layout of widgets.
     """
 
-    css_classes = param.List(default=['widget-box'], doc="""
+    css_classes = param.List(default=['panel-widget-box'], doc="""
         CSS classes to apply to the layout.""")
 
     disabled = param.Boolean(default=False, doc="""


### PR DESCRIPTION
Because it overwrites the style of ipywidgets.

https://github.com/jupyter-widgets/ipywidgets/blob/3bd75276370271e43ca5aa38d59a1848dfb65fb7/packages/controls/css/widgets-base.css#L99

Because of this code, running `holoviews.notebook_extension()` overwrites existing css that changes an `ipywidget` from:
![image](https://user-images.githubusercontent.com/6897215/82263542-6e538200-9963-11ea-9961-deed3c8ce5cf.png)
to
<img width="1006" alt="Screenshot 2020-05-18 at 23 55 00" src="https://user-images.githubusercontent.com/6897215/82263526-64ca1a00-9963-11ea-8e76-fed4d8886c0a.png">

The annoying thing is that this change persists over kernel restarts *and* clearing of the notebook.