### PR TITLE
Updated environments docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,11 +54,11 @@ jupyter labextension install @pyviz/jupyterlab_pyviz
 
 ## Usage
 
-Panel can be used in a wide range of environments:
+Panel can be used in a wide range of development environments:
 
-### Command line
+### Editor + Server
 
-When working on the command line, just put your Panel code in a simple .py script, mark the objects you want to render as `.servable()`, and launch a server with `panel serve my_script.py --show` to open a browser tab showing your app or dashboard and backed by a live Python process.
+You can edit your Panel code as a .py file in any text editor, marking the objects you want to render as `.servable()`, then launch a server with `panel serve my_script.py --show` to open a browser tab showing your app or dashboard and backed by a live Python process.
 
 ### JupyterLab and Classic notebook
 
@@ -70,13 +70,16 @@ In Google Colaboratory, rendering for each notebook cell is isolated, which mean
 
 ### VSCode
 
-Visual Studio Code (VSCode) versions 2020.4.74986 and later support ipywidgets, and Panel objects can be used as ipywidgets since Panel 0.10 thanks to `jupyter_bokeh`, which means that you can now use Panel components interactively in VSCode.  Ensure you install `jupyter_bokeh` with `pip install jupyter_bokeh` or `conda install -c bokeh jupyter_bokeh` and then enable the extension with `pn.extension(comms='vscode')`.
+Visual Studio Code (VSCode) versions 2020.4.74986 and later support ipywidgets, and Panel objects can be used as ipywidgets since Panel 0.10 thanks to `jupyter_bokeh`, which means that you can now use Panel components interactively in VSCode. Ensure you install `jupyter_bokeh` with `pip install jupyter_bokeh` or `conda install -c bokeh jupyter_bokeh` and then enable the extension with `pn.extension(comms='vscode')`.
 
-### nteract
+### nteract and other ipywidgets notebooks
 
-nteract is another notebook environment which supports rendering ipywidgets, so just like VSCode you can make use of that to get fully interactive Panel output. Install `jupyter_bokeh` and then use `pn.extension(comms='ipywidgets')`.
+In other notebook environments that support rendering ipywidgets interactively, such as nteract, you can use the same underlying ipywidgets support as for vscode: Install `jupyter_bokeh` and then use `pn.extension(comms='ipywidgets')`.
 
-Notebooks created with either `comms='vscode'` or `comms='colab'` will still work outside of those environments, but less efficiently, so it's best to remove those options when sharing such notebooks.
+### Other environments
+
+If your development environment offers embedded Python processes but does not support ipywidgets or Jupyter "comms" (communication channels), you will notice that some or all interactive functionality is missing. Some widgets that operate only in JavaScript will work fine, but others require communication channels between JavaScript and Python. In such cases you can either request ipywidgets or Panel support from the editor or environment, or else use the Editor + Server approach above.
+
 
 ## Sponsors
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -83,7 +83,7 @@ And then you can launch Jupyter to explore them yourself using either Jupyter No
 Usage
 -----
 
-Panel can be used in a wide range of environments:
+Panel can be used in a wide range of development environments:
 
 Editor + Server
 ===============
@@ -103,17 +103,16 @@ In Google Colaboratory, rendering for each notebook cell is isolated, which mean
 VSCode
 ======
 
-Visual Studio Code (VSCode) versions 2020.4.74986 and later support ipywidgets, and Panel objects can be used as ipywidgets since Panel 0.10 thanks to `jupyter_bokeh`, which means that you can now use Panel components interactively in VSCode.  Ensure you install `jupyter_bokeh` with `pip install jupyter_bokeh` or `conda install -c bokeh jupyter_bokeh` and then enable the extension with `pn.extension(comms='vscode')`.
+Visual Studio Code (VSCode) versions 2020.4.74986 and later support ipywidgets, and Panel objects can be used as ipywidgets since Panel 0.10 thanks to `jupyter_bokeh`, which means that you can now use Panel components interactively in VSCode. Ensure you install `jupyter_bokeh` with `pip install jupyter_bokeh` or `conda install -c bokeh jupyter_bokeh` and then enable the extension with `pn.extension(comms='vscode')`.
 
-nteract
-=======
+nteract and other ipywidgets notebooks
+======================================
 
-nteract is another notebook environment which supports rendering ipywidgets, so just like VSCode you can make use of that to get fully interactive Panel output. Install `jupyter_bokeh` and then use `pn.extension(comms='ipywidgets')`.
+In other notebook environments that support rendering ipywidgets interactively, such as nteract, you can use the same underlying ipywidgets support as for vscode: Install `jupyter_bokeh` and then use `pn.extension(comms='ipywidgets')`.
 
 Other environments
 ==================
-
-Panel widgets may also work interactively in other notebook environments or other editors with embedded Python processes, using either `pn.extension()` or `pn.extension(comms='ipywidgets')`. However, if the environment does not support Jupyter "comms" (communication channels) and/or ipywidgets, you will notice that some or all interactive functionality is missing, typically because events in JavaScript have no way to reach Python and vice versa. In such cases you can either request ipywidgets support from the editor or environment, or else use the Editor + Server approach above.
+If your development environment offers embedded Python processes but does not support ipywidgets or Jupyter "comms" (communication channels), you will notice that some or all interactive functionality is missing. Some widgets that operate only in JavaScript will work fine, but others require communication channels between JavaScript and Python. In such cases you can either request ipywidgets or Panel support from the editor or environment, or else use the Editor + Server approach above.
 
 
 Sponsors

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -85,10 +85,10 @@ Usage
 
 Panel can be used in a wide range of environments:
 
-Command line
-============
+Editor + Server
+===============
 
-When working on the command line, just put your Panel code in a simple .py script, mark the objects you want to render as `.servable()`, and launch a server with `panel serve my_script.py --show` to open a browser tab showing your app or dashboard and backed by a live Python process.
+You can edit your Panel code as a .py file in any text editor, marking the objects you want to render as `.servable()`, then launch a server with `panel serve my_script.py --show` to open a browser tab showing your app or dashboard and backed by a live Python process.
 
 JupyterLab and Classic notebook
 ===============================
@@ -110,7 +110,11 @@ nteract
 
 nteract is another notebook environment which supports rendering ipywidgets, so just like VSCode you can make use of that to get fully interactive Panel output. Install `jupyter_bokeh` and then use `pn.extension(comms='ipywidgets')`.
 
-Notebooks created with either `comms='vscode'` or `comms='colab'` will still work outside of those environments, but less efficiently, so it's best to remove those options when sharing such notebooks.
+Other environments
+==================
+
+Panel widgets may also work interactively in other notebook environments or other editors with embedded Python processes, using either `pn.extension()` or `pn.extension(comms='ipywidgets')`. However, if the environment does not support Jupyter "comms" (communication channels) and/or ipywidgets, you will notice that some or all interactive functionality is missing, typically because events in JavaScript have no way to reach Python and vice versa. In such cases you can either request ipywidgets support from the editor or environment, or else use the Editor + Server approach above.
+
 
 Sponsors
 --------


### PR DESCRIPTION
- The "Command line" environment previously listed for Panel actually only covers server usage, so this PR changes it to say "Editor + Server" instead.
- What about exporting static HTML? Seems like that ought to be in the list, but I don't know how to tell Panel users how to do it. I myself only do it using nbconvert, but presumably there's a more direct way not involving Jupyter?
- I also put in a section about what to do if your desired environment is not on this list. That may be too much detail, so please pare it down if you think it should say less.
- Presumably these changes, once finalized, should also be reflected into the readme.