### PR TITLE
Improvements for ipywidgets support

### DIFF
--- a/panel/io/ipywidget.py
+++ b/panel/io/ipywidget.py
@@ -1,6 +1,5 @@
 import logging
 
-from bokeh.io import curdoc
 from bokeh.document.events import MessageSentEvent
 from ipykernel.comm import CommManager
 from ipywidgets_bokeh.kernel import BokehKernel, SessionWebsocket, WebsocketStream

--- a/panel/io/ipywidget.py
+++ b/panel/io/ipywidget.py
@@ -1,0 +1,72 @@
+import logging
+
+from bokeh.io import curdoc
+from bokeh.document.events import MessageSentEvent
+from ipykernel.comm import CommManager
+from ipywidgets_bokeh.kernel import BokehKernel, SessionWebsocket, WebsocketStream
+
+
+class PanelSessionWebsocket(SessionWebsocket):
+
+    def __init__(self, *args, **kwargs):
+        self._document = kwargs.pop('document', None)
+        self._queue = []
+        super(PanelSessionWebsocket, self).__init__(*args, **kwargs)
+
+    def send(self, stream, msg_type, content=None, parent=None, ident=None, buffers=None, track=False, header=None, metadata=None):
+        msg = self.msg(msg_type, content=content, parent=parent, header=header, metadata=metadata)
+        msg['channel'] = stream.channel
+
+        doc = self._document
+        doc.on_message("ipywidgets_bokeh", self.receive)
+
+        packed = self.pack(msg)
+
+        if buffers is not None and len(buffers) != 0:
+            buffers = [packed] + buffers
+            nbufs = len(buffers)
+
+            start = 4*(1 + nbufs)
+            offsets = [start]
+
+            for buffer in buffers[:-1]:
+                start += len(buffer)
+                offsets.append(start)
+
+            u32 = lambda n: n.to_bytes(4, "big")
+            items = [u32(nbufs)] + [ u32(offset) for offset in offsets ] + buffers
+            data = b"".join(items)
+        else:
+            data = packed.decode("utf-8")
+
+        event = MessageSentEvent(doc, "ipywidgets_bokeh", data)
+        self._queue.append(event)
+        doc.add_next_tick_callback(self._dispatch)
+
+    def _dispatch(self):
+        try:
+            for event in self._queue:
+                self._document._trigger_on_change(event)
+        except Exception:
+            pass
+        finally:
+            self._queue = []
+
+
+class PanelKernel(BokehKernel):
+
+    def __init__(self, key=None, document=None):
+        super(BokehKernel, self).__init__()
+
+        self.session = PanelSessionWebsocket(document=document, parent=self, key=key)
+        self.stream = self.iopub_socket = WebsocketStream(self.session)
+
+        self.iopub_socket.channel = 'iopub'
+        self.session.stream = self.iopub_socket
+        self.comm_manager = CommManager(parent=self, kernel=self)
+        self.shell = None
+        self.log = logging.getLogger('fake')
+
+        comm_msg_types = ['comm_open', 'comm_msg', 'comm_close']
+        for msg_type in comm_msg_types:
+            self.shell_handlers[msg_type] = getattr(self.comm_manager, msg_type)

--- a/panel/io/resources.py
+++ b/panel/io/resources.py
@@ -31,8 +31,15 @@ def css_raw(self):
 def js_files(self):
     from ..config import config
     files = super(Resources, self).js_files
-    return files + list(config.js_files.values())
+    js_files = files + list(config.js_files.values())
 
+    # Load requirejs last to avoid interfering with other libraries
+    require_index = [i for i, jsf in enumerate(js_files) if 'require' in jsf]
+    if require_index:
+        requirejs = js_files.pop(require_index[0])
+        js_files.append(requirejs)
+    return js_files
+                    
 def css_files(self):
     from ..config import config
     files = super(Resources, self).css_files

--- a/panel/pane/ipywidget.py
+++ b/panel/pane/ipywidget.py
@@ -19,20 +19,20 @@ class IPyWidget(PaneBase):
         if root is None:
             return self._get_root(doc, comm)
 
-        import ipykernel
         if isinstance(comm, JupyterComm) and not config.embed:
             IPyWidget = _BkIPyWidget
         else:
+            import ipykernel
             from ipywidgets_bokeh.widget import IPyWidget
             from ipywidgets_bokeh.kernel import BokehKernel
+            if not isinstance(ipykernel.kernelbase.Kernel._instance, BokehKernel):
+                from ..io.ipywidget import PanelKernel
+                kernel = PanelKernel(key=root.ref['id'].encode('utf-8'), document=doc)
+                for w in self.object.widgets.values():
+                    w.comm.kernel = kernel
+                    w.comm.open()
 
         props = self._process_param_change(self._init_properties())
-        if not isinstance(ipykernel.kernelbase.Kernel._instance, BokehKernel):
-            from ..io.ipywidget import PanelKernel
-            kernel = PanelKernel(key=root.ref['id'].encode('utf-8'), document=doc)
-            for w in self.object.widgets.values():
-                w.comm.kernel = kernel
-                w.comm.open()
         model = IPyWidget(widget=self.object, **props)
         self._models[root.ref['id']] = (model, parent)
         return model

--- a/panel/pane/ipywidget.py
+++ b/panel/pane/ipywidget.py
@@ -19,12 +19,20 @@ class IPyWidget(PaneBase):
         if root is None:
             return self._get_root(doc, comm)
 
+        import ipykernel
         if isinstance(comm, JupyterComm) and not config.embed:
             IPyWidget = _BkIPyWidget
         else:
             from ipywidgets_bokeh.widget import IPyWidget
+            from ipywidgets_bokeh.kernel import BokehKernel
 
         props = self._process_param_change(self._init_properties())
+        if not isinstance(ipykernel.kernelbase.Kernel._instance, BokehKernel):
+            from ..io.ipywidget import PanelKernel
+            kernel = PanelKernel(key=root.ref['id'].encode('utf-8'), document=doc)
+            for w in self.object.widgets.values():
+                w.comm.kernel = kernel
+                w.comm.open()
         model = IPyWidget(widget=self.object, **props)
         self._models[root.ref['id']] = (model, parent)
         return model


### PR DESCRIPTION
Previously we had supported using ipywidgets in the notebook (using the regular Jupyter CommManager) and on the server using ipywidgets_bokeh. I had however overlooked the case where you start a server inside the notebook, e.g. when using `.show()`. This PR provides a custom IPyKernel to be used in such scenarios, when rendering a plot with `.show()` the kernel on each Comm is updated to point to this custom kernel allowing communication on the server even when it has been launched inside a notebook.