### PR TITLE
Add docs for recent widget changes

### DIFF
--- a/examples/reference/widgets/FileInput.ipynb
+++ b/examples/reference/widgets/FileInput.ipynb
@@ -14,7 +14,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The ``FileInput`` widget allows uploading a file from the frontend and makes the file data and MIME type available in Python.\n",
+    "The ``FileInput`` widget allows uploading one or more file from the frontend and makes the filename, file data and MIME type available in Python.\n",
     "\n",
     "For more information about listening to widget events and laying out widgets refer to the [widgets user guide](../../user_guide/Widgets.ipynb). Alternatively you can learn how to build GUIs by declaring parameters independently of any specific widgets in the [param user guide](../../user_guide/Param.ipynb). To express interactivity entirely using Javascript without the need for a Python server take a look at the [links user guide](../../user_guide/Param.ipynb).\n",
     "\n",
@@ -25,9 +25,10 @@
     "##### Core\n",
     "\n",
     "* **``accept``** (str):  A list of file input filters that restrict what files the user can pick from\n",
-    "* **``filename``** (str): The filename of the uploaded file\n",
-    "* **``mime_type``** (str): The mime type of the uploaded file\n",
-    "* **``value``** (bytes): A bytes object containing the file data\n",
+    "* **``filename``** (str/list): The filename(s) of the uploaded file(s)\n",
+    "* **``mime_type``** (str/list): The mime type(s) of the uploaded file(s)\n",
+    "* **``multiple``** (boolean): Whether to allow uploading multiple files\n",
+    "* **``value``** (bytes/list): A bytes object containing the file data or if `multiple` is set a list of bytes types.\n",
     "\n",
     "___"
    ]
@@ -99,6 +100,31 @@
     "file_input = pn.widgets.FileInput(accept='.csv,.json')\n",
     "\n",
     "file_input"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To allow uploading multiple files we can also set `multiple=True`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "file_input = pn.widgets.FileInput(accept='.png', multiple=True)\n",
+    "\n",
+    "file_input"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "When uploading one or more files the `filename`, `mime_type` and `value` parameters will now be lists. "
    ]
   },
   {

--- a/examples/reference/widgets/MenuButton.ipynb
+++ b/examples/reference/widgets/MenuButton.ipynb
@@ -132,6 +132,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "If the button itself is clicked in `split` mode, the `clicked` property will report the value of the `name` parameter, i.e. in this case clicking it will set the `clicked` parameter to `'Split Menu'`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### Controls\n",
     "\n",
     "The `MenuButton` widget exposes a number of options which can be changed from both Python and Javascript. Try out the effect of these parameters interactively:"

--- a/panel/widgets/input.py
+++ b/panel/widgets/input.py
@@ -65,9 +65,9 @@ class FileInput(Widget):
                                is_instance=True)
 
     multiple = param.Boolean(default=False)
-    
+
     value = param.Parameter(default=None)
-    
+
     _widget_type = _BkFileInput
 
     _source_transforms = {'value': "'data:' + source.mime_type + ';base64,' + value"}


### PR DESCRIPTION
Updates `FileInput` docs to explain `multiple` parameter (added in #1911) and the behavior when clicking the button on a `MenuButton` in `split` mode (fixed in #1915).