### PR TITLE
Avoid recursive preprocessing

### DIFF
--- a/panel/layout/base.py
+++ b/panel/layout/base.py
@@ -75,7 +75,7 @@ class Panel(Reactive):
                 if ref in state._views:
                     state._views[ref][0]._preprocess(root)
             finally:
-                Panel._batch_update = False
+                Panel._batch_update = update
 
     #----------------------------------------------------------------
     # Model API

--- a/panel/layout/grid.py
+++ b/panel/layout/grid.py
@@ -155,10 +155,17 @@ class GridBox(ListPanel):
 
         with hold(doc):
             msg = {k: v for k, v in msg.items() if k not in ('nrows', 'ncols')}
-            super(Panel, self)._update_model(events, msg, root, model, doc, comm)
-            ref = root.ref['id']
-            if ref in state._views:
-                state._views[ref][0]._preprocess(root)
+            update = Panel._batch_update
+            Panel._batch_update = True
+            try:
+                super(Panel, self)._update_model(events, msg, root, model, doc, comm)
+                if update:
+                    return
+                ref = root.ref['id']
+                if ref in state._views:
+                    state._views[ref][0]._preprocess(root)
+            finally:
+                Panel._batch_update = True
 
 
 class GridSpec(Panel):

--- a/panel/layout/grid.py
+++ b/panel/layout/grid.py
@@ -165,7 +165,7 @@ class GridBox(ListPanel):
                 if ref in state._views:
                     state._views[ref][0]._preprocess(root)
             finally:
-                Panel._batch_update = True
+                Panel._batch_update = update
 
 
 class GridSpec(Panel):


### PR DESCRIPTION
Preprocessors in certain cases can trigger further events which lead to additional preprocessors being called. Since preprocessing happens at the root-level we can simply skip preprocessing until the layout that originally triggered the model update is done updating, ensuring that preprocessing is only run once.