### PR TITLE
Plotly reactive height

### DIFF
--- a/panel/models/plotly.ts
+++ b/panel/models/plotly.ts
@@ -103,6 +103,12 @@ const filterEventData = (gd: any, eventData: any, event: string) => {
 };
 
 
+const _isHidden = (gd: any) => {
+  var display = window.getComputedStyle(gd).display;
+  return !display || display === 'none';
+};
+
+
 export class PlotlyPlotView extends PanelHTMLBoxView {
   model: PlotlyPlot
   _setViewport: Function
@@ -231,7 +237,8 @@ export class PlotlyPlotView extends PanelHTMLBoxView {
         }
         this._plotInitialized = true;
         this._reacting = false;
-        (window as any).Plotly.Plots.resize(this._layout_wrapper);
+        if(!_isHidden(this._layout_wrapper))
+          (window as any).Plotly.Plots.resize(this._layout_wrapper);
       }
     );
   }


### PR DESCRIPTION
should fix https://github.com/holoviz/panel/issues/1770
Based on @jonmmease comment I wrapped ploty plot inside a div with height and width set to 100%
I had to call PlotlyPlots.resize on the plotly plot creation for the first resize to work
```python
import pandas as pd
import plotly.express as px

data = pd.DataFrame([
    ('Monday', 7), ('Tuesday', 4), ('Wednesday', 9), ('Thursday', 4),
    ('Friday', 4), ('Saturday', 4), ('Sunay', 4)], columns=['Day', 'Orders']
)

fig = px.line(data, x="Day", y="Orders")
fig.update_traces(mode="lines+markers", marker=dict(size=10), line=dict(width=4))
fig.layout.autosize = True

responsive = pn.pane.Plotly(fig, config={'responsive': True})

pn.Column('# A responsive plot', responsive, sizing_mode='stretch_both').show()
```
![plotly_reactive](https://user-images.githubusercontent.com/18531147/99097139-7b31f500-25d7-11eb-8091-f786b3c2a4d8.gif)
![plotly_reactive](https://user-images.githubusercontent.com/18531147/99097515-057a5900-25d8-11eb-92bd-29575b410b51.gif)

