### PR TITLE
Fixes Alert c.f. #1728

### DIFF
--- a/examples/reference/panes/Alert.ipynb
+++ b/examples/reference/panes/Alert.ipynb
@@ -22,7 +22,7 @@
     "\n",
     "For layout and styling related parameters see the [customization user guide](../../user_guide/Customization.ipynb).\n",
     "\n",
-    "* **``text``** (str): The contextual feedback message.\n",
+    "* **``object``** (str): The contextual feedback message.\n",
     "* **``alert_type``** (str): The type of Alert and one of `primary`, `secondary`, `success`, `danger`, `warning`, `info`, `light`, `dark`.\n",
     "\n",
     "___"
@@ -96,9 +96,22 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
    "name": "python",
-   "pygments_lexer": "ipython3"
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.8"
   }
  },
  "nbformat": 4,

--- a/panel/pane/alert.py
+++ b/panel/pane/alert.py
@@ -19,6 +19,10 @@ class Alert(Markdown):
 
     alert_type = param.ObjectSelector("primary", objects=ALERT_TYPES)
 
+    priority = 0
+
+    _rename=dict(Markdown._rename, alert_type=None)
+
     @classmethod
     def applies(cls, obj):
         priority = Markdown.applies(obj)

--- a/panel/tests/pane/test_alert.py
+++ b/panel/tests/pane/test_alert.py
@@ -39,14 +39,25 @@ def test_all_view():
         text = f"""\
             This is a **{alert_type}** alert with [an example link](https://panel.holoviz.org/).
             Give it a click if you like."""
-        alert = Alert(text=text, alert_type=alert_type)
-        alerts.append(alert)
+        alert = Alert(object=text, alert_type=alert_type)
+        alert_app = pn.Column(
+            alert,
+            pn.Param(
+                alert,
+                parameters=["object", "alert_type"],
+                widgets={"object":
+                pn.widgets.TextAreaInput},
+            ),
+        )
+        alerts.append(alert_app)
 
         assert "alert" in alert.css_classes
         assert f"alert-{alert_type}" in alert.css_classes
 
-    return pn.Column(*alerts, sizing_mode="stretch_width")
+    return pn.Column(*alerts, margin=50)
 
 
-if __name__.startswith("bk"):
+if __name__.startswith("bokeh"):
+    pn.config.sizing_mode="stretch_width"
     test_all_view().servable()
+    print("served")


### PR DESCRIPTION
This is a fix of #1728.

The manual test `python -m panel serve 'panel\pane\alert.py' --dev` is shown below. 

![alert_test](https://user-images.githubusercontent.com/42288570/97770771-7e88a380-1b36-11eb-81c2-d7df7874c930.gif)

I've verified there are no exceptions in the console. I don't know how to setup an a automated test of this.