### PR TITLE
add option to serialize all vtkDataset arrays

### DIFF
--- a/panel/models/vtk/vtkfollower.ts
+++ b/panel/models/vtk/vtkfollower.ts
@@ -10,7 +10,6 @@ if(vtk) {
   const vtkActor = vtk.Rendering.Core.vtkActor
 
   function vtkFollower(publicAPI: any, model: any) {
-    console.log("Hello")
     // Set our className
     model.classHierarchy.push('vtkFollower')
 
@@ -113,22 +112,21 @@ if(vtk) {
   Follower = {
     newInstance: macro.newInstance((publicAPI: any, model: any, initialValues = {}) => {
       Object.assign(model, DEFAULT_VALUES, initialValues)
-  
+
       // Inheritance
       vtkActor.extend(publicAPI, model, initialValues)
-  
+
       model.followerMatrix = mat4.create()
       model.camera = vtk.Rendering.Core.vtkCamera.newInstance()
       mat4.identity(model.followerMatrix)
-  
+
       // Build VTK API
       macro.setGet(publicAPI, model, ['useViewUp', 'camera'])
-  
+
       macro.setGetArray(publicAPI, model, ['viewUp'], 3)
-  
+
       // Object methods
       vtkFollower(publicAPI, model);
     }, 'vtkFollower')
   }
-
 }

--- a/panel/pane/vtk/synchronizable_serializer.py
+++ b/panel/pane/vtk/synchronizable_serializer.py
@@ -635,6 +635,19 @@ def genericActorSerializer(parent, actor, actorId, context, depth):
 
     if not instance: return
 
+    # # actor may have a backface property instance (not used by vtkjs rendering)
+    # # https://github.com/Kitware/vtk-js/issues/1545
+
+    # backfaceProperties = actor.GetBackfaceProperty()
+
+    # if backfaceProperties:
+    #     backfacePropId = context.getReferenceId(backfaceProperties)
+    #     backPropertyInstance = serializeInstance(
+    #         actor, backfaceProperties, backfacePropId, context, depth + 1)
+    #     if backPropertyInstance:
+    #         instance['dependencies'].append(backPropertyInstance)
+    #         instance['calls'].append(['setBackfaceProperty', [wrapId(backfacePropId)]])
+
     instance['properties'].update({
         # vtkActor
         'forceOpaque': actor.GetForceOpaque(),
@@ -1195,7 +1208,8 @@ def rendererSerializer(parent, instance, objId, context, depth):
             'useShadows': instance.GetUseShadows(),
             'useDepthPeeling': instance.GetUseDepthPeeling(),
             'occlusionRatio': instance.GetOcclusionRatio(),
-            'maximumNumberOfPeels': instance.GetMaximumNumberOfPeels()
+            'maximumNumberOfPeels': instance.GetMaximumNumberOfPeels(),
+            'interactive': instance.GetInteractive(),
         },
         'dependencies': dependencies,
         'calls': calls

--- a/panel/pane/vtk/vtk.py
+++ b/panel/pane/vtk/vtk.py
@@ -211,7 +211,7 @@ class BaseVTKRenderWindow(AbstractVTK):
         By default the value is False and only active scalars of each dataset are serialized and transfer to the
         javascript side.
 
-        Enabling it will increase memory and data transfert usage but allows to create more reactive visualization
+        Enabling this option will increase memory and network transfer volume but results in more reactive visualizations
         by using some custom javascript functions.
     """)
 


### PR DESCRIPTION
A vtk dataset can contain several data arrays but only one is used to color the mesh, the "active scalars".
Until now only this array was serialized, it allow to minimize the size of the serialized scene.
However by allowing the serialization of all data arrays and using some custom javascript functions we could make some temporal 3d visualization easier.
This PR add a parameter `serialize_all_data_arrays` to allow this
Here is a comparison between both options:
![vtk_all_arrays](https://user-images.githubusercontent.com/18531147/93771171-70816200-fc1d-11ea-91a6-bececfcdb3a8.gif)

