### PR TITLE
Fixing enabling and disabling FileDownload

### DIFF
--- a/panel/models/file_download.ts
+++ b/panel/models/file_download.ts
@@ -1,6 +1,7 @@
 import {InputWidget, InputWidgetView} from "@bokehjs/models/widgets/input_widget"
 
 import {bk_btn, bk_btn_type} from "@bokehjs/styles/buttons"
+import {input} from "@bokehjs/core/dom"
 
 import {ButtonType} from "@bokehjs/core/enums"
 import * as p from "@bokehjs/core/properties"
@@ -34,6 +35,8 @@ export class FileDownloadView extends InputWidgetView {
   _prev_href: string | null = ""
   _prev_download: string | null = ""
 
+  protected input_el: HTMLInputElement
+
   initialize(): void {
     super.initialize()
     if ( this.model.data && this.model.filename ) {
@@ -47,6 +50,7 @@ export class FileDownloadView extends InputWidgetView {
     this.connect(this.model.properties.filename.change, () => this._update_download())
     this.connect(this.model.properties._transfers.change, () => this._handle_click())
     this.connect(this.model.properties.label.change, () => this._update_label())
+    this.connect(this.model.properties.disabled.change, () => this.set_disabled())
   }
 
   render(): void {
@@ -96,6 +100,12 @@ export class FileDownloadView extends InputWidgetView {
       this.anchor_el.addEventListener("click", this._click_listener)
     }
     this.group_el.appendChild(this.anchor_el)
+
+    this.input_el = input({
+      type: "bk_btn, bk_btn_type",
+      disabled: this.model.disabled,
+    })
+    this.input_el.addEventListener("change", () => this.change_input())
   }
 
   _increment_clicks() : void {
@@ -164,6 +174,14 @@ export class FileDownloadView extends InputWidgetView {
       if ( prev_button_type ) {
         this.anchor_el.classList.replace(prev_button_type, bk_btn_type(this.model.button_type))
       }
+    }
+  }
+
+  set_disabled(): void {
+    if (this.model.disabled){
+      this.anchor_el.setAttribute("disabled", "")
+    } else {
+      this.anchor_el.removeAttribute("disabled")
     }
   }
 }

--- a/panel/models/file_download.ts
+++ b/panel/models/file_download.ts
@@ -101,9 +101,12 @@ export class FileDownloadView extends InputWidgetView {
     }
     this.group_el.appendChild(this.anchor_el)
 
+    // If this is not added it will give the following error
+    // "Uncaught TypeError: t is undefined"
+    // This seems to be related to button do not have a value
+    // property.
     this.input_el = input({
       type: "bk_btn, bk_btn_type",
-      disabled: this.model.disabled,
     })
     this.input_el.addEventListener("change", () => this.change_input())
   }


### PR DESCRIPTION
Fixes #1510 and #1820

There seems to have been two problems: The first problem is that Button do not have a `value` property and therefore give the `"Uncaught TypeError: t is undefined"` as mentioned in #1510 and [here](https://github.com/bokeh/bokeh/issues/10345#issuecomment-664407341). 
The second problem was that the change in `disabled` was not connected to the anchor element. 

This is my first time trying to write code in TypeScript, so I think it would be very good if someone with more experience in TypeScript can take a look at it and test that I haven't done something wrong or if there is something which can be done better.

An example of the fix in action can be seen below:

``` python
from io import StringIO

import param
import panel as pn


class Download(param.Parameterized):
    enable = param.Action(lambda self: self._enable())
    disable = param.Action(lambda self: self._disable())

    def __init__(self, **params):
        super(Download, self).__init__(**params)
        self.fd = pn.widgets.FileDownload(callback=self.cb, filename='data.txt')
        self.fd.disabled = True

    def cb(self):
        return StringIO('foobar')

    def panel(self):
        return pn.Column(self.fd, *pn.Param(self.param, show_name=False))

    def _enable(self):
        self.fd.disabled = False

    def _disable(self):
        self.fd.disabled = True


dl = Download()
dl.panel().servable()
```
![ezgif-7-a036f5dfebd8](https://user-images.githubusercontent.com/19758978/101987062-14fdc800-3c92-11eb-8c51-ad641d84d29f.gif)
