### PR TITLE
Ensure panel.js is served before session is started

### DIFF
--- a/panel/io/server.py
+++ b/panel/io/server.py
@@ -14,6 +14,7 @@ from functools import partial
 from types import FunctionType, MethodType
 
 from bokeh.document.events import ModelChangedEvent
+from bokeh.embed.bundle import extension_dirs
 from bokeh.embed.server import server_html_page_for_session
 from bokeh.server.server import Server
 from bokeh.server.views.session_handler import SessionHandler
@@ -32,6 +33,9 @@ from .state import state
 #---------------------------------------------------------------------
 # Private API
 #---------------------------------------------------------------------
+
+# Handle serving of the panel extension before session is loaded
+extension_dirs['panel'] = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'dist'))
 
 INDEX_HTML = os.path.join(os.path.dirname(__file__), '..', '_templates', "index.html")
 


### PR DESCRIPTION
When scaling Panel behind a load balancer it can occur that the request for the Panel.js extension arrives on a server which does has not yet loaded a session and therefore isn't aware of the extension. Here we simply make sure that the extension is registered as soon as Panel is imported.