### PR TITLE
Fixed compatibility with Bokeh 2.1

### DIFF
--- a/panel/models/html.ts
+++ b/panel/models/html.ts
@@ -2,7 +2,7 @@ import * as p from "@bokehjs/core/properties"
 import {Markup} from "@bokehjs/models/widgets/markup"
 import {PanelMarkupView} from "./layout"
 
-function htmlDecode(input: string): string | null {
+export function htmlDecode(input: string): string | null {
   var doc = new DOMParser().parseFromString(input, "text/html");
   return doc.documentElement.textContent;
 }

--- a/panel/models/layout.ts
+++ b/panel/models/layout.ts
@@ -1,4 +1,4 @@
-import {Layoutable} from "@bokehjs/core/layout/layoutable"
+import {VariadicBox} from "@bokehjs/core/layout/html"
 import {Size, SizeHint, Sizeable} from "@bokehjs/core/layout/types"
 import {sized, content_size, extents} from "@bokehjs/core/dom"
 
@@ -47,15 +47,13 @@ export function set_size(el: HTMLElement, model: HTMLBox): void {
   else if (height_policy == "max")
     el.style.height = "100%";
 }
-  
 
-export class CachedVariadicBox extends Layoutable {
-  _cache: {[key: string]: Size}
-  _cache_count: {[key: string]: number}
+export class CachedVariadicBox extends VariadicBox {
+  private readonly _cache: Map<string, SizeHint> = new Map()
+  private _cache_count: {[key: string]: number}
 
   constructor(readonly el: HTMLElement, readonly sizing_mode: string | null, readonly changed: boolean) {
-    super()
-    this._cache = {};
+    super(el)
     this._cache_count = {}
   }
 
@@ -67,7 +65,9 @@ export class CachedVariadicBox extends Layoutable {
     const min_count = (!this.changed || (this.sizing_mode == 'fixed') || (this.sizing_mode == null)) ? 0 : 1;
     if ((key_str in this._cache) && (this._cache_count[key_str] >= min_count)) {
       this._cache_count[key_str] = this._cache_count[key_str] + 1;
-      return this._cache[key_str]
+      const cached_size = this._cache.get(key_str)
+      if (cached_size != null)
+        return cached_size
     }
     const bounded = new Sizeable(viewport).bounded_to(this.sizing.size)
     const size = sized(this.el, bounded, () => {
@@ -75,13 +75,13 @@ export class CachedVariadicBox extends Layoutable {
       const {border, padding} = extents(this.el)
       return content.grow_by(border).grow_by(padding).map(Math.ceil)
     })
-    this._cache[key_str] = size;
+    this._cache.set(key_str, size);
     this._cache_count[key_str] = 0;
     return size;
   }
 
   invalidate_cache(): void {
-    this._cache = {};
+     this._cache.clear()
   }
 }
 
@@ -92,7 +92,7 @@ export class PanelMarkupView extends MarkupView {
     let changed = ((this._prev_sizing_mode !== undefined) &&
                    (this._prev_sizing_mode !== this.model.sizing_mode))
     this._prev_sizing_mode = this.model.sizing_mode;
-    this.layout = new CachedVariadicBox(this.el, this.model.sizing_mode, changed)
+    this.layout = (new CachedVariadicBox(this.el, this.model.sizing_mode, changed) as any)
     this.layout.set_sizing(this.box_sizing())
   }
 

--- a/panel/models/layout.ts
+++ b/panel/models/layout.ts
@@ -79,6 +79,10 @@ export class CachedVariadicBox extends Layoutable {
     this._cache_count[key_str] = 0;
     return size;
   }
+
+  invalidate_cache(): void {
+    this._cache = {};
+  }
 }
 
 export class PanelMarkupView extends MarkupView {

--- a/panel/models/plotly.ts
+++ b/panel/models/plotly.ts
@@ -244,7 +244,7 @@ export class PlotlyPlotView extends PanelHTMLBoxView {
       let prop = prop_path[prop_path.length - 1];
       var prop_parent = trace;
       for(let k of prop_path.slice(0, -1)) {
-        prop_parent = prop_parent[k]
+        prop_parent = (prop_parent[k] as any)
       }
 
       if (update && prop_path.length == 1) {

--- a/panel/models/vtk/util.ts
+++ b/panel/models/vtk/util.ts
@@ -1,5 +1,17 @@
-import {ARRAY_TYPES, DType} from "@bokehjs/core/util/serialization"
 import {linspace} from "@bokehjs/core/util/array"
+
+export const ARRAY_TYPES = {
+  uint8:   Uint8Array,
+  int8:    Int8Array,
+  uint16:  Uint16Array,
+  int16:   Int16Array,
+  uint32:  Uint32Array,
+  int32:   Int32Array,
+  float32: Float32Array,
+  float64: Float64Array,
+}
+
+export type DType = keyof typeof ARRAY_TYPES
 
 export const vtk = (window as any).vtk
 

--- a/panel/package-lock.json
+++ b/panel/package-lock.json
@@ -5,11 +5,10 @@
   "requires": true,
   "dependencies": {
     "@bokeh/bokehjs": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@bokeh/bokehjs/-/bokehjs-2.0.1.tgz",
-      "integrity": "sha512-jTcjrL/zxKZbyBtr2BVl+f8sLbKOH9dwmEzR3s1qd6XWTeVSjwQwNbzjPniFwGtNN/iv0LzO6+Rt7vaY/VbEow==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@bokeh/bokehjs/-/bokehjs-2.1.0.tgz",
+      "integrity": "sha512-oBADp1JbhxYzDmQSSYm99UHZ5IM07b3AYbVWC+7qhG9C8Bq9uUgUh9Hisy8UjtPLKb3JLHRIFaCr+xVsAG8RMw==",
       "requires": {
-        "@bokeh/canvas2svg": "^1.0.22",
         "@bokeh/gloo2": "^0.0.1",
         "@bokeh/numbro": "^1.6.2",
         "@bokeh/slickgrid": "^2.3.23",
@@ -22,18 +21,13 @@
         "flatbush": "^3.2.1",
         "flatpickr": "^4.6.3",
         "hammerjs": "^2.0.4",
-        "nouislider": "^10.0.0",
+        "nouislider": "^14.5.0",
         "proj4": "^2.6.0",
         "sprintf-js": "^1.1.2",
         "timezone": "^1.0.23",
         "tslib": "^1.11.0",
         "underscore.template": "^0.1.7"
       }
-    },
-    "@bokeh/canvas2svg": {
-      "version": "1.0.22",
-      "resolved": "https://registry.npmjs.org/@bokeh/canvas2svg/-/canvas2svg-1.0.22.tgz",
-      "integrity": "sha512-jLA/AmmQEjpCJq5U838exrWR/EtnBqfy5qaG/oKpnGXYKj3VcJIUL0WgYMVMHxRZmEUk1GO7SChaUk0Gz4h/vA=="
     },
     "@bokeh/gloo2": {
       "version": "0.0.1",
@@ -72,9 +66,9 @@
       "integrity": "sha512-0L8Mq1+oaIW0oVzGUDbSW+HnTjCNb4CmoIQE5BkoHt/A7x20z0MJ1PnwfH3atty/vbWLGgvJwVu2Mz3SKFiEFw=="
     },
     "@types/jquery": {
-      "version": "3.3.34",
-      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.3.34.tgz",
-      "integrity": "sha512-lW9vsVL53Xu/Nj4gi2hNmHGc4u3KKghjqTkAlO0kF5GIOPxbqqnQpgqJBzmn3yXLrPqHb6cmNJ6URnS23Vtvbg==",
+      "version": "3.3.38",
+      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.3.38.tgz",
+      "integrity": "sha512-nkDvmx7x/6kDM5guu/YpXkGZ/Xj/IwGiLDdKM99YA5Vag7pjGyTJ8BNUh/6hxEn/sEu5DKtyRgnONJ7EmOoKrA==",
       "requires": {
         "@types/sizzle": "*"
       }
@@ -85,9 +79,9 @@
       "integrity": "sha512-7EJYyKTL7tFR8+gDbB6Wwz/arpGa0Mywk1TJbNzKzHtzbwVmY4HR9WqS5VV7dsBUKQmPNr192jHr/VpBluj/hg=="
     },
     "@types/slickgrid": {
-      "version": "2.1.29",
-      "resolved": "https://registry.npmjs.org/@types/slickgrid/-/slickgrid-2.1.29.tgz",
-      "integrity": "sha512-dAWPuYLDb4EfEaMZtbI2Z/4epL1o8tazkv+7gIEwbU2gYwATW4cce75/R6m2/Zfxj1FmEX71SL9WRwf2x4VQQw==",
+      "version": "2.1.30",
+      "resolved": "https://registry.npmjs.org/@types/slickgrid/-/slickgrid-2.1.30.tgz",
+      "integrity": "sha512-9nTqNWD3BtEVK0CP+G+mBtvSrKTfQy3Dg5/al+GdTSVMHFm37UxsHJ1eURwPg7rYu6vc7xU95fGTCKMZbxsD5w==",
       "requires": {
         "@types/jquery": "*"
       }
@@ -227,9 +221,9 @@
       }
     },
     "flatbush": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/flatbush/-/flatbush-3.2.1.tgz",
-      "integrity": "sha512-RAqcCyM18R0HhGIcZ7nTRImHnvmJAQqxSN8VIrRLPyWDuFjxluiyE99wuDqFiwNwBodlHXBQNf/9CrlfSqJq2A==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/flatbush/-/flatbush-3.3.0.tgz",
+      "integrity": "sha512-F3EzQvKpdmXUbFwWxLKBpytOFEGYQMCTBLuqZ4GEajFOEAvnOIBiyxW3OFSZXIOtpCS8teN6bFEpNZtnVXuDQA==",
       "requires": {
         "flatqueue": "^1.2.0"
       }
@@ -240,9 +234,9 @@
       "integrity": "sha512-007VucCkqNOMMb9ggRLNuJowwaJcyOh4sKAFcdGfahfGc7JQbf94zSzjdBq/wVyHWUEs5o3+idhFZ0wbZMRmVQ=="
     },
     "flatqueue": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/flatqueue/-/flatqueue-1.2.0.tgz",
-      "integrity": "sha512-Z/nhmRwSywE3xnHXHqbLzJiUZ9akOHZlB1IIqCzRRldWrxqp6EzqGVxTl9Fl5cSoUzC5ge7xq3WIPct8ADYdhw=="
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/flatqueue/-/flatqueue-1.2.1.tgz",
+      "integrity": "sha512-X86TpWS1rGuY7m382HuA9vngLeDuWA9lJvhEG+GfgKMV5onSvx5a71cl7GMbXzhWtlN9dGfqOBrpfqeOtUfGYQ=="
     },
     "fuse.js": {
       "version": "3.6.1",
@@ -260,9 +254,9 @@
       "integrity": "sha1-BO93hiz/K7edMPdpIJWTAiK/YPE="
     },
     "jquery": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.5.0.tgz",
-      "integrity": "sha512-Xb7SVYMvygPxbFMpTFQiHh1J7HClEaThguL15N/Gg37Lri/qKyhRGZYzHRyLH8Stq3Aow0LsHO2O2ci86fCrNQ=="
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.5.1.tgz",
+      "integrity": "sha512-XwIBPqcMn57FxfT+Go5pzySnm4KWkT1Tv7gjrpT1srtf8Weynl6R273VJ5GjkRb51IzMp5nbaPjJXMWeju2MKg=="
     },
     "jquery-ui": {
       "version": "1.12.1",
@@ -298,17 +292,17 @@
       "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
     },
     "nouislider": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/nouislider/-/nouislider-10.1.0.tgz",
-      "integrity": "sha512-lENwxlpoYg4/5gjdaY/PMNHeVL+CMJyrO+7RzXi1MqhSSGwuJsQSJteXCQV5bE2UKEdSLARWrqIF8XSWAq7h+A=="
+      "version": "14.5.0",
+      "resolved": "https://registry.npmjs.org/nouislider/-/nouislider-14.5.0.tgz",
+      "integrity": "sha512-EzI2Y0pO+x20c8yHLvhmT9HXexkbncXHKcnNb6abN48a3F8QEGb73v2W6aPolQytoyjCalUrozSeHBTlpz2jfg=="
     },
     "proj4": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/proj4/-/proj4-2.6.0.tgz",
-      "integrity": "sha512-ll2WyehUFOyzEZtN8hAiOTmZpuDCN5V+4A/HjhPbhlwVwlsFKnIHSZ3l3uhzgDndHjoL2MyERFGe9VmXN4rYUg==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/proj4/-/proj4-2.6.2.tgz",
+      "integrity": "sha512-Pn0+HZtXb4JzuN8RR0VM7yyseegiYHbXkF+2FOdGpzRojcZ1BTjWxOh7qfp2vH0EyLu8pvcrhLxidwzgyUy/Gw==",
       "requires": {
         "mgrs": "1.0.0",
-        "wkt-parser": "^1.2.0"
+        "wkt-parser": "^1.2.4"
       }
     },
     "redux": {
@@ -336,9 +330,9 @@
       "integrity": "sha512-yhQgk6qmSLB+TF8HGmApZAVI5bfzR1CoKUGr+WMZWmx75ED1uDewAZA8QMGCQ70TEv4GmM8pDB9jrHuxdaQ1PA=="
     },
     "tslib": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
-      "integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA=="
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
+      "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
     },
     "type": {
       "version": "1.2.0",

--- a/panel/package.json
+++ b/panel/package.json
@@ -8,7 +8,7 @@
     "url": "https://github.com/holoviz/panel.git"
   },
   "dependencies": {
-    "@bokeh/bokehjs": "^2.0.1",
+    "@bokeh/bokehjs": "^2.1.0",
     "@types/gl-matrix": "^2.4.5",
     "gl-matrix": "^3.1.0",
     "json-formatter-js": "^2.2.1",

--- a/setup.py
+++ b/setup.py
@@ -89,7 +89,7 @@ except Exception:
 ########## dependencies ##########
 
 install_requires = [
-    'bokeh >=2.0.1',
+    'bokeh >=2.1',
     'param >=1.9.3',
     'pyviz_comms >=0.7.4',
     'markdown',


### PR DESCRIPTION
There was a regression because bokeh added a `invalidate_cache` method on the internal layout class which we override for the Markup models.