### PR TITLE
Handle errors when syncing URL parameters

### DIFF
--- a/panel/io/location.py
+++ b/panel/io/location.py
@@ -94,7 +94,12 @@ class Location(Syncable):
                     v = p.param[pname].deserialize(v)
                 except Exception:
                     pass
-                mapped[pname] = v
+                try:
+                    equal = v == getattr(p, pname)
+                except Exception:
+                    equal = False
+                if not equal:
+                    mapped[pname] = v
             try:
                 p.param.set_param(**mapped)
             except Exception:

--- a/panel/io/location.py
+++ b/panel/io/location.py
@@ -191,14 +191,14 @@ class Location(Syncable):
             raise ValueError(f"Cannot unsync {ptype} object since it "
                              "was never synced in the first place.")
         synced = []
-        for p, params, watcher, _ in self._synced:
+        for p, params, watcher, on_error in self._synced:
             if parameterized is p:
                 parameterized.param.unwatch(watcher)
                 if parameters is not None:
                     new_params = {p: q for p, q in params.items()
                                   if p not in parameters}
                     new_watcher = parameterized.param.watch(watcher.fn, list(new_params))
-                    synced.append((p, new_params, new_watcher))
+                    synced.append((p, new_params, new_watcher, on_error))
             else:
-                synced.append((p, params, watcher))
+                synced.append((p, params, watcher, on_error))
         self._synced = synced

--- a/panel/tests/io/test_location.py
+++ b/panel/tests/io/test_location.py
@@ -93,6 +93,18 @@ def test_location_sync_param_init(location):
     location.unsync(p)
     assert location._synced == []
 
+def test_location_sync_on_error(location):
+    p = SyncParameterized(string='abc')
+    changes = []
+    def on_error(change):
+        print(change)
+        changes.append(change)
+    location.sync(p, on_error=on_error)
+    location.search = "?integer=a&string=abc"
+    assert changes == [{'integer': 'a'}]
+    location.unsync(p)
+    assert location._synced == []
+
 def test_location_sync_param_init_partial(location):
     p = SyncParameterized()
     location.search = "?integer=1&string=abc"


### PR DESCRIPTION
Ensures that if an invalid URL parameter is passed in it does not error and allows user to provide an `on_error` callback function.