### PR TITLE
Unpin pytest now nbsmoke 0.5 is released

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -108,7 +108,7 @@ _recommended = [
 _tests = [
     'flake8',
     'parameterized',
-    'pytest<6.0', # temporary fix for nbval incompatibility
+    'pytest',
     'scipy',
     'nbsmoke >=0.2.0',
     'pytest-cov',


### PR DESCRIPTION
I guess you meant `nbsmoke` in the comment? (Although I bet `nbval` has exactly the same problem. And I would like to replace `nbsmoke` with `nbval`. Maybe that's why you wrote nbval? :) )
