### PR TITLE
Fix numeric widget

### DIFF
--- a/panel/param.py
+++ b/panel/param.py
@@ -359,7 +359,7 @@ class Param(PaneBase):
         kw = dict(disabled=p_obj.constant, name=label)
 
         value = getattr(self.object, p_name)
-        if value is not None:
+        if value is not None or getattr(p_obj, 'allow_None', False):
             kw['value'] = value
 
         # Update kwargs

--- a/panel/tests/widgets/test_input.py
+++ b/panel/tests/widgets/test_input.py
@@ -3,6 +3,8 @@ from __future__ import absolute_import, division, unicode_literals
 import pytest
 from datetime import datetime, date
 
+import param
+import panel as pn
 from bokeh.models.widgets import FileInput as BkFileInput
 from panel.widgets import (
     Checkbox, DatePicker, DatetimeInput, DatetimeRangeInput, FileInput,
@@ -204,3 +206,13 @@ def test_datetime_range_input(document, comm):
     dt_input._start._process_events({'value': '2018-01-01 00:00:00'})
     assert dt_input.value == (datetime(2018, 1, 1), datetime(2018, 1, 3))
     assert label.text == 'Datetime'
+
+
+def test_number_input():
+    class Test(param.Parameterized) :
+        number = param.Number(default=0, allow_None=True)
+        none = param.Number(default=None, allow_None=True)
+
+    test_widget = pn.panel(Test())
+    assert test_widget[1].value == 0
+    assert test_widget[2].value is None

--- a/panel/widgets/input.py
+++ b/panel/widgets/input.py
@@ -234,7 +234,7 @@ class _SpinnerBase(_NumericInputBase):
     __abstract = True
 
     def __init__(self, **params):
-        if params.get('value') is None:
+        if 'value' not in params:
             value = params.get('start', self.value)
             if value is not None:
                 params['value'] = value

--- a/panel/widgets/input.py
+++ b/panel/widgets/input.py
@@ -507,6 +507,11 @@ class Checkbox(Widget):
 
     _widget_type = _BkCheckboxGroup
 
+    def __init__(self, **params):
+        if params.get('value') is None:
+            params['value'] = False
+        super().__init__(**params)
+
     def _process_property_change(self, msg):
         msg = super(Checkbox, self)._process_property_change(msg)
         if 'value' in msg:

--- a/panel/widgets/input.py
+++ b/panel/widgets/input.py
@@ -507,11 +507,6 @@ class Checkbox(Widget):
 
     _widget_type = _BkCheckboxGroup
 
-    def __init__(self, **params):
-        if params.get('value') is None:
-            params['value'] = False
-        super().__init__(**params)
-
     def _process_property_change(self, msg):
         msg = super(Checkbox, self)._process_property_change(msg)
         if 'value' in msg:

--- a/panel/widgets/slider.py
+++ b/panel/widgets/slider.py
@@ -67,7 +67,7 @@ class ContinuousSlider(_SliderBase):
     __abstract = True
 
     def __init__(self, **params):
-        if 'value' not in params:
+        if params.get('value') is None:
             params['value'] = params.get('start', self.start)
         super(ContinuousSlider, self).__init__(**params)
 

--- a/panel/widgets/slider.py
+++ b/panel/widgets/slider.py
@@ -67,7 +67,7 @@ class ContinuousSlider(_SliderBase):
     __abstract = True
 
     def __init__(self, **params):
-        if params.get('value') is None:
+        if 'value' not in params:
             params['value'] = params.get('start', self.start)
         super(ContinuousSlider, self).__init__(**params)
 
@@ -112,7 +112,7 @@ class FloatSlider(ContinuousSlider):
 
     end = param.Number(default=1.0)
 
-    value = param.Number(default=0.0)
+    value = param.Number(default=0.0, allow_None=True)
 
     value_throttled = param.Number(default=None, constant=True)
 
@@ -121,7 +121,7 @@ class FloatSlider(ContinuousSlider):
 
 class IntSlider(ContinuousSlider):
 
-    value = param.Integer(default=0)
+    value = param.Integer(default=0, allow_None=True)
 
     value_throttled = param.Integer(default=None, constant=True)
 

--- a/panel/widgets/tables.py
+++ b/panel/widgets/tables.py
@@ -633,7 +633,7 @@ class DataFrame(BaseTable):
     hierarchical = param.Boolean(default=False, constant=True, doc="""
         Whether to generate a hierachical index.""")
 
-    fit_columns = param.Boolean(default=None, doc="""
+    fit_columns = param.Boolean(default=True, doc="""
         Whether columns should expand to the available width. This
         results in no horizontal scrollbar showing up, but data can
         get unreadable if there is no enough space available.""")


### PR DESCRIPTION
Fixes #1836

 I'm a bit uncertain if the change in `panel/param.py` is okay, since I don't know if every widgets accepts None as a value. If there is a better way to implement this, this PR can be closed.

Example of fix:
``` python
import param
import panel as pn


class Test(param.Parameterized) :
    number = param.Number(default=0, allow_None=True)
    none = param.Number(default=None, allow_None=True)

    def view(self):
        return self.number, self.none


t = Test()
pn.Column(t, t.view).servable()
```
![2020-12-14 16_59_35](https://user-images.githubusercontent.com/19758978/102105498-c84ff380-3e2f-11eb-8c6c-44dceb7eba4c.png)
