### PR TITLE
Fix location sync

### DIFF
--- a/panel/io/location.py
+++ b/panel/io/location.py
@@ -96,6 +96,8 @@ class Location(Syncable):
                         v = p.param[pname].deserialize(v)
                     except Exception:
                         pass
+                if hasattr(p, '_validate_value'):
+                    v = p._validate_value(v)
                 mapped[pname] = v
             p.param.set_param(**mapped)
 

--- a/panel/widgets/input.py
+++ b/panel/widgets/input.py
@@ -149,11 +149,19 @@ class DatePicker(Widget):
 
     _widget_type = _BkDatePicker
 
+    @staticmethod
+    def _validate_value(x):
+        if isinstance(x, string_types):
+            try:
+                x = datetime.date(datetime.strptime(x, '%Y-%m-%d'))
+            except ValueError:
+                x = None
+        return x
+
     def _process_property_change(self, msg):
         msg = super(DatePicker, self)._process_property_change(msg)
         if 'value' in msg:
-            if isinstance(msg['value'], string_types):
-                msg['value'] = datetime.date(datetime.strptime(msg['value'], '%Y-%m-%d'))
+            msg['value'] = self._validate_value(msg['value'])
         return msg
 
 


### PR DESCRIPTION
This is a fix to the location sync mentioned in #1784. 

I have not done this for any other widgets than `DatePicker`, because I don´t know if there is a smarter way to do it, if there is let me know. Also need to create unit test for it. 

![animated](https://user-images.githubusercontent.com/19758978/99188307-a6dde800-275b-11eb-87ac-e5a5fe6b728d.gif)

