### PR TITLE
Serialize Perspective schema

### DIFF
--- a/panel/models/perspective.py
+++ b/panel/models/perspective.py
@@ -26,6 +26,8 @@ class Perspective(HTMLBox):
 
     selectable = Nullable(Bool())
 
+    schema = Dict(String, String)
+
     sort = Either(List(List(String)), Null())
 
     source = Instance(ColumnDataSource)

--- a/panel/models/perspective.ts
+++ b/panel/models/perspective.ts
@@ -106,7 +106,8 @@ export class PerspectiveView extends PanelHTMLBoxView {
   render(): void {
     super.render()
     this.worker = (window as any).perspective.worker();
-    this.table = this.worker.table(this.data);
+    this.table = this.worker.table(this.model.schema);
+    this.table.update(this.data);
     const container = div({class: "pnx-perspective-viewer"})
     set_size(container, this.model)
     container.innerHTML = this.getInnerHTML();
@@ -261,6 +262,7 @@ export namespace Perspective {
     row_pivots: p.Property<any[] | null>
     selectable: p.Property<boolean | null>
     toggle_config: p.Property<boolean>
+    schema: p.Property<any>
     sort: p.Property<any[] | null>
     source: p.Property<ColumnDataSource>
     theme: p.Property<any>
@@ -292,6 +294,7 @@ export class Perspective extends HTMLBox {
       plugin_config:    [ Any,                     ],
       row_pivots:       [ Nullable(Array(String)), ],
       selectable:       [ Nullable(Boolean),       ],
+      schema:           [ Any,                  {} ],
       toggle_config:    [ Boolean,            true ],
       sort:             [ Nullable(Array(Array(String))), ],
       source:           [ Ref(ColumnDataSource),   ],


### PR DESCRIPTION
Ensures that Perspective handles datetime and other dtypes correctly and also handles pandas (multi-)indexes and column pivots.

Fixes https://github.com/holoviz/panel/issues/2124

```python
data = pd.DataFrame({
    "int": np.arange(100),
    "float": [i * 1.5 for i in range(100)],
    "bool": [True for i in range(100)],
    "date": [date.today() for i in range(100)],
    "datetime": [datetime.now() for i in range(100)],
    "string": [chr(64+i) for i in range(100)]
})


pn.pane.Perspective(
    data, sizing_mode='stretch_width', height=400
)
```

<img width="1034" alt="Screen Shot 2021-03-30 at 1 04 44 PM" src="https://user-images.githubusercontent.com/1550771/112979215-8fc2f400-9158-11eb-9e5c-1f84a1d84dfc.png">
