### PR TITLE
Set alignment of Widgets to ('start', 'end')

### DIFF
--- a/panel/widgets/base.py
+++ b/panel/widgets/base.py
@@ -16,6 +16,12 @@ class Widget(Reactive):
     parameters on the Widget instance.
     """
 
+    align = param.ClassSelector(default=('start', 'end'),
+                                class_=(str, tuple), doc="""
+        Whether the object should be aligned with the start, end or
+        center of its container. If set as a tuple it will declare
+        (horizontal, vertical) alignment.""")
+
     disabled = param.Boolean(default=False, doc="""
        Whether the widget is disabled.""")
 


### PR DESCRIPTION
Implements a mechanism by which `Panel` types can override the properties on their children and utilizes that mechanism to override the alignment of Widgets in a Row to be 'end' ensuring that they line up nicely.

Does not handle GridBox alignments yet.

Supersedes https://github.com/holoviz/panel/pull/1376