### PR TITLE
Add empty progress bar

### DIFF
--- a/panel/tests/widgets/test_misc.py
+++ b/panel/tests/widgets/test_misc.py
@@ -41,7 +41,7 @@ def test_audio_url(document, comm):
 def test_progress_bounds():
     progress = Progress()
     progress.max = 200
-    assert progress.param.value.bounds == (0, 200)
+    assert progress.param.value.bounds == (-1, 200)
     progress.value = 120
     assert progress.value == 120
 

--- a/panel/widgets/indicators.py
+++ b/panel/widgets/indicators.py
@@ -122,10 +122,10 @@ class Progress(ValueIndicator):
 
     max = param.Integer(default=100, doc="The maximum value of the progress bar.")
 
-    value = param.Integer(default=None, bounds=(0, None), doc="""
+    value = param.Integer(default=None, bounds=(-1, None), doc="""
         The current value of the progress bar. If set to None the progress
         bar will be indeterminate and animate depending on the active
-        parameter.""")
+        parameter. If set to -1 the progress bar will be empty.""")
 
     _rename = {'name': None}
 
@@ -133,7 +133,7 @@ class Progress(ValueIndicator):
 
     @param.depends('max', watch=True)
     def _update_value_bounds(self):
-        self.param.value.bounds = (0, self.max)
+        self.param.value.bounds = (-1, self.max)
 
     def __init__(self,**params):
         super().__init__(**params)


### PR DESCRIPTION
Fixes #2080

By setting the value to -1 the progress bar is empty. 

```python
import panel as pn

progress1 = pn.widgets.indicators.Progress(value=-1, active=False)
progress2 = pn.widgets.indicators.Progress(value=-1, active=True)
progress3 = pn.widgets.indicators.Progress(value=0, active=False)
progress4 = pn.widgets.indicators.Progress(value=0, active=True)
progress = pn.Column(progress1, progress2, progress3, progress4)
progress.servable()
```


https://user-images.githubusercontent.com/19758978/111211562-d5b38000-85ce-11eb-9da4-e0ec5c179216.mp4

