### PR TITLE
Ensure ListPanel objects can be passed as keyword

### DIFF
--- a/panel/layout/base.py
+++ b/panel/layout/base.py
@@ -358,6 +358,8 @@ class ListPanel(ListLike, Panel):
                                  "as positional arguments or as a keyword, "
                                  "not both." % type(self).__name__)
             params['objects'] = [panel(pane) for pane in objects]
+        elif 'objects' in params:
+            params['objects'] = [panel(pane) for pane in params['objects']]
         super(Panel, self).__init__(**params)
 
     def _process_param_change(self, params):

--- a/panel/tests/layout/test_base.py
+++ b/panel/tests/layout/test_base.py
@@ -54,6 +54,14 @@ def test_layout_constructor(panel):
     assert all(isinstance(p, Bokeh) for p in layout.objects)
 
 
+@pytest.mark.parametrize('panel', [Card, Column, Row])
+def test_layout_constructor_with_objects_param(panel):
+    div1 = Div()
+    div2 = Div()
+    layout = panel(objects=[div1, div2])
+    assert all(isinstance(p, Bokeh) for p in layout.objects)
+
+
 @pytest.mark.parametrize('panel', [Column, Row])
 def test_layout_add(panel, document, comm):
     div1 = Div()


### PR DESCRIPTION
Passing `objects` as a keyword was not previously supported.