### PR TITLE
Fix counting of live sessions in session_info

### DIFF
--- a/panel/viewable.py
+++ b/panel/viewable.py
@@ -445,10 +445,10 @@ class Renderable(param.Parameterized):
         session_id = session_context.id
         sessions = state.session_info['sessions']
         if session_id in sessions and sessions[session_id]['ended'] is None:
-            state.session_info['live'] -= 1
-            sessions[session_id].update({
-                'ended': dt.datetime.now().timestamp()
-            })
+            session = sessions[session_id]
+            if session['rendered'] is not None:
+                state.session_info['live'] -= 1
+            session['ended'] = dt.datetime.now().timestamp()
         doc = session_context._document
         root = self._documents[doc]
         ref = root.ref['id']


### PR DESCRIPTION
If a session was established but never rendered it wouldn't count as live but still subtract from the live count.