### PR TITLE
Correctly set up preprocessor on Template root

### DIFF
--- a/panel/template/base.py
+++ b/panel/template/base.py
@@ -142,9 +142,14 @@ class BaseTemplate(param.Parameterized, ServableMixin):
             loc = self._add_location(doc, location)
             doc.on_session_destroyed(loc._server_destroy)
         doc.title = title
+
+        # Initialize fake root
         col = Column()
         preprocess_root = col.get_root(doc, comm)
+        col._hooks.append(self._apply_hooks)
         ref = preprocess_root.ref['id']
+
+        # Process real roots
         for name, (obj, tags) in self._render_items.items():
             if self._apply_hooks not in obj._hooks:
                 obj._hooks.append(self._apply_hooks)
@@ -165,9 +170,9 @@ class BaseTemplate(param.Parameterized, ServableMixin):
             self._apply_root(name, model, tags)
             add_to_doc(model, doc, hold=bool(comm))
 
+        # Process fake root
         state._fake_roots.append(ref)
         state._views[ref] = (col, preprocess_root, doc, comm)
-
         col._preprocess(preprocess_root)
         col._documents[doc] = preprocess_root
         doc.on_session_destroyed(col._server_destroy)


### PR DESCRIPTION
Ensures the template preprocessor is applied to Template roots on initialization.