### PR TITLE
Bokeh theme reference

### DIFF
--- a/examples/reference/panes/Bokeh.ipynb
+++ b/examples/reference/panes/Bokeh.ipynb
@@ -20,8 +20,10 @@
     "The ``Bokeh`` pane allows displaying any displayable [Bokeh](http://bokeh.org) model inside a Panel app. Since Panel is built on Bokeh internally, the Bokeh model is simply inserted into the plot. Since Bokeh models are ordinarily only displayed once, some Panel-related functionality such as syncing multiple views of the same model may not work. Nonetheless this pane type is very useful for combining raw Bokeh code with the higher-level Panel API.\n",
     "\n",
     "#### Parameters:\n",
+    "For the ``theme`` parameter, see the [bokeh themes docs](https://docs.bokeh.org/en/latest/docs/reference/themes.html).\n",
     "\n",
     "* **``object``** (bokeh.layouts.LayoutDOM): The Bokeh model to be displayed\n",
+    "* **``theme``** (bokeh.themes.Theme): The Bokeh theme to apply\n",
     "\n",
     "___"
    ]
@@ -68,7 +70,7 @@
     "p.axis.visible=False\n",
     "p.grid.grid_line_color = None\n",
     "\n",
-    "bokeh_pane = pn.pane.Bokeh(p)\n",
+    "bokeh_pane = pn.pane.Bokeh(p, theme=\"dark_minimal\")\n",
     "bokeh_pane"
    ]
   },


### PR DESCRIPTION
Updated the Bokeh pane reference notebook to include information about themes.

Based on my testing, and seemingly unrelated to these changes, the last cell of the notebook does not render anything using the master branch of panel and bokeh 2.3.1, but does work in an environment with panel 0.10.3 and bokeh 2.2.3.