### PR TITLE
Distinguish between session creation and execution in session info

### DIFF
--- a/panel/io/server.py
+++ b/panel/io/server.py
@@ -65,7 +65,9 @@ def init_doc(doc):
     if session_id not in sessions:
         return doc
 
-    sessions[session_id].update({'started': dt.datetime.now().timestamp()})
+    sessions[session_id].update({
+        'started': dt.datetime.now().timestamp()
+    })
     doc.on_event('document_ready', state._init_session)
     return doc
 
@@ -149,7 +151,7 @@ def _initialize_session_info(session_context):
         'started': None,
         'rendered': None,
         'ended': None,
-        'user_agent': None
+        'user_agent': session_context.request.headers.get('User-Agent')
     }
 
 state.on_session_created(_initialize_session_info)

--- a/panel/io/server.py
+++ b/panel/io/server.py
@@ -338,7 +338,7 @@ def get_server(panel, port=0, address=None, websocket_origin=None,
                verbose=False, location=True, static_dirs={},
                oauth_provider=None, oauth_key=None, oauth_secret=None,
                oauth_extra_params={}, cookie_secret=None,
-               oauth_encryption_key=None, session_history=0, **kwargs):
+               oauth_encryption_key=None, session_history=None, **kwargs):
     """
     Returns a Server instance with this panel attached as the root
     app.
@@ -389,6 +389,11 @@ def get_server(panel, port=0, address=None, websocket_origin=None,
     oauth_encryption_key: str (optional, default=False)
       A random encryption key used for encrypting OAuth user
       information and access tokens.
+    session_history: int (optional, default=None)
+      The amount of session history to accumulate. If set to non-zero
+      and non-None value will launch a REST endpoint at
+      /rest/session_info, which returns information about the session
+      history.
     kwargs: dict
       Additional keyword arguments to pass to Server instance.
 

--- a/panel/io/server.py
+++ b/panel/io/server.py
@@ -66,7 +66,7 @@ def init_doc(doc):
     if session_id not in sessions:
         return doc
 
-    sessions[session_id].update({'executed': dt.datetime.now().timestamp()})
+    sessions[session_id].update({'started': dt.datetime.now().timestamp()})
     doc.on_event('document_ready', state._init_session)
     return doc
 
@@ -146,8 +146,8 @@ def _initialize_session_info(session_context):
         sessions = OrderedDict(old_history[-(config.session_history-1):])
         state.session_info['sessions'] = sessions
     sessions[session_id] = {
-        'started': dt.datetime.now().timestamp(),
-        'executed': None,
+        'launched': dt.datetime.now().timestamp(),
+        'started': None,
         'rendered': None,
         'ended': None,
         'user_agent': None

--- a/panel/io/server.py
+++ b/panel/io/server.py
@@ -60,7 +60,6 @@ def init_doc(doc):
     if not doc.session_context:
         return doc
 
-    from ..config import config
     session_id = doc.session_context.id
     sessions = state.session_info['sessions']
     if session_id not in sessions:

--- a/panel/io/server.py
+++ b/panel/io/server.py
@@ -17,7 +17,11 @@ from functools import partial, wraps
 from types import FunctionType, MethodType
 
 import param
+import bokeh
+import bokeh.command.util
 
+from bokeh.application import Application as BkApplication
+from bokeh.application.handlers.function import FunctionHandler
 from bokeh.document.events import ModelChangedEvent
 from bokeh.embed.bundle import extension_dirs
 from bokeh.io import curdoc
@@ -56,23 +60,6 @@ def init_doc(doc):
     if not doc.session_context:
         return doc
 
-    from ..config import config
-    session_id = doc.session_context.id
-    sessions = state.session_info['sessions']
-    if config.session_history == 0 or session_id in sessions:
-        return doc
-
-    state.session_info['total'] += 1
-    if config.session_history > 0 and len(sessions) >= config.session_history:
-        old_history = list(sessions.items())
-        sessions = OrderedDict(old_history[-(config.session_history-1):])
-        state.session_info['sessions'] = sessions
-    sessions[session_id] = {
-        'started': dt.datetime.now().timestamp(),
-        'rendered': None,
-        'ended': None,
-        'user_agent': state.headers.get('User-Agent')
-    }
     doc.on_event('document_ready', state._init_session)
     return doc
 
@@ -128,6 +115,37 @@ def async_execute(func):
 
 param.parameterized.async_executor = async_execute
 
+
+class Application(BkApplication):
+
+    async def on_session_created(self, session_context):
+        for cb in state._on_session_created:
+            cb(session_context)
+        await super().on_session_created(session_context)
+
+bokeh.command.util.Application = Application
+
+
+def _initialize_session_info(session_context):
+    from ..config import config
+    session_id = session_context.id
+    sessions = state.session_info['sessions']
+    if config.session_history == 0 or session_id in sessions:
+        return
+
+    state.session_info['total'] += 1
+    if config.session_history > 0 and len(sessions) >= config.session_history:
+        old_history = list(sessions.items())
+        sessions = OrderedDict(old_history[-(config.session_history-1):])
+        state.session_info['sessions'] = sessions
+    sessions[session_id] = {
+        'started': dt.datetime.now().timestamp(),
+        'rendered': None,
+        'ended': None,
+        'user_agent': None
+    }
+
+state.on_session_created(_initialize_session_info)
 
 #---------------------------------------------------------------------
 # Public API
@@ -312,7 +330,7 @@ def get_server(panel, port=0, address=None, websocket_origin=None,
                verbose=False, location=True, static_dirs={},
                oauth_provider=None, oauth_key=None, oauth_secret=None,
                oauth_extra_params={}, cookie_secret=None,
-               oauth_encryption_key=None, **kwargs):
+               oauth_encryption_key=None, session_history=0, **kwargs):
     """
     Returns a Server instance with this panel attached as the root
     app.
@@ -371,6 +389,9 @@ def get_server(panel, port=0, address=None, websocket_origin=None,
     server : bokeh.server.server.Server
       Bokeh Server instance running this panel
     """
+    from ..config import config
+    from .rest import REST_PROVIDERS
+
     server_id = kwargs.pop('server_id', uuid.uuid4().hex)
     kwargs['extra_patterns'] = extra_patterns = kwargs.get('extra_patterns', [])
     if isinstance(panel, dict):
@@ -398,11 +419,18 @@ def get_server(panel, port=0, address=None, websocket_origin=None,
                     extra_patterns.append(('^'+slug+'.*', ProxyFallbackHandler,
                                            dict(fallback=wsgi, proxy=slug)))
                     continue
-            apps[slug] = partial(_eval_panel, app, server_id, title_, location)
+            apps[slug] = Application(FunctionHandler(partial(_eval_panel, app, server_id, title_, location)))
     else:
-        apps = {'/': partial(_eval_panel, panel, server_id, title, location)}
+        apps = {'/': Application(FunctionHandler(partial(_eval_panel, panel, server_id, title, location)))}
 
     extra_patterns += get_static_routes(static_dirs)
+
+    if session_history is not None:
+        config.session_history = session_history
+    if config.session_history != 0:
+        pattern = REST_PROVIDERS['param']([], 'rest')
+        extra_patterns.extend(pattern)
+        state.publish('session_info', state, ['session_info'])
 
     opts = dict(kwargs)
     if loop:

--- a/panel/io/server.py
+++ b/panel/io/server.py
@@ -60,6 +60,13 @@ def init_doc(doc):
     if not doc.session_context:
         return doc
 
+    from ..config import config
+    session_id = doc.session_context.id
+    sessions = state.session_info['sessions']
+    if session_id not in sessions:
+        return doc
+
+    sessions[session_id].update({'executed': dt.datetime.now().timestamp()})
     doc.on_event('document_ready', state._init_session)
     return doc
 
@@ -140,6 +147,7 @@ def _initialize_session_info(session_context):
         state.session_info['sessions'] = sessions
     sessions[session_id] = {
         'started': dt.datetime.now().timestamp(),
+        'executed': None,
         'rendered': None,
         'ended': None,
         'user_agent': None

--- a/panel/io/state.py
+++ b/panel/io/state.py
@@ -79,6 +79,7 @@ class _state(param.Parameterized):
 
     # Dictionary of callbacks to be triggered on app load
     _onload = WeakKeyDictionary()
+    _on_session_created = []
 
     # Stores a set of locked Websockets, reset after every change event
     _locks = WeakSet()
@@ -113,10 +114,13 @@ class _state(param.Parameterized):
         if not self.curdoc.session_context:
             return
         session_id = self.curdoc.session_context.id
+        session_info = self.session_info['sessions'].get(session_id, {})
+        if session_info.get('rendered') is not None:
+            return
         self.session_info['live'] += 1
-        session_info = self.session_info['sessions'][session_id]
         session_info.update({
             'rendered': dt.datetime.now().timestamp(),
+            'user_agent': state.headers.get('User-Agent')
         })
 
     def _get_callback(self, endpoint):
@@ -235,6 +239,12 @@ class _state(param.Parameterized):
             self._onload[self.curdoc] = []
             self.curdoc.on_event('document_ready', self._on_load)
         self._onload[self.curdoc].append(callback)
+
+    def on_session_created(self, callback):
+        """
+        Callback that is triggered when a session is created.
+        """
+        self._on_session_created.append(callback)
 
     def publish(self, endpoint, parameterized, parameters=None):
         """

--- a/panel/io/state.py
+++ b/panel/io/state.py
@@ -119,8 +119,7 @@ class _state(param.Parameterized):
             return
         self.session_info['live'] += 1
         session_info.update({
-            'rendered': dt.datetime.now().timestamp(),
-            'user_agent': state.headers.get('User-Agent')
+            'rendered': dt.datetime.now().timestamp()
         })
 
     def _get_callback(self, endpoint):


### PR DESCRIPTION
Panel has supported recording information about user sessions for a while. In doing so it recorded three events, 'started', 'rendered' and 'ended'. However the 'started' event was really recording the time after the session had already been created and fully initialized. This adds a fourth key called `'launched'`, which records when the initial request arrives but before the dashboard script has been executed.

This means that we can separately compute execution time (server-side) and time to render since initial request (client-side).