### PR TITLE
fix vanilla issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -121,3 +121,4 @@ builtdocs/
 discover/
 
 node_modules/
+tmp/

--- a/panel/template/vanilla/default.css
+++ b/panel/template/vanilla/default.css
@@ -3,7 +3,7 @@
 }
 
 #sidebar {
-  background-color: white;
+  background-color: 	#F8F8F8;
   box-shadow: 0px 0px 1px;
 }
 

--- a/panel/template/vanilla/vanilla.css
+++ b/panel/template/vanilla/vanilla.css
@@ -2,17 +2,32 @@ body {
   height: 100vh;
   margin: 0px;
   font-family: "Lato", sans-serif;
+  overflow-x: hidden;
+  overflow-y: hidden;
 }
 
 #container {
   padding:0px;
   width: 100vw;
+  max-width: 100vw;
 }
 
 #header{
   display: flex;
   align-items: center;
   padding: 10px;
+  box-shadow: 5px 5px 20px silver;
+}
+
+#header-items {
+  width: 100%;
+  margin-left:15px;
+}
+
+#app-title {
+  min-width:230px;
+  margin-right: 15px;
+  padding-left: 10px;
 }
 
 .title {
@@ -24,6 +39,7 @@ body {
   text-decoration-color: initial;
   font-weight: 400;
   font-size: 28px;
+  width: 200px;
 }
 
 .pn-bar {
@@ -44,21 +60,33 @@ body {
   display: inline-flex;
 }
 
+#sidebar-button {
+  font-size:30px;
+  cursor:pointer;
+  margin-left: 0.25em;
+  margin-right: 0.25em;
+}
+
 #sidebar {
   transition: all 0.2s cubic-bezier(0.945, 0.020, 0.270, 0.665);
   transform-origin: center left; /* Set the transformed position of sidebar to center left side. */
-  width: 16.7vw;
+  width: 290px;
+  height: calc(100vh - 52px);
 }
 
 #sidebar.active {
-  margin-left: -16.7%;
+  margin-left: -300px;
 }
 
 #main {
   transition: all 0.2s cubic-bezier(0.945, 0.020, 0.270, 0.665);
   overflow-y: scroll;
   width: 100vw;
-  margin-left: 16.7vw;
+  height: calc(100vh - 52px);
+  margin-left: 300px;
+  padding-right: 20px;
+  padding-top: 10px;
+  padding-left: 10px;
   overflow-y: scroll;
 }
 
@@ -73,13 +101,14 @@ a.navbar-brand {
 
 p.bk.card-button {
   display: none;
-}  
+}
 
 .sidenav {
   height: 100%;
-  overflow-x: hidden;
-  padding-top: 15px;
+  padding-top: 10px;
+  padding-left: 10px;
   position: absolute;
+  overflow-x: hidden;
   overflow-y: scroll;
 }
 
@@ -87,18 +116,18 @@ p.bk.card-button {
   position: absolute !important;
 }
 
-.sidenav a {
+/* .sidenav a {
   padding: 8px 8px 8px 32px;
   text-decoration: none;
   font-size: 25px;
   color: #818181;
   display: block;
   transition: 0.3s;
-}
+} */
 
-.sidenav a:hover {
+/* .sidenav a:hover {
   color: #f1f1f1;
-}
+} */
 
 .sidenav .closebtn {
   position: absolute;

--- a/panel/template/vanilla/vanilla.html
+++ b/panel/template/vanilla/vanilla.html
@@ -5,13 +5,16 @@
 <div class="" id="container">
   <nav class="" style="{% if header_background %}background-color: {{ header_background }} !important;{% endif %}{% if header_color %}color: {{ header_color }}{% endif %}" id="header">
     {% if nav %}
-    <span style="font-size:30px;cursor:pointer" onclick="closeNav()" id="sidebar-button">
-	  <div class="pn-bar"></div>
-	  <div class="pn-bar"></div>
-	  <div class="pn-bar"></div>
-	</span>
+    <span onclick="closeNav()" id="sidebar-button">
+      <div class="pn-bar"></div>
+      <div class="pn-bar"></div>
+      <div class="pn-bar"></div>
+    </span>
     {% endif %}
-    <a class="title" href="#">{{ app_title }}</a>
+    <span id="app-title">
+      <a class="title" href="#" >{{ app_title }}</a>
+    </span>
+    <div id="header-items">
     {% for doc in docs %}
     {% for root in doc.roots %}
     {% if "header" in root.tags %}
@@ -19,7 +22,7 @@
     {% endif %}
     {% endfor %}
     {% endfor %}
-
+    </div>
 	{% if busy %}
 	<div class="pn-busy-container">
 	  {{ embed(roots.busy_indicator) | indent(6) }}
@@ -71,14 +74,14 @@
 <script>
   function openNav() {
     document.getElementById("sidebar").style.left = 0;
-    document.getElementById("main").style.marginLeft = "16.7vw";
+    document.getElementById("main").style.marginLeft = "300px";
     document.getElementById("sidebar-button").onclick = closeNav;
     var interval = setInterval(function () { window.dispatchEvent(new Event('resize')); }, 10);
     setTimeout(function () { clearInterval(interval) }, 210)
   }
 
   function closeNav() {
-    document.getElementById("sidebar").style.left = "-16.7vw";
+    document.getElementById("sidebar").style.left = "-300px";
     document.getElementById("main").style.marginLeft = 0;
     document.getElementById("sidebar-button").onclick = openNav;
     var interval = setInterval(function () { window.dispatchEvent(new Event('resize')); }, 10);

--- a/panel/tests/template/test_vanilla_manual.py
+++ b/panel/tests/template/test_vanilla_manual.py
@@ -1,0 +1,64 @@
+import panel as pn
+import numpy as np
+import holoviews as hv
+
+
+def test_vanilla():
+    """Returns an app that uses the vanilla template in various ways.
+
+Inspect the app and verify that the issues of [Issue 1641]\
+(https://github.com/holoviz/panel/issues/1641) have been solved
+
+- Navbar is "sticky"/ fixed to the top
+- Navbar supports adding header items to left, center and right
+- There is a nice padding/ margin everywhere
+- Independent scroll for sidebar and main
+- Only vertical scrollbars
+"""
+    vanilla = pn.template.VanillaTemplate(title="Vanilla Template")
+
+    pn.config.sizing_mode = "stretch_width"
+
+    xs = np.linspace(0, np.pi)
+    freq = pn.widgets.FloatSlider(name="Frequency", start=0, end=10, value=2)
+    phase = pn.widgets.FloatSlider(name="Phase", start=0, end=np.pi)
+
+    @pn.depends(freq=freq, phase=phase)
+    def sine(freq, phase):
+        return hv.Curve((xs, np.sin(xs * freq + phase))).opts(responsive=True, min_height=400)
+
+    @pn.depends(freq=freq, phase=phase)
+    def cosine(freq, phase):
+        return hv.Curve((xs, np.cos(xs * freq + phase))).opts(responsive=True, min_height=400)
+
+    vanilla.sidebar.append(freq)
+    vanilla.sidebar.append(phase)
+    vanilla.sidebar.append(pn.pane.Markdown(test_vanilla.__doc__))
+    vanilla.sidebar.append(pn.pane.Markdown("## Sidebar Item\n" * 50))
+
+    vanilla.main.append(
+        pn.Row(
+            pn.Card(hv.DynamicMap(sine), title="Sine"),
+            pn.Card(hv.DynamicMap(cosine), title="Cosine"),
+        )
+    )
+    vanilla.main.append(
+        pn.Row(
+            pn.Card(hv.DynamicMap(sine), title="Sine"),
+            pn.Card(hv.DynamicMap(cosine), title="Cosine"),
+        )
+    )
+    vanilla.header[:] = [
+        pn.Row(
+            pn.widgets.Button(name="Left", sizing_mode="fixed", width=50),
+            pn.layout.HSpacer(),
+            pn.widgets.Button(name="Center", sizing_mode="fixed", width=50),
+            pn.layout.HSpacer(),
+            pn.widgets.Button(name="Right", sizing_mode="fixed", width=50),
+        )
+    ]
+    return vanilla
+
+
+if __name__.startswith("bokeh"):
+    test_vanilla().servable()


### PR DESCRIPTION
I've tested out the Vanilla Template and could see it would not work for users. 

I've listed some issues here https://github.com/holoviz/panel/issues/1641 that this PR tries to solve.

You can try out the vanilla template example by running

```python
python -m panel serve 'panel\tests\template\test_vanilla_manual.py' --dev
```

![vanilla (1)](https://user-images.githubusercontent.com/42288570/96361089-1a6fe380-1123-11eb-969d-f65dfdccd647.gif)

Comments:

- I've fixed the sidebar width at `300px` as that in my experience is a good width. It's also the width used by Streamlit and I've never heard users propose any change to that. Maybe the width should be user customizable such that you can specify a string like `250px` or `16.67vw`?
- I've added a little bit more margin/ padding (~`10px`) in different places to make things look a little less busy. Maybe that should be user customizable as well.
- I've setup the template such that the sidebar button and title always have a width of 300px (same as sidebar). Then the header items will always be on top of the main area. In my experience that is a very nice looking layout. But if people have a very large app title it can cause problems.
- I've set `overflow-x: hidden` on both sidebar and main area. In my experience that is a very, very good solution. But if some people have very wide plots or images they would like to show it will not work. But in my experience there should be as few scrollbars as possible. There is no horizontal scrollbar in the Streamlit template and I've never heard users complain.

FYI @nghenzi and @philippjfr . This might have the implications for the other templates and themes like the React Template.