### PR TITLE
Fix MenuButton in split mode

### DIFF
--- a/panel/widgets/button.py
+++ b/panel/widgets/button.py
@@ -12,6 +12,8 @@ from bokeh.models import (
     Button as _BkButton, Toggle as _BkToggle, Dropdown as _BkDropdown
 )
 
+from bokeh.events import (MenuItemClick, ButtonClick)
+
 from .base import Widget
 
 
@@ -153,6 +155,11 @@ class MenuButton(_ClickButton):
         self.param.watch(callback, 'clicked', onlychanged=False)
 
     def _server_click(self, doc, ref, event):
+        if isinstance(event, MenuItemClick):
+            self._events.update({"clicked": event.item})
+        elif isinstance(event, ButtonClick):
+            self._events.update({"clicked": self.name})
+            
         self._events.update({"clicked": event.item})
         if not self._processing:
             self._processing = True

--- a/panel/widgets/button.py
+++ b/panel/widgets/button.py
@@ -159,8 +159,7 @@ class MenuButton(_ClickButton):
             self._events.update({"clicked": event.item})
         elif isinstance(event, ButtonClick):
             self._events.update({"clicked": self.name})
-            
-        self._events.update({"clicked": event.item})
+
         if not self._processing:
             self._processing = True
             if doc.session_context:


### PR DESCRIPTION
When the MenuButton is in split mode and the Button is pressed (not a menu item) the 'event.item' property does not exist in bokeh.event.ButtonClick. I propose to split with a check if it is MenuItemClick, and output as default, or ButtonClick, and output the button name, on 'clicked' parameter