### PR TITLE
Add Jupyter server extension to serve files

### DIFF
--- a/jupyter-config/jupyter_notebook_config.d/panel-client-jupyter.json
+++ b/jupyter-config/jupyter_notebook_config.d/panel-client-jupyter.json
@@ -3,5 +3,10 @@
     "jpserver_extensions": {
       "panel": true
     }
+  },
+  "NotebookApp": {
+    "nbserver_extensions": {
+      "panel": true
+    }
   }
 }

--- a/jupyter-config/jupyter_notebook_config.d/panel-client-jupyter.json
+++ b/jupyter-config/jupyter_notebook_config.d/panel-client-jupyter.json
@@ -1,0 +1,7 @@
+{
+  "ServerApp": {
+    "jpserver_extensions": {
+      "panel": true
+    }
+  }
+}

--- a/jupyter-config/notebook.d/panel-client-jupyter.json
+++ b/jupyter-config/notebook.d/panel-client-jupyter.json
@@ -1,6 +1,0 @@
-
-{
-  "load_extensions": {
-    "panel-client-jupyter/extension": true
-  }
-}

--- a/jupyter-config/notebook.d/panel-client-jupyter.json
+++ b/jupyter-config/notebook.d/panel-client-jupyter.json
@@ -1,0 +1,6 @@
+
+{
+  "load_extensions": {
+    "panel-client-jupyter/extension": true
+  }
+}

--- a/panel/__init__.py
+++ b/panel/__init__.py
@@ -8,7 +8,7 @@ from . import widgets # noqa
 from .config import config, panel_extension as extension, __version__ # noqa
 from .depends import bind, depends # noqa
 from .interact import interact # noqa
-from .io import ipywidget, serve, state # noqa
+from .io import _jupyter_server_extension_paths, ipywidget, serve, state # noqa
 from .layout import ( # noqa
     Accordion, Card, Row, Column, WidgetBox, Tabs, Spacer, 
     GridSpec, GridBox

--- a/panel/io/__init__.py
+++ b/panel/io/__init__.py
@@ -13,7 +13,10 @@ from .state import state # noqa
 from .model import add_to_doc, remove_root, diff # noqa
 from .resources import Resources # noqa
 from .server import get_server, init_doc, serve, unlocked, with_lock # noqa
-from .notebook import block_comm, ipywidget, load_notebook, push # noqa
+from .notebook import ( # noqa
+    block_comm, ipywidget, _jupyter_server_extension_paths,
+    load_notebook, push
+)
 
 panel_logger = logging.getLogger('panel')
 

--- a/panel/io/jupyter_server_extension.py
+++ b/panel/io/jupyter_server_extension.py
@@ -7,7 +7,7 @@ from .resources import DIST_DIR
 
 def load_jupyter_server_extension(notebook_app):
     web_app = notebook_app.web_app
-    route_pattern = urljoin(web_app.settings["base_url"], "_panel/(.*)")
+    route_pattern = urljoin(web_app.settings["base_url"], "panel_dist/(.*)")
     web_app.add_handlers(
         host_pattern=".*$",
         host_handlers=[

--- a/panel/io/jupyter_server_extension.py
+++ b/panel/io/jupyter_server_extension.py
@@ -1,12 +1,9 @@
 from urllib.parse import urljoin
 
-from notebook.notebookapp import NotebookApp
 from tornado.web import StaticFileHandler
-from tornado.web import Application
 
-from .server import PANEL_DIST_DIR
+from .resources import DIST_DIR
 
-print('ABC')
 
 def load_jupyter_server_extension(notebook_app):
     web_app = notebook_app.web_app
@@ -14,6 +11,10 @@ def load_jupyter_server_extension(notebook_app):
     web_app.add_handlers(
         host_pattern=".*$",
         host_handlers=[
-            (route_pattern, StaticFileHandler, {"path": PANEL_DIST_DIR}),
+            (
+                route_pattern,
+                StaticFileHandler,
+                {"path": DIST_DIR}
+            ),
         ]
     )

--- a/panel/io/jupyter_server_extension.py
+++ b/panel/io/jupyter_server_extension.py
@@ -1,0 +1,19 @@
+from urllib.parse import urljoin
+
+from notebook.notebookapp import NotebookApp
+from tornado.web import StaticFileHandler
+from tornado.web import Application
+
+from .server import PANEL_DIST_DIR
+
+print('ABC')
+
+def load_jupyter_server_extension(notebook_app):
+    web_app = notebook_app.web_app
+    route_pattern = urljoin(web_app.settings["base_url"], "_panel/(.*)")
+    web_app.add_handlers(
+        host_pattern=".*$",
+        host_handlers=[
+            (route_pattern, StaticFileHandler, {"path": PANEL_DIST_DIR}),
+        ]
+    )

--- a/panel/io/notebook.py
+++ b/panel/io/notebook.py
@@ -50,6 +50,10 @@ LOAD_MIME = 'application/vnd.holoviews_load.v0+json'
 EXEC_MIME = 'application/vnd.holoviews_exec.v0+json'
 HTML_MIME = 'text/html'
 
+def _jupyter_server_extension_paths():
+    return [{"module": "panel.io.jupyter_server_extension"}]
+
+
 def push(doc, comm, binary=True):
     """
     Pushes events stored on the document across the provided comm.

--- a/setup.py
+++ b/setup.py
@@ -192,6 +192,17 @@ setup_args = dict(
     cmdclass=_COMMANDS,
     packages=find_packages(),
     include_package_data=True,
+    data_files=[
+        (
+            "etc/jupyter/nbconfig/notebook.d",
+            ["jupyter-config/notebook.d/panel-client-jupyter.json"],
+        ),
+        # like `jupyter serverextension enable --sys-prefix`
+        (
+            "etc/jupyter/jupyter_notebook_config.d",
+            ["jupyter-config/jupyter_notebook_config.d/panel-client-jupyter.json"],
+        ),
+    ],
     classifiers=[
         "License :: OSI Approved :: BSD License",
         "Development Status :: 5 - Production/Stable",

--- a/setup.py
+++ b/setup.py
@@ -193,10 +193,6 @@ setup_args = dict(
     packages=find_packages(),
     include_package_data=True,
     data_files=[
-        (
-            "etc/jupyter/nbconfig/notebook.d",
-            ["jupyter-config/notebook.d/panel-client-jupyter.json"],
-        ),
         # like `jupyter serverextension enable --sys-prefix`
         (
             "etc/jupyter/jupyter_notebook_config.d",


### PR DESCRIPTION
In a Bokeh server context we serve the `panel/dist` directory on an endpoint, which makes it possible to load all bundled resources from there, while in the notebook we have to rely on either inlining the resources or loading it from CDN. This PR adds a server extension to Panel, which serves the `panel/dist` directory under a `/panel_dist/` endpoint in Jupyter.