### PR TITLE
Panel 0.11.0rc4: Auto Reload- Should not get a module_name not in sys.modules

### DIFF
--- a/panel/io/reload.py
+++ b/panel/io/reload.py
@@ -137,6 +137,8 @@ def _reload_on_update(modify_times):
         # in the standard library), and occasionally this can cause strange
         # failures in getattr.  Just ignore anything that's not an ordinary
         # module.
+        if not module in sys.modules:
+            continue
         module = sys.modules[module_name]
         if not isinstance(module, types.ModuleType):
             continue

--- a/panel/io/reload.py
+++ b/panel/io/reload.py
@@ -137,7 +137,7 @@ def _reload_on_update(modify_times):
         # in the standard library), and occasionally this can cause strange
         # failures in getattr.  Just ignore anything that's not an ordinary
         # module.
-        if not module in sys.modules:
+        if not module_name in sys.modules:
             continue
         module = sys.modules[module_name]
         if not isinstance(module, types.ModuleType):


### PR DESCRIPTION
I'm using `panel serve` with the `--auto` flag on awesome-panel locally. When I edit the awesome-panel package (an external package which is installed via `pip install -e`) I get the below error 

```python
 File "c:\repos\private\awesome-panel\.venv\lib\site-packages\tornado\ioloop.py", line 905, in _run
    return self.callback()
  File "c:\repos\private\awesome-panel\.venv\lib\site-packages\panel\io\callbacks.py", line 70, in _periodic_callback
    self.callback()
  File "c:\repos\private\awesome-panel\.venv\lib\site-packages\panel\io\reload.py", line 140, in _reload_on_update
    module = sys.modules[module_name]
KeyError: 'awesome_panel'
```

This provides a fix. 