### PR TITLE
Use param serializer for synced URL parameters

### DIFF
--- a/panel/io/location.py
+++ b/panel/io/location.py
@@ -99,7 +99,7 @@ class Location(Syncable):
                 pname = mapping[k]
                 try:
                     v = p.param[pname].deserialize(v)
-                except Exception as e:
+                except Exception:
                     pass
                 mapped[pname] = v
             p.param.set_param(**mapped)


### PR DESCRIPTION
Ensures parameter types other than the real basics can be synced with the `Location` components query parameters.