### PR TITLE
Ensure Bokeh model changes are always pushed

### DIFF
--- a/panel/io/model.py
+++ b/panel/io/model.py
@@ -63,7 +63,7 @@ def add_to_doc(obj, doc, hold=False):
         doc.hold()
 
 @contextmanager
-def hold(doc, policy='combine'):
+def hold(doc, policy='combine', comm=None):
     held = doc._hold
     try:
         if policy is None:
@@ -75,6 +75,9 @@ def hold(doc, policy='combine'):
         if held:
             doc._hold = held
         else:
+            if comm is not None:
+                from .notebook import push
+                push(doc, comm)
             doc.unhold()
 
 

--- a/panel/layout/tabs.py
+++ b/panel/layout/tabs.py
@@ -81,7 +81,7 @@ class Tabs(NamedListPanel):
             new = [old[i] for i in inds]
         return old, new
 
-    def _comm_change(self, doc, ref, attr, old, new):
+    def _comm_change(self, doc, ref, comm, attr, old, new):
         if attr in self._changing.get(ref, []):
             self._changing[ref].remove(attr)
             return
@@ -89,7 +89,7 @@ class Tabs(NamedListPanel):
             old, new = self._process_close(ref, attr, old, new)
             if new is None:
                 return
-        super(Tabs, self)._comm_change(doc, ref, attr, old, new)
+        super(Tabs, self)._comm_change(doc, ref, comm, attr, old, new)
 
     def _server_change(self, doc, ref, attr, old, new):
         if attr in self._changing.get(ref, []):

--- a/panel/reactive.py
+++ b/panel/reactive.py
@@ -116,7 +116,7 @@ class Syncable(Renderable):
             if isinstance(p, tuple):
                 _, p = p
             if comm:
-                model.on_change(p, partial(self._comm_change, doc, ref))
+                model.on_change(p, partial(self._comm_change, doc, ref, comm))
             else:
                 model.on_change(p, partial(self._server_change, doc, ref))
 
@@ -207,12 +207,12 @@ class Syncable(Renderable):
             state.curdoc = None
             state._thread_id = None
 
-    def _comm_change(self, doc, ref, attr, old, new):
+    def _comm_change(self, doc, ref, comm, attr, old, new):
         if attr in self._changing.get(ref, []):
             self._changing[ref].remove(attr)
             return
 
-        with hold(doc):
+        with hold(doc, comm=comm):
             self._process_events({attr: new})
 
     def _server_change(self, doc, ref, attr, old, new):

--- a/panel/tests/layout/test_tabs.py
+++ b/panel/tests/layout/test_tabs.py
@@ -254,7 +254,7 @@ def test_tabs_close_tab_in_notebook(document, comm, tabs):
     old_tabs = list(model.tabs)
     _, div2 = tabs
 
-    tabs._comm_change(document, model.ref['id'], 'tabs', old_tabs, [model.tabs[1]])
+    tabs._comm_change(document, model.ref['id'], comm, 'tabs', old_tabs, [model.tabs[1]])
 
     assert len(tabs.objects) == 1
     assert tabs.objects[0] is div2

--- a/panel/tests/test_reactive.py
+++ b/panel/tests/test_reactive.py
@@ -59,7 +59,7 @@ def test_link_properties_nb(document, comm):
     # Assert callback is set up correctly
     cb = div._callbacks['text'][0]
     assert isinstance(cb, partial)
-    assert cb.args == (document, div.ref['id'])
+    assert cb.args == (document, div.ref['id'], comm)
     assert cb.func == obj._comm_change
 
 


### PR DESCRIPTION
The problem is that bokeh model changes were simply being dropped instead of being pushed through the comm so this ensures that if there are outstanding held events once we get to the end of a callback triggered by a change on the frontend those changes are pushed.

- Fixes https://github.com/holoviz/panel/issues/1618