### PR TITLE
Skip serializing undefined hover locations in DeckGL pane

### DIFF
--- a/panel/models/deckgl.ts
+++ b/panel/models/deckgl.ts
@@ -106,6 +106,8 @@ export class DeckGLPlotView extends PanelHTMLBoxView {
   }
 
   _on_hover_event(event: any): void {
+    if (event.coordinate == null)
+      return
     const hoverState = {
       coordinate: event.coordinate,
       lngLat: event.lngLat,


### PR DESCRIPTION
These events were causing serialization errors.