### PR TITLE
Standardize build process

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,9 +38,9 @@ stages:
   - name: pip_package
     if: tag =~ ^v(\d+|\.)+[^a-z]\d+$
   - name: website_dev
-    if: (tag =~ ^v(\d+|\.)+[a-z]\d+$) OR (tag = website_dev) OR (commit_message =~ /^.*(website_dev).*$/)
+    if: (tag =~ ^v(\d+|\.)+[a|b|rc]\d+$) OR (tag = website_dev) OR (commit_message =~ /^.*(website_dev).*$/)
   - name: website_release
-    if: (tag =~ ^v(\d+|\.)+[^a-z]\d+$) OR (tag = website) OR (commit_message =~ /^.*(website_release).*$/)
+    if: (tag =~ ^v(\d+|\.)+\d+$) OR (tag = website_release) OR (commit_message =~ /^.*(website_release).*$/)
   - name: docs_daily
     if: ((type = cron and branch = master) OR (commit_message =~ /\[doc-build\]/))
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,10 +37,10 @@ stages:
     if: tag =~ ^v(\d+|\.)+([a-z]|rc)\d+$
   - name: pip_package
     if: tag =~ ^v(\d+|\.)+[^a-z]\d+$
-  - name: docs
-    if: tag =~ ^v(\d+|\.)+[^a-z]\d+$
-  - name: docs_dev
-    if: tag =~ ^v(\d+|\.)+([a-z]|rc)\d+$
+  - name: website_dev
+    if: tag =~ ^v(\d+|\.)+[a-z]\d+$ OR tag = website_dev
+  - name: website_release
+    if: tag =~ ^v(\d+|\.)+[^a-z]\d+$ OR tag = website
   - name: docs_daily
     if: ((type = cron and branch = master) OR (commit_message =~ /\[doc-build\]/))
 
@@ -112,7 +112,7 @@ jobs:
 
     - &doc_build
       <<: *conda_default
-      stage: docs
+      stage: website_release
       env: DESC="docs" PANEL_DOC_BUILD='true' PANEL_EMBED="true" PANEL_EMBED_JSON="true" PANEL_EMBED_JSON_PREFIX="json"
       script:
         - doit develop_install $CHANS_DEV -o doc -o examples
@@ -136,7 +136,7 @@ jobs:
         - sleep 10
 
     - <<: *doc_build
-      stage: docs_dev
+      stage: website_dev
       deploy:
         provider: pages
         skip_cleanup: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,9 +38,9 @@ stages:
   - name: pip_package
     if: tag =~ ^v(\d+|\.)+[^a-z]\d+$
   - name: website_dev
-    if: tag =~ ^v(\d+|\.)+[a-z]\d+$ OR tag = website_dev
+    if: (tag =~ ^v(\d+|\.)+[a-z]\d+$) OR (tag = website_dev) OR (commit_message =~ /^.*(website_dev).*$/)
   - name: website_release
-    if: tag =~ ^v(\d+|\.)+[^a-z]\d+$ OR tag = website
+    if: (tag =~ ^v(\d+|\.)+[^a-z]\d+$) OR (tag = website) OR (commit_message =~ /^.*(website_release).*$/)
   - name: docs_daily
     if: ((type = cron and branch = master) OR (commit_message =~ /\[doc-build\]/))
 


### PR DESCRIPTION
This adds support for building dev and release websites with commit messages containing `website_dev` and `website_release` respectively, and building building from tags using `website_release` and `website_dev`, as well as tags of the format `v1.3.1a4` for dev, and `v1.3.1A4` for release.