### PR TITLE
Add support for Pyecharts

### DIFF
--- a/examples/reference/panes/ECharts.ipynb
+++ b/examples/reference/panes/ECharts.ipynb
@@ -14,13 +14,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The ``ECharts`` pane renders [Apache ECharts](https://echarts.apache.org/en/index.html) plots inside Panel. Note that to use the ``ECharts`` pane in the notebook the Panel extension has to be loaded with 'echarts' as an argument to ensure that echarts.js is initialized. \n",
+    "The ``ECharts`` pane renders [Apache ECharts](https://echarts.apache.org/en/index.html) and [pyecharts](https://pyecharts.org/#/) plots inside Panel. Note that to use the ``ECharts`` pane in the notebook the Panel extension has to be loaded with 'echarts' as an argument to ensure that echarts.js is initialized. \n",
     "\n",
     "#### Parameters:\n",
     "\n",
     "For layout and styling related parameters see the [customization user guide](../../user_guide/Customization.ipynb).\n",
     "\n",
-    "* **``object``** (dict): A ECharts plot specification expressed as a Python dictionary, which is then converted to JSON\n",
+    "* **``object``** (dict): An ECharts plot specification expressed as a Python dictionary, which is then converted to JSON. Or a pyecharts chart like `pyecharts.charts.Bar`.\n",
     "* **``renderer``** (str): Whether to render with HTML 'canvas' (default) or 'svg'\n",
     "* **``theme``** (str): Theme to apply to plots (one of 'default', 'dark', 'light')\n",
     "___"
@@ -30,7 +30,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The ``ECharts`` pane supports ECharts specs which may be provided in a raw form (i.e. a dictionary), e.g. here we declare a bar plot:"
+    "Lets try the ``ECharts`` pane support for ECharts specs in its raw form (i.e. a dictionary), e.g. here we declare a bar plot:"
    ]
   },
   {
@@ -154,9 +154,22 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
    "name": "python",
-   "pygments_lexer": "ipython3"
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.8"
   }
  },
  "nbformat": 4,

--- a/panel/tests/pane/test_echart.py
+++ b/panel/tests/pane/test_echart.py
@@ -1,4 +1,3 @@
-from panel.models.echarts import ECharts
 import panel as pn
 
 ECHART = {
@@ -21,7 +20,7 @@ def test_echart():
     assert pane.object == echart
     return pane
 
-def test_pyechart():
+def get_pyechart():
     from pyecharts.charts import Bar
     from pyecharts import options as opts
 
@@ -37,6 +36,8 @@ def test_pyechart():
     return pane
 
 if __name__.startswith("bokeh"):
-    test_pyechart().servable()
+    # test_echart().servable()
+    get_pyechart().servable()
 if __name__.startswith("__main__"):
-    test_pyechart().show(port=5007)
+    test_echart().show(port=5007)
+    get_pyechart().show(port=5007)

--- a/panel/tests/pane/test_echarts.py
+++ b/panel/tests/pane/test_echarts.py
@@ -1,6 +1,7 @@
+from panel.models.echarts import ECharts
 import panel as pn
-def test_echart():
-    echart = {
+
+ECHART = {
         "xAxis": {
             "type": 'category',
             "data": ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']
@@ -13,11 +14,29 @@ def test_echart():
             "type": 'line'
         }]
     }
+
+def test_echart():
+    echart = ECHART
     pane = pn.pane.ECharts(echart, width=500, height=500)
     assert pane.object == echart
     return pane
 
+def test_pyechart():
+    from pyecharts.charts import Bar
+    from pyecharts import options as opts
+
+    bar = (
+        Bar()
+        .add_xaxis(["A", "B", "C", "D", "E", "F", "G"])
+        .add_yaxis("Series1", [114, 55, 27, 101, 125, 27, 105])
+        .add_yaxis("Series2", [57, 134, 137, 129, 145, 60, 49])
+        .set_global_opts(title_opts=opts.TitleOpts(title="PyeCharts"))
+    )
+    pane = pn.pane.ECharts(bar, width=500, height=500)
+    assert pane.object == bar
+    return pane
+
 if __name__.startswith("bokeh"):
-    test_echart().servable()
+    test_pyechart().servable()
 if __name__.startswith("__main__"):
-    test_echart().show(port=5007)
+    test_pyechart().show(port=5007)

--- a/panel/tests/pane/test_echarts.py
+++ b/panel/tests/pane/test_echarts.py
@@ -1,0 +1,23 @@
+import panel as pn
+def test_echart():
+    echart = {
+        "xAxis": {
+            "type": 'category',
+            "data": ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']
+        },
+        "yAxis": {
+            "type": 'value'
+        },
+        "series": [{
+            "data": [820, 932, 901, 934, 1290, 1330, 1320],
+            "type": 'line'
+        }]
+    }
+    pane = pn.pane.ECharts(echart, width=500, height=500)
+    assert pane.object == echart
+    return pane
+
+if __name__.startswith("bokeh"):
+    test_echart().servable()
+if __name__.startswith("__main__"):
+    test_echart().show(port=5007)


### PR DESCRIPTION
Finalizes the request for Echarts **and** Pyecharts https://github.com/holoviz/panel/issues/1133.

I believe it's important to support pyecharts as this is **THE** Python wrapper for ECharts and it's highly popular with ~10.000 stars on Github.

I've now added support for Pyecharts. I've tried to see how other plotting panes support dictionary specification and python wrapper specification.

I've added a test for ECharts and a manual test for pyecharts. I've tried to define the manual test for pyecharts such that its not disturbing the normal test suite, but can be run manually on demand.

I've added a comment to the ECharts notebook about suppport for pyecharts. But I've not provided an example as I was not sure you would like to add that dependency. But there is a simple example in the `test_echart.py` file.

You can test the manual example via `python -m panel serve 'panel\tests\pane\test_echart.py' --dev`

![image](https://user-images.githubusercontent.com/42288570/97070097-e63e6c00-15d5-11eb-8c1f-dbc6e49ceab1.png)

FYI @philippjfr . It's ready for review

### Note

I cannot get BokehJS to load in the Notebook. I don't believe this has anything to do with the `pyecharts` support as I could not before as well.

![image](https://user-images.githubusercontent.com/42288570/97070129-33224280-15d6-11eb-8cd7-ac940a169d4f.png)
