### PR TITLE
Add preprocessor to link parameter widgets with loading indicators

### DIFF
--- a/panel/links.py
+++ b/panel/links.py
@@ -434,7 +434,7 @@ class JSLinkCallbackGenerator(JSCallbackGenerator):
       var value = source['{src_attr}'];
       value = {src_transform};
     }}
-    if (typeof value !== 'boolean') {{
+    if (typeof value !== 'boolean' || source.labels !== ['Loading']) {{
       value = true
     }}
     var css_classes = target.css_classes.slice()
@@ -500,7 +500,7 @@ class JSLinkCallbackGenerator(JSCallbackGenerator):
                     value = msg[tgt_spec]
             else:
                 value = getattr(src_model, src_spec)
-            if value:
+            if value and hasattr(tgt_model, tgt_spec):
                 setattr(tgt_model, tgt_spec, value)
         if tgt_model is None and not link.code:
             raise ValueError('Model could not be resolved on target '

--- a/panel/param.py
+++ b/panel/param.py
@@ -25,7 +25,7 @@ from .util import (
     param_name, recursive_parameterized
 )
 from .reactive import Reactive
-from .viewable import Layoutable
+from .viewable import Layoutable, Viewable
 from .widgets import (
     Button, Checkbox, ColorPicker, DataFrame, DatePicker,
     DatetimeInput, DateRangeSlider, FileSelector, FloatSlider,
@@ -896,3 +896,24 @@ class JSONInit(param.Parameterized):
                 parameterized.param.set_param(**{name:value})
             except ValueError as e:
                 warnobj.warning(str(e))
+
+
+def link_param_method(root_view, root_model):
+    """
+    This preprocessor jslinks ParamMethod loading parameters to any
+    widgets generated from those parameters ensuring that the loading
+    indicator is enabled client side.
+    """
+    methods = root_view.select(lambda p: isinstance(p, ParamMethod) and p.loading_indicator)
+    widgets = root_view.select(lambda w: isinstance(w, Widget) and getattr(w, '_param_pane', None) is not None)
+
+    for widget in widgets:
+        for method in methods:
+            for cb in method._callbacks:
+                pobj = cb.cls if cb.inst is None else cb.inst
+                if widget._param_pane.object is pobj:
+                    if 'value' in widget._linkable_params:
+                        widget.jslink(method._inner_layout, value='loading')
+
+
+Viewable._preprocessing_hooks.insert(0, link_param_method)

--- a/panel/param.py
+++ b/panel/param.py
@@ -28,9 +28,10 @@ from .reactive import Reactive
 from .viewable import Layoutable, Viewable
 from .widgets import (
     Button, Checkbox, ColorPicker, DataFrame, DatePicker,
-    DatetimeInput, DateRangeSlider, FileSelector, FloatSlider,
-    IntInput, IntSlider, LiteralInput, MultiSelect, RangeSlider,
-    Select, FloatInput, StaticText, TextInput, Toggle, Widget
+    DatetimeInput, DateRangeSlider, DiscreteSlider, FileSelector,
+    FloatSlider, IntInput, IntSlider, LiteralInput, MultiSelect,
+    RangeSlider, Select, FloatInput, StaticText, TextInput, Toggle,
+    Widget
 )
 from .widgets.button import _ButtonBase
 
@@ -912,8 +913,12 @@ def link_param_method(root_view, root_model):
             for cb in method._callbacks:
                 pobj = cb.cls if cb.inst is None else cb.inst
                 if widget._param_pane.object is pobj:
-                    if 'value' in widget._linkable_params:
-                        widget.jslink(method._inner_layout, value='loading')
+                    if isinstance(widget, DiscreteSlider):
+                        w = widget._slider
+                    else:
+                        w = widget
+                    if 'value' in w._linkable_params:
+                        w.jslink(method._inner_layout, value='loading')
 
 
 Viewable._preprocessing_hooks.insert(0, link_param_method)


### PR DESCRIPTION
This means that parameter widgets generated from a Parameterized are jslinked to any reactive methods that depend on those parameters. This means the loading indicator is enabled as soon the widget is changed. 

One good use case is the Gapminder demo which uses a Param based approach and is now automatically jslinked:

![loading_indicator](https://user-images.githubusercontent.com/1550771/109301138-ca72fd00-7837-11eb-8d9f-c70c49b0a77a.gif)
