### PR TITLE
Remove bootstrap css from FastGridTemplate

### DIFF
--- a/panel/template/fast/base.py
+++ b/panel/template/fast/base.py
@@ -78,6 +78,6 @@ class FastGridBaseTemplate(FastBaseTemplate, ReactTemplate):
     Combines the FastTemplate and the React template.
     """
 
-    _resources = dict(FastBaseTemplate._resources, **ReactTemplate._resources)
+    _resources = dict(FastBaseTemplate._resources, js=ReactTemplate._resources['js'])
 
     __abstract = True


### PR DESCRIPTION
I was updating my site to Panel 0.11.1 and suddenly the menu looks like shown below.

I investigate and realize its bootstrap css that sets the header size. WTF?

I investigate and find out it because the css of the ReactTemplate is used in the FastGridTemplate and it contains bootstrap. Oh no.

![image](https://user-images.githubusercontent.com/42288570/112676919-5d1faf80-8e69-11eb-8ec2-740abc24a208.png)

If this could be a part of a 0.11.2 release it would be highly appreciated.