### PR TITLE
Add missing end tag in Templates

### DIFF
--- a/panel/template/bootstrap/bootstrap.html
+++ b/panel/template/bootstrap/bootstrap.html
@@ -18,7 +18,7 @@
 <link rel="stylesheet" href="{{ css }}">
 {% endfor %}
 {% for src in template_resources['extra_css'] %}
-<link rel="stylesheet"  href="{{ src }}"
+<link rel="stylesheet"  href="{{ src }}">
 {% endfor %}
 {% for raw_css in template_resources['raw_css'] %}
 <style type="text/css">

--- a/panel/template/fast/grid/fast_grid_template.html
+++ b/panel/template/fast/grid/fast_grid_template.html
@@ -17,7 +17,7 @@
 <link rel="stylesheet" href="{{ css }}">
 {% endfor %}
 {% for src in template_resources['extra_css'] %}
-<link rel="stylesheet"  href="{{ src }}"
+<link rel="stylesheet"  href="{{ src }}">
 {% endfor %}
 {% for raw_css in template_resources['raw_css'] %}
 <style type="text/css">

--- a/panel/template/fast/list/fast_list_template.html
+++ b/panel/template/fast/list/fast_list_template.html
@@ -17,7 +17,7 @@
 <link rel="stylesheet" href="{{ css }}">
 {% endfor %}
 {% for src in template_resources['extra_css'] %}
-<link rel="stylesheet"  href="{{ src }}"
+<link rel="stylesheet"  href="{{ src }}">
 {% endfor %}
 {% for raw_css in template_resources['raw_css'] %}
 <style type="text/css">

--- a/panel/template/golden/golden.html
+++ b/panel/template/golden/golden.html
@@ -18,7 +18,7 @@
 <link rel="stylesheet" href="{{ css }}">
 {% endfor %}
 {% for src in template_resources['extra_css'] %}
-<link rel="stylesheet"  href="{{ src }}"
+<link rel="stylesheet"  href="{{ src }}">
 {% endfor %}
 {% for raw_css in template_resources['raw_css'] %}
 <style type="text/css">

--- a/panel/template/material/material.html
+++ b/panel/template/material/material.html
@@ -18,7 +18,7 @@
 <link rel="stylesheet" href="{{ css }}">
 {% endfor %}
 {% for src in template_resources['extra_css'] %}
-<link rel="stylesheet"  href="{{ src }}"
+<link rel="stylesheet"  href="{{ src }}">
 {% endfor %}
 {% for raw_css in template_resources['raw_css'] %}
 <style type="text/css">

--- a/panel/template/react/react.html
+++ b/panel/template/react/react.html
@@ -17,7 +17,7 @@
 <link rel="stylesheet" href="{{ css }}">
 {% endfor %}
 {% for src in template_resources['extra_css'] %}
-<link rel="stylesheet"  href="{{ src }}"
+<link rel="stylesheet"  href="{{ src }}">
 {% endfor %}
 {% for raw_css in template_resources['raw_css'] %}
 <style type="text/css">

--- a/panel/template/vanilla/vanilla.html
+++ b/panel/template/vanilla/vanilla.html
@@ -17,7 +17,7 @@
 <link rel="stylesheet" href="{{ css }}">
 {% endfor %}
 {% for src in template_resources['extra_css'] %}
-<link rel="stylesheet"  href="{{ src }}"
+<link rel="stylesheet"  href="{{ src }}">
 {% endfor %}
 {% for raw_css in template_resources['raw_css'] %}
 <style type="text/css">


### PR DESCRIPTION
Fixes a template that looks like 

![image](https://user-images.githubusercontent.com/42288570/112665258-26429d00-8e5b-11eb-9171-a445c607c6f0.png)

If this could be a part of Panel 0.11.2 it would be much appreciated :-)