### PR TITLE
Add a throttled argument to depends, interact and bind

### DIFF
--- a/examples/user_guide/Interact.ipynb
+++ b/examples/user_guide/Interact.ipynb
@@ -393,6 +393,25 @@
    "source": [
     "interact(f, x=dict([('one', 10), ('two', 20)]))"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Disabling continuous updates for slider widgets\n",
+    "When interacting with functions which takes a long time to run, realtime feedback can be a burden instead of being helpful.\n",
+    "\n",
+    "If you are using slider widgets and you have a function which takes long time to calculate, you can set the keyword argument `throttled` to `True` in `interact`. This will then first run the function after the release of the mouse button."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "interact(f, x=(0.0, 20.0, None, 5.5), throttled=True)"
+   ]
   }
  ],
  "metadata": {

--- a/panel/depends.py
+++ b/panel/depends.py
@@ -7,12 +7,9 @@ from .widgets import Widget
 ipywidget_classes = {}
 
 
-def param_value_if_widget(arg, throttled=False):
+def param_value_if_widget(arg):
     if isinstance(arg, Widget):
-        if throttled is True and hasattr(arg, 'value_throttled'):
-            return arg.param.value_throttled
-        else:
-            return arg.param.value
+        return arg.param.value
 
     from .pane.ipywidget import IPyWidget
     if IPyWidget.applies(arg) and hasattr(arg, 'value'):
@@ -28,7 +25,7 @@ def param_value_if_widget(arg, throttled=False):
     return arg
 
 
-def depends(*args, throttled=False, **kwargs):
+def depends(*args, **kwargs):
     """
     Python decorator annotating a function or Parameterized method to
     express its dependencies on a set of Parameters. This declaration
@@ -54,13 +51,12 @@ def depends(*args, throttled=False, **kwargs):
     Parameters). See the docs for the corresponding param.depends
     decorator for further details.
     """
-    updated_args = [param_value_if_widget(a, throttled) for a in args]
-    updated_kwargs = {k: param_value_if_widget(v, throttled) for k, v in kwargs.items()}
-
+    updated_args = [param_value_if_widget(a) for a in  args]
+    updated_kwargs = {k: param_value_if_widget(v) for k, v in kwargs.items()}
     return param.depends(*updated_args, **updated_kwargs)
 
 
-def bind(function, *args, throttled=False, **kwargs):
+def bind(function, *args, **kwargs):
     """
     Given a function, returns a wrapper function that binds the values
     of some or all arguments to Parameter values and expresses Param
@@ -96,8 +92,8 @@ def bind(function, *args, throttled=False, **kwargs):
     Returns a new function with the args and kwargs bound to it and
     annotated with all dependencies.
     """
-    updated_args = [param_value_if_widget(a, throttled) for a in args]
-    updated_kwargs = {k: param_value_if_widget(v, throttled) for k, v in kwargs.items()}
+    updated_args = [param_value_if_widget(a) for a in args]
+    updated_kwargs = {k: param_value_if_widget(v) for k, v in kwargs.items()}
     return _param_bind(function, *updated_args, **updated_kwargs)
 
 

--- a/panel/depends.py
+++ b/panel/depends.py
@@ -7,10 +7,9 @@ from .widgets import Widget
 ipywidget_classes = {}
 
 
-def param_value_if_widget(arg, throttled):
+def param_value_if_widget(arg, throttled=False):
     if isinstance(arg, Widget):
         if throttled is True and hasattr(arg, 'value_throttled'):
-            arg.value = arg.value_throttled
             return arg.param.value_throttled
         else:
             return arg.param.value
@@ -61,7 +60,7 @@ def depends(*args, throttled=False, **kwargs):
     return param.depends(*updated_args, **updated_kwargs)
 
 
-def bind(function, *args, **kwargs):
+def bind(function, *args, throttled=False, **kwargs):
     """
     Given a function, returns a wrapper function that binds the values
     of some or all arguments to Parameter values and expresses Param
@@ -97,8 +96,8 @@ def bind(function, *args, **kwargs):
     Returns a new function with the args and kwargs bound to it and
     annotated with all dependencies.
     """
-    updated_args = [param_value_if_widget(a) for a in args]
-    updated_kwargs = {k: param_value_if_widget(v) for k, v in kwargs.items()}
+    updated_args = [param_value_if_widget(a, throttled) for a in args]
+    updated_kwargs = {k: param_value_if_widget(v, throttled) for k, v in kwargs.items()}
     return _param_bind(function, *updated_args, **updated_kwargs)
 
 

--- a/panel/depends.py
+++ b/panel/depends.py
@@ -44,7 +44,7 @@ def depends(*args, throttled=False, **kwargs):
     synonym for the underlying parameter. Apart from that extension,
     this decorator otherwise behaves the same as the underlying Param
     depends decorator.
-
+    
     For the Panel version of the decorator, the specified dependencies
     can either be Parameter instances, Panel or ipywidgets widgets,
     or, if a Parameterized method is supplied rather than a function,
@@ -74,7 +74,7 @@ def bind(function, *args, throttled=False, **kwargs):
     allowing the widget to be passed in as a synonym for the
     underlying parameter. Apart from that extension, this function
     otherwise behaves the same as the corresponding Param function.
-
+    
     This function allows dynamically recomputing the output of the
     provided function whenever one of the bound parameters
     changes. For Panel, the parameters are typically values of
@@ -110,7 +110,7 @@ def _param_bind(function, *args, **kwargs):
     whenever the underlying values change and the output will reflect
     those updated values.
 
-    As for functools.partial, arguments can also be bound to constants,
+    As for functools.partial, arguments can also be bound to constants, 
     which allows all of the arguments to be bound, leaving a simple
     callable object.
 

--- a/panel/interact.py
+++ b/panel/interact.py
@@ -470,8 +470,6 @@ class _InteractFactory(object):
             self = type(self)(self.cls, opts, kw)
 
         f = __interact_f
-        if f is not None and 'throttled' in check_argspec(f).args:
-            raise ValueError('A function cannot have "throttled" as an argument')
 
         if f is None:
             # This branch handles the case 3
@@ -481,6 +479,9 @@ class _InteractFactory(object):
             #
             # Simply return the new factory
             return self
+        elif 'throttled' in check_argspec(f).args:
+            raise ValueError('A function cannot have "throttled" as an argument')
+
 
         # positional arg support in: https://gist.github.com/8851331
         # Handle the cases 1 and 2

--- a/panel/interact.py
+++ b/panel/interact.py
@@ -133,6 +133,7 @@ class interactive(PaneBase):
 
         super(interactive, self).__init__(object, **params)
 
+        self.throttled = kwargs.pop('throttled', False)
         new_kwargs = self.find_abbreviations(kwargs)
         # Before we proceed, let's make sure that the user has passed a set of args+kwargs
         # that will lead to a valid call of the function. This protects against unspecified
@@ -199,7 +200,13 @@ class interactive(PaneBase):
                 self._inner_layout[0] = new_pane
                 self._internal = internal
 
-            pname = 'clicks' if name == 'manual' else 'value'
+            if self.throttled is True and hasattr(widget, 'value_throttled'):
+                widget.value = widget.value_throttled
+                v = 'value_throttled'
+            else:
+                v = 'value'
+
+            pname = 'clicks' if name == 'manual' else v
             watcher = widget.param.watch(update_pane, pname)
             self._callbacks.append(watcher)
 
@@ -463,6 +470,9 @@ class _InteractFactory(object):
             self = type(self)(self.cls, opts, kw)
 
         f = __interact_f
+        if 'throttled' in check_argspec(f).args:
+            raise ValueError('A function cannot have "throttled" as an argument')
+
         if f is None:
             # This branch handles the case 3
             # @interact(a=30, b=40)

--- a/panel/interact.py
+++ b/panel/interact.py
@@ -470,7 +470,7 @@ class _InteractFactory(object):
             self = type(self)(self.cls, opts, kw)
 
         f = __interact_f
-        if 'throttled' in check_argspec(f).args:
+        if f is not None and 'throttled' in check_argspec(f).args:
             raise ValueError('A function cannot have "throttled" as an argument')
 
         if f is None:

--- a/panel/interact.py
+++ b/panel/interact.py
@@ -200,8 +200,7 @@ class interactive(PaneBase):
                 self._inner_layout[0] = new_pane
                 self._internal = internal
 
-            if self.throttled is True and hasattr(widget, 'value_throttled'):
-                widget.value = widget.value_throttled
+            if self.throttled and hasattr(widget, 'value_throttled'):
                 v = 'value_throttled'
             else:
                 v = 'value'
@@ -470,7 +469,6 @@ class _InteractFactory(object):
             self = type(self)(self.cls, opts, kw)
 
         f = __interact_f
-
         if f is None:
             # This branch handles the case 3
             # @interact(a=30, b=40)
@@ -481,7 +479,6 @@ class _InteractFactory(object):
             return self
         elif 'throttled' in check_argspec(f).args:
             raise ValueError('A function cannot have "throttled" as an argument')
-
 
         # positional arg support in: https://gist.github.com/8851331
         # Handle the cases 1 and 2

--- a/panel/tests/test_interact.py
+++ b/panel/tests/test_interact.py
@@ -1,3 +1,5 @@
+from datetime import date
+
 from bokeh.models import Div as BkDiv, Column as BkColumn
 
 from panel.interact import interactive
@@ -232,3 +234,33 @@ def test_interact_replaces_model(document, comm):
 
     interact_pane._cleanup(column)
     assert len(interact_pane._callbacks) == 2
+
+
+def test_interact_throttled():
+    slider_dict = {
+        "DateSlider": dict(start=date(2018, 9, 1), end=date(2018, 9, 10)),
+        "DateRangeSlider": dict(
+            start=date(2018, 9, 1),
+            end=date(2018, 9, 10),
+            value=(date(2018, 9, 2), date(2018, 9, 4)),
+        ),
+        "DiscreteSlider": dict(
+            options=[0.1, 1, 10, 100],
+            value=1,
+        ),
+        "FloatSlider": dict(start=1, end=10, value=5),
+        "IntSlider": dict(start=1, end=10, value=5),
+        "IntRangeSlider": dict(start=1, end=10, value=(2, 5)),
+        "RangeSlider": dict(start=1, end=10, value=(2, 5)),
+    }
+
+    func = lambda x: repr(x)
+    throttled = True
+
+    for slider, kwargs in slider_dict.items():
+        widget = getattr(widgets, slider)(**kwargs)
+        try:
+            interactive(func, x=widget, throttled=throttled)
+            assert True
+        except Exception as e:
+            assert False, e


### PR DESCRIPTION
Supersede #1400 

The goal of this PR is to discuss the option to add a argument to `pn.depends` , `pn.interact` and `pn.bind` which throttles the slider widgets as mention in #1259. 

This is a work in progress and await input from @philippjfr. 

For testing purpose I use this script:
``` python
from datetime import datetime, date

import panel as pn

pn.extension()

slider_dict = {
    "DateSlider": dict(start=date(2018, 9, 1), end=date(2018, 9, 10)),
    "DateRangeSlider": dict(
        start=date(2018, 9, 1),
        end=date(2018, 9, 10),
        value=(date(2018, 9, 2), date(2018, 9, 4)),
    ),
    "DiscreteSlider": dict(
        options=[0.1, 1, 10, 100],
        value=1,
    ),
    "FloatSlider": dict(start=1, end=10, value=5),
    "IntSlider": dict(start=1, end=10, value=5),
    "IntRangeSlider": dict(start=1, end=10, value=(2, 5)),
    "RangeSlider": dict(start=1, end=10, value=(2, 5)),
}

func = lambda x: repr(x)
throttled = True

dashboard = []
for slider, kwargs in slider_dict.items():
    widget = getattr(pn.widgets, slider)(**kwargs)
    bind = pn.bind(func, widget, throttled=throttled)
    depends = pn.depends(widget, throttled=throttled)(func)
    interact = pn.interact(func, x=widget, throttled=throttled)
    slider = pn.Column("## " + slider, widget, bind, depends, interact)
    dashboard.append(slider)

pn.Row(*dashboard).show()
```

Missing tasks:
 - [ ] Discussion if this is the best implementation or the implementation is needed.
 - [ ] Keyword argument to be used to enable value_throttled on sliders, right now it is `throttled`.
 - [ ] Create tests for the chosen implementation.
 - [ ] Update documentation with the new implementation.
 - [ ] Other?