### PR TITLE
Ensure Tabulator configuration is updated when data changes

### DIFF
--- a/panel/tests/widgets/test_tables.py
+++ b/panel/tests/widgets/test_tables.py
@@ -7,7 +7,9 @@ import numpy as np
 
 try:
     import pandas as pd
-    from pandas.util.testing import makeTimeDataFrame, makeMixedDataFrame
+    from pandas.util.testing import (
+        makeCustomDataframe, makeMixedDataFrame, makeTimeDataFrame
+    )
 except ImportError:
     pytestmark = pytest.mark.skip('pandas not available')
 
@@ -753,6 +755,32 @@ def test_tabulator_stream_dataframe_with_filter(document, comm):
         'D': np.array(['2009-01-02T00:00:00.000000000',
                        '2009-01-09T00:00:00.000000000'],
                       dtype='datetime64[ns]')
+    }
+    for col, values in model.source.data.items():
+        np.testing.assert_array_equal(values, expected[col])
+
+
+def test_tabulator_dataframe_replace_data(document, comm):
+    df = makeMixedDataFrame()
+    table = Tabulator(df)
+
+    model = table.get_root(document, comm)
+
+    table.value = makeCustomDataframe(2, 2)
+
+    assert len(model.columns) == 3
+    c1, c2, c3 = model.columns
+    assert c1.field == 'R0'
+    assert c2.field == 'C_l0_g0'
+    assert c3.field == 'C_l0_g1'
+    assert model.configuration == {
+        'columns': [{'field': 'R0'}, {'field': 'C_l0_g0'}, {'field': 'C_l0_g1'}],
+        'selectable': True
+    }
+    expected = {
+        'C_l0_g0': np.array(['R0C0', 'R1C0'], dtype=object),
+        'C_l0_g1': np.array(['R0C1', 'R1C1'], dtype=object),
+        'R0': np.array(['R_l0_g0', 'R_l0_g1'], dtype=object)
     }
     for col, values in model.source.data.items():
         np.testing.assert_array_equal(values, expected[col])

--- a/panel/widgets/tables.py
+++ b/panel/widgets/tables.py
@@ -197,7 +197,7 @@ class BaseTable(Widget):
             if event.type == 'triggered' and self._updating:
                 continue
             elif event.name in ('value', 'show_index'):
-                model.columns = self._get_columns()
+                self._update_columns(event, model)
                 if isinstance(model, DataCube):
                     model.groupings = self._get_groupings()
             elif hasattr(self, '_update_' + event.name):


### PR DESCRIPTION
The tabulator wasn't updating the configuration which meant that it wasn't rendering the new data.