### PR TITLE
Add seek(0) to pane.image

### DIFF
--- a/panel/pane/image.py
+++ b/panel/pane/image.py
@@ -78,6 +78,8 @@ class ImageBase(DivPaneBase):
                 with open(self.object, 'rb') as f:
                     return f.read()
         if hasattr(self.object, 'read'):
+            if hasattr(self.object, 'seek'):
+                self.object.seek(0)
             return self.object.read()
         if isurl(self.object, None):
             import requests

--- a/panel/tests/pane/test_image.py
+++ b/panel/tests/pane/test_image.py
@@ -70,7 +70,7 @@ def test_load_from_byteio():
     path = os.path.dirname(__file__)
     with open(os.path.join(path, '../test_data/logo.png'), 'rb') as image_file:
         memory.write(image_file.read())
-    memory.seek(0)
+
     image_pane = PNG(memory)
     image_data = image_pane._img()
     assert b'PNG' in image_data
@@ -79,11 +79,11 @@ def test_load_from_byteio():
 def test_load_from_stringio():
     """Testing a loading a image from a StringIO"""
     memory = StringIO()
-    
+
     path = os.path.dirname(__file__)
     with open(os.path.join(path, '../test_data/logo.png'), 'rb') as image_file:
         memory.write(str(image_file.read()))
-    memory.seek(0)
+
     image_pane = PNG(memory)
     image_data = image_pane._img()
     assert 'PNG' in image_data


### PR DESCRIPTION
Attempt to fix #1711 by forcing attribute with read to set seek(0). 

I can't think of a good reason not to start the read at 0, but if there is this PR can be closed. 