### PR TITLE
Bug fix: make max as upper bound for value

### DIFF
--- a/panel/widgets/indicators.py
+++ b/panel/widgets/indicators.py
@@ -127,6 +127,10 @@ class Progress(ValueIndicator):
     @param.depends('max', watch=True)
     def _update_value_bounds(self):
         self.param.value.bounds = (0, self.max)
+               
+    def __init__(self,**params):
+        super().__init__(**params)
+        self._update_value_bounds()
 
 
 class Number(ValueIndicator):

--- a/panel/widgets/indicators.py
+++ b/panel/widgets/indicators.py
@@ -115,7 +115,7 @@ class Progress(ValueIndicator):
 
     max = param.Integer(default=100, doc="The maximum value of the progress bar.")
 
-    value = param.Integer(default=None, bounds=(0, 100), doc="""
+    value = param.Integer(default=None, bounds=(0, None), doc="""
         The current value of the progress bar. If set to None the progress
         bar will be indeterminate and animate depending on the active
         parameter.""")


### PR DESCRIPTION
Currently defining `max` when creating the instance does not change the upper `value` bound. Which leads to a ValueError.
Simply calling the method `_update_value_bounds` in `__init__` fixes the problem.