### PR TITLE
Add DatetimeRangeInput widget

### DIFF
--- a/examples/reference/widgets/DatetimeRangeInput.ipynb
+++ b/examples/reference/widgets/DatetimeRangeInput.ipynb
@@ -1,0 +1,123 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import datetime as dt\n",
+    "import panel as pn\n",
+    "\n",
+    "pn.extension()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The ``DatetimeRangeInput`` widget allows selecting a datetime range using two [`DatetimeInput`](./DatetimeInput.ipynb) widgets, which return a tuple range.\n",
+    "\n",
+    "For more information about listening to widget events and laying out widgets refer to the [widgets user guide](../../user_guide/Widgets.ipynb). Alternatively you can learn how to build GUIs by declaring parameters independently of any specific widgets in the [param user guide](../../user_guide/Param.ipynb). To express interactivity entirely using Javascript without the need for a Python server take a look at the [links user guide](../../user_guide/Param.ipynb).\n",
+    "\n",
+    "#### Parameters:\n",
+    "\n",
+    "For layout and styling related parameters see the [customization user guide](../../user_guide/Customization.ipynb).\n",
+    "\n",
+    "\n",
+    "##### Core\n",
+    "\n",
+    "* **``format``** (str): Datetime formatting string that determines how the value is formatted and parsed (``default='%Y-%m-%d %H:%M:%S'``)\n",
+    "* **``start``** (datetime): The range's lower bound\n",
+    "* **``end``** (datetime): The range's upper bound\n",
+    "* **``value``** (tuple): Tuple of upper and lower bounds of the selected range expressed as datetime types\n",
+    "\n",
+    "##### Display\n",
+    "\n",
+    "* **``disabled``** (boolean): Whether the widget is editable\n",
+    "* **``name``** (str): The title of the widget\n",
+    "\n",
+    "___\n",
+    "\n",
+    "The datetime parser uses the defined ``format`` to validate the input value, if the entered text is not a valid datetime a warning will be shown in the title as \"`(invalid)`\":"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "datetime_range_slider = pn.widgets.DatetimeRangeInput(\n",
+    "    name='Datetime Range Input',\n",
+    "    start=dt.datetime(2017, 1, 1), end=dt.datetime(2019, 1, 1),\n",
+    "    value=(dt.datetime(2017, 1, 1), dt.datetime(2018, 1, 10))\n",
+    ")\n",
+    "\n",
+    "datetime_range_slider"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "``DatetimeRangeInput.value`` returns a tuple of datetime values that can be read out and set like other widgets:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "datetime_range_slider.value"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Controls\n",
+    "\n",
+    "The `DatetimeRangeInput` widget exposes a number of options which can be changed from both Python and Javascript. Try out the effect of these parameters interactively:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pn.Row(datetime_range_slider.controls(jslink=True), datetime_range_slider)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.5"
+  },
+  "widgets": {
+   "application/vnd.jupyter.widget-state+json": {
+    "state": {},
+    "version_major": 2,
+    "version_minor": 0
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/panel/tests/widgets/test_input.py
+++ b/panel/tests/widgets/test_input.py
@@ -4,8 +4,10 @@ import pytest
 from datetime import datetime, date
 
 from bokeh.models.widgets import FileInput as BkFileInput
-from panel.widgets import (Checkbox, DatePicker, DatetimeInput, FileInput,
-                           LiteralInput, TextInput, StaticText)
+from panel.widgets import (
+    Checkbox, DatePicker, DatetimeInput, DatetimeRangeInput, FileInput,
+    LiteralInput, TextInput, StaticText
+)
 
 
 def test_checkbox(document, comm):
@@ -158,3 +160,47 @@ def test_datetime_input(document, comm):
 
     with pytest.raises(ValueError):
         dt_input.value = datetime(2017, 12, 30)
+
+
+def test_datetime_range_input(document, comm):
+    dt_input = DatetimeRangeInput(
+        value=(datetime(2018, 1, 1), datetime(2018, 1, 3)),
+        start=datetime(2017, 12, 31), end=datetime(2018, 1, 10),
+        name='Datetime')
+
+    composite = dt_input.get_root(document, comm=comm)
+    label, start, end = composite.children
+
+    assert isinstance(composite, dt_input._composite_type._bokeh_model)
+    assert label.text == 'Datetime'
+    assert start.value == '2018-01-01 00:00:00'
+    assert end.value == '2018-01-03 00:00:00'
+
+    dt_input._start._process_events({'value': '2018-01-01 00:00:01'})
+    assert dt_input.value == (datetime(2018, 1, 1, 0, 0, 1), datetime(2018, 1, 3))
+    assert label.text == 'Datetime'
+
+    dt_input._start._process_events({'value': '2018-01-01 00:00:01a'})
+    assert dt_input.value == (datetime(2018, 1, 1, 0, 0, 1), datetime(2018, 1, 3))
+    assert label.text == 'Datetime (invalid)'
+
+    dt_input._start._process_events({'value': '2018-01-11 00:00:00'})
+    assert dt_input.value == (datetime(2018, 1, 1, 0, 0, 1), datetime(2018, 1, 3))
+    assert label.text == 'Datetime (out of bounds)'
+
+    dt_input._end._process_events({'value': '2018-01-11 00:00:00a'})
+    assert dt_input.value == (datetime(2018, 1, 1, 0, 0, 1), datetime(2018, 1, 3))
+    assert label.text == 'Datetime (out of bounds) (invalid)'
+
+    dt_input._start._process_events({'value': '2018-01-02 00:00:00'})
+    dt_input._end._process_events({'value': '2018-01-03 00:00:00'})
+    assert dt_input.value == (datetime(2018, 1, 2), datetime(2018, 1, 3))
+    assert label.text == 'Datetime'
+
+    dt_input._start._process_events({'value': '2018-01-05 00:00:00'})
+    assert dt_input.value == (datetime(2018, 1, 2), datetime(2018, 1, 3))
+    assert label.text == 'Datetime (start of range must be <= end)'
+
+    dt_input._start._process_events({'value': '2018-01-01 00:00:00'})
+    assert dt_input.value == (datetime(2018, 1, 1), datetime(2018, 1, 3))
+    assert label.text == 'Datetime'

--- a/panel/widgets/__init__.py
+++ b/panel/widgets/__init__.py
@@ -21,6 +21,7 @@ from .input import (  # noqa
     Checkbox,
     DatetimeInput,
     DatePicker,
+    DatetimeRangeInput,
     FileInput,
     LiteralInput,
     StaticText,


### PR DESCRIPTION
We didn't have any widget that would let you enter a range of datetimes so this adds a simple composite widget consisting of two `DatetimeInput` widgets:

<img width="280" alt="Screen Shot 2020-11-06 at 1 21 05 PM" src="https://user-images.githubusercontent.com/1550771/98365615-f4a77180-2032-11eb-882f-5e4ed796ad99.png">
