### PR TITLE
Template Fixes

### DIFF
--- a/panel/template/material/material.css
+++ b/panel/template/material/material.css
@@ -8,6 +8,9 @@ body {
 .bk-root .bk, .bk-root .bk:before, .bk-root .bk:after {
   font-family: inherit;
 }
+img {
+  max-width: 100%;
+}
 
 #container {
   padding:0px;

--- a/panel/template/material/material.html
+++ b/panel/template/material/material.html
@@ -74,6 +74,9 @@
 
 <div class="mdc-drawer-app-content mdc-top-app-bar--fixed-adjust">
 <main class="main-content" id="main">
+  {% if main_max_width %}
+    <div style="margin-left: auto; margin-right: auto;max-width: {{main_max_width}}">
+  {% endif %}
   {% for doc in docs %}
   {% for root in doc.roots %}
   {% if "main" in root.tags %}
@@ -81,6 +84,9 @@
   {% endif %}
   {% endfor %}
   {% endfor %}
+  {% if main_max_width %}
+    </div>
+  {% endif %}
 </main>
 
 <div id="pn-Modal" class="pn-modal mdc-top-app-bar--fixed-adjust">

--- a/panel/template/vanilla/vanilla.css
+++ b/panel/template/vanilla/vanilla.css
@@ -5,6 +5,9 @@ body {
   overflow-x: hidden;
   overflow-y: hidden;
 }
+img {
+  max-width: 100%;
+}
 
 #container {
   padding:0px;

--- a/panel/template/vanilla/vanilla.html
+++ b/panel/template/vanilla/vanilla.html
@@ -73,7 +73,7 @@
     {% endif %}
     >
       {% if main_max_width %}
-      <div style="margin-left: auto; margin-right: auto;">
+      <div style="margin-left: auto; margin-right: auto;max-width: {{main_max_width}}">
       {% endif %}
       {% for doc in docs %}
       {% for root in doc.roots %}


### PR DESCRIPTION
So far I've

- Vanilla Template apply `main_max_width`.
- Set `max-with: 100%` for img. It's a hazzle using images in Markdown without this.

Such that this looks nice

![image](https://user-images.githubusercontent.com/42288570/96843663-df392180-144e-11eb-80c0-09a447419ac4.png)