### PR TITLE
Updated documentation to pn.state.add_periodic_callback

### DIFF
--- a/examples/gallery/simple/deckgl_game_of_life.ipynb
+++ b/examples/gallery/simple/deckgl_game_of_life.ipynb
@@ -214,7 +214,7 @@
     "reset = pn.widgets.Button(name='Reset', button_type='warning', width=60, align='end')\n",
     "reset.on_click(reset_board)\n",
     "\n",
-    "periodic_cb = gol.add_periodic_callback(run_gol, start=False, period=period.value)\n",
+    "periodic_cb = pn.state.add_periodic_callback(run_gol, start=False, period=period.value)\n",
     "\n",
     "pn.Column(\n",
     "    '## Game of Life (using Deck.GL)',\n",

--- a/examples/gallery/simple/random_number_generator.ipynb
+++ b/examples/gallery/simple/random_number_generator.ipynb
@@ -51,19 +51,12 @@
     "period = pn.widgets.Spinner(name=\"Period (ms)\", value=500, step=50, start=50)\n",
     "period.param.watch(update_period, 'value')\n",
     "\n",
-    "periodic_cb = static_text.add_periodic_callback(\n",
-    "    generate_random_number, period=period.value, start=False)  # period in milliseconds\n",
+    "periodic_cb = pn.state.add_periodic_callback(\n",
+    "    generate_random_number, period=period.value, start=False)\n",
     "\n",
     "col = pn.Column(generate_button, period, periodic_toggle, static_text)\n",
     "col.servable()"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/examples/reference/panes/Streamz.ipynb
+++ b/examples/reference/panes/Streamz.ipynb
@@ -77,7 +77,7 @@
     "    count += 1\n",
     "    source.emit(count)\n",
     "\n",
-    "streamz_pane.add_periodic_callback(emit_count, period=100)"
+    "pn.state.add_periodic_callback(emit_count, period=100);"
    ]
   },
   {
@@ -96,6 +96,7 @@
     "import numpy as np\n",
     "import altair as alt\n",
     "import pandas as pd\n",
+    "from datetime import datetime\n",
     "from streamz.dataframe import DataFrame as sDataFrame\n",
     "\n",
     "df = sDataFrame(example=pd.DataFrame({'y': []}, index=pd.DatetimeIndex([])))\n",
@@ -111,7 +112,7 @@
     "altair_pane = pn.pane.Streamz(altair_stream, height=350, always_watch=True)\n",
     "\n",
     "for i in range(100):\n",
-    "    df.emit(pd.DataFrame({'y': [np.random.randn()]}, index=pd.DatetimeIndex([pd.datetime.now()])))\n",
+    "    df.emit(pd.DataFrame({'y': [np.random.randn()]}, index=pd.DatetimeIndex([datetime.now()])))\n",
     "\n",
     "altair_pane"
    ]
@@ -130,9 +131,9 @@
    "outputs": [],
    "source": [
     "def emit():\n",
-    "    df.emit(pd.DataFrame({'y': [np.random.randn()]}, index=pd.DatetimeIndex([pd.datetime.now()])))\n",
+    "    df.emit(pd.DataFrame({'y': [np.random.randn()]}, index=pd.DatetimeIndex([datetime.now()])))\n",
     "\n",
-    "altair_pane.add_periodic_callback(emit, period=100)"
+    "pn.state.add_periodic_callback(emit, period=100);"
    ]
   }
  ],


### PR DESCRIPTION
Fixes #1717 

And I also updated pd.datetime.now() to datetime.now() from Streamz.ipynb because it is deprecated. 
`FutureWarning: The pandas.datetime class is deprecated and will be removed from pandas in a future version. Import from datetime module instead.`