### PR TITLE
Add .devcontainer to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -122,3 +122,4 @@ discover/
 
 node_modules/*
 /tmp
+.devcontainer/*


### PR DESCRIPTION
VS Code recognizes a special .devcontainer folder to define working directly inside a docker container.

I would like to be able to use this. But I would like to avoid adding those files to Panel.