### PR TITLE
Minor widget and indicator fixes

### DIFF
--- a/panel/widgets/indicators.py
+++ b/panel/widgets/indicators.py
@@ -431,7 +431,7 @@ class Dial(ValueIndicator):
         colors = self.colors or []
         for (val, _), (_, clr) in zip(colors[:-1], colors[1:]):
             tangle = start-(distance*val)
-            if (vmin + val * (vmax-vmin)) <= self.value:
+            if (vmin + val * (vmax-vmin)) <= value:
                 continue
             x0, y0 = np.cos(tangle), np.sin(tangle)
             x1, y1 = x0*inner_radius, y0*inner_radius

--- a/panel/widgets/input.py
+++ b/panel/widgets/input.py
@@ -449,6 +449,8 @@ class DatetimeRangeInput(CompositeWidget):
         self._text = StaticText(margin=(5, 0, 0, 0), style={'white-space': 'nowrap'})
         self._start = DatetimeInput(sizing_mode='stretch_width', margin=(5, 0, 0, 0))
         self._end = DatetimeInput(sizing_mode='stretch_width', margin=(5, 0, 0, 0))
+        if 'value' not in params:
+            params['value'] = (params['start'], params['end'])
         super().__init__(**params)
         self._msg = ''
         self._composite.extend([self._text, self._start, self._end])


### PR DESCRIPTION
- Ensures that Dial does not error on None/NaN value
- Ensures that DatetimeRange initializes on start-end range