### PR TITLE
Serve template CSS files per Document

### DIFF
--- a/panel/io/resources.py
+++ b/panel/io/resources.py
@@ -45,7 +45,7 @@ def js_files(self):
         if any('ace' in jsf for jsf in js_files):
             js_files.append('/panel_dist/post_require.js')
     return js_files
-                    
+
 def css_files(self):
     from ..config import config
     files = super(Resources, self).css_files
@@ -58,10 +58,30 @@ def css_files(self):
 def conffilter(value):
     return json.dumps(OrderedDict(value)).replace('"', '\'')
 
-Resources.css_raw = property(css_raw)
-Resources.js_files = property(js_files)
-Resources.css_files = property(css_files)
+
+class PanelResources(Resources):
+
+    def __init__(self, extra_css_files=None, **kwargs):
+        super(PanelResources, self).__init__(**kwargs)
+        self._extra_css_files = extra_css_files
+
+    @property
+    def css_raw(self):
+        raw = super(PanelResources, self).css_raw
+        for cssf in self._extra_css_files:
+            if not os.path.isfile(cssf):
+                continue
+            with open(cssf) as f:
+                css_txt = f.read()
+                if css_txt not in raw:
+                    raw.append(css_txt)
+        return raw
+
 
 _env = get_env()
 _env.filters['json'] = lambda obj: Markup(json.dumps(obj))
 _env.filters['conffilter'] = conffilter
+
+Resources.css_raw = property(css_raw)
+Resources.js_files = property(js_files)
+Resources.css_files = property(css_files)

--- a/panel/io/server.py
+++ b/panel/io/server.py
@@ -14,11 +14,17 @@ from functools import partial
 from types import FunctionType, MethodType
 
 from bokeh.document.events import ModelChangedEvent
+from bokeh.embed.server import server_html_page_for_session
 from bokeh.server.server import Server
+from bokeh.server.views.session_handler import SessionHandler
+from bokeh.server.views.static_handler import StaticHandler
+from bokeh.server.urls import per_app_patterns
+from bokeh.settings import settings
 from tornado.websocket import WebSocketHandler
-from tornado.web import RequestHandler, StaticFileHandler
+from tornado.web import RequestHandler, StaticFileHandler, authenticated
 from tornado.wsgi import WSGIContainer
 
+from .resources import PanelResources
 from .state import state
 
 
@@ -60,6 +66,39 @@ def _eval_panel(panel, server_id, title, location, doc):
         else:
             doc = as_panel(panel)._modify_doc(server_id, title, doc, location)
         return doc
+
+
+class PanelDocHandler(SessionHandler):
+    """
+    Implements a custom Tornado handler for document display page
+    overriding the default bokeh DocHandler to replace the default
+    resources with a Panel resources object.
+    """
+
+    @authenticated
+    async def get(self, *args, **kwargs):
+        session = await self.get_session()
+
+        mode = settings.resources(default="server")
+        css_files = session.document.template_variables.get('template_css_files')
+        resource_opts = dict(mode=mode, extra_css_files=css_files)
+        if mode == "server":
+            resource_opts.update({
+                'root_url': self.application._prefix,
+                'path_versioner': StaticHandler.append_version
+            })
+        resources = PanelResources(**resource_opts)
+
+        page = server_html_page_for_session(
+            session, resources=resources, title=session.document.title,
+            template=session.document.template,
+            template_variables=session.document.template_variables
+        )
+
+        self.set_header("Content-Type", 'text/html')
+        self.write(page)
+
+per_app_patterns[0] = (r'/?', PanelDocHandler)
 
 #---------------------------------------------------------------------
 # Public API

--- a/panel/io/server.py
+++ b/panel/io/server.py
@@ -407,18 +407,9 @@ def get_server(panel, port=0, address=None, websocket_origin=None,
 class StoppableThread(threading.Thread):
     """Thread class with a stop() method."""
 
-    def __init__(self, io_loop=None, timeout=1000, **kwargs):
-        from tornado import ioloop
+    def __init__(self, io_loop=None,, **kwargs):
         super(StoppableThread, self).__init__(**kwargs)
-        self._stop_event = threading.Event()
         self.io_loop = io_loop
-        self._cb = ioloop.PeriodicCallback(self._check_stopped, timeout)
-        self._cb.start()
-
-    def _check_stopped(self):
-        if self.stopped:
-            self._cb.stop()
-            self.io_loop.stop()
 
     def run(self):
         if hasattr(self, '_target'):
@@ -439,8 +430,4 @@ class StoppableThread(threading.Thread):
                 del self._Thread__target, self._Thread__args, self._Thread__kwargs
 
     def stop(self):
-        self._stop_event.set()
-
-    @property
-    def stopped(self):
-        return self._stop_event.is_set()
+        self.io_loop.add_callback(self.io_loop.stop)

--- a/panel/io/server.py
+++ b/panel/io/server.py
@@ -407,7 +407,7 @@ def get_server(panel, port=0, address=None, websocket_origin=None,
 class StoppableThread(threading.Thread):
     """Thread class with a stop() method."""
 
-    def __init__(self, io_loop=None,, **kwargs):
+    def __init__(self, io_loop=None, **kwargs):
         super(StoppableThread, self).__init__(**kwargs)
         self.io_loop = io_loop
 

--- a/panel/template/base.py
+++ b/panel/template/base.py
@@ -158,6 +158,9 @@ class BaseTemplate(param.Parameterized, ServableMixin):
         else:
             doc.template = self.template
         doc._template_variables.update(self._render_variables)
+        doc._template_variables['template_css_files'] = [
+            str(cssf) for cssf in self._css_files
+        ]
         return doc
 
     def _repr_mimebundle_(self, include=None, exclude=None):
@@ -201,6 +204,10 @@ class BaseTemplate(param.Parameterized, ServableMixin):
 
         return render_template(doc, comm, manager)
 
+    @property
+    def _css_files(self):
+        return []
+
     #----------------------------------------------------------------
     # Public API
     #----------------------------------------------------------------
@@ -236,6 +243,7 @@ class BaseTemplate(param.Parameterized, ServableMixin):
         """
         if embed:
             raise ValueError("Embedding is not yet supported on Template.")
+
         return save(self, filename, title, resources, self.template,
                     self._render_variables, embed, max_states, max_opts,
                     embed_json, json_prefix, save_path, load_path)
@@ -320,8 +328,6 @@ class BasicTemplate(BaseTemplate):
     __abstract = True
 
     def __init__(self, **params):
-        if self._css and self._css not in config.css_files:
-            config.css_files.append(self._css)
         template = self._template.read_text()
         if 'header' not in params:
             params['header'] = ListLike()
@@ -330,16 +336,23 @@ class BasicTemplate(BaseTemplate):
         if 'sidebar' not in params:
             params['sidebar'] = ListLike()
         super(BasicTemplate, self).__init__(template=template, **params)
-        if self.theme:
-            theme = self.theme.find_theme(type(self))
-            if theme and theme.css and theme.css not in config.css_files:
-                config.css_files.append(theme.css)
         self._update_vars()
         self.main.param.watch(self._update_render_items, ['objects'])
         self.sidebar.param.watch(self._update_render_items, ['objects'])
         self.header.param.watch(self._update_render_items, ['objects'])
         self.param.watch(self._update_vars, ['title', 'header_background',
                                              'header_color'])
+
+    @property
+    def _css_files(self):
+        css_files = []
+        if self._css and self._css not in config.css_files:
+            css_files.append(self._css)
+        if self.theme:
+            theme = self.theme.find_theme(type(self))
+            if theme and theme.css and theme.css not in config.css_files:
+                css_files.append(theme.css)
+        return css_files
 
     def _init_doc(self, doc=None, comm=None, title=None, notebook=False, location=True):
         doc = super(BasicTemplate, self)._init_doc(doc, comm, title, notebook, location)

--- a/panel/template/base.py
+++ b/panel/template/base.py
@@ -158,9 +158,11 @@ class BaseTemplate(param.Parameterized, ServableMixin):
         else:
             doc.template = self.template
         doc._template_variables.update(self._render_variables)
-        doc._template_variables['template_css_files'] = [
-            str(cssf) for cssf in self._css_files
-        ]
+        doc._template_variables['template_css_files'] = css_files = (
+            doc._template_variables.get('template_css_files', [])
+        )
+        for cssf in self._css_files:
+            css_files.append(str(cssf))
         return doc
 
     def _repr_mimebundle_(self, include=None, exclude=None):


### PR DESCRIPTION
Previously we added the Template CSS to the global list of CSS to be served. This meant that this CSS would pollute the notebook, cause issues when switching templates since the CSS would persist and cause issues when multiple pages being served used different templates or themes.

This PR replaces the default bokeh `DocHandler` with a `PanelDocHandler` which in turn replaces bokeh `Resources` with `PanelResources`. This gives us more control over the CSS and JS files being served up.