### PR TITLE
AutocompleteInput: allow user-defined values

### DIFF
--- a/examples/reference/widgets/AutocompleteInput.ipynb
+++ b/examples/reference/widgets/AutocompleteInput.ipynb
@@ -26,6 +26,7 @@
     "\n",
     "* **``options``** (list or dict): A list or dictionary of options to select from\n",
     "* **``value``** (object): The current value; must be one of the option values\n",
+    "* **``restrict``** (boolean): Set to False in order to allow users to enter text that is not present in the options list.\n",
     "\n",
     "##### Display\n",
     "\n",

--- a/panel/package-lock.json
+++ b/panel/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@holoviz/panel",
-  "version": "0.10.0-a24",
+  "version": "0.10.0-a25",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/panel/widgets/select.py
+++ b/panel/widgets/select.py
@@ -19,7 +19,7 @@ from bokeh.models.widgets import (
 
 from ..layout import Column, VSpacer
 from ..models import SingleSelect as _BkSingleSelect
-from ..util import as_unicode, isIn, indexOf
+from ..util import as_unicode, isIn, indexOf, bokeh_version
 from .base import Widget, CompositeWidget
 from .button import _ButtonBase, Button
 from .input import TextInput, TextAreaInput
@@ -205,6 +205,11 @@ class MultiChoice(_MultiSelectBase):
     _widget_type = _BkMultiChoice
 
 
+_AutocompleteInput_rename = {'name': 'title', 'options': 'completions'}
+if bokeh_version < '2.3.0':
+    # disable restrict keyword
+    _AutocompleteInput_rename['restrict'] = None
+
 class AutocompleteInput(Widget):
 
     min_characters = param.Integer(default=2, doc="""
@@ -223,7 +228,7 @@ class AutocompleteInput(Widget):
 
     _widget_type = _BkAutocompleteInput
 
-    _rename = {'name': 'title', 'options': 'completions'}
+    _rename = _AutocompleteInput_rename
 
 
 class _RadioGroupBase(SingleSelectBase):

--- a/panel/widgets/select.py
+++ b/panel/widgets/select.py
@@ -219,6 +219,8 @@ class AutocompleteInput(Widget):
     
     case_sensitive = param.Boolean(default=True)
 
+    restrict = param.Boolean(default=True)
+
     _widget_type = _BkAutocompleteInput
 
     _rename = {'name': 'title', 'options': 'completions'}

--- a/setup.py
+++ b/setup.py
@@ -89,7 +89,7 @@ except Exception:
 ########## dependencies ##########
 
 install_requires = [
-    'bokeh >=2.1',
+    'bokeh >=2.3.0.dev1',
     'param >=1.9.3',
     'pyviz_comms >=0.7.4',
     'markdown',

--- a/setup.py
+++ b/setup.py
@@ -89,7 +89,7 @@ except Exception:
 ########## dependencies ##########
 
 install_requires = [
-    'bokeh >=2.3.0.dev1',
+    'bokeh >=2.1',
     'param >=1.9.3',
     'pyviz_comms >=0.7.4',
     'markdown',


### PR DESCRIPTION
fixes #685

bokeh 2.3.0 introduces a new `restrict` keyword (default: True).
Setting it to False allows users to enter values that are not present in
the list of completions.