### PR TITLE
Fix missing video in pn.pane.Video

### DIFF
--- a/panel/pane/media.py
+++ b/panel/pane/media.py
@@ -60,6 +60,8 @@ class _MediaBase(PaneBase):
 
     def _get_model(self, doc, root=None, parent=None, comm=None):
         props = self._process_param_change(self._init_params())
+        if self.object is not None:
+            props['value'] = self.object
         model = self._bokeh_model(**props)
         if root is None:
             root = model

--- a/panel/tests/pane/test_media.py
+++ b/panel/tests/pane/test_media.py
@@ -1,0 +1,10 @@
+from panel.pane import Video
+
+
+def test_video_url(document, comm):
+    url = 'https://file-examples-com.github.io/uploads/2017/04/file_example_MP4_640_3MG.mp4'
+    video = Video(url)
+    model = video.get_root(document, comm=comm)
+
+    # To check if url is send to the bokeh model
+    assert model.value == url


### PR DESCRIPTION
Fixes #2105

The object parameter is not found when running `self._process_param_change(self._init_params())` in `pn.pane.media._MediaBase` because it inherits from `PaneBase` which sets `_rerender_params = ['object']` and ignores it in `self._synced_params`.

The solution I have done is to add it to props afterwards if it is not None. Another way could be to remove it from `_rerender_params` but I have a feeling this will properly break something. 