### PR TITLE
Add support for hierarchical multi-indexed DataFrame

### DIFF
--- a/examples/reference/widgets/DataFrame.ipynb
+++ b/examples/reference/widgets/DataFrame.ipynb
@@ -16,7 +16,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The ``DataFrame`` widget allows displaying and editing a pandas DataFrame.\n",
+    "The ``DataFrame`` widget allows displaying and editing a pandas DataFrame. Note that for multi-indexed DataFrames editing is not possible and you will have to reduce the DataFrame to a single index.\n",
     "\n",
     "For more information about listening to widget events and laying out widgets refer to the [widgets user guide](../../user_guide/Widgets.ipynb). Alternatively you can learn how to build GUIs by declaring parameters independently of any specific widgets in the [param user guide](../../user_guide/Param.ipynb). To express interactivity entirely using Javascript without the need for a Python server take a look at the [links user guide](../../user_guide/Param.ipynb).\n",
     "\n",
@@ -26,9 +26,11 @@
     "\n",
     "##### Core\n",
     "\n",
-    "* **``editors``** (``dict``):  A dictionary mapping from column name to a bokeh CellEditor instance, which overrides the default.\n",
+    "* **``aggregators``** (``dict``): A dictionary mapping from index name to an aggregator to be used for hierarchical multi-indexes (valid aggregators include 'min', 'max', 'mean' and 'sum'). If separate aggregators for different columns are required the dictionary may be nested as `{index_name: {column_name: aggregator}}`\n",
+    "* **``editors``** (``dict``):  A dictionary mapping from column name to a bokeh `CellEditor` instance, which overrides the default.\n",
+    "* **``hierarchical``** (boolean, default=False): Whether to render multi-indexes as hierarchical index (note hierarchical must be enabled during instantiation and cannot be modified later)\n",
     "* **``fit_columns``** (``boolean``, default=True): Whether columns should expand to the available width. \n",
-    "* **``formatters``** (``dict``): A dictionary mapping from column name to a bokeh CellFormatter instance, which overrides the default.\n",
+    "* **``formatters``** (``dict``): A dictionary mapping from column name to a bokeh `CellFormatter` instance, which overrides the default.\n",
     "* **``row_height``** (``int``): The height of each table row.\n",
     "* **``selection``** (``list``) The currently selected rows \n",
     "* **``value``** (``pd.DataFrame``): The pandas DataFrame to display and edit\n",
@@ -100,6 +102,30 @@
     "table.selection = [0, 2]\n",
     "\n",
     "table.selected_dataframe"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Hierarchical Multi-index\n",
+    "\n",
+    "The `DataFrame` widget can also render a hierarchical multi-index and aggregate over specific categories. If a DataFrame with a hierarchical multi-index is supplied and the `hierarchical` is enabled the widget will group data by the categories in the order they are defined in. Additionally for each group in the multi-index an aggregator may be provided which will aggregate over the values in that category.\n",
+    "\n",
+    "For example we may load population data for locations around the world broken down by sex and age-group. If we specify aggregators over the 'Sex' and 'Location' indexes we can see the aggregated values for each of those groups:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from bokeh.sampledata.population import data as population_data \n",
+    "\n",
+    "pop_df = population_data[population_data.Year == 2020].set_index(['Location', 'Sex', 'AgeGrp'])[['Value']]\n",
+    "\n",
+    "pn.widgets.DataFrame(value=pop_df, hierarchical=True, aggregators={'Sex': 'sum', 'Location': 'sum'}, height=400)"
    ]
   },
   {

--- a/examples/reference/widgets/DataFrame.ipynb
+++ b/examples/reference/widgets/DataFrame.ipynb
@@ -112,7 +112,7 @@
     "\n",
     "The `DataFrame` widget can also render a hierarchical multi-index and aggregate over specific categories. If a DataFrame with a hierarchical multi-index is supplied and the `hierarchical` is enabled the widget will group data by the categories in the order they are defined in. Additionally for each group in the multi-index an aggregator may be provided which will aggregate over the values in that category.\n",
     "\n",
-    "For example we may load population data for locations around the world broken down by sex and age-group. If we specify aggregators over the 'Sex' and 'Location' indexes we can see the aggregated values for each of those groups:"
+    "For example we may load population data for locations around the world broken down by sex and age-group. If we specify aggregators over the 'AgeGrp' and 'Sex' indexes we can see the aggregated values for each of those groups (note that we do not have to specify an aggregator for the outer index since we specify the aggregators over the subgroups in this case the 'Sex'):"
    ]
   },
   {
@@ -123,9 +123,9 @@
    "source": [
     "from bokeh.sampledata.population import data as population_data \n",
     "\n",
-    "pop_df = population_data[population_data.Year == 2020].set_index(['Location', 'Sex', 'AgeGrp'])[['Value']]\n",
+    "pop_df = population_data[population_data.Year == 2020].set_index(['Location', 'AgeGrp', 'Sex'])[['Value']]\n",
     "\n",
-    "pn.widgets.DataFrame(value=pop_df, hierarchical=True, aggregators={'Sex': 'sum', 'Location': 'sum'}, height=400)"
+    "pn.widgets.DataFrame(value=pop_df, hierarchical=True, aggregators={'Sex': 'sum', 'AgeGrp': 'sum'}, height=400)"
    ]
   },
   {

--- a/panel/tests/widgets/test_tables.py
+++ b/panel/tests/widgets/test_tables.py
@@ -10,7 +10,7 @@ except ImportError:
 
 from bokeh.models.widgets.tables import (
     NumberFormatter, IntEditor, NumberEditor, StringFormatter,
-    SelectEditor, DateFormatter, DateEditor, DataCube, CellEditor,
+    SelectEditor, DateFormatter, DataCube, CellEditor,
     SumAggregator, AvgAggregator, MinAggregator
 )
 

--- a/panel/tests/widgets/test_tables.py
+++ b/panel/tests/widgets/test_tables.py
@@ -10,7 +10,8 @@ except ImportError:
 
 from bokeh.models.widgets.tables import (
     NumberFormatter, IntEditor, NumberEditor, StringFormatter,
-    SelectEditor, DateFormatter, DateEditor
+    SelectEditor, DateFormatter, DateEditor, DataCube, CellEditor,
+    SumAggregator, AvgAggregator, MinAggregator
 )
 
 from panel.widgets import DataFrame
@@ -26,7 +27,7 @@ def test_dataframe_widget(dataframe, document, comm):
 
     assert index_col.title == 'index'
     assert isinstance(index_col.formatter, NumberFormatter)
-    assert isinstance(index_col.editor, IntEditor)
+    assert isinstance(index_col.editor, CellEditor)
 
     assert int_col.title == 'int'
     assert isinstance(int_col.formatter, NumberFormatter)
@@ -51,7 +52,7 @@ def test_dataframe_widget_datetimes(document, comm):
 
     assert dt_col.title == 'index'
     assert isinstance(dt_col.formatter, DateFormatter)
-    assert isinstance(dt_col.editor, DateEditor)
+    assert isinstance(dt_col.editor, CellEditor)
 
 
 def test_dataframe_editors(dataframe, document, comm):
@@ -132,3 +133,37 @@ def test_dataframe_duplicate_column_name(document, comm):
     table.get_root(document, comm)
     with pytest.raises(ValueError):
         table.value = table.value.rename(columns={'a': 'b'})
+
+
+def test_hierarchical_index(document, comm):
+    df = pd.DataFrame([
+        ('Germany', 2020, 9, 2.4, 'A'),
+        ('Germany', 2021, 3, 7.3, 'C'),
+        ('Germany', 2022, 6, 3.1, 'B'),
+        ('UK', 2020, 5, 8.0, 'A'),
+        ('UK', 2021, 1, 3.9, 'B'),
+        ('UK', 2022, 9, 2.2, 'A')
+    ], columns=['Country', 'Year', 'Int', 'Float', 'Str']).set_index(['Country', 'Year'])
+
+    table = DataFrame(value=df, hierarchical=True,
+                      aggregators={'Year': {'Int': 'sum', 'Float': 'mean'}})
+
+    model = table.get_root(document, comm)
+    assert isinstance(model, DataCube)
+    assert len(model.grouping) == 1
+    grouping = model.grouping[0]
+    assert len(grouping.aggregators) == 2
+    agg1, agg2 = grouping.aggregators
+    assert agg1.field_ == 'Int'
+    assert isinstance(agg1, SumAggregator)
+    assert agg2.field_ == 'Float'
+    assert isinstance(agg2, AvgAggregator)
+
+    table.aggregators = {'Year': 'min'}
+
+    agg1, agg2 = grouping.aggregators
+    print(grouping)
+    assert agg1.field_ == 'Int'
+    assert isinstance(agg1, MinAggregator)
+    assert agg2.field_ == 'Float'
+    assert isinstance(agg2, MinAggregator)

--- a/panel/widgets/tables.py
+++ b/panel/widgets/tables.py
@@ -4,9 +4,11 @@ import numpy as np
 import param
 
 from bokeh.models import ColumnDataSource
-from bokeh.models.widgets import (
-    DataTable, TableColumn, NumberEditor, NumberFormatter,
-    DateFormatter, DateEditor, StringFormatter, StringEditor, IntEditor
+from bokeh.models.widgets.tables import (
+    DataTable, DataCube, TableColumn, GroupingInfo, RowAggregator,
+    NumberEditor, NumberFormatter, DateFormatter, CellEditor,
+    DateEditor, StringFormatter, StringEditor, IntEditor,
+    AvgAggregator, MaxAggregator, MinAggregator, SumAggregator
 )
 
 from ..viewable import Layoutable
@@ -16,9 +18,19 @@ from .base import Widget
 
 class DataFrame(Widget):
 
+    aggregators = param.Dict(default={}, doc="""
+        A dictionary mapping from index name to an aggregator to
+        be used for hierarchical multi-indexes (valid aggregators
+        include 'min', 'max', 'mean' and 'sum'). If separate
+        aggregators for different columns are required the dictionary
+        may be nested as `{index_name: {column_name: aggregator}}`""")
+
     editors = param.Dict(default={}, doc="""
         Bokeh CellEditor to use for a particular column
         (overrides the default chosen based on the type).""")
+
+    hierarchical = param.Boolean(default=False, constant=True, doc="""
+        Whether to generate a hierachical index.""")
 
     formatters = param.Dict(default={}, doc="""
         Bokeh CellFormatter to use for a particular column
@@ -43,7 +55,11 @@ class DataFrame(Widget):
     _rename = {'editors': None, 'formatters': None, 'widths': None,
                'disabled': None}
 
-    _manual_params = ['value', 'editors', 'formatters', 'selection', 'widths']
+    _manual_params = ['value', 'editors', 'formatters', 'selection',
+                      'widths', 'aggregators']
+
+    _aggregators = {'sum': SumAggregator, 'max': MaxAggregator,
+                    'min': MinAggregator, 'mean': AvgAggregator}
 
     def __init__(self, value=None, **params):
         super(DataFrame, self).__init__(value=value, **params)
@@ -59,18 +75,31 @@ class DataFrame(Widget):
             raise ValueError('Cannot display a pandas.DataFrame with '
                              'duplicate column names.')
 
+    @property
+    def indexes(self):
+        import pandas as pd
+        if isinstance(self.value.index, pd.MultiIndex):
+            return list(self.value.index.names)
+        return [self.value.index.name or 'index']
+
     def _get_columns(self):
         if self.value is None:
             return []
 
-        index = [self.value.index.name or 'index']
-        col_names = index + list(self.value.columns)
+        indexes = self.indexes
+        col_names = list(self.value.columns)
+        if not self.hierarchical or len(indexes) == 1:
+            col_names = indexes + col_names
+        else:
+            col_names = indexes[-1:] + col_names
+        df = self.value.reset_index() if len(indexes) > 1 else self.value
         columns = []
         for col in col_names:
-            if col in self.value.columns:
-                data = self.value[col]
+            if col in df.columns:
+                data = df[col]
             else:
-                data = self.value.index
+                data = df.index
+
             kind = data.dtype.kind
             if kind == 'i':
                 formatter = NumberFormatter()
@@ -87,43 +116,84 @@ class DataFrame(Widget):
 
             if col in self.editors:
                 editor = self.editors[col]
+
+            if col in indexes or editor is None:
+                editor = CellEditor()
+
             if col in self.formatters:
                 formatter = self.formatters[col]
             if str(col) != col:
                 self._renamed_cols[str(col)] = col
             width = self.widths.get(str(col))
-            column = TableColumn(field=str(col), title=str(col),
+
+            title = str(col)
+            if col in indexes and len(indexes) > 1 and self.hierarchical:
+                title = 'Index: %s' % ' | '.join(indexes)
+            column = TableColumn(field=str(col), title=title,
                                  editor=editor, formatter=formatter,
                                  width=width)
             columns.append(column)
         return columns
 
+    def _get_groupings(self):
+        if self.value is None:
+            return []
+
+        groups = []
+        for group in self.indexes[:-1]:
+            if str(group) != group:
+                self._renamed_cols[str(group)] = group
+            aggs = self._get_aggregators(group)
+            groups.append(GroupingInfo(getter=str(group), aggregators=aggs))
+        return groups
+
+    def _get_aggregators(self, group):
+        numeric_cols = list(self.value.select_dtypes(include='number').columns)
+        aggs = self.aggregators.get(group, [])
+        if not isinstance(aggs, list):
+            aggs = [aggs]
+        expanded_aggs = []
+        for col_aggs in aggs:
+            if not isinstance(col_aggs, dict):
+                col_aggs = {col: col_aggs for col in numeric_cols}
+            for col, agg in col_aggs.items():
+                if isinstance(agg, str):
+                    agg = self._aggregators.get(agg)
+                if issubclass(agg, RowAggregator):
+                    expanded_aggs.append(agg(field_=str(col)))
+        return expanded_aggs
+
     def _get_properties(self):
         props = {p : getattr(self, p) for p in list(Layoutable.param)
                  if getattr(self, p) is not None}
-        if self.value is None:
+        df = self.value.reset_index() if len(self.indexes) > 1 else self.value
+        if df is None:
             data = {}
         else:
             data = {k if isinstance(k, str) else str(k): v
-                    for k, v in ColumnDataSource.from_df(self.value).items()}
+                    for k, v in ColumnDataSource.from_df(df).items()}
         if props.get('height', None) is None:
             length = max([len(v) for v in data.values()]) if data else 0
             props['height'] = length * self.row_height + 30
+        if self.hierarchical:
+            props['target'] = ColumnDataSource(data=dict(row_indices=[], labels=[]))
+            props['grouping'] = self._get_groupings()
         props['source'] = ColumnDataSource(data=data)
         props['columns'] = self._get_columns()
         props['index_position'] = None
         props['fit_columns'] = self.fit_columns
         props['row_height'] = self.row_height
-        props['editable'] = not self.disabled
+        props['editable'] = not self.disabled and len(self.indexes) == 1
         return props
 
     def _process_param_change(self, msg):
         if 'disabled' in msg:
-            msg['editable'] = not msg.pop('disabled')
+            msg['editable'] = not msg.pop('disabled') and len(self.indexes) == 1
         return super(DataFrame, self)._process_param_change(msg)
-    
+
     def _get_model(self, doc, root=None, parent=None, comm=None):
-        model = DataTable(**self._get_properties())
+        model_type = DataCube if self.hierarchical else DataTable
+        model = model_type(**self._get_properties())
         if root is None:
             root = model
         self._link_props(model.source, ['data', ('patching', 'data')], doc, root, comm)
@@ -142,6 +212,10 @@ class DataFrame(Widget):
                 model.columns = self._get_columns()
             elif event.name == 'selection':
                 model.source.selected.indices = self.selection
+            elif event.name == 'aggregators':
+                for g in model.groups:
+                    index = self._renamed_cols.get(g.getter, g.getter)
+                    g.aggregators = self._get_aggregators(index)
             else:
                 for col in model.columns:
                     if col.name in self.editors:
@@ -156,7 +230,7 @@ class DataFrame(Widget):
             data = events.pop('data')
             updated = False
             for k, v in data.items():
-                if k == 'index':
+                if k in self.indexes:
                     continue
                 k = self._renamed_cols.get(k, k)
                 if isinstance(v, dict):


### PR DESCRIPTION
This PR improves the `DataFrame` widget in a two ways relating to support for DataFrame indexes:

1. It fixes a bug editing DataFrames with a non-default index name
2. It adds support for displaying hierarchical multi-indexed dataframes with aggregators

As an example here is a three-level DataFrame aggregated over the indexes:

```python
from bokeh.sampledata.population import data as population_data 

pop_df = population_data[population_data.Year == 2020].set_index(['Location', 'Sex', 'AgeGrp'])[['Value']]

pn.widgets.DataFrame(value=pop_df, hierarchical=True, aggregators={'Sex': 'sum', 'Location': 'sum'}, height=400) 
```

![Screen Shot 2020-06-04 at 3 10 24 PM](https://user-images.githubusercontent.com/1550771/83760673-8c182b00-a675-11ea-82a2-d873e44413f4.png)
