### PR TITLE
[VTKVolume] add option to expand the controller

### DIFF
--- a/examples/reference/panes/VTKVolume.ipynb
+++ b/examples/reference/panes/VTKVolume.ipynb
@@ -32,6 +32,8 @@
     "\n",
     "* **``camera``** (dict): A dictionary reflecting the current state of the VTK camera\n",
     "\n",
+    "* **``controller_expanded``** (bool): A boolean to expand/collapse the volume controller panel in the view. If True the controller is expanded else it is collapsed\n",
+    "\n",
     "* **``orientation_widget``** (bool): A boolean to activate/deactivate the orientation widget in the 3D pane. This widget is clickable and allows to rotate the scene in one of the orthographic projections.\n",
     "\n",
     "* **``colormap``** (string): Name of the colormap used to transform pixel value in color. All allowed colormaps are referenced in `PRESET_CMAPS` in `panel.pane.vtk.enums`. By default the value is 'erdc_rainbow_bright'\n",

--- a/panel/models/vtk.py
+++ b/panel/models/vtk.py
@@ -104,6 +104,9 @@ class VTKVolumePlot(AbstractVTKPlot):
 
     colormap = String(help="Colormap Name")
 
+    controller_expanded = Bool(default=True, help="""
+        If True the volume controller panel options is expanded in the view""")
+
     data = Dict(String, Any)
 
     diffuse = Float(default=0.7)

--- a/panel/models/vtk/vtkvolume.ts
+++ b/panel/models/vtk/vtkvolume.ts
@@ -71,19 +71,19 @@ export class VTKVolumePlotView extends AbstractVTKView {
       this._vtk_renwin.getRenderWindow().render()
     })
     this.connect(this.model.properties.slice_i.change, () => {
-      if(this.image_actor_i !== undefined){
+      if (this.image_actor_i !== undefined) {
         this.image_actor_i.getMapper().setISlice(this.model.slice_i)
         this._vtk_renwin.getRenderWindow().render()
       }
     })
     this.connect(this.model.properties.slice_j.change, () => {
-      if(this.image_actor_j !== undefined){
+      if (this.image_actor_j !== undefined) {
         this.image_actor_j.getMapper().setJSlice(this.model.slice_j)
         this._vtk_renwin.getRenderWindow().render()
       }
     })
     this.connect(this.model.properties.slice_k.change, () => {
-      if(this.image_actor_k !== undefined){
+      if (this.image_actor_k !== undefined) {
         this.image_actor_k.getMapper().setKSlice(this.model.slice_k)
         this._vtk_renwin.getRenderWindow().render()
       }
@@ -98,8 +98,12 @@ export class VTKVolumePlotView extends AbstractVTKView {
       this._set_interpolation(this.model.interpolation)
       this._vtk_renwin.getRenderWindow().render()
     })
+    this.connect(this.model.properties.controller_expanded.change, () => {
+      if (this._controllerWidget != null)
+        this._controllerWidget.setExpanded(this.model.controller_expanded)
+    })
   }
-  
+
   render(): void {
     this._vtk_renwin = null
     this._orientationWidget = null
@@ -107,15 +111,14 @@ export class VTKVolumePlotView extends AbstractVTKView {
     super.render()
     this._create_orientation_widget()
     this._set_axes()
-    if (!this.model.camera)
-      this._vtk_renwin.getRenderer().resetCamera()
+    if (!this.model.camera) this._vtk_renwin.getRenderer().resetCamera()
   }
 
   invalidate_render(): void {
     this._vtk_renwin = null
     super.invalidate_render()
   }
-  
+
   init_vtk_renwin(): void {
     this._vtk_renwin = vtkns.FullScreenRenderWindow.newInstance({
       rootContainer: this.el,
@@ -136,6 +139,7 @@ export class VTKVolumePlotView extends AbstractVTKView {
       true
     )
     this._controllerWidget.setContainer(this.el)
+    this._controllerWidget.setExpanded(this.model.controller_expanded)
     this._connect_js_controls()
     this._vtk_renwin.getRenderWindow().getInteractor()
     this._vtk_renwin.getRenderWindow().getInteractor().setDesiredUpdateRate(45)
@@ -193,7 +197,7 @@ export class VTKVolumePlotView extends AbstractVTKView {
     if (!this.model.colormap) this.model.colormap = this.colormap_selector.value
     else this.model.properties.colormap.change.emit()
 
-      // Shadow selector
+    // Shadow selector
     this.shadow_selector.addEventListener("change", () => {
       this.model.shadow = !!Number(this.shadow_selector.value)
     })
@@ -351,11 +355,10 @@ export class VTKVolumePlotView extends AbstractVTKView {
       .getActors()
       .map((actor: any) => actor.setVisibility(visibility))
   }
-  
+
   _set_volume_visibility(visibility: boolean): void {
     this.volume.setVisibility(visibility)
   }
-
 }
 
 export namespace VTKVolumePlot {
@@ -378,6 +381,7 @@ export namespace VTKVolumePlot {
     slice_k: p.Property<number>
     specular: p.Property<number>
     specular_power: p.Property<number>
+    controller_expanded: p.Property<boolean>
   }
 }
 
@@ -394,24 +398,25 @@ export class VTKVolumePlot extends AbstractVTKPlot {
     this.prototype.default_view = VTKVolumePlotView
 
     this.define<VTKVolumePlot.Props>({
-      ambient:           [ p.Number,            0.2 ],
-      colormap:          [ p.String                 ],
-      data:              [ p.Instance               ],
-      diffuse:           [ p.Number,            0.7 ],
-      display_slices:    [ p.Boolean,         false ],
-      display_volume:    [ p.Boolean,          true ],
-      edge_gradient:     [ p.Number,            0.2 ],
-      interpolation:     [ p.Any,      'fast_linear'],
-      mapper:            [ p.Instance               ],
-      render_background: [ p.String,      '#52576e' ],
-      rescale:           [ p.Boolean,         false ],
-      sampling:          [ p.Number,            0.4 ],
-      shadow:            [ p.Boolean,          true ],
-      slice_i:           [ p.Int,               0   ],
-      slice_j:           [ p.Int,               0   ],
-      slice_k:           [ p.Int,               0   ],
-      specular:          [ p.Number,            0.3 ],
-      specular_power:    [ p.Number,            8.0 ],
+      ambient:              [ p.Number,            0.2 ],
+      colormap:             [ p.String                 ],
+      data:                 [ p.Instance               ],
+      diffuse:              [ p.Number,            0.7 ],
+      display_slices:       [ p.Boolean,         false ],
+      display_volume:       [ p.Boolean,          true ],
+      edge_gradient:        [ p.Number,            0.2 ],
+      interpolation:        [ p.Any,      'fast_linear'],
+      mapper:               [ p.Instance               ],
+      render_background:    [ p.String,      '#52576e' ],
+      rescale:              [ p.Boolean,         false ],
+      sampling:             [ p.Number,            0.4 ],
+      shadow:               [ p.Boolean,          true ],
+      slice_i:              [ p.Int,               0   ],
+      slice_j:              [ p.Int,               0   ],
+      slice_k:              [ p.Int,               0   ],
+      specular:             [ p.Number,            0.3 ],
+      specular_power:       [ p.Number,            8.0 ],
+      controller_expanded:  [ p.Boolean,          true ],
     })
   }
 }

--- a/panel/models/vtk/vtkvolume.ts
+++ b/panel/models/vtk/vtkvolume.ts
@@ -190,6 +190,11 @@ export class VTKVolumePlotView extends AbstractVTKView {
   }
 
   _connect_js_controls(): void {
+    const {el: controller_el} = this._controllerWidget.get('el')
+    if(controller_el !== undefined) {
+      const controller_button = (controller_el as HTMLElement).querySelector('.js-button')
+      controller_button!.addEventListener('click', () => this.model.controller_expanded = this._controllerWidget.getExpanded())
+    }
     // Colormap selector
     this.colormap_selector.addEventListener("change", () => {
       this.model.colormap = this.colormap_selector.value

--- a/panel/pane/vtk/vtk.py
+++ b/panel/pane/vtk/vtk.py
@@ -520,6 +520,9 @@ class VTKVolume(AbstractVTK):
         object gives even in the absence of strong light. It is
         constant in all directions.""")
 
+    controller_expanded = param.Boolean(default=True, doc="""
+        If True the volume controller panel options is expanded in the view""")
+
     colormap = param.Selector(default='erdc_rainbow_bright', objects=PRESET_CMAPS, doc="""
         Name of the colormap used to transform pixel value in color.""")
 
@@ -643,7 +646,7 @@ class VTKVolume(AbstractVTK):
                               **props)
         if root is None:
             root = model
-        self._link_props(model, ['colormap', 'orientation_widget', 'camera', 'mapper'], doc, root, comm)
+        self._link_props(model, ['colormap', 'orientation_widget', 'camera', 'mapper', 'controller_expanded'], doc, root, comm)
         self._models[root.ref['id']] = (model, parent)
         return model
 


### PR DESCRIPTION
implements https://github.com/holoviz/panel/issues/1630

by default I let it to true 

![controller_expand](https://user-images.githubusercontent.com/18531147/95991017-8a811f80-0e2c-11eb-9369-ff72d906d35e.gif)

Customizing the controller widget is doable but it should be more a vtk.js request since I use directly the VolumeController class defined in vtkjs and there are not options to customize it (https://kitware.github.io/vtk-js/api/Interaction_UI_VolumeController.html)
