### PR TITLE
Update releases.rst (typo)

### DIFF
--- a/doc/releases.rst
+++ b/doc/releases.rst
@@ -6,7 +6,7 @@ Version 0.9.7
 
 Date: 2020-06-23
 
-The 0.9.7 release unfortunately caused a major regression in layout performance due to the way optimizations in Bokeh and Panel interacted. This release fixes this regression.
+The 0.9.6 release unfortunately caused a major regression in layout performance due to the way optimizations in Bokeh and Panel interacted. This release fixes this regression.
 
 - Fix regression in layout performance (`#1453 <https://github.com/holoviz/panel/pull/1453>`_)
 


### PR DESCRIPTION
The 0.9.6 release has the error, so the 0.9.7 versions fixes it, if I am not mistaken.