### PR TITLE
Fix value_throttled in pn.depends decorator

### DIFF
--- a/panel/widgets/input.py
+++ b/panel/widgets/input.py
@@ -19,7 +19,7 @@ from bokeh.models.widgets import (
     NumericInput as _BkNumericInput)
 
 from ..layout import Column
-from ..util import as_unicode
+from ..util import param_reprs, as_unicode
 from .base import Widget, CompositeWidget
 
 
@@ -245,6 +245,16 @@ class _SpinnerBase(_NumericInputBase):
             params['value_throttled'] = params['value']
         super().__init__(**params)
 
+    def __repr__(self, depth=0):
+        return '{cls}({params})'.format(cls=type(self).__name__,
+                                        params=', '.join(param_reprs(self, ['value_throttled'])))
+
+    def _update_model(self, events, msg, root, model, doc, comm):
+        if 'value_throttled' in msg:
+            del msg['value_throttled']
+
+        return super()._update_model(events, msg, root, model, doc, comm)
+
 
 class IntInput(_SpinnerBase, _IntInputBase):
 
@@ -252,17 +262,12 @@ class IntInput(_SpinnerBase, _IntInputBase):
 
     value_throttled = param.Integer(default=None, constant=True)
 
-    _rename = dict(_NumericInputBase._rename, value_throttled=None)
-
-
 
 class FloatInput(_SpinnerBase, _FloatInputBase):
 
     step = param.Number(default=0.1)
 
     value_throttled = param.Number(default=None, constant=True)
-
-    _rename = dict(_NumericInputBase._rename, value_throttled=None)
 
 
 class NumberInput(_SpinnerBase):

--- a/panel/widgets/slider.py
+++ b/panel/widgets/slider.py
@@ -426,6 +426,8 @@ class DateRangeSlider(_SliderBase):
         msg = super()._process_param_change(msg)
         if msg.get('value') == (None, None):
             del msg['value']
+        if msg.get('value_throttled') == (None, None):
+            del msg['value_throttled']
         return msg
 
     def _process_property_change(self, msg):

--- a/panel/widgets/slider.py
+++ b/panel/widgets/slider.py
@@ -16,12 +16,11 @@ from bokeh.models.widgets import (
 
 from ..config import config
 from ..io import state
-from ..util import unicode_repr, value_as_datetime, value_as_date
+from ..util import param_reprs, unicode_repr, value_as_datetime, value_as_date
 from ..viewable import Layoutable
 from .base import Widget, CompositeWidget
 from ..layout import Column
 from .input import StaticText
-
 
 
 class _SliderBase(Widget):
@@ -53,6 +52,10 @@ class _SliderBase(Widget):
         if 'value' in params and 'value_throttled' in self.param:
             params['value_throttled'] = params['value']
         super().__init__(**params)
+
+    def __repr__(self, depth=0):
+        return '{cls}({params})'.format(cls=type(self).__name__,
+                                        params=', '.join(param_reprs(self, ['value_throttled'])))
 
     def _update_model(self, events, msg, root, model, doc, comm):
         if 'value_throttled' in msg:

--- a/panel/widgets/slider.py
+++ b/panel/widgets/slider.py
@@ -54,6 +54,12 @@ class _SliderBase(Widget):
             params['value_throttled'] = params['value']
         super().__init__(**params)
 
+    def _update_model(self, events, msg, root, model, doc, comm):
+        if 'value_throttled' in msg:
+            del msg['value_throttled']
+
+        return super()._update_model(events, msg, root, model, doc, comm)
+
 
 class ContinuousSlider(_SliderBase):
 
@@ -116,7 +122,7 @@ class FloatSlider(ContinuousSlider):
 
     step = param.Number(default=0.1)
 
-    _rename = {'name': 'title', 'value_throttled': None}
+    _rename = {'name': 'title'}
 
 
 class IntSlider(ContinuousSlider):
@@ -131,7 +137,7 @@ class IntSlider(ContinuousSlider):
 
     step = param.Integer(default=1)
 
-    _rename = {'name': 'title', 'value_throttled': None}
+    _rename = {'name': 'title'}
 
     def _process_property_change(self, msg):
         msg = super(_SliderBase, self)._process_property_change(msg)
@@ -153,7 +159,7 @@ class DateSlider(_SliderBase):
 
     end = param.Date(default=None)
 
-    _rename = {'name': 'title', 'value_throttled': None}
+    _rename = {'name': 'title'}
 
     _source_transforms = {'value': None, 'value_throttled': None, 'start': None, 'end': None}
 
@@ -349,7 +355,7 @@ class RangeSlider(_SliderBase):
 
     step = param.Number(default=0.1)
 
-    _rename = {'name': 'title', 'value_throttled': None}
+    _rename = {'name': 'title'}
 
     _widget_type = _BkRangeSlider
 
@@ -406,7 +412,7 @@ class DateRangeSlider(_SliderBase):
     _source_transforms = {'value': None, 'value_throttled': None,
                          'start': None, 'end': None, 'step': None}
 
-    _rename = {'name': 'title', 'value_throttled': None}
+    _rename = {'name': 'title'}
 
     _widget_type = _BkDateRangeSlider
 


### PR DESCRIPTION
Fixes #2082 

**Todo**
- [x] <s>Before merge I need to check if this affect `pn.depends` in parameterized classes.</s> Update: This fix is also needed to get `value_throttled` to work in a parameterized classes.
- [x] <s> Check if other widgets have `value_throttled`. </s> Update: IntInput and FloatInput.

@nghenzi can you double check if this fixes all the sliders problems?
@philippjfr  I have taken the liberty to remove `value_throttled` from `__repr__` to avoid confusion.  <s>I will do the todo later today, but you can take over the PR if you need to release 0.11.1 before that and want to include this.</s>