### PR TITLE
Add print_margin and filename option to Ace widget

### DIFF
--- a/examples/reference/widgets/Ace.ipynb
+++ b/examples/reference/widgets/Ace.ipynb
@@ -32,7 +32,9 @@
     "    - `'column'`: column of the annotation\n",
     "    - `'text'`: text displayed when hovering over the annotation\n",
     "    - `'type'`: type of annotation and the icon displayed {`warning` | `error`}\n",
-    "* **``language``** (str): A string declaring which language to use for code syntax highlighting (default: 'python')\n",
+    "* **``filename``** (str): If filename is provided the file extension will be used to determine the language\n",
+    "* **``language``** (str): A string declaring which language to use for code syntax highlighting (default: 'text')\n",
+    "* **``print_margin``** (boolean): Whether to show a print margin in the editor\n",
     "* **``theme``** (str): theme of the editor (default: 'chrome')\n",
     "* **``readonly``** (boolean): Whether the editor should be opened in read-only mode\n",
     "* **``value``** (str): A string with (initial) code to set in the editor\n",
@@ -55,7 +57,7 @@
    "outputs": [],
    "source": [
     "py_code = \"\"\"import sys\"\"\"\n",
-    "editor = pn.widgets.Ace(value=py_code, sizing_mode='stretch_both', height=300)\n",
+    "editor = pn.widgets.Ace(value=py_code, sizing_mode='stretch_both', language='python', height=300)\n",
     "editor"
    ]
   },
@@ -72,7 +74,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "editor.value += \"\"\"import Math\n",
+    "editor.value += \"\"\"\n",
+    "import Math\n",
     "\n",
     "x = Math.cos(x)**2 + Math.cos(y)**2\n",
     "\"\"\""
@@ -146,6 +149,22 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "If instead of setting the language explicitly we want to set the filename and automatically detect the language based on the file extension we can do that too:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "editor.filename = 'test.html'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### Including the Ace editor in a parameterized class\n",
     "\n",
     "You can view the Ace widget as part of a `param.Parameterized` class:"
@@ -194,6 +213,13 @@
     "widget = pn.widgets.Ace(name='Ace', value=py_code, sizing_mode='stretch_both', height=300)\n",
     "\n",
     "pn.Row(widget.controls(jslink=True), widget)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Try changing the filename including a file extension and watch the language automatically update."
    ]
   }
  ],

--- a/panel/models/ace.py
+++ b/panel/models/ace.py
@@ -41,6 +41,8 @@ class AcePlot(HTMLBox):
 
     readonly = Bool(default=False)
 
+    print_margin = Bool(default=False)
+
     height = Override(default=300)
 
     width = Override(default=300)

--- a/panel/models/ace.py
+++ b/panel/models/ace.py
@@ -16,8 +16,9 @@ class AcePlot(HTMLBox):
     """
 
     __javascript__ = [
-        'https://cdnjs.cloudflare.com/ajax/libs/ace/1.4.7/ace.js',
-        'https://cdnjs.cloudflare.com/ajax/libs/ace/1.4.7/ext-language_tools.js'
+        'https://cdnjs.cloudflare.com/ajax/libs/ace/1.4.11/ace.js',
+        'https://cdnjs.cloudflare.com/ajax/libs/ace/1.4.11/ext-language_tools.js',
+        'https://cdnjs.cloudflare.com/ajax/libs/ace/1.4.11/ext-modelist.min.js'
     ]
 
     __js_skip__ = {'ace': __javascript__}
@@ -27,7 +28,8 @@ class AcePlot(HTMLBox):
             ('ace', ('ace/ace', 'ace/ext-language_tools')): '//cdnjs.cloudflare.com/ajax/libs/ace/1.4.7'},
         'exports': {'ace': 'ace'},
         'shim': {
-            'ace/ext-language_tools': { 'deps': ["ace/ace"] }
+            'ace/ext-language_tools': { 'deps': ["ace/ace"] },
+            'ace/ext-modelist': { 'deps': ["ace/ace"] }
         }
     }
 
@@ -35,7 +37,9 @@ class AcePlot(HTMLBox):
 
     theme = Enum(ace_themes, default='chrome')
 
-    language = String(default='python')
+    filename = String()
+
+    language = String()
 
     annotations = List(Dict(String, Any), default=[])
 

--- a/panel/models/ace.ts
+++ b/panel/models/ace.ts
@@ -17,6 +17,7 @@ export class AcePlotView extends PanelHTMLBoxView {
   protected _ace: any
   protected _editor: any
   protected _langTools: any
+  protected _modelist: any
   protected _container: HTMLDivElement
 
   initialize(): void {
@@ -36,6 +37,7 @@ export class AcePlotView extends PanelHTMLBoxView {
     this.connect(this.model.properties.code.change, () => this._update_code_from_model())
     this.connect(this.model.properties.theme.change, () => this._update_theme())
     this.connect(this.model.properties.language.change, () => this._update_language())
+    this.connect(this.model.properties.filename.change, () => this._update_filename())
     this.connect(this.model.properties.print_margin.change, () => this._update_print_margin())
     this.connect(this.model.properties.annotations.change, () => this._add_annotations())
     this.connect(this.model.properties.readonly.change, () => {
@@ -49,16 +51,18 @@ export class AcePlotView extends PanelHTMLBoxView {
       this.el.appendChild(this._container)
       this._container.textContent = this.model.code
       this._editor = this._ace.edit(this._container.id)
-      this._editor.setTheme("ace/theme/" + `${this.model.theme}`)
-      this._editor.session.setMode("ace/mode/" + `${this.model.language}`)
-      this._editor.setReadOnly(this.model.readonly)
       this._langTools = this._ace.require('ace/ext/language_tools')
+      this._modelist = this._ace.require("ace/ext/modelist")
       this._editor.setOptions({
         enableBasicAutocompletion: true,
         enableSnippets: true,
         fontFamily: "monospace", //hack for cursor position
       });
-	  this._editor.setShowPrintMargin(this.model.print_margin);
+      this._update_theme()
+      this._update_filename()
+      this._update_language()
+      this._editor.setReadOnly(this.model.readonly)
+      this._editor.setShowPrintMargin(this.model.print_margin);
       this._editor.on('change', () => this._update_code_from_editor())
   }
 
@@ -77,12 +81,21 @@ export class AcePlotView extends PanelHTMLBoxView {
     }
   }
 
-  _update_theme(): void{
+  _update_theme(): void {
     this._editor.setTheme("ace/theme/" + `${this.model.theme}`)
   }
 
+  _update_filename(): void {
+    if (this.model.filename) {
+      const mode = this._modelist.getModeForPath(this.model.filename).mode
+      this.model.language = mode.slice(9)
+    }
+  }
+
   _update_language(): void{
-    this._editor.session.setMode("ace/mode/" + `${this.model.language}`)
+    if (this.model.language != null) {
+      this._editor.session.setMode("ace/mode/" + `${this.model.language}`)
+    }
   }
 
   _add_annotations(): void{
@@ -93,7 +106,6 @@ export class AcePlotView extends PanelHTMLBoxView {
     super.after_layout()
     this._editor.resize()
   }
-
 }
 
 export namespace AcePlot {
@@ -101,8 +113,10 @@ export namespace AcePlot {
   export type Props = HTMLBox.Props & {
     code: p.Property<string>
     language: p.Property<string>
+    filename: p.Property<string>
     theme: p.Property<string>
     annotations: p.Property<any[]>
+    print_margin: p.Property<boolean> 
     readonly: p.Property<boolean>
   }
 }
@@ -123,7 +137,8 @@ export class AcePlot extends HTMLBox {
 
     this.define<AcePlot.Props>({
       code:         [ p.String            ],
-      language:     [ p.String,  'python' ],
+      filename:     [ p.String            ],
+      language:     [ p.String            ],
       theme:        [ p.String,  'chrome' ],
       annotations:  [ p.Array,   []       ],
       readonly:     [ p.Boolean, false    ],

--- a/panel/models/ace.ts
+++ b/panel/models/ace.ts
@@ -36,6 +36,7 @@ export class AcePlotView extends PanelHTMLBoxView {
     this.connect(this.model.properties.code.change, () => this._update_code_from_model())
     this.connect(this.model.properties.theme.change, () => this._update_theme())
     this.connect(this.model.properties.language.change, () => this._update_language())
+    this.connect(this.model.properties.print_margin.change, () => this._update_print_margin())
     this.connect(this.model.properties.annotations.change, () => this._add_annotations())
     this.connect(this.model.properties.readonly.change, () => {
       this._editor.setReadOnly(this.model.readonly)
@@ -57,12 +58,17 @@ export class AcePlotView extends PanelHTMLBoxView {
         enableSnippets: true,
         fontFamily: "monospace", //hack for cursor position
       });
+	  this._editor.setShowPrintMargin(this.model.print_margin);
       this._editor.on('change', () => this._update_code_from_editor())
   }
 
   _update_code_from_model(): void {
     if (this._editor && this._editor.getValue() !=  this.model.code)
       this._editor.setValue(this.model.code)
+  }
+
+  _update_print_margin(): void {
+    this._editor.setShowPrintMargin(this.model.print_margin);
   }
 
   _update_code_from_editor(): void {
@@ -116,11 +122,12 @@ export class AcePlot extends HTMLBox {
     this.prototype.default_view = AcePlotView
 
     this.define<AcePlot.Props>({
-      code:        [ p.String            ],
-      language:    [ p.String,  'python' ],
-      theme:       [ p.String,  'chrome' ],
-      annotations: [ p.Array,   []       ],
-      readonly:    [ p.Boolean, false    ]
+      code:         [ p.String            ],
+      language:     [ p.String,  'python' ],
+      theme:        [ p.String,  'chrome' ],
+      annotations:  [ p.Array,   []       ],
+      readonly:     [ p.Boolean, false    ],
+      print_margin: [ p.Boolean, false    ]
     })
 
     this.override({

--- a/panel/widgets/ace.py
+++ b/panel/widgets/ace.py
@@ -29,6 +29,9 @@ class Ace(Widget):
 
     language = param.String(default="python", doc="Language of the editor")
 
+    print_margin = param.Boolean(default=False, doc="""
+        Whether to show the a print margin.""")
+
     readonly = param.Boolean(default=False, doc="""
         Define if editor content can be modified""")
 

--- a/panel/widgets/ace.py
+++ b/panel/widgets/ace.py
@@ -27,7 +27,9 @@ class Ace(Widget):
     theme = param.ObjectSelector(default="chrome", objects=list(ace_themes),
                                  doc="Theme of the editor")
 
-    language = param.String(default="python", doc="Language of the editor")
+    filename = param.String(doc="Filename from which to deduce language")
+
+    language = param.String(allow_None=True, doc="Language of the editor")
 
     print_margin = param.Boolean(default=False, doc="""
         Whether to show the a print margin.""")
@@ -56,3 +58,10 @@ class Ace(Widget):
             self._widget_type = getattr(sys.modules["panel.models.ace"], "AcePlot")
 
         return super(Ace, self)._get_model(doc, root, parent, comm)
+
+    def __init__(self, value=None, **params):
+        if value is not None:
+            params['value'] = value
+        super(Ace, self).__init__(**params)
+        if self.language is None and self.filename is None:
+            self.language = 'text'

--- a/panel/widgets/ace.py
+++ b/panel/widgets/ace.py
@@ -29,7 +29,7 @@ class Ace(Widget):
 
     filename = param.String(doc="Filename from which to deduce language")
 
-    language = param.String(allow_None=True, doc="Language of the editor")
+    language = param.String(default='text', doc="Language of the editor")
 
     print_margin = param.Boolean(default=False, doc="""
         Whether to show the a print margin.""")
@@ -58,10 +58,3 @@ class Ace(Widget):
             self._widget_type = getattr(sys.modules["panel.models.ace"], "AcePlot")
 
         return super(Ace, self)._get_model(doc, root, parent, comm)
-
-    def __init__(self, value=None, **params):
-        if value is not None:
-            params['value'] = value
-        super(Ace, self).__init__(**params)
-        if self.language is None and self.filename is None:
-            self.language = 'text'


### PR DESCRIPTION
The print margin often overlaps with other components so this PR allows disabling it.

- [x] Update docs
- [x] Fixes https://github.com/holoviz/panel/issues/1404