### PR TITLE
Provide Viewer baseclass

### DIFF
--- a/panel/pane/base.py
+++ b/panel/pane/base.py
@@ -44,6 +44,8 @@ def panel(obj, **kwargs):
     """
     if isinstance(obj, Viewable):
         return obj
+    elif hasattr(obj, '__panel__'):
+        return panel(obj.__panel__())
     if kwargs.get('name', False) is None:
         kwargs.pop('name')
     pane = PaneBase.get_pane_type(obj, **kwargs)(obj, **kwargs)

--- a/panel/pipeline.py
+++ b/panel/pipeline.py
@@ -11,6 +11,7 @@ from .pane import HoloViews, Pane, Markdown
 from .widgets import Button, Select
 from .param import Param
 from .util import param_reprs
+from .viewable import ViewableWrapper
 
 
 class PipelineError(RuntimeError):
@@ -102,7 +103,7 @@ def get_breadths(node, graph, depth=0, breadths=None):
 
 
 
-class Pipeline(param.Parameterized):
+class Pipeline(ViewableWrapper):
     """
     A Pipeline represents a directed graph of stages, which each
     return a panel object to render. A pipeline therefore represents
@@ -221,6 +222,9 @@ class Pipeline(param.Parameterized):
                 name, stage, kwargs = stage
             self.add_stage(name, stage, **kwargs)
         self.define_graph(graph)
+
+    def __panel__(self):
+        return self.layout
 
     def _validate(self, stage):
         if any(stage is s for n, (s, kw) in self._stages.items()):
@@ -526,9 +530,6 @@ class Pipeline(param.Parameterized):
             ylim=(0, 1), default_tools=['hover'], toolbar=None, backend='bokeh'
         )
         return plot
-
-    def _repr_mimebundle_(self, include=None, exclude=None):
-        return self.layout._repr_mimebundle_(include, exclude)
 
     #----------------------------------------------------------------
     # Public API

--- a/panel/pipeline.py
+++ b/panel/pipeline.py
@@ -11,7 +11,7 @@ from .pane import HoloViews, Pane, Markdown
 from .widgets import Button, Select
 from .param import Param
 from .util import param_reprs
-from .viewable import ViewableWrapper
+from .viewable import Viewer
 
 
 class PipelineError(RuntimeError):
@@ -103,7 +103,7 @@ def get_breadths(node, graph, depth=0, breadths=None):
 
 
 
-class Pipeline(ViewableWrapper):
+class Pipeline(Viewer):
     """
     A Pipeline represents a directed graph of stages, which each
     return a panel object to render. A pipeline therefore represents

--- a/panel/viewable.py
+++ b/panel/viewable.py
@@ -773,9 +773,10 @@ class Viewable(Renderable, Layoutable, ServableMixin):
 
 class Viewer(param.Parameterized):
     """
-    A baseclass for custom components which return a Panel object. By
-    implementing the __panel__ method users can make a panel component
-    usable inside Panel without explicitly returning a Panel object.
+    A baseclass for custom components that behave like a Panel object.
+    By implementing __panel__ method an instance of this class will
+    behave like the returned Panel component when placed in a layout,
+    render itself in a notebook and provide show and servable methods.
     """
 
     def __panel__(self):

--- a/panel/viewable.py
+++ b/panel/viewable.py
@@ -771,7 +771,7 @@ class Viewable(Renderable, Layoutable, ServableMixin):
         return doc
 
 
-class ViewableWrapper(param.Parameterized):
+class Viewer(param.Parameterized):
     """
     A baseclass for custom components which return a Panel object. By
     implementing the __panel__ method users can make a panel component
@@ -793,7 +793,7 @@ class ViewableWrapper(param.Parameterized):
              threaded=False, verbose=True, open=True, location=True, **kwargs):
         return self.__panel__().show(
             title, port, address, websocket_origin, threaded,
-            verbose, option, location, **kwargs
+            verbose, open, location, **kwargs
         )
 
     show.__doc__ = ServableMixin.show.__doc__

--- a/panel/viewable.py
+++ b/panel/viewable.py
@@ -769,3 +769,34 @@ class Viewable(Renderable, Layoutable, ServableMixin):
         add_to_doc(model, doc)
         if location: self._add_location(doc, location, model)
         return doc
+
+
+class ViewableWrapper(param.Parameterized):
+    """
+    A baseclass for custom components which return a Panel object. By
+    implementing the __panel__ method users can make a panel component
+    usable inside Panel without explicitly returning a Panel object.
+    """
+
+    def __panel__(self):
+        """
+        Subclasses should return a Panel component to be rendered.
+        """
+        raise NotImplementedError
+
+    def servable(self, title=None, location=True):
+        return self.__panel__().servable(title, location)
+
+    servable.__doc__ = ServableMixin.servable.__doc__
+
+    def show(self, title=None, port=0, address=None, websocket_origin=None,
+             threaded=False, verbose=True, open=True, location=True, **kwargs):
+        return self.__panel__().show(
+            title, port, address, websocket_origin, threaded,
+            verbose, option, location, **kwargs
+        )
+
+    show.__doc__ = ServableMixin.show.__doc__
+
+    def _repr_mimebundle_(self, include=None, exclude=None):
+        return self.__panel__._repr_mimebundle_(include, exclude)


### PR DESCRIPTION
Provides a `Viewer` baseclass which can be used to make custom components viewable (i.e. provide `.servable`, `.show` and `_repr_mimebundle_` methods. A user just has to implement ``__panel__``.

Closes https://github.com/holoviz/panel/issues/1979
Fixes https://github.com/holoviz/panel/issues/1981
Fixes  https://github.com/holoviz/panel/issues/1980
