### PR TITLE
Add state.busy and onload callback

### DIFF
--- a/examples/user_guide/Deploy_and_Export.ipynb
+++ b/examples/user_guide/Deploy_and_Export.ipynb
@@ -236,12 +236,12 @@
     "    {'markdown': '# This is a Panel app', 'json': pn.pane.JSON({'abc': 123})},\n",
     "    title={'markdown': 'A Markdown App', 'json': 'A JSON App'}\n",
     ")\n",
+    "```\n",
     "\n",
     "The ``pn.serve`` function accepts the same arguments as the `show` method.\n",
     "\n",
     "\n",
-    "\n",
-    "## Launching a server on the commandline\n",
+    "### Launching a server on the commandline\n",
     "\n",
     "Once the app is ready for deployment it can be served using the Bokeh server.  For a detailed breakdown of the design and functionality of Bokeh server, see the [Bokeh documentation](https://bokeh.pydata.org/en/latest/docs/user_guide/server.html). The most important thing to know is that Panel (and Bokeh) provide a CLI command to serve a Python script, app directory, or Jupyter notebook containing a Bokeh or Panel app. To launch a server using the CLI, simply run:\n",
     "\n",
@@ -365,6 +365,77 @@
     "* **``href``** (string): The full url, e.g. 'https://panel.holoviz.org/user_guide/Interact.html:80?color=blue#interact'.\n",
     "* **``protocol``** (string): protocol part of the url, e.g. 'http:' or 'https:'\n",
     "* **``port``** (string): port number, e.g. '80'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### pn.state.busy\n",
+    "\n",
+    "Often an application will have longer running callbacks which are being processed on the server, to give users some indication that the server is busy you may therefore have some way of indicating that busy state. The `pn.state.busy` parameter indicates whether a callback is being actively processed and may be linked to some visual indicator.\n",
+    "\n",
+    "Below we will create a little application to demonstrate this, we will create a button which executes some longer running task on click and then create an indicator function that displays `'I'm busy'` when the `pn.state.busy` parameter is `True` and `'I'm idle'` when it is not:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import time\n",
+    "\n",
+    "def processing(event):\n",
+    "    # Some longer running task\n",
+    "    time.sleep(1)\n",
+    "    \n",
+    "button = pn.widgets.Button(name='Click me!')\n",
+    "button.on_click(processing)\n",
+    "\n",
+    "@pn.depends(pn.state.param.busy)\n",
+    "def indicator(busy):\n",
+    "    return \"I'm busy\" if busy else \"I'm idle\"\n",
+    "\n",
+    "pn.Row(button, indicator)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This way we can create a global indicator for the busy state instead of modifying all our callbacks."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### pn.state.onload\n",
+    "\n",
+    "Another useful callback to define the onload callback, in a server context this will execute when a session is first initialized. Let us for example define a minimal example inside a function which we will pass to `pn.serve`. This emulates what happens when we call `panel serve` on the commandline. We will create a widget without populating its options, then we will add an `onload` callback, which will set the options once the initial page is loaded. Imagine for example that we have to fetch the options from some database which might take a little while, by deferring the loading of the options to the callback we can get something on the screen as quickly as possible and only run the expensive callback when we have already rendered something for the user to look at."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import time\n",
+    "\n",
+    "def app():\n",
+    "    widget = pn.widgets.Select()\n",
+    "\n",
+    "    def on_load():\n",
+    "        time.sleep(1) # Emulate some long running process\n",
+    "        widget.options = ['A', 'B', 'C']\n",
+    "\n",
+    "    pn.state.onload(on_load)\n",
+    "\n",
+    "    return widget\n",
+    "\n",
+    "# pn.serve(app) "
    ]
   },
   {

--- a/examples/user_guide/Overview.ipynb
+++ b/examples/user_guide/Overview.ipynb
@@ -182,6 +182,7 @@
     "\n",
     "The `pn.state` object makes various global state available and provides methods to manage that state:\n",
     "\n",
+    "> - `busy`: A boolean value to indicate whether a callback is being actively processed.\n",
     "> - `cache`: A global cache which can be used to share data between different processes.\n",
     "> - `cookies`: HTTP request cookies for the current session.\n",
     "> - `curdoc`: When running a server session this property holds the current bokeh Document.\n",
@@ -200,7 +201,8 @@
     "\n",
     "> #### Methods\n",
     "\n",
-    "> - `kill_all_servers`: Stops all running server sessions."
+    "> - `kill_all_servers`: Stops all running server sessions.\n",
+    "> - `onload`: Allows defining a callback which is run when a server is fully loaded"
    ]
   }
  ],

--- a/panel/io/location.py
+++ b/panel/io/location.py
@@ -56,7 +56,8 @@ class Location(Syncable):
         self.param.watch(self._onload, ['href'])
 
     def _onload(self, event):
-        if event.old: # Skip if href was not previously empty
+        # Skip if href was not previously empty or not in a server context
+        if event.old or not state.curdoc: 
             return
         for cb in state._onload[state.curdoc]:
             cb()

--- a/panel/io/location.py
+++ b/panel/io/location.py
@@ -9,6 +9,7 @@ import param
 from ..models.location import Location as _BkLocation
 from ..reactive import Syncable
 from ..util import parse_query
+from .state import state
 
 
 class Location(Syncable):
@@ -52,6 +53,13 @@ class Location(Syncable):
         self._synced = []
         self._syncing = False
         self.param.watch(self._update_synced, ['search'])
+        self.param.watch(self._onload, ['href'])
+
+    def _onload(self, event):
+        if event.old: # Skip if href was not previously empty
+            return
+        for cb in state._onload[state.curdoc]:
+            cb()
 
     def _get_model(self, doc, root=None, parent=None, comm=None):
         model = _BkLocation(**self._process_param_change(self._init_properties()))

--- a/panel/io/server.py
+++ b/panel/io/server.py
@@ -40,15 +40,26 @@ def _server_url(url, port):
     else:
         return 'http://%s:%d%s' % (url.split(':')[0], port, "/")
 
+
+@contextmanager
+def set_curdoc(doc):
+    state.curdoc = doc
+    yield
+    state.curdoc = None
+
+
 def _eval_panel(panel, server_id, title, location, doc):
     from ..template import BaseTemplate
     from ..pane import panel as as_panel
 
-    if isinstance(panel, FunctionType):
-        panel = panel()
-    if isinstance(panel, BaseTemplate):
-        return panel._modify_doc(server_id, title, doc, location)
-    return as_panel(panel)._modify_doc(server_id, title, doc, location)
+    with set_curdoc(doc):
+        if isinstance(panel, FunctionType):
+            panel = panel()
+        if isinstance(panel, BaseTemplate):
+            doc = panel._modify_doc(server_id, title, doc, location)
+        else:
+            doc = as_panel(panel)._modify_doc(server_id, title, doc, location)
+        return doc
 
 #---------------------------------------------------------------------
 # Public API

--- a/panel/reactive.py
+++ b/panel/reactive.py
@@ -180,8 +180,12 @@ class Syncable(Renderable):
                 doc.add_next_tick_callback(cb)
 
     def _process_events(self, events):
+        with edit_readonly(state):
+            state.busy = True
         with edit_readonly(self):
             self.param.set_param(**self._process_property_change(events))
+        with edit_readonly(state):
+            state.busy = False
 
     @gen.coroutine
     def _change_coroutine(self, doc=None):


### PR DESCRIPTION
* Adds a `state.busy` parameter which is toggled whenever an event is received and being processed. This will enable visual busy indicators.
* Adds `onload` callbacks which are triggered once a session has been loaded in the browser.

Partially addresses https://github.com/holoviz/panel/issues/1362