### PR TITLE
Ensure Document and Location models are garbage collected

### DIFF
--- a/panel/viewable.py
+++ b/panel/viewable.py
@@ -399,10 +399,9 @@ class Renderable(param.Parameterized):
         root: bokeh.model.Model
           Bokeh model for the view being cleaned up
         """
-        if root.ref['id'] in state._handles:
-            del state._handles[root.ref['id']]
-        if root.document in state._locations:
-            del state._locations[root.document]
+        ref = root.ref['id']
+        if ref in state._handles:
+            del state._handles[ref]
 
     def _preprocess(self, root):
         """
@@ -544,8 +543,16 @@ class Viewable(Renderable, Layoutable, ServableMixin):
         Server lifecycle hook triggered when session is destroyed.
         """
         doc = session_context._document
-        self._cleanup(self._documents[doc])
+        root = self._documents[doc]
+        ref = root.ref['id']
+        self._cleanup(root)
         del self._documents[doc]
+        if ref in state._views:
+            del state._views[ref]
+        if doc in state._locations:
+            loc = state._locations[doc]
+            loc._cleanup(root)
+            del state._locations[doc]
 
     #----------------------------------------------------------------
     # Public API


### PR DESCRIPTION
So there appear to have been two garbage collection issues, 1) the `state._views` dict was not cleaned up leaving references to the `Document` and b) the Location models were not correctly cleaned up again leaving potential references to a `Document`. 

Fixes https://github.com/holoviz/panel/issues/1399