### PR TITLE
Add channels to extra dependencies

### DIFF
--- a/examples/user_guide/Django_Apps.ipynb
+++ b/examples/user_guide/Django_Apps.ipynb
@@ -8,7 +8,7 @@
     "\n",
     "To run this example app yourself, you will first need to install django 2 (e.g. `conda install \"django=2\"`).\n",
     "\n",
-    "Additionally you should also install the `channels` library (using `pip install channels`). This makes it possible to run bokeh without launching a separate Tornado server."
+    "Additionally you should also install the `channels` library (using `pip install channels` or `conda install channels -c conda-forge`). This makes it possible to run bokeh without launching a separate Tornado server."
    ]
   },
   {
@@ -84,7 +84,7 @@
     "\n",
     "and lastly add the app(s) and `static_extensions()` to the `urlpatterns` in the `urls.py` file:\n",
     "\n",
-    "```\n",
+    "```python\n",
     "from bokeh.server.django import autoload, static_extensions\n",
     "from django.apps import apps\n",
     "from django.contrib import admin\n",
@@ -290,13 +290,6 @@
     "\n",
     "This is the most basic configuration for a bokeh server. It is of course possible to add multiple apps in the same way and then registering them with Django in the way described in the [configuration](#Configuration) section above. To see a multi-app Django server have a look at ``examples/apps/django_multi_apps`` and launch it with `python manage.py runserver` as before."
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/setup.py
+++ b/setup.py
@@ -128,6 +128,7 @@ extras_require = {
         'datashader',
         'jupyter_bokeh',
         'django',
+        'channels',
         'pyvista',
         'ipywidgets',
         'ipywidgets_bokeh',


### PR DESCRIPTION
To be able to run the Django and panel together, [channels](https://channels.readthedocs.io/en/latest/) is needed. 

A reason why it was not added together with Django at first, is that it was not on conda-forge before April this year.

I have also updated the documentation for the Django Apps page.