### PR TITLE
configure IDOM_CLIENT_IMPORT_SOURCE_URL

### DIFF
--- a/jupyter-config/jupyter_notebook_config.d/panel-client-jupyter.json
+++ b/jupyter-config/jupyter_notebook_config.d/panel-client-jupyter.json
@@ -1,7 +1,7 @@
 {
   "ServerApp": {
     "jpserver_extensions": {
-      "panel": true
+      "panel.io.jupyter_server_extension": true
     }
   },
   "NotebookApp": {

--- a/panel/io/jupyter_server_extension.py
+++ b/panel/io/jupyter_server_extension.py
@@ -5,7 +5,7 @@ from tornado.web import StaticFileHandler
 from .resources import DIST_DIR
 
 
-def load_jupyter_server_extension(notebook_app):
+def _load_jupyter_server_extension(notebook_app):
     web_app = notebook_app.web_app
     route_pattern = urljoin(web_app.settings["base_url"], "panel_dist/(.*)")
     web_app.add_handlers(
@@ -18,3 +18,7 @@ def load_jupyter_server_extension(notebook_app):
             ),
         ]
     )
+
+
+# compat for older versions of Jupyter
+load_jupyter_server_extension = _load_jupyter_server_extension

--- a/panel/pane/idom.py
+++ b/panel/pane/idom.py
@@ -4,12 +4,17 @@ import asyncio
 from functools import partial
 from threading import Thread
 from queue import Queue as SyncQueue
+from packaging.version import Version
 
 from ..io.notebook import push_on_root
 from ..io.resources import DIST_DIR, LOCAL_DIST
 from ..io.state import state
 from ..models import IDOM as _BkIDOM
 from .base import PaneBase
+
+
+_IDOM_MIN_VER = "0.23"
+_IDOM_MAX_VER = "0.24"
 
 
 def _spawn_threaded_event_loop(coro):
@@ -38,6 +43,11 @@ class IDOM(PaneBase):
     _bokeh_model = _BkIDOM
 
     def __init__(self, object=None, **params):
+        from idom import __version__ as idom_version
+        if Version(_IDOM_MIN_VER) > Version(idom_version) >= Version(_IDOM_MAX_VER):
+            raise RuntimeError(
+                f"Expected idom>={_IDOM_MIN_VER},<{_IDOM_MAX_VER}, but found {idom_version}"
+            )
         super().__init__(object, **params)
         self._idom_loop = None
         self._idom_model = {}

--- a/panel/pane/idom.py
+++ b/panel/pane/idom.py
@@ -64,10 +64,15 @@ class IDOM(PaneBase):
 
     def _get_model(self, doc, root=None, parent=None, comm=None):
         from idom.core.layout import LayoutUpdate
+        from idom.config import IDOM_CLIENT_IMPORT_SOURCE_URL
+
+        # let the client determine import source location
+        IDOM_CLIENT_IMPORT_SOURCE_URL.set("./")
+
         if comm:
-            url = '/panel_dist/idom/build/web_modules'
+            url = '/panel_dist/idom'
         else:
-            url = '/'+LOCAL_DIST+'idom/build/web_modules'
+            url = '/'+LOCAL_DIST+'idom'
 
         if self._idom_loop is None:
             self._setup()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,9 +2,10 @@
 requires = [
     "param >=1.9.0",
     "pyct >=0.4.4",
-    "setuptools >=30.3.0",   
+    "setuptools >=30.3.0",
     "bokeh >=2.3.0,<2.4.0",
     "pyviz_comms >=0.6.0",
     "requests",
-    "bleach"
+    "bleach",
+    "packaging",
 ]


### PR DESCRIPTION
NOTE: The version of IDOM for which these changes would apply has not been released yet.

@philippjfr thoughts on using [`packaging`](https://pypi.org/project/packaging/) to do a runtime check to ensure the installed version of IDOM is compatible?

I also had a bit of difficulty getting the panel Jupyter server extension to work:

```
$ jupyter serverextension list
config dir: /home/ryan/Code/rmorshea/panel/venv/etc/jupyter
    jupyterlab  enabled 
    - Validating...
      jupyterlab 3.0.11 OK
    panel  enabled 
    - Validating...
      X is panel importable?
config dir: /usr/local/etc/jupyter
    jupyterlab  enabled 
    - Validating...
      jupyterlab 3.0.11 OK
```