### PR TITLE
Fixed handling of ColumnDataSource array shapes for bokeh 2.1

### DIFF
--- a/panel/models/deckgl.ts
+++ b/panel/models/deckgl.ts
@@ -93,11 +93,11 @@ export class DeckGLPlotView extends PanelHTMLBoxView {
       }
       const data: any = []
       const columns = cds.columns()
-      for (let i = 0; i < cds.data[columns[0]].length; i++) {
+      for (let i = 0; i < cds.get_length(); i++) {
         const item: any = {}
         for (const column of columns) {
-          let array = cds.get_array(column)[0];
-          const shape = array.shape == null ? null : array.shape;
+          let array = cds.get_array(column);
+          const shape = array[0].shape == null ? null : array[0].shape;
           if ((shape != null) && (shape.length > 1) && (typeof shape[0] == "number"))
             item[column] = array.slice(i*shape[1], i*shape[1]+shape[1])
           else

--- a/panel/models/deckgl.ts
+++ b/panel/models/deckgl.ts
@@ -96,11 +96,12 @@ export class DeckGLPlotView extends PanelHTMLBoxView {
       for (let i = 0; i < cds.data[columns[0]].length; i++) {
         const item: any = {}
         for (const column of columns) {
-          const shape = cds._shapes[column]
-          if ((shape !== undefined) && (shape.length > 1) && (typeof shape[0] == "number"))
-            item[column] = cds.data[column].slice(i*shape[1], i*shape[1]+shape[1])
+          let array = cds.get_array(column)[0];
+          const shape = array.shape == null ? null : array.shape;
+          if ((shape != null) && (shape.length > 1) && (typeof shape[0] == "number"))
+            item[column] = array.slice(i*shape[1], i*shape[1]+shape[1])
           else
-            item[column] = cds.data[column][i]
+            item[column] = array[i]
         }
         data.push(item)
       }

--- a/panel/models/plotly.ts
+++ b/panel/models/plotly.ts
@@ -231,10 +231,10 @@ export class PlotlyPlotView extends PanelHTMLBoxView {
     const trace = clone(this.model.data[index]);
     const cds = this.model.data_sources[index];
     for (const column of cds.columns()) {
-      const shape: number[] = cds._shapes[column][0];
       let array = cds.get_array(column)[0];
-      if (shape.length > 1) {
+      if (array.shape != null && array.shape.length > 1) {
         const arrays = [];
+        const shape = array.shape;
         for (let s = 0; s < shape[0]; s++) {
           arrays.push(array.slice(s*shape[1], (s+1)*shape[1]));
         }
@@ -242,8 +242,8 @@ export class PlotlyPlotView extends PanelHTMLBoxView {
       }
       let prop_path = column.split(".");
       let prop = prop_path[prop_path.length - 1];
-      var prop_parent = trace;
-      for(let k of prop_path.slice(0, -1)) {
+      let prop_parent = trace;
+      for (let k of prop_path.slice(0, -1)) {
         prop_parent = (prop_parent[k] as any)
       }
 


### PR DESCRIPTION
In bokeh 2.1 arrays with more than 1 dimension now have a proper shape attribute.