### PR TITLE
Ensure Tabulator.theme_url matches in Python and JS

### DIFF
--- a/panel/models/tabulator.ts
+++ b/panel/models/tabulator.ts
@@ -547,7 +547,7 @@ export class DataTabulator extends HTMLBox {
       sorters: [ p.Array, []],
       styles: [ p.Any, ],
       theme: [ p.String, "simple"],
-      theme_url: [p.String, "https://unpkg.com/tabulator-tables@4.9/dist/css/"]
+      theme_url: [p.String, "https://unpkg.com/tabulator-tables@4.9.3/dist/css/"]
     })
   }
 }


### PR DESCRIPTION
This caused the CSS theme to be reloaded unneccessarily.