### PR TITLE
Expose Indicators at top-level

### DIFF
--- a/examples/reference/indicators/BooleanStatus.ipynb
+++ b/examples/reference/indicators/BooleanStatus.ipynb
@@ -8,8 +8,6 @@
    "source": [
     "import panel as pn\n",
     "\n",
-    "from panel.widgets.indicators import BooleanStatus\n",
-    "\n",
     "pn.extension()"
    ]
   },
@@ -42,8 +40,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "false_status = BooleanStatus(value=False)\n",
-    "true_status = BooleanStatus(value=True)\n",
+    "false_status = pn.indicators.BooleanStatus(value=False)\n",
+    "true_status = pn.indicators.BooleanStatus(value=True)\n",
     "\n",
     "pn.Row(false_status, true_status)"
    ]
@@ -63,9 +61,9 @@
    "source": [
     "grid = pn.GridBox('', 'False', 'True', ncols=3)\n",
     "\n",
-    "for color in BooleanStatus.param.color.objects:\n",
-    "    false = BooleanStatus(width=50, height=50, value=False, color=color)\n",
-    "    true = BooleanStatus(width=50, height=50, value=True, color=color)\n",
+    "for color in pn.indicators.BooleanStatus.param.color.objects:\n",
+    "    false = pn.indicators.BooleanStatus(width=50, height=50, value=False, color=color)\n",
+    "    true = pn.indicators.BooleanStatus(width=50, height=50, value=True, color=color)\n",
     "    grid.extend((color, false, true))\n",
     "\n",
     "grid"

--- a/examples/reference/indicators/Dial.ipynb
+++ b/examples/reference/indicators/Dial.ipynb
@@ -8,8 +8,6 @@
    "source": [
     "import panel as pn\n",
     "\n",
-    "from panel.widgets.indicators import Dial\n",
-    "\n",
     "pn.extension()"
    ]
   },
@@ -54,7 +52,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "Dial(name='Failure Rate', value=10, bounds=(0, 100))"
+    "pn.indicators.Dial(name='Failure Rate', value=10, bounds=(0, 100))"
    ]
   },
   {
@@ -70,8 +68,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "Dial(name='Engine', value=2500, bounds=(0, 3000), format='{value} rpm',\n",
-    "      colors=[(0.2, 'green'), (0.8, 'gold'), (1, 'red')])"
+    "pn.indicators.Dial(\n",
+    "    name='Engine', value=2500, bounds=(0, 3000), format='{value} rpm',\n",
+    "    colors=[(0.2, 'green'), (0.8, 'gold'), (1, 'red')]\n",
+    ")"
    ]
   }
  ],

--- a/examples/reference/indicators/Gauge.ipynb
+++ b/examples/reference/indicators/Gauge.ipynb
@@ -8,8 +8,6 @@
    "source": [
     "import panel as pn\n",
     "\n",
-    "from panel.widgets.indicators import Gauge\n",
-    "\n",
     "pn.extension('echarts')"
    ]
   },
@@ -53,7 +51,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "Gauge(name='Failure Rate', value=10, bounds=(0, 100))"
+    "pn.indicators.Gauge(name='Failure Rate', value=10, bounds=(0, 100))"
    ]
   },
   {
@@ -69,8 +67,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "Gauge(name='Engine', value=2500, bounds=(0, 3000), format='{value} rpm',\n",
-    "      colors=[(0.2, 'green'), (0.8, 'gold'), (1, 'red')])"
+    "pn.indicators.Gauge(\n",
+    "    name='Engine', value=2500, bounds=(0, 3000), format='{value} rpm',\n",
+    "    colors=[(0.2, 'green'), (0.8, 'gold'), (1, 'red')]\n",
+    ")"
    ]
   }
  ],

--- a/examples/reference/indicators/LoadingSpinner.ipynb
+++ b/examples/reference/indicators/LoadingSpinner.ipynb
@@ -64,7 +64,7 @@
     "\n",
     "for color in pn.indicators.LoadingSpinner.param.color.objects:\n",
     "    dark = pn.indicators.LoadingSpinner(width=50, height=50, value=True, color=color, bgcolor='dark')\n",
-    "    light = vLoadingSpinner(width=50, height=50, value=True, color=color, bgcolor='light')\n",
+    "    light = pn.indicators.LoadingSpinner(width=50, height=50, value=True, color=color, bgcolor='light')\n",
     "    grid.extend((color, light, dark))\n",
     "\n",
     "grid"

--- a/examples/reference/indicators/LoadingSpinner.ipynb
+++ b/examples/reference/indicators/LoadingSpinner.ipynb
@@ -7,7 +7,6 @@
    "outputs": [],
    "source": [
     "import panel as pn\n",
-    "from panel.widgets.indicators import LoadingSpinner\n",
     "\n",
     "pn.extension()"
    ]
@@ -42,8 +41,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "idle = LoadingSpinner(value=False, width=100, height=100)\n",
-    "loading = LoadingSpinner(value=True, width=100, height=100)\n",
+    "idle = pn.indicators.LoadingSpinner(value=False, width=100, height=100)\n",
+    "loading = pn.indicators.LoadingSpinner(value=True, width=100, height=100)\n",
     "\n",
     "pn.Row(idle, loading)"
    ]
@@ -63,9 +62,9 @@
    "source": [
     "grid = pn.GridBox('', 'light', 'dark', ncols=3)\n",
     "\n",
-    "for color in LoadingSpinner.param.color.objects:\n",
-    "    dark = LoadingSpinner(width=50, height=50, value=True, color=color, bgcolor='dark')\n",
-    "    light = LoadingSpinner(width=50, height=50, value=True, color=color, bgcolor='light')\n",
+    "for color in pn.indicators.LoadingSpinner.param.color.objects:\n",
+    "    dark = pn.indicators.LoadingSpinner(width=50, height=50, value=True, color=color, bgcolor='dark')\n",
+    "    light = vLoadingSpinner(width=50, height=50, value=True, color=color, bgcolor='light')\n",
     "    grid.extend((color, light, dark))\n",
     "\n",
     "grid"

--- a/examples/reference/indicators/Number.ipynb
+++ b/examples/reference/indicators/Number.ipynb
@@ -8,8 +8,6 @@
    "source": [
     "import panel as pn\n",
     "\n",
-    "from panel.widgets.indicators import Number\n",
-    "\n",
     "pn.extension()"
    ]
   },
@@ -46,7 +44,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "Number(name='Failure Rate', value=10, format='{value}%')"
+    "pn.indicators.Number(name='Failure Rate', value=10, format='{value}%')"
    ]
   },
   {
@@ -62,8 +60,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "number = Number(name='Failure Rate', value=72, format='{value}%',\n",
-    "                colors=[(33, 'green'), (66, 'gold'), (100, 'red')])\n",
+    "number = pn.indicators.Number(\n",
+    "    name='Failure Rate', value=72, format='{value}%',\n",
+    "    colors=[(33, 'green'), (66, 'gold'), (100, 'red')]\n",
+    ")\n",
     "\n",
     "pn.Row(number.clone(value=10), number.clone(value=42), number.clone(value=93))"
    ]

--- a/examples/reference/indicators/Progress.ipynb
+++ b/examples/reference/indicators/Progress.ipynb
@@ -44,7 +44,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "progress = pn.widgets.Progress(name='Progress', value=20, width=200)\n",
+    "progress = pn.indicators.Progress(name='Progress', value=20, width=200)\n",
     "progress"
    ]
   },
@@ -77,7 +77,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "indeterminate = pn.widgets.Progress(name='Indeterminate Progress', active=True, width=200)\n",
+    "indeterminate = pn.indicators.Progress(name='Indeterminate Progress', active=True, width=200)\n",
     "indeterminate"
    ]
   },
@@ -95,8 +95,8 @@
    "outputs": [],
    "source": [
     "running = pn.Column(*[\n",
-    "    pn.Row(pn.panel(bs, width=100), pn.widgets.misc.Progress(width=300, value=10+i*10, bar_color=bs))\n",
-    "        for i, bs in enumerate(pn.widgets.misc.Progress.param.bar_color.objects)\n",
+    "    pn.Row(pn.panel(bs, width=100), pn.indicators.Progress(width=300, value=10+i*10, bar_color=bs))\n",
+    "        for i, bs in enumerate(pn.indicators.Progress.param.bar_color.objects)\n",
     "])\n",
     "running"
    ]

--- a/panel/__init__.py
+++ b/panel/__init__.py
@@ -18,3 +18,4 @@ from .layout import ( # noqa
 from .pane import panel, Pane # noqa
 from .param import Param # noqa
 from .template import Template # noqa
+from .widgets import indicators # noqa

--- a/panel/models/progress.ts
+++ b/panel/models/progress.ts
@@ -97,7 +97,7 @@ export class Progress extends HTMLBox {
       bar_color: [ p.String, 'primary' ],
       style:     [ p.Any, {} ],
       max:       [ p.Number, 100 ],
-      value:     [ p.Number, null ],
+      value:     [ p.Any, null ],
     })
   }
 }


### PR DESCRIPTION
Allows using `pn.indicators` instead of `pn.widgets.indicators` and updates docs to reflect this.