### PR TITLE
Updated json pane to accept single quote

### DIFF
--- a/panel/models/json.ts
+++ b/panel/models/json.ts
@@ -15,7 +15,7 @@ export class JSONView extends PanelMarkupView {
 
   render(): void {
     super.render();
-    const text = this.model.text
+    const text = this.model.text.replace(/(\r\n|\n|\r)/gm, "")
     let json;
     try {
       json = window.JSON.parse(text)

--- a/panel/models/json.ts
+++ b/panel/models/json.ts
@@ -15,7 +15,7 @@ export class JSONView extends PanelMarkupView {
 
   render(): void {
     super.render();
-    const text = this.model.text.replace(/(\r\n|\n|\r)/gm, "").replace("'", '"')
+    const text = this.model.text
     let json;
     try {
       json = window.JSON.parse(text)

--- a/panel/pane/markup.py
+++ b/panel/pane/markup.py
@@ -4,6 +4,7 @@ Markdown, and also regular strings.
 """
 import json
 import textwrap
+from ast import literal_eval
 
 from six import string_types
 
@@ -338,10 +339,11 @@ class JSON(DivPaneBase):
 
     def _get_properties(self):
         properties = super()._get_properties()
-        if isinstance(self.object, string_types):
-            text = self.object
-        else:
-            text = json.dumps(self.object or {}, cls=self.encoder)
+        try:
+            data = literal_eval(self.object)
+        except Exception:
+            data = self.object
+        text = json.dumps(data or {}, cls=self.encoder)
         depth = None if self.depth < 0 else self.depth
         return dict(text=text, theme=self.theme, depth=depth,
                     hover_preview=self.hover_preview, **properties)

--- a/panel/pane/markup.py
+++ b/panel/pane/markup.py
@@ -4,7 +4,6 @@ Markdown, and also regular strings.
 """
 import json
 import textwrap
-from ast import literal_eval
 
 from six import string_types
 
@@ -340,7 +339,7 @@ class JSON(DivPaneBase):
     def _get_properties(self):
         properties = super()._get_properties()
         try:
-            data = literal_eval(self.object)
+            data = json.loads(self.object)
         except Exception:
             data = self.object
         text = json.dumps(data or {}, cls=self.encoder)

--- a/panel/tests/pane/test_markup.py
+++ b/panel/tests/pane/test_markup.py
@@ -201,7 +201,7 @@ def test_json_pane(document, comm):
     assert model.text == '{"a": 2}'
     assert pane._models[model.ref['id']][0] is model
 
-    pane.object = "{'b': 3}"
+    pane.object = '{"b": 3}'
     assert model.text == '{"b": 3}'
     assert pane._models[model.ref['id']][0] is model
 

--- a/panel/tests/pane/test_markup.py
+++ b/panel/tests/pane/test_markup.py
@@ -201,8 +201,24 @@ def test_json_pane(document, comm):
     assert model.text == '{"a": 2}'
     assert pane._models[model.ref['id']][0] is model
 
-    pane.object = '{"b": 3}'
+    pane.object = "{'b': 3}"
     assert model.text == '{"b": 3}'
+    assert pane._models[model.ref['id']][0] is model
+
+    pane.object = {"test": "can't show this"}
+    assert model.text == '{"test": "can\'t show this"}'
+    assert pane._models[model.ref['id']][0] is model
+
+    pane.object = ["can't show this"]
+    assert model.text == '["can\'t show this"]'
+    assert pane._models[model.ref['id']][0] is model
+
+    pane.object = "can't show this"
+    assert model.text == '"can\'t show this"'
+    assert pane._models[model.ref['id']][0] is model
+
+    pane.object = "can show this"
+    assert model.text == '"can show this"'
     assert pane._models[model.ref['id']][0] is model
 
     # Cleanup


### PR DESCRIPTION
Fixes #1798

Trying to use `literal_eval` for the `object` and then `json.dumps`. This PR also makes it possible to be more flexible with the `object`. 

The only thing I'm not completely sure about is if overlook something with the removal of `.replace(/(\r\n|\n|\r)/gm, "")`. 

```python
import panel as pn

json1 = pn.pane.JSON(object={"test": "can't show this"})
json2 = pn.pane.JSON(object=["can't show this"])
json3 = pn.pane.JSON(object="can't show this")
json4 = pn.pane.JSON(object="can show this")
json5 = pn.pane.JSON(object='{"b": 3}')
json6 = pn.pane.JSON(object="{'b': 3}")

pn.Column(json1, json2, json3, json4, json5, json6).servable()
```


| Without the PR | With the PR (`literal_eval`)|With the PR (`json.loads`)
|--------|-------|-------|
|![2021-04-04 15_24_39](https://user-images.githubusercontent.com/19758978/113510945-93da8180-955d-11eb-8106-c3a7cf728bdb.png)|![2021-04-04 15_25_19](https://user-images.githubusercontent.com/19758978/113510947-94731800-955d-11eb-8cf5-4cdbecced245.png)|![2021-04-05 14_52_45](https://user-images.githubusercontent.com/19758978/113576298-9a313200-961f-11eb-84a8-0611bf9e9dfb.png)|
