### PR TITLE
Add throttled argument to pn.param widgets parameter

### DIFF
--- a/examples/reference/panes/Param.ipynb
+++ b/examples/reference/panes/Param.ipynb
@@ -47,6 +47,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## Model building\n",
     "Let's build a model of a cycling Athlete and her PowerCurve. \n",
     "\n",
     "The PowerCurve is a recording of her maximum power output in Watt per kg for fixed durations of time."
@@ -326,11 +327,53 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Disabling continuous updates for slider widgets\n",
+    "When a function takes a long time to run and depends on a parameter, realtime feedback can be a burden instead of being helpful.\n",
+    "\n",
+    "Therefore if a slider widget is used for a parameter and you have a function which takes long time to calculate, you can set the `throttled` keyword in the `panel.param.widgets` to `True` for the given parameter. This will then first run the function after the release of the mouse button of the slider.\n",
+    "\n",
+    "An example can be seen below where two parameters is connected to two sliders, one with and one without `throttled` enabled."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "class A(param.Parameterized):\n",
+    "    without_throttled_enabled = param.Range(\n",
+    "        default=(100, 250),\n",
+    "        bounds=(0, 250),\n",
+    "    )\n",
+    "\n",
+    "    with_throttled_enabled = param.Range(\n",
+    "        default=(100, 250),\n",
+    "        bounds=(0, 250),\n",
+    "    )\n",
+    "\n",
+    "    def __init__(self, **params):\n",
+    "        super().__init__(**params)\n",
+    "        widgets = {\n",
+    "            \"without_throttled_enabled\": pn.widgets.IntRangeSlider,\n",
+    "            \"with_throttled_enabled\": {\n",
+    "                \"type\": pn.widgets.IntRangeSlider,\n",
+    "                \"throttled\": True,\n",
+    "            },\n",
+    "        }\n",
+    "        self.controls = pn.Param(self, widgets=widgets)\n",
+    "\n",
+    "    @param.depends(\"controls\")\n",
+    "    def calculation(self):\n",
+    "        return self.without_throttled_enabled, self.with_throttled_enabled\n",
+    "\n",
+    "\n",
+    "a = A()\n",
+    "pn.Column(a.controls, a.calculation)"
+   ]
   }
  ],
  "metadata": {

--- a/panel/param.py
+++ b/panel/param.py
@@ -466,6 +466,8 @@ class Param(PaneBase):
                 return
             else:
                 updates['value'] = change.new
+                if hasattr(widget, 'value_throttled'):
+                    updates['value_throttled'] = change.new
 
             try:
                 self._updating.append(p_name)
@@ -474,7 +476,8 @@ class Param(PaneBase):
                         widget.param.set_param(**updates)
                     widget.param.trigger(*updates)
                 else:
-                    widget.param.set_param(**updates)
+                    with param.edit_constant(widget):
+                        widget.param.set_param(**updates)
             finally:
                 self._updating.remove(p_name)
 

--- a/panel/param.py
+++ b/panel/param.py
@@ -114,10 +114,6 @@ class Param(PaneBase):
         Dictionary of widget overrides, mapping from parameter name
         to widget class.""")
 
-    throttled = param.Boolean(default=False, doc="""
-        If a widget has value_throttled as a param it will only report
-        on mouse up.""")
-
     priority = 0.1
 
     _unpack = True
@@ -420,7 +416,7 @@ class Param(PaneBase):
             def action(change):
                 value(self.object)
             watcher = widget.param.watch(action, 'clicks')
-        elif self.throttled and hasattr(widget, 'value_throttled'):
+        elif kw_widget.get('throttled', False) and hasattr(widget, 'value_throttled'):
             watcher = widget.param.watch(link_widget, 'value_throttled')
         else:
             watcher = widget.param.watch(link_widget, 'value')

--- a/panel/param.py
+++ b/panel/param.py
@@ -114,6 +114,10 @@ class Param(PaneBase):
         Dictionary of widget overrides, mapping from parameter name
         to widget class.""")
 
+    throttled = param.Boolean(default=False, doc="""
+        If a widget has value_throttled as a param it will only report
+        on mouse up.""")
+
     priority = 0.1
 
     _unpack = True
@@ -416,6 +420,8 @@ class Param(PaneBase):
             def action(change):
                 value(self.object)
             watcher = widget.param.watch(action, 'clicks')
+        elif self.throttled and hasattr(widget, 'value_throttled'):
+            watcher = widget.param.watch(link_widget, 'value_throttled')
         else:
             watcher = widget.param.watch(link_widget, 'value')
         watchers.append(watcher)

--- a/panel/param.py
+++ b/panel/param.py
@@ -464,10 +464,10 @@ class Param(PaneBase):
                 idx = self._callbacks.index(prev_watcher)
                 self._callbacks[idx] = watchers[0]
                 return
+            elif kw_widget.get('throttled', False) and hasattr(widget, 'value_throttled'):
+                updates['value_throttled'] = change.new
             else:
                 updates['value'] = change.new
-                if hasattr(widget, 'value_throttled'):
-                    updates['value_throttled'] = change.new
 
             try:
                 self._updating.append(p_name)
@@ -476,8 +476,7 @@ class Param(PaneBase):
                         widget.param.set_param(**updates)
                     widget.param.trigger(*updates)
                 else:
-                    with param.edit_constant(widget):
-                        widget.param.set_param(**updates)
+                    widget.param.set_param(**updates)
             finally:
                 self._updating.remove(p_name)
 

--- a/panel/tests/test_param.py
+++ b/panel/tests/test_param.py
@@ -626,6 +626,44 @@ def test_set_widgets(document, comm):
     assert number.height == 100
     assert isinstance(text, TextInput)
 
+
+def test_set_widgets_throttled(document, comm):
+    class Test(param.Parameterized):
+        a = param.Number(default=0, bounds=(0, 10), precedence=1)
+
+    test = Test()
+    pane = Param(test)
+
+    model = pane.get_root(document, comm=comm)
+
+    pane.widgets = {"a": {"throttled": False}}
+    assert len(model.children) == 2
+    _, number = model.children
+
+    number.value = 1
+    assert number.value == 1
+    # assert number.value_throttled == 1  # Should this work?
+    assert test.a == 1
+
+    test.a = 2
+    assert number.value == 2
+    assert number.value_throttled == 2
+    assert test.a == 2
+
+    pane.widgets = {"a": {"throttled": True}}
+    _, number = model.children
+
+    number.value_throttled = 3
+    # assert number.value == 3  # Should this work?
+    assert number.value_throttled == 3
+    assert test.a == 3
+
+    test.a = 4
+    assert number.value == 4
+    assert number.value_throttled == 4
+    assert test.a == 4
+
+
 def test_set_show_name(document, comm):
     class Test(param.Parameterized):
         a = param.Number(bounds=(0, 10))

--- a/panel/tests/test_param.py
+++ b/panel/tests/test_param.py
@@ -633,7 +633,6 @@ def test_set_widgets_throttled(document, comm):
 
     test = Test()
     pane = Param(test)
-
     model = pane.get_root(document, comm=comm)
 
     pane.widgets = {"a": {"throttled": False}}
@@ -642,24 +641,28 @@ def test_set_widgets_throttled(document, comm):
 
     number.value = 1
     assert number.value == 1
-    # assert number.value_throttled == 1  # Should this work?
+    assert number.value_throttled != 1
     assert test.a == 1
 
     test.a = 2
     assert number.value == 2
-    assert number.value_throttled == 2
+    assert number.value_throttled != 2
     assert test.a == 2
 
+    # By setting throttled to true,
+    # `test.a` is linked to `number.value_throttled`
+    # instead of `number.value`.
     pane.widgets = {"a": {"throttled": True}}
+    assert len(model.children) == 2
     _, number = model.children
 
     number.value_throttled = 3
-    # assert number.value == 3  # Should this work?
+    assert number.value != 3
     assert number.value_throttled == 3
     assert test.a == 3
 
     test.a = 4
-    assert number.value == 4
+    assert number.value != 4
     assert number.value_throttled == 4
     assert test.a == 4
 


### PR DESCRIPTION
The reason for this PR it is hard to incorporate `value_throttled` for sliders into a parametrized class. 
This will add the possibility to add a `throttled` argument to pn.param `widgets` argument. So the following is possible:

``` python
import param
import panel as pn


class A(param.Parameterized):
    value_ = param.Range(
        default=(100, 250),
        bounds=(0, 250),
    )
    
    value_throttled_ = param.Range(
        default=(100, 250),
        bounds=(0, 250),
    )
  
    def __init__(self, **params):
        super().__init__(**params)
        widgets = {
            "value_": pn.widgets.IntRangeSlider,
            "value_throttled_": {
                "type": pn.widgets.IntRangeSlider,
                "throttled": True
            },
        }
        self.controls = pn.Param(self, widgets=widgets)

    @param.depends("controls")
    def calculation(self):
        return self.value_, self.value_throttled_


a = A()
pn.Column(a.controls, a.calculation)
```

![screen](https://user-images.githubusercontent.com/19758978/100267990-a52ed400-2f54-11eb-99a4-b3ce2bdcd48f.gif)

To get this to work I'm changing the param object from linking with `value` to linking with `value_throttled` of the slider and vice versa. This is only done if `throttled` is enabled and the widget contains the attribute `value_throttled`. 

This is the reason why the unit test without `throttled` enabled is on `value` and with `throttled` enabled is on `value_throttled`.

I hope that the configuration of `throttled` is done as mentioned [here](https://github.com/holoviz/panel/pull/1754#issuecomment-729053796). 

If there is a better way to implement this, this PR can be closed. 

TODO:
- [ ] I need some guidance if I need to add more to the unit test. 
- [x] Add some documentation for this feature. I think it properly should be located [here](https://panel.holoviz.org/reference/panes/Param.html#panes-gallery-param).