### PR TITLE
Add link to installation instructions to getting started guide

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -53,10 +53,7 @@ Installation
 |CondaPyViz|_ |CondaDefaults|_ |PyPI|_ |License|_
 
 
-Panel works with `Python 3 <https://github.com/holoviz/panel/actions?query=workflow%3Apytest>`_ on Linux, Windows, or Mac. The recommended way to install Panel is using the
-`conda <https://docs.conda.io/projects/conda/en/latest/index.html>`_ command provided by
-`Anaconda <https://docs.anaconda.com/anaconda/install/>`_ or
-`Miniconda <https://docs.conda.io/en/latest/miniconda.html>`_::
+Panel works with `Python 3 <https://github.com/holoviz/panel/actions?query=workflow%3Apytest>`_ on Linux, Windows, or Mac. The recommended way to install Panel is using the `conda <https://docs.conda.io/projects/conda/en/latest/index.html>`_ command provided by `Anaconda <https://docs.anaconda.com/anaconda/install/>`_ or `Miniconda <https://docs.conda.io/en/latest/miniconda.html>`_::
 
   conda install -c pyviz panel
 

--- a/examples/getting_started/Introduction.ipynb
+++ b/examples/getting_started/Introduction.ipynb
@@ -5,10 +5,12 @@
    "metadata": {},
    "source": [
     "<div style=\"background-color: #007bff; border-radius: 5px; width: 100%; padding: 10px; color: white\">\n",
-    "    <b>Note:</b> This guide is written for an interactive environment such as Jupyter notebooks. The interactive widgets will not work in a static version of this documentation.\n",
+    "    <b>Note:</b> This guide is written for an interactive environment such as Jupyter notebooks. The interactive widgets will not work in a static version of this documentation. \n",
+    "    \n",
+    "Instructions for installing Panel and the example notebooks can be found in the <a href=\"https://panel.holoviz.org/#installation\" target=\"_blank\" style=\"color:white\">Installation Guide</a>\n",
     "</div>\n",
     "\n",
-    "<br>\n",
+    "\n",
     "\n",
     "Panel lets you add interactive controls for just about anything you can display in Python. Panel can help you build simple interactive apps, complex multi-page dashboards, or anything in between. As a simple example, let's say we have loaded the [UCI ML dataset measuring the environment in a meeting room](http://archive.ics.uci.edu/ml/datasets/Occupancy+Detection+):"
    ]
@@ -409,9 +411,22 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
    "name": "python",
-   "pygments_lexer": "ipython3"
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.4"
   }
  },
  "nbformat": 4,

--- a/examples/getting_started/Introduction.ipynb
+++ b/examples/getting_started/Introduction.ipynb
@@ -411,22 +411,9 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
    "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.8.4"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Fixes https://github.com/holoviz/panel/issues/1924

I've added the line below

![image](https://user-images.githubusercontent.com/42288570/105611976-22da5900-5db9-11eb-8ca1-0a2d3b0b8557.png)

I cannot remove Python 2.7 mention as the section below is not included in the notebook or Panel repository.

![image](https://user-images.githubusercontent.com/42288570/105612012-44d3db80-5db9-11eb-9512-a05164d3e6c1.png)
