### PR TITLE
Add busy/loading indicators and enable on Template

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,6 +52,7 @@ jobs:
       stage: test
       env: DESC="dev test_all"
       before_install:
+        - python --version
         # install doit/pyctdev and use to install miniconda...
         - pip install pyctdev && doit miniconda_install && pip uninstall -y doit pyctdev
         - export PATH="$HOME/miniconda/bin:$PATH" && hash -r

--- a/examples/reference/indicators/BooleanStatus.ipynb
+++ b/examples/reference/indicators/BooleanStatus.ipynb
@@ -1,0 +1,103 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import panel as pn\n",
+    "\n",
+    "from panel.widgets.indicators import BooleanStatus\n",
+    "\n",
+    "pn.extension()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The ``BooleanStatus`` is a boolean indicator providing a visual representation of a boolean status as filled or non-filled circle. If the `value` is set to `True` the indicator will be filled while setting it to `False` will cause it to be non-filled.\n",
+    "\n",
+    "#### Parameters:\n",
+    "\n",
+    "For layout and styling related parameters see the [customization user guide](../../user_guide/Customization.ipynb).\n",
+    "\n",
+    "* **``color``** (str): The color of the bar, one of 'primary', 'secondary', 'success', 'info', 'warn', 'danger', 'light', 'dark'\n",
+    "* **``value``** (int or None): Whether the status indicator is filled or not.\n",
+    "\n",
+    "___"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The `BooleanStatus` widget can be instantiated as either `False` or `True`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "false_status = BooleanStatus(value=False)\n",
+    "true_status = BooleanStatus(value=True)\n",
+    "\n",
+    "pn.Row(false_status, true_status)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The `BooleanStatus` indicator also supports a range of colors:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "grid = pn.GridBox('', 'False', 'True', ncols=3)\n",
+    "\n",
+    "for color in BooleanStatus.param.color.objects:\n",
+    "    false = BooleanStatus(width=50, height=50, value=False, color=color)\n",
+    "    true = BooleanStatus(width=50, height=50, value=True, color=color)\n",
+    "    grid.extend((color, false, true))\n",
+    "\n",
+    "grid"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.5"
+  },
+  "widgets": {
+   "application/vnd.jupyter.widget-state+json": {
+    "state": {},
+    "version_major": 2,
+    "version_minor": 0
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/examples/reference/indicators/LoadingSpinner.ipynb
+++ b/examples/reference/indicators/LoadingSpinner.ipynb
@@ -1,0 +1,108 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import panel as pn\n",
+    "from panel.widgets.indicators import LoadingSpinner\n",
+    "\n",
+    "pn.extension()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The ``LoadingSpinner`` is a boolean indicator providing a visual representation of the loading status. If the `value` is set to `True` the spinner will rotate while setting it to `False` will disable the rotating segment.\n",
+    "\n",
+    "#### Parameters:\n",
+    "\n",
+    "For layout and styling related parameters see the [customization user guide](../../user_guide/Customization.ipynb).\n",
+    "\n",
+    "* **``bgcolor``** (str): The color of spinner background segment, either 'light' or 'dark'\n",
+    "* **``color``** (str): The color of the spinning segment, one of 'primary', 'secondary', 'success', 'info', 'warn', 'danger', 'light', 'dark'\n",
+    "* **``value``** (boolean): Whether the indicator is spinning or not.\n",
+    "\n",
+    "___"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The `Progress` widget can be instantiated with and without a value. If given a `value` the progress bar will fill according to the progress to the `max` value which is 100 by default:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "progress = LoadingSpinner(name='Progress', value=True)\n",
+    "progress"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The `LoadingSpinner` indicator also supports a range of spinner colors and backgrounds:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "grid = pn.GridBox('', 'light', 'dark', ncols=3)\n",
+    "\n",
+    "for color in LoadingSpinner.param.color.objects:\n",
+    "    dark = LoadingSpinner(width=50, height=50, value=True, color=color, bgcolor='dark')\n",
+    "    light = LoadingSpinner(width=50, height=50, value=True, color=color, bgcolor='light')\n",
+    "    grid.extend((color, light, dark))\n",
+    "\n",
+    "grid"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.5"
+  },
+  "widgets": {
+   "application/vnd.jupyter.widget-state+json": {
+    "state": {},
+    "version_major": 2,
+    "version_minor": 0
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/examples/reference/indicators/LoadingSpinner.ipynb
+++ b/examples/reference/indicators/LoadingSpinner.ipynb
@@ -9,6 +9,7 @@
     "import panel as pn\n",
     "from panel.widgets.indicators import LoadingSpinner\n",
     "\n",
+    "\n",
     "pn.extension()"
    ]
   },
@@ -33,7 +34,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The `Progress` widget can be instantiated with and without a value. If given a `value` the progress bar will fill according to the progress to the `max` value which is 100 by default:"
+    "The `LoadingSpinner` can be instantiated in a spinning or idle state:"
    ]
   },
   {
@@ -42,8 +43,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "progress = LoadingSpinner(name='Progress', value=True)\n",
-    "progress"
+    "idle = LoadingSpinner(value=False, width=100, height=100)\n",
+    "loading = LoadingSpinner(value=True, width=100, height=100)\n",
+    "\n",
+    "pn.Row(idle, loading)"
    ]
   },
   {
@@ -68,13 +71,6 @@
     "\n",
     "grid"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/panel/_styles/widgets.css
+++ b/panel/_styles/widgets.css
@@ -139,3 +139,55 @@ progress:not([value])::before {
   from {background-position: 0%}
   to {background-position: 100%}
 }
+
+div.loader:after {
+  content: "";
+  background: conic-gradient(
+    #f3f3f3 0 100%
+  );
+  border-radius: 50%;
+  -webkit-mask-image: radial-gradient(transparent 50%, rgba(0, 0, 0, 1) 50%);
+  width: 100%;
+  height: 100%;
+  left: 0;
+  top: 0;
+  position: absolute;
+}
+
+div.loader.spin:after {
+  background: conic-gradient(
+    #3498db 25%,
+    #f3f3f3 0 50%
+  );
+  animation: spin 2s linear infinite;
+}
+
+/* Safari */
+@-webkit-keyframes spin {
+  0% { -webkit-transform: rotate(0deg); }
+  100% { -webkit-transform: rotate(360deg); }
+}
+
+@keyframes spin {
+  0% { transform: rotate(0deg); }
+  100% { transform: rotate(360deg); }
+}
+
+
+.dot div {
+  height: 100%;
+  width: 100%;
+  border: 1px solid #444 !important;
+  background-color: #fff;
+  border-radius: 50%;
+  display: inline-block;
+}
+
+.dot-filled div {
+  height: 100%;
+  width: 100%;
+  border: 1px solid #444 !important;
+  background-color: #444;
+  border-radius: 50%;
+  display: inline-block;
+}

--- a/panel/_styles/widgets.css
+++ b/panel/_styles/widgets.css
@@ -144,9 +144,9 @@ div.loader:after {
   content: "";
   background: conic-gradient(
     #f3f3f3 0 100%
-  );
+  ) !important;
   border-radius: 50%;
-  -webkit-mask-image: radial-gradient(transparent 50%, rgba(0, 0, 0, 1) 50%);
+  -webkit-mask-image: radial-gradient(transparent 50%, rgba(0, 0, 0, 1) 54%);
   width: 100%;
   height: 100%;
   left: 0;
@@ -158,7 +158,7 @@ div.loader.spin:after {
   background: conic-gradient(
     #3498db 25%,
     #f3f3f3 0 50%
-  );
+  ) !important;
   animation: spin 2s linear infinite;
 }
 
@@ -172,7 +172,6 @@ div.loader.spin:after {
   0% { transform: rotate(0deg); }
   100% { transform: rotate(360deg); }
 }
-
 
 .dot div {
   height: 100%;

--- a/panel/_styles/widgets.css
+++ b/panel/_styles/widgets.css
@@ -176,7 +176,7 @@ div.loader.spin:after {
 .dot div {
   height: 100%;
   width: 100%;
-  border: 1px solid #444 !important;
+  border: 1px solid #000 !important;
   background-color: #fff;
   border-radius: 50%;
   display: inline-block;
@@ -185,8 +185,8 @@ div.loader.spin:after {
 .dot-filled div {
   height: 100%;
   width: 100%;
-  border: 1px solid #444 !important;
-  background-color: #444;
+  border: 1px solid #000 !important;
+  background-color: #000;
   border-radius: 50%;
   display: inline-block;
 }

--- a/panel/_styles/widgets.css
+++ b/panel/_styles/widgets.css
@@ -142,9 +142,6 @@ progress:not([value])::before {
 
 div.loader:after {
   content: "";
-  background: conic-gradient(
-    #f3f3f3 0 100%
-  ) !important;
   border-radius: 50%;
   -webkit-mask-image: radial-gradient(transparent 50%, rgba(0, 0, 0, 1) 54%);
   width: 100%;
@@ -154,12 +151,133 @@ div.loader:after {
   position: absolute;
 }
 
-div.loader.spin:after {
+div.loader.dark:after {
   background: conic-gradient(
-    #3498db 25%,
-    #f3f3f3 0 50%
+    #0f0f0f 0 100%
   ) !important;
+}
+
+
+div.loader.light:after {
+  background: conic-gradient(
+    #f0f0f0 0 100%
+  ) !important;
+}
+
+div.loader.spin:after {
   animation: spin 2s linear infinite;
+}
+
+div.loader.spin.primary-light:after {
+  background: conic-gradient(
+    #007bff 25%,
+    #f0f0f0 0 50%
+  ) !important;
+}
+
+div.loader.spin.secondary-light:after {
+  background: conic-gradient(
+    #6c757d 25%,
+    #f0f0f0 0 50%
+  ) !important;
+}
+
+div.loader.spin.success-light:after {
+  background: conic-gradient(
+    #28a745 25%,
+    #f0f0f0 0 50%
+  ) !important;
+}
+
+div.loader.spin.danger-light:after {
+  background: conic-gradient(
+    #dc3545 25%,
+    #f0f0f0 0 50%
+  ) !important;
+}
+
+div.loader.spin.warning-light:after {
+  background: conic-gradient(
+    #ffc107 25%,
+    #f0f0f0 0 50%
+  ) !important;
+}
+
+div.loader.spin.info-light:after {
+  background: conic-gradient(
+    #17a2b8 25%,
+    #f0f0f0 0 50%
+  ) !important;
+}
+
+div.loader.spin.light-light:after {
+  background: conic-gradient(
+    #f8f9fa 25%,
+    #f0f0f0 0 50%
+  ) !important;
+}
+
+div.loader.spin.dark-light:after {
+  background: conic-gradient(
+    #343a40 25%,
+    #f0f0f0 0 50%
+  ) !important;
+}
+
+div.loader.spin.primary-dark:after {
+  background: conic-gradient(
+    #007bff 25%,
+    #0f0f0f 0 50%
+  ) !important;
+}
+
+div.loader.spin.secondary-dark:after {
+  background: conic-gradient(
+    #6c757d 25%,
+    #0f0f0f 0 50%
+  ) !important;
+}
+
+div.loader.spin.success-dark:after {
+  background: conic-gradient(
+    #28a745 25%,
+    #0f0f0f 0 50%
+  ) !important;
+}
+
+div.loader.spin.danger-dark:after {
+  background: conic-gradient(
+    #dc3545 25%,
+    #0f0f0f 0 50%
+  ) !important;
+}
+
+div.loader.spin.warning-dark:after {
+  background: conic-gradient(
+    #ffc107 25%,
+    #0f0f0f 0 50%
+  ) !important;
+}
+
+div.loader.spin.info-dark:after {
+  background: conic-gradient(
+    #17a2b8 25%,
+    #0f0f0f 0 50%
+  ) !important;
+}
+
+div.loader.spin.light-dark:after {
+  background: conic-gradient(
+    #f8f9fa 25%,
+    #0f0f0f 0 50%
+  ) !important;
+}
+
+div.loader.spin.dark-dark:after {
+  background: conic-gradient(
+    #343a40 25%,
+    #0f0f0f 0 50%
+  ) !important;
 }
 
 /* Safari */
@@ -186,7 +304,38 @@ div.loader.spin:after {
   height: 100%;
   width: 100%;
   border: 1px solid #000 !important;
-  background-color: #000;
   border-radius: 50%;
   display: inline-block;
+}
+
+.dot-filled.primary div {
+  background-color: #007bff;
+}
+
+.dot-filled.secondary div {
+  background-color: #6c757d;
+}
+
+.dot-filled.success div {
+  background-color: #28a745;
+}
+
+.dot-filled.danger div {
+  background-color: #dc3545;
+}
+
+.dot-filled.warning div {
+  background-color: #ffc107;
+}
+
+.dot-filled.info div {
+  background-color: #17a2b8;
+}
+
+.dot-filled.dark div {
+  background-color: #343a40;
+}
+
+.dot-filled.light div {
+  background-color: #f8f9fa;
 }

--- a/panel/_styles/widgets.css
+++ b/panel/_styles/widgets.css
@@ -140,7 +140,7 @@ progress:not([value])::before {
   to {background-position: 100%}
 }
 
-div.loader:after {
+.bk.loader::after {
   content: "";
   border-radius: 50%;
   -webkit-mask-image: radial-gradient(transparent 50%, rgba(0, 0, 0, 1) 54%);
@@ -151,133 +151,80 @@ div.loader:after {
   position: absolute;
 }
 
-div.loader.dark:after {
-  background: conic-gradient(
-    #0f0f0f 0 100%
-  ) !important;
+.bk-root .bk.loader.dark::after {
+  background: #0f0f0f;
 }
 
-
-div.loader.light:after {
-  background: conic-gradient(
-    #f0f0f0 0 100%
-  ) !important;
+.bk-root .bk.loader.light::after {
+  background: #f0f0f0;
 }
 
-div.loader.spin:after {
+.bk-root .bk.loader.spin::after {
   animation: spin 2s linear infinite;
 }
 
-div.loader.spin.primary-light:after {
-  background: conic-gradient(
-    #007bff 25%,
-    #f0f0f0 0 50%
-  ) !important;
+.bk-root div.bk.loader.spin.primary-light::after {
+  background: linear-gradient(135deg, #f0f0f0 50%, transparent 50%), linear-gradient(45deg, #f0f0f0 50%, #007bff 50%);
 }
 
-div.loader.spin.secondary-light:after {
-  background: conic-gradient(
-    #6c757d 25%,
-    #f0f0f0 0 50%
-  ) !important;
+.bk-root div.bk.loader.spin.secondary-light::after {
+  background: linear-gradient(135deg, #f0f0f0 50%, transparent 50%), linear-gradient(45deg, #f0f0f0 50%, #6c757d 50%);
 }
 
-div.loader.spin.success-light:after {
-  background: conic-gradient(
-    #28a745 25%,
-    #f0f0f0 0 50%
-  ) !important;
+.bk-root div.bk.loader.spin.success-light::after {
+  background: linear-gradient(135deg, #f0f0f0 50%, transparent 50%), linear-gradient(45deg, #f0f0f0 50%, #28a745 50%);
 }
 
-div.loader.spin.danger-light:after {
-  background: conic-gradient(
-    #dc3545 25%,
-    #f0f0f0 0 50%
-  ) !important;
+.bk-root div.bk.loader.spin.danger-light::after {
+  background: linear-gradient(135deg, #f0f0f0 50%, transparent 50%), linear-gradient(45deg, #f0f0f0 50%, #dc3545 50%);
 }
 
-div.loader.spin.warning-light:after {
-  background: conic-gradient(
-    #ffc107 25%,
-    #f0f0f0 0 50%
-  ) !important;
+.bk-root div.bk.loader.spin.warning-light::after {
+  background: linear-gradient(135deg, #f0f0f0 50%, transparent 50%), linear-gradient(45deg, #f0f0f0 50%, #ffc107 50%);
 }
 
-div.loader.spin.info-light:after {
-  background: conic-gradient(
-    #17a2b8 25%,
-    #f0f0f0 0 50%
-  ) !important;
+.bk-root div.bk.loader.spin.info-light::after {
+  background: linear-gradient(135deg, #f0f0f0 50%, transparent 50%), linear-gradient(45deg, #f0f0f0 50%, #17a2b8 50%);
 }
 
-div.loader.spin.light-light:after {
-  background: conic-gradient(
-    #f8f9fa 25%,
-    #f0f0f0 0 50%
-  ) !important;
+.bk-root div.bk.loader.spin.light-light::after {
+  background: linear-gradient(135deg, #f0f0f0 50%, transparent 50%), linear-gradient(45deg, #f0f0f0 50%, #f8f9fa 50%);
 }
 
-div.loader.spin.dark-light:after {
-  background: conic-gradient(
-    #343a40 25%,
-    #f0f0f0 0 50%
-  ) !important;
+.bk-root div.bk.loader.dark-light::after {
+  background: linear-gradient(135deg, #f0f0f0 50%, transparent 50%), linear-gradient(45deg, #f0f0f0 50%, #343a40 50%);
 }
 
-div.loader.spin.primary-dark:after {
-  background: conic-gradient(
-    #007bff 25%,
-    #0f0f0f 0 50%
-  ) !important;
+.bk-root div.bk.loader.spin.primary-dark::after {
+  background: linear-gradient(135deg, #0f0f0f 50%, transparent 50%), linear-gradient(45deg, #0f0f0f 50%, #007bff 50%);
 }
 
-div.loader.spin.secondary-dark:after {
-  background: conic-gradient(
-    #6c757d 25%,
-    #0f0f0f 0 50%
-  ) !important;
+.bk-root div.bk.loader.spin.secondary-dark::after {
+  background: linear-gradient(135deg, #0f0f0f 50%, transparent 50%), linear-gradient(45deg, #0f0f0f 50%, #6c757d 50%);
 }
 
-div.loader.spin.success-dark:after {
-  background: conic-gradient(
-    #28a745 25%,
-    #0f0f0f 0 50%
-  ) !important;
+.bk-root div.bk.loader.spin.success-dark::after {
+  background: linear-gradient(135deg, #0f0f0f 50%, transparent 50%), linear-gradient(45deg, #0f0f0f 50%, #28a745 50%);
 }
 
-div.loader.spin.danger-dark:after {
-  background: conic-gradient(
-    #dc3545 25%,
-    #0f0f0f 0 50%
-  ) !important;
+.bk-root div.bk.loader.spin.danger-dark::after {
+  background: linear-gradient(135deg, #0f0f0f 50%, transparent 50%), linear-gradient(45deg, #0f0f0f 50%, #dc3545 50%)
 }
 
-div.loader.spin.warning-dark:after {
-  background: conic-gradient(
-    #ffc107 25%,
-    #0f0f0f 0 50%
-  ) !important;
+.bk-root div.bk.loader.spin.warning-dark::after {
+  background: linear-gradient(135deg, #0f0f0f 50%, transparent 50%), linear-gradient(45deg, #0f0f0f 50%, #ffc107 50%);
 }
 
-div.loader.spin.info-dark:after {
-  background: conic-gradient(
-    #17a2b8 25%,
-    #0f0f0f 0 50%
-  ) !important;
+.bk-root div.bk.loader.spin.info-dark::after {
+  background: linear-gradient(135deg, #0f0f0f 50%, transparent 50%), linear-gradient(45deg, #0f0f0f 50%, #17a2b8 50%);
 }
 
-div.loader.spin.light-dark:after {
-  background: conic-gradient(
-    #f8f9fa 25%,
-    #0f0f0f 0 50%
-  ) !important;
+.bk-root div.bk.loader.spin.light-dark::after {
+  background: linear-gradient(135deg, #0f0f0f 50%, transparent 50%), linear-gradient(45deg, #0f0f0f 50%, #f8f9fa 50%);
 }
 
-div.loader.spin.dark-dark:after {
-  background: conic-gradient(
-    #343a40 25%,
-    #0f0f0f 0 50%
-  ) !important;
+.bk-root div.bk.loader.spin.dark-dark::after {
+  background: linear-gradient(135deg, #0f0f0f 50%, transparent 50%), linear-gradient(45deg, #0f0f0f 50%, #343a40 50%);
 }
 
 /* Safari */

--- a/panel/io/state.py
+++ b/panel/io/state.py
@@ -117,7 +117,7 @@ class _state(param.Parameterized):
         """
         self._indicators.append(indicator)
 
-    @param.depends('busy')
+    @param.depends('busy', watch=True)
     def _update_busy(self):
         for indicator in self._indicators:
             indicator.value = self.busy

--- a/panel/template/base.py
+++ b/panel/template/base.py
@@ -27,6 +27,7 @@ from ..models.comm_manager import CommManager
 from ..pane import panel as _panel, HTML, Str, HoloViews
 from ..viewable import ServableMixin, Viewable
 from ..widgets import Button
+from ..widgets.indicators import Indicator
 from .theme import DefaultTheme, Theme
 
 _server_info = (
@@ -312,6 +313,9 @@ class BasicTemplate(BaseTemplate):
     sidebar = param.ClassSelector(class_=ListLike, constant=True, doc="""
         A list-like container which populates the sidebar.""")
 
+    busy_indicator = param.ClassSelector(class_=Indicator, constant=True, doc="""
+        Indicator class""")
+
     title = param.String(doc="A title to show in the header.")
 
     header_background = param.String(doc="Optional header background color override")
@@ -331,6 +335,8 @@ class BasicTemplate(BaseTemplate):
 
     def __init__(self, **params):
         template = self._template.read_text()
+        if 'busy_indicator' in params:
+            state.sync_busy(params['busy_indicator'])
         if 'header' not in params:
             params['header'] = ListLike()
         if 'main' not in params:
@@ -387,6 +393,8 @@ class BasicTemplate(BaseTemplate):
             if ref not in self._render_items:
                 self._render_items[ref] = (obj, [tag])
         tags = [tags for _, tags in self._render_items.values()]
+        self._render_items['busy_indicator'] = (self.busy_indicator, [])
+        self._render_variables['busy'] = self.busy_indicator is not None
         self._render_variables['nav'] = any('nav' in ts for ts in tags)
         self._render_variables['header'] = any('header' in ts for ts in tags)
         self._render_variables['root_labels'] = labels

--- a/panel/template/base.py
+++ b/panel/template/base.py
@@ -27,19 +27,20 @@ from ..models.comm_manager import CommManager
 from ..pane import panel as _panel, HTML, Str, HoloViews
 from ..viewable import ServableMixin, Viewable
 from ..widgets import Button
-from ..widgets.indicators import Indicator, Busy
+from ..widgets.indicators import BooleanIndicator, LoadingSpinner
 from .theme import DefaultTheme, Theme
 
 _server_info = (
     '<b>Running server:</b> <a target="_blank" href="https://localhost:{port}">'
-    'https://localhost:{port}</a>')
+    'https://localhost:{port}</a>'
+)
 
 
 class BaseTemplate(param.Parameterized, ServableMixin):
 
     # Dictionary of property overrides by bokeh Model type
     _modifiers = {}
-    
+
     __abstract = True
 
     def __init__(self, template=None, items=None, nb_template=None, **params):
@@ -304,9 +305,9 @@ class BasicTemplate(BaseTemplate):
     feel without having to write any Jinja2 template themselves.
     """
 
-    busy_indicator = param.ClassSelector(default=Busy(), class_=Indicator,
-                                         constant=True, doc="""
-        Indicator class""")
+    busy_indicator = param.ClassSelector(default=LoadingSpinner(width=20, height=20),
+                                         class_=BooleanIndicator, constant=True, doc="""
+        Visual indicator of application busy state.""")
 
     header = param.ClassSelector(class_=ListLike, constant=True, doc="""
         A list-like container which populates the header bar.""")

--- a/panel/template/base.py
+++ b/panel/template/base.py
@@ -357,8 +357,8 @@ class BasicTemplate(BaseTemplate):
         self.header.param.watch(self._update_render_items, ['objects'])
         self.param.watch(self._update_vars, ['title', 'header_background',
                                              'header_color'])
-        self._callbacks = {'main': [], 'sidebar': [], 'header': []}
-        self._js_area = HTML(margin=0)
+        self._callbacks = {'main': [], 'sidebar': [], 'header': [], 'modal': []}
+        self._js_area = HTML(margin=0, width=0, height=0)
 
     @property
     def _css_files(self):

--- a/panel/template/base.py
+++ b/panel/template/base.py
@@ -369,7 +369,6 @@ class BasicTemplate(BaseTemplate):
         self.header.param.watch(self._update_render_items, ['objects'])
         self.param.watch(self._update_vars, ['title', 'header_background',
                                              'header_color'])
-        self._callbacks = {'main': [], 'nav': [], 'header': [], 'modal': []}
         self._js_area = HTML(margin=0, width=0, height=0)
 
     @property
@@ -396,11 +395,6 @@ class BasicTemplate(BaseTemplate):
         self._render_variables['header_background'] = self.header_background
         self._render_variables['header_color'] = self.header_color
 
-    def _on_objects_change(self, event):
-        for ref in event.obj._models:
-            for o in event.obj.select():
-                self._apply_modifiers(o, ref)
-
     def _update_render_items(self, event):
         if event.obj is self.main:
             tag = 'main'
@@ -415,22 +409,12 @@ class BasicTemplate(BaseTemplate):
             ref = str(id(obj))
             if obj not in event.new and ref in self._render_items:
                 del self._render_items[ref]
-                cbs = self._callbacks[tag]
-                new_cbs = []
-                for cb in cbs:
-                    if cb.owner is obj:
-                        obj.param.unwatch(cb)
-                    else:
-                        new_cbs.append(cb)
 
         labels = {}
         for obj in event.new:
             ref = str(id(obj))
             labels[ref] = 'Content' if obj.name.startswith(type(obj).__name__) else obj.name
             if ref not in self._render_items:
-                if hasattr(obj, 'objects'):
-                    watcher = obj.param.watch(self._on_objects_change, 'objects')
-                    self._callbacks[tag].append(watcher)
                 self._render_items[ref] = (obj, [tag])
         self._render_items['js_area'] = (self._js_area, [])
         tags = [tags for _, tags in self._render_items.values()]

--- a/panel/template/bootstrap/bootstrap.css
+++ b/panel/template/bootstrap/bootstrap.css
@@ -36,3 +36,42 @@ a.navbar-brand {
 p.bk.card-button {
   display: none;
 }
+
+.pn-modal {
+  overflow-y: scroll;
+  width: 100%;
+  display: none;
+  position: absolute;
+  top: 0;
+  left: 0;
+}
+
+.pn-modal-content {
+  background-color: #fefefe;
+  margin: auto;
+  margin-top: 25px;
+  margin-bottom: 25px;
+  padding: 15px 20px 20px 20px;
+  border: 1px solid #888;
+  width: 80% !important;
+}
+
+.pn-modal-close {
+  position: absolute;
+  right: 25px;
+  z-index: 100;
+}
+
+.pn-modal-close:hover,
+.pn-modal-close:focus {
+  color: #000;
+  text-decoration: none;
+  cursor: pointer;
+}
+
+.pn-busy-container {
+  align-items: center;
+  justify-content: center;
+  display: flex;
+  margin-left: auto;
+}

--- a/panel/template/bootstrap/bootstrap.html
+++ b/panel/template/bootstrap/bootstrap.html
@@ -25,6 +25,9 @@
     {% endif %}
     {% endfor %}
     {% endfor %}
+    {% if busy %}
+	{{ embed(roots.busy_indicator) | indent(6) }}
+	{% endif %}
   </nav>
 
   <div class="row overflow-hidden" id="content">

--- a/panel/template/bootstrap/bootstrap.html
+++ b/panel/template/bootstrap/bootstrap.html
@@ -5,7 +5,6 @@
 <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/css/bootstrap.min.css" integrity="sha384-Vkoo8x4CGsO3+Hhxv8T/Q5PaXtkKtu6ug5TOeNV6gBiFeWPGFN9MuhOf23Q9Ifjh" crossorigin="anonymous">
 <script src="https://code.jquery.com/jquery-3.4.1.slim.min.js" integrity="sha384-J6qa4849blE2+poT4WnyKhv5vZF5SrPo0iEjwBvKU7imGFAV0wwj1yYfoRSJoZ+n" crossorigin="anonymous"></script>
 <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/js/bootstrap.min.js" integrity="sha384-wfSDF2E50Y2D1uUdj0O3uMBJnjuUD4Ih7YwaYd1iqfktj0Uod8GCExl3Og8ifwB6" crossorigin="anonymous"></script>
-
 {% endblock %}
 
 <!-- goes in body -->
@@ -26,7 +25,9 @@
     {% endfor %}
     {% endfor %}
     {% if busy %}
-	{{ embed(roots.busy_indicator) | indent(6) }}
+	<div class="pn-busy-container">
+	  {{ embed(roots.busy_indicator) | indent(6) }}
+	</div>
 	{% endif %}
   </nav>
 
@@ -53,6 +54,18 @@
       {% endif %}
       {% endfor %}
       {% endfor %}
+	  <div id="pn-Modal" class="pn-modal mdc-top-app-bar--fixed-adjust">
+		<div class="pn-modal-content">
+		  <span class="pn-modalclose" id="pn-closeModal">&times;</span>
+		  {% for doc in docs %}
+		  {% for root in doc.roots %}
+		  {% if "modal" in root.tags %}
+		  {{ embed(root) | indent(6) }}
+		  {% endif %}
+		  {% endfor %}
+		  {% endfor %}
+		</div>
+	  </div>
     </div>
   </div>
 </div>
@@ -66,5 +79,22 @@
       setTimeout(function () { clearInterval(interval) }, 210)
     });
   });
+
+  var modal = document.getElementById("pn-Modal");
+  var span = document.getElementById("pn-closeModal");
+
+  span.onclick = function() {
+    modal.style.display = "none";
+  }
+
+  window.onclick = function(event) {
+    if (event.target == modal) {
+      modal.style.display = "none";
+    }
+  }
 </script>
+
+{{ embed(roots.js_area) }}
+
 {% endblock %}
+

--- a/panel/template/golden/golden.css
+++ b/panel/template/golden/golden.css
@@ -66,3 +66,43 @@ p.bk.golden-card-button {
 .bk-canvas {
   padding-right: 2px !important;
 }
+
+
+.pn-modal {
+  overflow-y: scroll;
+  width: 100%;
+  position: absolute;
+  display: none;
+  top: 0;
+  left: 0;
+}
+
+.pn-modal-content {
+  background-color: #fefefe;
+  margin: auto;
+  margin-top: 25px;
+  margin-bottom: 25px;
+  padding: 15px 20px 20px 20px;
+  border: 1px solid #888;
+  width: 80% !important;
+}
+
+.pn-modal-close {
+  position: absolute;
+  right: 25px;
+  z-index: 100;
+}
+
+.pn-modal-close:hover,
+.pn-modal-close:focus {
+  color: #000;
+  text-decoration: none;
+  cursor: pointer;
+}
+
+.pn-busy-container {
+  align-items: center;
+  justify-content: center;
+  display: flex;
+  margin-left: auto;
+}

--- a/panel/template/golden/golden.html
+++ b/panel/template/golden/golden.html
@@ -22,13 +22,27 @@
       {% endfor %}
     </section>
 	{% if busy %}
-	{{ embed(roots.busy_indicator) | indent(6) }}
+	<div class="pn-busy-container">
+	  {{ embed(roots.busy_indicator) | indent(6) }}
+	</div>
 	{% endif %}
   </div>
 </header>
 
 <div class="main-area header-adjust" id="main">
   <main class="main-content" id="main-content"></main>
+  <div id="pn-Modal" class="pn-modal header-adjust">
+	<div class="pn-modal-content">
+	  <span class="pn-modalclose" id="pn-closeModal">&times;</span>
+	  {% for doc in docs %}
+	  {% for root in doc.roots %}
+	  {% if "modal" in root.tags %}
+	  {{ embed(root) | indent(6) }}
+	  {% endif %}
+	  {% endfor %}
+	  {% endfor %}
+	</div>
+  </div>
 </div>
 
 <script>
@@ -96,6 +110,21 @@
       myLayout.updateSize(window.innerWidth, window.innerHeight)
     }
   });
+
+  var modal = document.getElementById("pn-Modal");
+  var span = document.getElementById("pn-closeModal");
+
+  span.onclick = function() {
+    modal.style.display = "none";
+  }
+
+  window.onclick = function(event) {
+    if (event.target == modal) {
+      modal.style.display = "none";
+    }
+  }
 </script>
+
+{{ embed(roots.js_area) }}
 
 {% endblock %}

--- a/panel/template/golden/golden.html
+++ b/panel/template/golden/golden.html
@@ -1,35 +1,38 @@
-{% extends base %}	
+{% extends base %}
 
-<!-- goes in body -->	
+<!-- goes in body -->
 {% block preamble %}
-<script type="text/javascript" src="http://code.jquery.com/jquery-1.11.1.min.js"></script>	
-<script type="text/javascript" src="https://golden-layout.com/files/latest/js/goldenlayout.js"></script>	
-<link type="text/css" rel="stylesheet" href="https://golden-layout.com/files/latest/css/goldenlayout-base.css" />	
+<script type="text/javascript" src="http://code.jquery.com/jquery-1.11.1.min.js"></script>
+<script type="text/javascript" src="https://golden-layout.com/files/latest/js/goldenlayout.js"></script>
+<link type="text/css" rel="stylesheet" href="https://golden-layout.com/files/latest/css/goldenlayout-base.css" />
 {% endblock %}
 
-<!-- goes in body -->	
-{% block contents %}	
-<header class="app-bar" id="header">	
-  <div class="">	
-    <section class="">	
-      <span class="header-title">{{ app_title }}</span>	
-	  {% for doc in docs %}	
-      {% for root in doc.roots %}	
-      {% if "header" in root.tags %}	
-      {type: 'component', componentName: 'view', componentState: {model: '{{ embed(root) }}', title: "{{ 'Sidebar' }}"}},	
-      {% endif %}	
-      {% endfor %}	
-      {% endfor %}	
-    </section>	
-  </div>	
-</header>	
+<!-- goes in body -->
+{% block contents %}
+<header class="app-bar" id="header">
+  <div>
+    <span class="header-title">{{ app_title }}</span>
+    <section>
+	  {% for doc in docs %}
+      {% for root in doc.roots %}
+      {% if "header" in root.tags %}
+      {{ embed(root) }}
+      {% endif %}
+      {% endfor %}
+      {% endfor %}
+    </section>
+	{% if "busy" in root.tags %}
+	{{ embed(roots.busy_indicator) | indent(6) }}
+	{% endif %}
+  </div>
+</header>
 
-<div class="main-area header-adjust" id="main">	
-  <main class="main-content" id="main-content"></main>	
-</div>	
+<div class="main-area header-adjust" id="main">
+  <main class="main-content" id="main-content"></main>
+</div>
 
-<script>	
-  var config = {	
+<script>
+  var config = {
     content: [
       {
         type: 'row',
@@ -46,10 +49,10 @@
           {
             type: 'stack',
             width: 80,
-            content: [	
-              {% for doc in docs %}	
-              {% for root in doc.roots %}	
-              {% if "main" in root.tags%}	
+            content: [
+              {% for doc in docs %}
+              {% for root in doc.roots %}
+              {% if "main" in root.tags%}
               {
                 type: 'component',
                 componentName: 'view',
@@ -58,13 +61,13 @@
                   title: "{{ root_labels[root.name] }}"
                 },
               }
-              {% endif %}	
-              {% endfor %}	
-              {% endfor %}	
+              {% endif %}
+              {% endfor %}
+              {% endfor %}
             ]
           }
         ]
-      }     
+      }
     ]
   };
 

--- a/panel/template/golden/golden.html
+++ b/panel/template/golden/golden.html
@@ -10,7 +10,7 @@
 <!-- goes in body -->
 {% block contents %}
 <header class="app-bar" id="header">
-  <div>
+  <div style="display: contents;">
     <span class="header-title">{{ app_title }}</span>
     <section>
 	  {% for doc in docs %}
@@ -21,7 +21,7 @@
       {% endfor %}
       {% endfor %}
     </section>
-	{% if "busy" in root.tags %}
+	{% if busy %}
 	{{ embed(roots.busy_indicator) | indent(6) }}
 	{% endif %}
   </div>

--- a/panel/template/material/material.css
+++ b/panel/template/material/material.css
@@ -22,6 +22,12 @@ body {
   z-index: 7;
 }
 
+.busy-container {
+  align-items: center;
+  justify-content: center;
+  display: flex;
+}
+
 button.mdc-button.mdc-card-button {
   color: transparent;
   height: 50px;

--- a/panel/template/material/material.css
+++ b/panel/template/material/material.css
@@ -22,7 +22,7 @@ body {
   z-index: 7;
 }
 
-.busy-container {
+.pn-busy-container {
   align-items: center;
   justify-content: center;
   display: flex;
@@ -44,4 +44,36 @@ div.bk.mdc-card {
 .bk.mdc-card-title {
   font-size: 1.5em;
   font-weight: bold;
+}
+
+.pn-modal {
+  overflow-y: scroll;
+  width: 100%;
+  display: none;
+  position: absolute;
+  top: 0;
+  left: 0;
+}
+
+.pn-modal-content {
+  background-color: #fefefe;
+  margin: auto;
+  margin-top: 25px;
+  margin-bottom: 25px;
+  padding: 15px 20px 20px 20px;
+  border: 1px solid #888;
+  width: 80% !important;
+}
+
+.pn-modal-close {
+  position: absolute;
+  right: 25px;
+  z-index: 100;
+}
+
+.pn-modal-close:hover,
+.pn-modal-close:focus {
+  color: #000;
+  text-decoration: none;
+  cursor: pointer;
 }

--- a/panel/template/material/material.html
+++ b/panel/template/material/material.html
@@ -76,8 +76,6 @@
 
 <script>
   var drawer = mdc.drawer.MDCDrawer.attachTo(document.querySelector('.mdc-drawer'));
-  drawer.open = true;
-  console.log(drawer)
   var topAppBar = mdc.topAppBar.MDCTopAppBar.attachTo(document.getElementById('header'));
   topAppBar.setScrollTarget(document.getElementById('main'));
   topAppBar.listen('MDCTopAppBar:nav', function() {
@@ -85,6 +83,8 @@
     // Ensure bokeh layout recomputes layout
     window.dispatchEvent(new Event('resize'));
   });
+
+  drawer.open = true;
 
   var modal = document.getElementById("pn-Modal");
   var span = document.getElementById("pn-closeModal");

--- a/panel/template/material/material.html
+++ b/panel/template/material/material.html
@@ -26,7 +26,7 @@
       {% endfor %}
     </section>
     {% if busy %}
-	<div class="busy-container">
+	<div class="pn-busy-container">
 	  {{ embed(roots.busy_indicator) | indent(6) }}
 	</div>
 	{% endif %}
@@ -59,6 +59,19 @@
   {% endfor %}
   {% endfor %}
 </main>
+
+<div id="pn-Modal" class="pn-modal mdc-top-app-bar--fixed-adjust">
+  <div class="pn-modal-content">
+    <span class="pn-modalclose" id="pn-closeModal">&times;</span>
+    {% for doc in docs %}
+	{% for root in doc.roots %}
+	{% if "modal" in root.tags %}
+	{{ embed(root) | indent(4) }}
+	{% endif %}
+	{% endfor %}
+	{% endfor %}
+  </div>
+</div>
 </div>
 
 <script>
@@ -72,7 +85,21 @@
     // Ensure bokeh layout recomputes layout
     window.dispatchEvent(new Event('resize'));
   });
+
+  var modal = document.getElementById("pn-Modal");
+  var span = document.getElementById("pn-closeModal");
+
+  span.onclick = function() {
+    modal.style.display = "none";
+  }
+
+  window.onclick = function(event) {
+    if (event.target == modal) {
+      modal.style.display = "none";
+    }
+  }
 </script>
 
+{{ embed(roots.js_area) }}
 
 {% endblock %}

--- a/panel/template/material/material.html
+++ b/panel/template/material/material.html
@@ -25,7 +25,7 @@
       {% endfor %}
       {% endfor %}
     </section>
-    {% if "busy" in root.tags %}
+    {% if busy %}
 	{{ embed(roots.busy_indicator) | indent(6) }}
 	{% endif %}
   </div>

--- a/panel/template/material/material.html
+++ b/panel/template/material/material.html
@@ -26,7 +26,9 @@
       {% endfor %}
     </section>
     {% if busy %}
-	{{ embed(roots.busy_indicator) | indent(6) }}
+	<div class="busy-container">
+	  {{ embed(roots.busy_indicator) | indent(6) }}
+	</div>
 	{% endif %}
   </div>
 </header>

--- a/panel/template/material/material.html
+++ b/panel/template/material/material.html
@@ -25,6 +25,9 @@
       {% endfor %}
       {% endfor %}
     </section>
+    {% if "busy" in root.tags %}
+	{{ embed(roots.busy_indicator) | indent(6) }}
+	{% endif %}
   </div>
 </header>
 

--- a/panel/template/vanilla/vanilla.css
+++ b/panel/template/vanilla/vanilla.css
@@ -1,116 +1,157 @@
 body {
-    height: 100vh;
-    margin: 0px;
-  }
+  height: 100vh;
+  margin: 0px;
+  font-family: "Lato", sans-serif;
+}
 
-  #container {
-    padding:0px;
-    width: 100vw;
-  }
+#container {
+  padding:0px;
+  width: 100vw;
+}
 
-  #header{
-    padding: 10px;
-  }
+#header{
+  display: flex;
+  align-items: center;
+  padding: 10px;
+}
 
-  .title{
-    color: #fff;
-    padding-left: 10px;
-    text-decoration: none;
-    text-decoration-line: none;
-    text-decoration-style: initial;
-    text-decoration-color: initial;
-    font-weight: 400;
-    font-size: 28px;
-  }
+.title {
+  color: #fff;
+  padding-left: 10px;
+  text-decoration: none;
+  text-decoration-line: none;
+  text-decoration-style: initial;
+  text-decoration-color: initial;
+  font-weight: 400;
+  font-size: 28px;
+}
 
-  .bk-canvas {
-    padding-right: 2px !important;
-  }
+.pn-bar {
+  width: 20px;
+  height: 2px;
+  background-color: white;
+  margin: 4px 0;
+}
 
-  #content {
-    height: 100vh;
-    margin: 0px;
-    width: 100vw;
-    display: inline-flex;
-  }
+.bk-canvas {
+  padding-right: 2px !important;
+}
 
-  #sidebar {
-    transition: all 0.2s cubic-bezier(0.945, 0.020, 0.270, 0.665);
-    transform-origin: center left; /* Set the transformed position of sidebar to center left side. */
-    width: 15vw;
-    margin-top: 60px;
-  }
+#content {
+  height: 100%;
+  margin: 0px;
+  width: 100vw;
+  display: inline-flex;
+}
 
-  #sidebar.active {
-    margin-left: -16.7%;
-  }
+#sidebar {
+  transition: all 0.2s cubic-bezier(0.945, 0.020, 0.270, 0.665);
+  transform-origin: center left; /* Set the transformed position of sidebar to center left side. */
+  width: 16.7vw;
+}
 
-  #main {
-    overflow-y: scroll;
-    width: 100vw;
-    margin-left: 15vw;
-  }
+#sidebar.active {
+  margin-left: -16.7%;
+}
 
-  #sidebarCollapse {
-    background: none;
-    border: none;
-  }
+#main {
+  transition: all 0.2s cubic-bezier(0.945, 0.020, 0.270, 0.665);
+  overflow-y: scroll;
+  width: 100vw;
+  margin-left: 16.7vw;
+  overflow-y: scroll;
+}
 
-  a.navbar-brand {
-    padding-left: 10px;
-  }
+#sidebarCollapse {
+  background: none;
+  border: none;
+}
 
-  p.bk.card-button {
-    display: none;
-  }  
+a.navbar-brand {
+  padding-left: 10px;
+}
 
-  body {
-    font-family: "Lato", sans-serif;
-  }
-  
-  .sidenav {
-    height: 100%;
-    width: 0;
-    position: absolute;
-    z-index: 1;
-    top: 0;
-    left: 0;
-    background-color: #eeeeee;
-    overflow-x: hidden;
-    transition: 0.5s;
-    padding-top: 15px;
-  }
+p.bk.card-button {
+  display: none;
+}  
 
-  .bk.card-title {
-    position: absolute !important;
-  }
-  
-  .sidenav a {
-    padding: 8px 8px 8px 32px;
-    text-decoration: none;
-    font-size: 25px;
-    color: #818181;
-    display: block;
-    transition: 0.3s;
-  }
-  
-  .sidenav a:hover {
-    color: #f1f1f1;
-  }
-  
-  .sidenav .closebtn {
-    position: absolute;
-    top: 0;
-    right: 25px;
-    font-size: 36px;
-    margin-left: 50px;
-  }
-  
-  @media screen and (max-height: 450px) {
-    .sidenav {padding-top: 15px;}
-    .sidenav a {font-size: 18px;}
-  }
+.sidenav {
+  height: 100%;
+  overflow-x: hidden;
+  padding-top: 15px;
+  position: absolute;
+  overflow-y: scroll;
+}
 
-  .nav.flex-column {
-    padding-inline-start: 0px;
-  }
+.bk.card-title {
+  position: absolute !important;
+}
+
+.sidenav a {
+  padding: 8px 8px 8px 32px;
+  text-decoration: none;
+  font-size: 25px;
+  color: #818181;
+  display: block;
+  transition: 0.3s;
+}
+
+.sidenav a:hover {
+  color: #f1f1f1;
+}
+
+.sidenav .closebtn {
+  position: absolute;
+  top: 0;
+  right: 25px;
+  font-size: 36px;
+  margin-left: 50px;
+}
+
+@media screen and (max-height: 450px) {
+  .sidenav {padding-top: 15px;}
+  .sidenav a {font-size: 18px;}
+}
+
+.nav.flex-column {
+  padding-inline-start: 0px;
+}
+
+.pn-modal {
+  overflow-y: scroll;
+  width: 100%;
+  position: absolute;
+  display: none;
+  top: 0;
+  left: 0;
+}
+
+.pn-modal-content {
+  background-color: #fefefe;
+  margin: auto;
+  margin-top: 25px;
+  margin-bottom: 25px;
+  padding: 15px 20px 20px 20px;
+  border: 1px solid #888;
+  width: 80% !important;
+}
+
+.pn-modal-close {
+  position: absolute;
+  right: 25px;
+  z-index: 100;
+}
+
+.pn-modal-close:hover,
+.pn-modal-close:focus {
+  color: #000;
+  text-decoration: none;
+  cursor: pointer;
+}
+
+.pn-busy-container {
+  align-items: center;
+  justify-content: center;
+  display: flex;
+  margin-left: auto;
+}

--- a/panel/template/vanilla/vanilla.html
+++ b/panel/template/vanilla/vanilla.html
@@ -5,7 +5,11 @@
 <div class="" id="container">
   <nav class="" style="{% if header_background %}background-color: {{ header_background }} !important;{% endif %}{% if header_color %}color: {{ header_color }}{% endif %}" id="header">
     {% if nav %}
-      <span style="font-size:30px;cursor:pointer" onclick="closeNav()" id="sidebar-button">&#9776;</span>
+    <span style="font-size:30px;cursor:pointer" onclick="closeNav()" id="sidebar-button">
+	  <div class="pn-bar"></div>
+	  <div class="pn-bar"></div>
+	  <div class="pn-bar"></div>
+	</span>
     {% endif %}
     <a class="title" href="#">{{ app_title }}</a>
     {% for doc in docs %}
@@ -15,9 +19,16 @@
     {% endif %}
     {% endfor %}
     {% endfor %}
+
+	{% if busy %}
+	<div class="pn-busy-container">
+	  {{ embed(roots.busy_indicator) | indent(6) }}
+	</div>
+	{% endif %}
+
   </nav>
 
-  <div class="row" id="content">
+  <div id="content">
     {% if nav %}
     <div class="sidenav" id="sidebar">
       <ul class="nav flex-column">
@@ -32,7 +43,7 @@
     </div>
     {% endif %}
 
-    <div class="" id="main">
+    <div class="main" id="main">
       {% for doc in docs %}
       {% for root in doc.roots %}
       {% if "main" in root.tags %}
@@ -40,23 +51,55 @@
       {% endif %}
       {% endfor %}
       {% endfor %}
+
+	  <div id="pn-Modal" class="pn-modal header-adjust">
+		<div class="pn-modal-content">
+		  <span class="pn-modalclose" id="pn-closeModal">&times;</span>
+		  {% for doc in docs %}
+		  {% for root in doc.roots %}
+		  {% if "modal" in root.tags %}
+		  {{ embed(root) | indent(10) }}
+		  {% endif %}
+		  {% endfor %}
+		  {% endfor %}
+		</div>
+	  </div>
     </div>
   </div>
 </div>
 
 <script>
   function openNav() {
-    document.getElementById("sidebar").style.width = "15vw";
-    document.getElementById("main").style.marginLeft = "15vw";
-    document.getElementById("sidebar-button").onclick=closeNav;
-    window.dispatchEvent(new Event("resize"))
+    document.getElementById("sidebar").style.left = 0;
+    document.getElementById("main").style.marginLeft = "16.7vw";
+    document.getElementById("sidebar-button").onclick = closeNav;
+    var interval = setInterval(function () { window.dispatchEvent(new Event('resize')); }, 10);
+    setTimeout(function () { clearInterval(interval) }, 210)
   }
 
   function closeNav() {
-    document.getElementById("sidebar").style.width = "0";
-    document.getElementById("main").style.marginLeft = "0";
-    document.getElementById("sidebar-button").onclick=openNav;
-    window.dispatchEvent(new Event("resize"))
+    document.getElementById("sidebar").style.left = "-16.7vw";
+    document.getElementById("main").style.marginLeft = 0;
+    document.getElementById("sidebar-button").onclick = openNav;
+    var interval = setInterval(function () { window.dispatchEvent(new Event('resize')); }, 10);
+    setTimeout(function () { clearInterval(interval) }, 210)
+  }
+
+  var modal = document.getElementById("pn-Modal");
+  var span = document.getElementById("pn-closeModal");
+
+  span.onclick = function() {
+    modal.style.display = "none";
+  }
+
+  window.onclick = function(event) {
+    if (event.target == modal) {
+      modal.style.display = "none";
+    }
   }
 </script>
+
+
+{{ embed(roots.js_area) }}
+
 {% endblock %}

--- a/panel/viewable.py
+++ b/panel/viewable.py
@@ -470,6 +470,11 @@ class Viewable(Renderable, Layoutable, ServableMixin):
 
     _preprocessing_hooks = []
 
+    def __init__(self, **params):
+        hooks = params.pop('hooks', [])
+        super().__init__(**params)
+        self._hooks = hooks
+
     def __repr__(self, depth=0):
         return '{cls}({params})'.format(cls=type(self).__name__,
                                         params=', '.join(param_reprs(self)))

--- a/panel/widgets/indicators.py
+++ b/panel/widgets/indicators.py
@@ -18,10 +18,10 @@ class Indicator(Widget):
 
 class Busy(Indicator):
 
-    height = param.Integer(default=25, doc="""
+    height = param.Integer(default=20, doc="""
         height of the circle.""")
 
-    width = param.Integer(default=25, doc="""
+    width = param.Integer(default=20, doc="""
         Width of the circle.""")
 
     value = param.Boolean(default=False, doc="""

--- a/panel/widgets/indicators.py
+++ b/panel/widgets/indicators.py
@@ -1,0 +1,58 @@
+import param
+
+from ..models import HTML
+from .base import Widget
+
+
+class Indicator(Widget):
+    """
+    Indicator is a baseclass for widgets which indicate some state.
+    """
+
+    sizing_mode = param.ObjectSelector(default='fixed', objects=[
+        'fixed', 'stretch_width', 'stretch_height', 'stretch_both',
+        'scale_width', 'scale_height', 'scale_both', None])
+
+    __abstract = True
+
+
+class Busy(Indicator):
+
+    height = param.Integer(default=25, doc="""
+        height of the circle.""")
+
+    width = param.Integer(default=25, doc="""
+        Width of the circle.""")
+
+    value = param.Boolean(default=False, doc="""
+        Whether the indicator is active or not.""")
+
+    _widget_type = HTML
+
+    def _process_param_change(self, msg):
+        value = msg.pop('value', None)
+        if value is None:
+            return msg
+        msg['css_classes'] = ['dot-filled'] if value else ['dot']
+        return msg
+
+
+class Spinner(Indicator):
+
+    height = param.Integer(default=125, doc="""
+        height of the circle.""")
+
+    width = param.Integer(default=125, doc="""
+        Width of the circle.""")
+
+    value = param.Boolean(default=False, doc="""
+        Whether the indicator is active or not.""")
+
+    _widget_type = HTML
+
+    def _process_param_change(self, msg):
+        value = msg.pop('value', None)
+        if value is None:
+            return msg
+        msg['css_classes'] = ['loader', 'spin'] if value else ['loader']
+        return msg

--- a/panel/widgets/indicators.py
+++ b/panel/widgets/indicators.py
@@ -16,7 +16,19 @@ class Indicator(Widget):
     __abstract = True
 
 
-class Busy(Indicator):
+class BooleanIndicator(Indicator):
+
+    value = param.Boolean(default=False, doc="""
+        Whether the indicator is active or not.""")
+
+    __abstract = True
+
+
+class BooleanStatus(BooleanIndicator):
+
+    color = param.ObjectSelector(default='dark', objects=[
+        'primary', 'secondary', 'success', 'info', 'danger', 'warning',
+        'light', 'dark'])
 
     height = param.Integer(default=20, doc="""
         height of the circle.""")
@@ -29,15 +41,24 @@ class Busy(Indicator):
 
     _widget_type = HTML
 
+    _rename = {'color': None}
+
     def _process_param_change(self, msg):
+        msg = super()._process_param_change(msg)
         value = msg.pop('value', None)
         if value is None:
             return msg
-        msg['css_classes'] = ['dot-filled'] if value else ['dot']
+        msg['css_classes'] = ['dot-filled', self.color] if value else ['dot']
         return msg
 
 
-class Spinner(Indicator):
+class LoadingSpinner(BooleanIndicator):
+
+    bgcolor = param.ObjectSelector(default='light', objects=['dark', 'light'])
+
+    color = param.ObjectSelector(default='dark', objects=[
+        'primary', 'secondary', 'success', 'info', 'danger', 'warning',
+        'light', 'dark'])
 
     height = param.Integer(default=125, doc="""
         height of the circle.""")
@@ -50,9 +71,13 @@ class Spinner(Indicator):
 
     _widget_type = HTML
 
+    _rename = {'color': None, 'bgcolor': None}
+
     def _process_param_change(self, msg):
+        msg = super()._process_param_change(msg)
         value = msg.pop('value', None)
         if value is None:
             return msg
-        msg['css_classes'] = ['loader', 'spin'] if value else ['loader']
+        color_cls = f'{self.color}-{self.bgcolor}'
+        msg['css_classes'] = ['loader', 'spin', color_cls] if value else ['loader', self.bgcolor]
         return msg

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@
 
 [tox]
 #          python version             test group                  extra envs  extra commands
-envlist = {py27,py36,py37,py38}-{flakes,unit,unit_deploy,examples,all_recommended,deprecations}-{default}-{dev,pkg}
+envlist = {py36,py37,py38,py39}-{flakes,unit,unit_deploy,examples,all_recommended,deprecations}-{default}-{dev,pkg}
 build = wheel
 
 [_flakes]


### PR DESCRIPTION
Adds two boolean indicators which can be used independently or in one of the default templates.

## BooleanStatus

![Screen Shot 2020-07-23 at 12 20 29 PM](https://user-images.githubusercontent.com/1550771/88276210-f2691380-ccde-11ea-81b5-84cca2da8eed.png)

## LoadingSpinner

![Screen Shot 2020-07-23 at 12 20 40 PM](https://user-images.githubusercontent.com/1550771/88276231-f8f78b00-ccde-11ea-9682-be4a4c492172.png)

## Template

![Screen Shot 2020-07-23 at 12 21 46 PM](https://user-images.githubusercontent.com/1550771/88276359-34925500-ccdf-11ea-9c8f-06229d2b9980.png)

Here we can see the indicator on the right of the template header.