### PR TITLE
fix local bundled paths for template resources

### DIFF
--- a/panel/template/base.py
+++ b/panel/template/base.py
@@ -449,7 +449,7 @@ class BasicTemplate(BaseTemplate):
         name = type(self).__name__.lower()
         resources = _settings.resources(default="server")
         if resources == 'server':
-            dist_path = urljoin(state.base_url, LOCAL_DIST)
+            dist_path = urljoin(state.app_url, LOCAL_DIST)
         else:
             dist_path = CDN_DIST
 

--- a/panel/template/base.py
+++ b/panel/template/base.py
@@ -448,8 +448,9 @@ class BasicTemplate(BaseTemplate):
     def _template_resources(self):
         name = type(self).__name__.lower()
         resources = _settings.resources(default="server")
+        base_url = state.base_url[1:] if state.base_url.startswith('/') else state.base_url        
         if resources == 'server':
-            dist_path = urljoin(state.app_url, LOCAL_DIST)
+            dist_path = urljoin(base_url, LOCAL_DIST)
         else:
             dist_path = CDN_DIST
 

--- a/panel/util.py
+++ b/panel/util.py
@@ -342,7 +342,7 @@ def bundled_files(model, file_type='javascript'):
         filepath = url_path(url)
         test_filepath = filepath.split('?')[0]
         if resources == 'server' and os.path.isfile(os.path.join(bdir, test_filepath)):
-            files.append(f'/static/extensions/panel/bundled/{name}/{filepath}')
+            files.append(f'static/extensions/panel/bundled/{name}/{filepath}')
         else:
             files.append(url)
     return files


### PR DESCRIPTION
While #1821  was partially resolved thanks to #1830 , the template resources were still not loading due to the same path issues. This PR aims to resolve those. Testing in a jupyter_server_proxy env and jupyterlab without proxy seems to work for the changes proposed. 

This allows the following example to work:

```python
import panel as pn
import numpy as np
import holoviews as hv

pn.extension()
react = pn.template.ReactTemplate(title='React Template')

pn.config.sizing_mode = 'stretch_both'

xs = np.linspace(0, np.pi)
freq = pn.widgets.FloatSlider(name="Frequency", start=0, end=10, value=2)
phase = pn.widgets.FloatSlider(name="Phase", start=0, end=np.pi)

@pn.depends(freq=freq, phase=phase)
def sine(freq, phase):
    return hv.Curve((xs, np.sin(xs*freq+phase))).opts(
        responsive=True, min_height=400)

@pn.depends(freq=freq, phase=phase)
def cosine(freq, phase):
    return hv.Curve((xs, np.cos(xs*freq+phase))).opts(
        responsive=True, min_height=400)

react.sidebar.append(freq)
react.sidebar.append(phase)

# Unlike other templates the `ReactTemplate.main` area acts like a GridSpec 
react.main[:4, :6] = pn.Card(hv.DynamicMap(sine), title='Sine')
react.main[:4, 6:] = pn.Card(hv.DynamicMap(cosine), title='Cosine')

react.show(port=5000) # go to localhost:5000
# OR
react.show(websocket_origin="localhost:8888", port=5000) # and then go to localhost:8888/proxy/5000/
```
cc @philippjfr 