### PR TITLE
More flexible control over ReactiveHTML child rendering

### DIFF
--- a/panel/models/reactive_html.py
+++ b/panel/models/reactive_html.py
@@ -53,7 +53,8 @@ class ReactiveHTMLParser(HTMLParser):
             return
         dom_id = self._current_node
         match = data[2:-1] if self._template_re.match(data) else None
-        if match in self.cls.param and isinstance(self.cls.param[match], pm.List):
+        config = self.cls._child_config.get(match, {})
+        if match in self.cls.param and config.get('type') != 'literal':
             self.children[dom_id] = match
             return
 
@@ -129,7 +130,11 @@ class ReactiveHTML(HTMLBox):
 
     callbacks = bp.Dict(bp.String, bp.List(bp.Tuple(bp.String, bp.String)))
 
-    children = bp.Dict(bp.String, bp.List(bp.Instance(LayoutDOM)))
+    children = bp.Dict(bp.String, bp.List(bp.Either(bp.Instance(LayoutDOM), bp.String)))
+
+    child_names = bp.Dict(bp.String, bp.List(bp.String))
+
+    child_templates = bp.Dict(bp.String, bp.String)
 
     data = bp.Instance(DataModel)
 


### PR DESCRIPTION
This PR aims to provide better control over the way children of DOM nodes are rendered inside ReactiveHTML. Specifically this PR adds a `_child_config` parameter. Additionally this PR renames the `_html` to `_template`.

## Child types

- `'model'`: The children are treated as Panel components, converted using `pn.panel` and inserted by bokeh as model roots.
- `'literal'`: The children are treated as a literal string.
- `'template'`: The child parameter treated like other DOM attributes, i.e. they are templated into the `_template` and bi-directionally synced.

## Child templates

The `_child_config` may also declare a child template which will be used to wrap children which are of`'model'` and `'literal'` type.
