### PR TITLE
Case-insensitive autocompletion

### DIFF
--- a/panel/widgets/select.py
+++ b/panel/widgets/select.py
@@ -216,6 +216,8 @@ class AutocompleteInput(Widget):
     placeholder = param.String(default='')
 
     value = param.Parameter(default=None)
+    
+    case_sensitive = param.Boolean(default=True)
 
     _widget_type = _BkAutocompleteInput
 


### PR DESCRIPTION
Updated select.py to support case-insensitive AutocompletionInput, which was added to bokeh in v 2.1.0 (https://github.com/bokeh/bokeh/issues/9922).