### PR TITLE
Datepicker jslink

### DIFF
--- a/panel/widgets/input.py
+++ b/panel/widgets/input.py
@@ -141,7 +141,7 @@ class DatePicker(Widget):
 
     enabled_dates = param.List(default=None, class_=(date, str))
 
-    _source_transforms = {'value': None, 'start': None, 'end': None}
+    _source_transforms = {}
 
     _rename = {'start': 'min_date', 'end': 'max_date', 'name': 'title'}
 


### PR DESCRIPTION
https://discourse.holoviz.org/t/using-jslink-with-pn-widgets-datepicker/1116
```
import panel as pn
pn.extension()

date_picker = pn.widgets.DatePicker()
text_box = pn.widgets.TextAreaInput()

date_picker.jslink(text_box, value='value')
layout = pn.Column(date_picker, text_box)
layout
```
![image](https://user-images.githubusercontent.com/15331990/90914436-86dc9980-e3a3-11ea-999a-52dc49f2b301.png)
