### PR TITLE
Add new features to DataTable

### DIFF
--- a/examples/reference/widgets/DataFrame.ipynb
+++ b/examples/reference/widgets/DataFrame.ipynb
@@ -27,10 +27,31 @@
     "##### Core\n",
     "\n",
     "* **``aggregators``** (``dict``): A dictionary mapping from index name to an aggregator to be used for hierarchical multi-indexes (valid aggregators include 'min', 'max', 'mean' and 'sum'). If separate aggregators for different columns are required the dictionary may be nested as `{index_name: {column_name: aggregator}}`\n",
+    "* **``autosize_mode``** (str): Describes the column autosizing mode with one of the following options: \n",
+    "  * ``\"fit_columns\"``\n",
+    "  Compute columns widths based on cell contents but ensure the\n",
+    "  table fits into the available viewport. This results in no\n",
+    "  horizontal scrollbar showing up, but data can get unreadable\n",
+    "  if there is not enough space available.\n",
+    "\n",
+    "  * ``\"fit_viewport\"``\n",
+    "  Adjust the viewport size after computing columns widths based\n",
+    "  on cell contents.\n",
+    "\n",
+    "  * ``\"force_fit\"``\n",
+    "  Fit columns into available space dividing the table width across\n",
+    "  the columns equally (equivalent to `fit_columns=True`).\n",
+    "  This results in no horizontal scrollbar showing up, but data\n",
+    "  can get unreadable if there is not enough space available.\n",
+    "\n",
+    "  * ``\"none\"``\n",
+    "  Do not automatically compute column widths.\n",
     "* **``editors``** (``dict``):  A dictionary mapping from column name to a bokeh `CellEditor` instance, which overrides the default.\n",
     "* **``hierarchical``** (boolean, default=False): Whether to render multi-indexes as hierarchical index (note hierarchical must be enabled during instantiation and cannot be modified later)\n",
     "* **``fit_columns``** (``boolean``, default=True): Whether columns should expand to the available width. \n",
     "* **``formatters``** (``dict``): A dictionary mapping from column name to a bokeh `CellFormatter` instance, which overrides the default.\n",
+    "* **``frozen_columns``** (int): Integer indicating the number of columns to freeze. If set the  first N columns will be frozen which prevents them from scrolling out of frame.\n",
+    "* **``frozen_rows``**: (int): Integer indicating the number of rows to freeze. If set the first N rows will be frozen which prevents them from scrolling out of frame, if set to a negative value last N rows will be frozen.\n",
     "* **``reorderable``** (``boolean``): Allows the reordering of a table's columns. To reorder a column, click and drag a table's header to the desired location in the table.  The columns on either side will remain in their previous order.\n",
     "* **``row_height``** (``int``): The height of each table row.\n",
     "* **``selection``** (``list``) The currently selected rows.\n",
@@ -105,6 +126,111 @@
     "table.selection = [0, 2]\n",
     "\n",
     "table.selected_dataframe"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Column layouts\n",
+    "\n",
+    "By default the DataFrame widget will equally split the available horizontal space between the columns, reflecting the default value of the parameter: `autosize_mode=\"force_fit\"`. Alternatively modes allow manually specifying the widths of the columns or automatically adjusting the column widths or overall table width to match the contents of the table.\n",
+    "\n",
+    "#### Manual column widths\n",
+    "\n",
+    "To manually adjust column widths set the `autosize_mode` to `\"none\"` and provide explicit `widths`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "custom_df = pd.util.testing.makeMixedDataFrame()\n",
+    "\n",
+    "pn.widgets.DataFrame(custom_df, autosize_mode='none', widths={'index': 50, 'A': 50, 'B': 50, 'C': 70, 'D': 130}, width=350)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Autosize columns\n",
+    "\n",
+    "To automatically adjust the columns dependending on their content set `autosize_mode='fit_columns'`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pn.widgets.DataFrame(custom_df, autosize_mode='fit_columns', width=300)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Autosize width\n",
+    "\n",
+    "To automatically adjust the width of the columns **and** the overall table use `autosize_mode='fit_viewport'`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pn.widgets.DataFrame(custom_df, autosize_mode='fit_viewport')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Freezing rows and columns\n",
+    "\n",
+    "Often times your table will be larger than can be displayed in a single viewport and scroll bars will be enabled. The issue with this is that you might want to make sure that certain information is always visible. This is where the `frozen_columns` and `frozen_rows` options come in.\n",
+    "\n",
+    "#### Frozen columns\n",
+    "\n",
+    "When you have a large number of columns and can't fit them all on the screen you might still want to make sure that certain columns do not scroll out of view. The `frozen_columns` option makes this possible by specifying the number of columns, counting from the left, that should be frozen, e.g. `frozen_columns=1` will freeze the last column:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "date_df = pd.util.testing.makeTimeDataFrame()\n",
+    "\n",
+    "pn.widgets.DataFrame(date_df, height=400, widths=150, frozen_columns=1, autosize_mode='none')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Frozen rows\n",
+    "\n",
+    "Another common scenario is when you have certain rows with special meaning, e.g. aggregates which summarize the information in the rest of the table. In this case you may want to freeze those rows so they do not scroll out of view. You can achieve this by setting `frozen_columns` to an integer value. If the value is positive the first N rows will be frozen, if the value is negative the last N rows will be frozen:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "agg_df = pd.concat([date_df, date_df.median().to_frame('Median').T, date_df.mean().to_frame('Mean').T])\n",
+    "agg_df.index= agg_df.index.map(str)\n",
+    "\n",
+    "pn.widgets.DataFrame(agg_df, frozen_rows=-2, height=400)"
    ]
   },
   {


### PR DESCRIPTION
Exposes some of the new features of the bokeh DataTable that will land in Bokeh 2.2. Including `autosize_mode`, `frozen_rows` and `frozen_cols` options.

- [x] Add docs