### PR TITLE
Add state.as_cached function

### DIFF
--- a/examples/user_guide/Overview.ipynb
+++ b/examples/user_guide/Overview.ipynb
@@ -201,6 +201,7 @@
     "\n",
     "> #### Methods\n",
     "\n",
+    "> - `as_cached`: Allows caching data across sessions by memoizing on the provided key and keyword arguments to the provided function.\n",
     "> - `add_periodic_callback`: Schedules a periodic callback to be run at an interval set by the period\n",
     "> - `kill_all_servers`: Stops all running server sessions.\n",
     "> - `onload`: Allows defining a callback which is run when a server is fully loaded\n",

--- a/panel/io/state.py
+++ b/panel/io/state.py
@@ -153,7 +153,7 @@ class _state(param.Parameterized):
         the cache.
         """
         key = (key,)+tuple((k, v) for k, v in sorted(kwargs.items()))
-        if key in self.cache and not update:
+        if key in self.cache:
             ret = self.cache.get(key)
         else:
             ret = self.cache[key] = fn(**kwargs)

--- a/panel/io/state.py
+++ b/panel/io/state.py
@@ -130,6 +130,35 @@ class _state(param.Parameterized):
     # Public Methods
     #----------------------------------------------------------------
 
+    def as_cached(self, key, fn, **kwargs):
+        """
+        Caches the return value of a function, memoizing on the given
+        key and supplied keyword arguments.
+
+        Note: Keyword arguments must be hashable.
+
+        Arguments
+        ---------
+        key: (str)
+          The key to cache the return value under.
+        fn: (callable)
+          The function or callable whose return value will be cached.
+        **kwargs: dict
+          Additional keyword arguments to supply to the function,
+          which will be memoized over as well.
+
+        Returns
+        -------
+        Returns the value returned by the cache or the value in
+        the cache.
+        """
+        key = (key,)+tuple((k, v) for k, v in sorted(kwargs.items()))
+        if key in self.cache and not update:
+            ret = self.cache.get(key)
+        else:
+            ret = self.cache[key] = fn(**kwargs)
+        return ret
+
     def add_periodic_callback(self, callback, period=500, count=None,
                               timeout=None, start=True):
         """
@@ -239,7 +268,7 @@ class _state(param.Parameterized):
         if self.encryption is None:
             return access_token.decode('utf-8')
         return self.encryption.decrypt(access_token).decode('utf-8')
-            
+
     @property
     def curdoc(self):
         if self._curdoc:

--- a/panel/tests/io/test_state.py
+++ b/panel/tests/io/test_state.py
@@ -1,0 +1,33 @@
+from panel.io.state import state
+
+
+def test_as_cached_key_only():
+    global i
+    i = 0
+
+    def test_fn():
+        global i
+        i += 1
+        return i
+
+    assert state.as_cached('test', test_fn) == 1
+    assert state.as_cached('test', test_fn) == 1
+    state.cache.clear()
+
+
+
+def test_as_cached_key_and_kwarg():
+    global i
+    i = 0
+
+    def test_fn(a):
+        global i
+        i += 1
+        return i
+
+    assert state.as_cached('test', test_fn, a=1) == 1
+    assert state.as_cached('test', test_fn, a=1) == 1
+    assert state.as_cached('test', test_fn, a=2) == 2
+    assert state.as_cached('test', test_fn, a=1) == 1
+    assert state.as_cached('test', test_fn, a=2) == 2
+    state.cache.clear()


### PR DESCRIPTION
The `state.as_cached` utility allows caching data across sessions by providing a key, a function and optionally a set of keyword arguments which will be memoized.