### PR TITLE
Remove change of theme_toggle

### DIFF
--- a/panel/template/fast/base.py
+++ b/panel/template/fast/base.py
@@ -1,8 +1,8 @@
 import pathlib
 
-import panel as pn
 import param
 
+from ...io.state import state
 from ..base import BasicTemplate
 from ..react import ReactTemplate
 from ..theme import THEMES, DefaultTheme
@@ -42,14 +42,14 @@ class FastBaseTemplate(BasicTemplate):
     __abstract = True
 
     def __init__(self, **params):
-        if "theme" not in params:
-            if params.get("theme_toggle", self.param.theme_toggle.default):
-                params['theme'] = THEMES[self._get_theme_from_query_args()]
-            else:
-                params['theme'] = DefaultTheme
-        else:
-            if isinstance(params['theme'], str):
-                params['theme'] = THEMES[params['theme']]
+        query_theme = self._get_theme_from_query_args()
+        if query_theme:
+            params['theme'] = THEMES[query_theme]
+        elif "theme" not in params:
+            params['theme'] = DefaultTheme
+        elif isinstance(params['theme'], str):
+            params['theme'] = THEMES[params['theme']]
+
         super().__init__(**params)
         theme = self._get_theme()
         if "header_color" not in params:
@@ -58,12 +58,12 @@ class FastBaseTemplate(BasicTemplate):
             self.header_background = theme.style.header_background
 
     @staticmethod
-    def _get_theme_from_query_args(default: str = "default") -> str:
-        theme_arg = pn.state.session_args.get("theme", default)
-        if isinstance(theme_arg, list):
-            theme_arg = theme_arg[0].decode("utf-8")
-            theme_arg = theme_arg.strip("'").strip('"')
-        return theme_arg
+    def _get_theme_from_query_args():
+        theme_arg = state.session_args.get("theme", None)
+        if not theme_arg:
+            return
+        theme_arg = theme_arg[0].decode("utf-8")
+        return theme_arg.strip("'").strip('"')
 
     def _update_vars(self):
         super()._update_vars()

--- a/panel/template/fast/base.py
+++ b/panel/template/fast/base.py
@@ -50,7 +50,6 @@ class FastBaseTemplate(BasicTemplate):
         else:
             if isinstance(params['theme'], str):
                 params['theme'] = THEMES[params['theme']]
-            params['theme_toggle'] = False
         super().__init__(**params)
         theme = self._get_theme()
         if "header_color" not in params:


### PR DESCRIPTION
When testing Panel 0.11.0rc3 I see an unintended behaviour from the FastListTemplate. When setting the theme via a string it sets `theme_toggle` to False. This was never intended. And it will make it difficult for my users of awesome-panel.org and at work to switch the theme.

So I removed the line of code.