### PR TITLE
Fixes widget player loop when start is 0

### DIFF
--- a/panel/models/player.ts
+++ b/panel/models/player.ts
@@ -343,8 +343,8 @@ export class Player extends Widget {
     this.define<Player.Props>(({Boolean, Int}) => ({
       direction:          [ Int,             0 ],
       interval:           [ Int,           500 ],
-      start:              [ Int                ],
-      end:                [ Int                ],
+      start:              [ Int,             0 ],
+      end:                [ Int,            10 ],
       step:               [ Int,             1 ],
       loop_policy:        [ LoopPolicy, "once" ],
       value:              [ Int,             0 ],

--- a/panel/models/widgets.py
+++ b/panel/models/widgets.py
@@ -16,9 +16,9 @@ class Player(Widget):
     The Player widget provides controls to play through a number of frames.
     """
 
-    start = Int(help="Lower bound of the Player slider")
+    start = Int(0, help="Lower bound of the Player slider")
 
-    end = Int(help="Upper bound of the Player slider")
+    end = Int(10, help="Upper bound of the Player slider")
 
     value = Int(0, help="Current value of the player app")
 


### PR DESCRIPTION
Fixes #2140 

If default parameters is not set, it sees 0 as Null. Default values are the same as the widgets.


![playerwidget](https://user-images.githubusercontent.com/19758978/113482058-2830df80-949d-11eb-8455-8dacd2ce786c.gif)



