### PR TITLE
Allow setting horizontal and vertical alignment separately

### DIFF
--- a/examples/user_guide/Customization.ipynb
+++ b/examples/user_guide/Customization.ipynb
@@ -174,6 +174,45 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## ``align``\n",
+    "\n",
+    "The `align` parameter controls how components align vertically and horizontally. It supports 'start', 'center', and 'end' values and can be set for both horizontal and vertical directions at once or for each separately by passing in a tuple of the form `(horizontal, vertical)`.\n",
+    "\n",
+    "One common use-case where alignment is important is when placing multiple items with different heights in a `Row`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pn.Row(pn.widgets.IntSlider(name='Test'), pn.widgets.IntSlider(align='end'))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In a grid you may also have to specify the horizontal and vertical alignment separately to achieve the layout you are after:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pn.GridBox(\n",
+    "    pn.widgets.IntSlider(name='Test'), pn.widgets.IntSlider(align='end'),\n",
+    "    pn.widgets.TextInput(name='Test', width=150), pn.widgets.TextInput(width=150, align=('start', 'end')),\n",
+    "    ncols=2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### Absolute sizing using ``width`` and ``height``\n",
     "\n",
     "By default all components use either auto-sizing or absolute sizing. Panels will generally take up as much space as the components within them, and text or image-based panes will adjust to the size of their contents. To set a fixed size on a component, it is usually sufficient to set a width or height, but in certain cases setting ``sizing_mode='fixed'`` explicitly may also be required."

--- a/panel/viewable.py
+++ b/panel/viewable.py
@@ -41,10 +41,11 @@ class Layoutable(param.Parameterized):
     for all Panel components with a visual representation.
     """
 
-    align = param.ObjectSelector(default='start',
-                                 objects=['start', 'end', 'center'], doc="""
+    align = param.ClassSelector(default='start',
+                                class_=(str, tuple), doc="""
         Whether the object should be aligned with the start, end or
-        center of its container""")
+        center of its container. If set as a tuple it will declare
+        (vertical, horizontal) alignment.""")
 
     aspect_ratio = param.Parameter(default=None, doc="""
         Describes the proportional relationship between component's


### PR DESCRIPTION
Somehow missed this entirely, the align property in bokeh has always supported providing a `(horizontal, vertical)` alignment tuple. This merely exposes this ability in Panel.