### PR TITLE
Fix of value_throttled in editable sliders

### DIFF
--- a/panel/widgets/slider.py
+++ b/panel/widgets/slider.py
@@ -457,9 +457,6 @@ class _EditableContinuousSlider(CompositeWidget):
     show_value = param.Boolean(default=False, readonly=True, precedence=-1, doc="""
         Whether to show the widget value.""")
 
-    exceed_bounds = param.Boolean(default=False, doc="""
-        Whether is it possible to exceed the bounds.""")
-
     _composite_type = Column
     _slider_widget = None
     _input_widget = None
@@ -518,8 +515,7 @@ class _EditableContinuousSlider(CompositeWidget):
         self._label.param.set_param(**{'margin': margin, 'value': label})
 
     @param.depends('start', 'end', 'step', 'bar_color', 'direction',
-                   'show_value', 'tooltips', 'format', 'exceed_bounds',
-                   watch=True)
+                   'show_value', 'tooltips', 'format', watch=True)
     def _update_slider(self):
         self._slider.param.set_param(**{
             'format': self.format,
@@ -531,13 +527,6 @@ class _EditableContinuousSlider(CompositeWidget):
             'show_value': self.show_value,
             'tooltips': self.tooltips
         })
-
-        if self.exceed_bounds:
-            self._value_edit.start = None
-            self._value_edit.end = None
-        else:
-            self._value_edit.start = self.start
-            self._value_edit.end = self.end
         self._value_edit.step = self.step
 
     @param.depends('value', watch=True)

--- a/panel/widgets/slider.py
+++ b/panel/widgets/slider.py
@@ -472,22 +472,15 @@ class _EditableContinuousSlider(CompositeWidget):
         )
         self._slider.param.watch(self._sync_value, 'value')
         self._slider.param.watch(self._sync_value, 'value_throttled')
+
         self._value_edit = self._input_widget(
             margin=0, align='end', css_classes=['slider-edit']
         )
+        self._value_edit.param.watch(self._sync_value, 'value')
+        self._value_edit.param.watch(self._sync_value, 'value_throttled')
+
         label = Row(self._label, self._value_edit)
         self._composite.extend([label, self._slider])
-        self._slider.jscallback(args={'value': self._value_edit}, value="""
-        value.value = cb_obj.value
-        """)
-        self._value_edit.jscallback(args={'slider': self._slider}, value="""
-        if (cb_obj.value < slider.start) {
-          slider.start = cb_obj.value
-        } else if (cb_obj.value > slider.end) {
-          slider.end = cb_obj.value
-        }
-        slider.value = cb_obj.value
-        """)
         self._update_editable()
         self._update_layout()
         self._update_name()
@@ -528,6 +521,8 @@ class _EditableContinuousSlider(CompositeWidget):
             'show_value': self.show_value,
             'tooltips': self.tooltips
         })
+        self._value_edit.start = self.start
+        self._value_edit.end = self.end
         self._value_edit.step = self.step
 
     @param.depends('value', watch=True)

--- a/panel/widgets/slider.py
+++ b/panel/widgets/slider.py
@@ -468,7 +468,7 @@ class _EditableContinuousSlider(CompositeWidget):
         super().__init__(**params)
         self._label = StaticText(margin=0, align='end')
         self._slider = self._slider_widget(
-            margin=(0, 0, 5, 0), sizing_mode='stretch_width'
+            value=self.value, margin=(0, 0, 5, 0), sizing_mode='stretch_width'
         )
         self._slider.param.watch(self._sync_value, 'value')
         self._slider.param.watch(self._sync_value, 'value_throttled')

--- a/panel/widgets/slider.py
+++ b/panel/widgets/slider.py
@@ -591,6 +591,9 @@ class EditableRangeSlider(CompositeWidget, _SliderBase):
                                       css_classes=['slider-edit'])
         self._end_edit = FloatInput(min_width=50, margin=(0, 0, 0, 10), format=self.format,
                                     css_classes=['slider-edit'])
+        self._start_edit.param.watch(self._sync_start_value, 'value_throttled')
+        self._end_edit.param.watch(self._sync_end_value, 'value_throttled')
+
         sep = StaticText(value='...', margin=(0, 2, 0, 2), align='end')
         edit = Row(self._label, self._start_edit, sep, self._end_edit,
                    sizing_mode='stretch_width', margin=0)
@@ -671,3 +674,15 @@ class EditableRangeSlider(CompositeWidget, _SliderBase):
     def _sync_value(self, event):
         with param.edit_constant(self):
             self.param.set_param(**{event.name: event.new})
+
+    def _sync_start_value(self, event):
+        with param.edit_constant(self):
+            self.param.set_param(
+                **{event.name: (event.new, self.value_throttled[1])}
+            )
+
+    def _sync_end_value(self, event):
+        with param.edit_constant(self):
+            self.param.set_param(
+                **{event.name: (self.value_throttled[0], event.new)}
+            )

--- a/panel/widgets/slider.py
+++ b/panel/widgets/slider.py
@@ -470,7 +470,8 @@ class _EditableContinuousSlider(CompositeWidget):
         self._slider = self._slider_widget(
             margin=(0, 0, 5, 0), sizing_mode='stretch_width'
         )
-        self._slider.param.watch(self._sync_value, ['value', 'value_throttled'])
+        self._slider.param.watch(self._sync_value, 'value')
+        self._slider.param.watch(self._sync_value, 'value_throttled')
         self._value_edit = self._input_widget(
             margin=0, align='end', css_classes=['slider-edit']
         )
@@ -535,8 +536,8 @@ class _EditableContinuousSlider(CompositeWidget):
         self._value_edit.value = self.value
 
     def _sync_value(self, event):
-        self.param.set_param(**{event.name: event.new})
-
+        with param.edit_constant(self):
+            self.param.set_param(**{event.name: event.new})
 
 
 class EditableFloatSlider(_EditableContinuousSlider, FloatSlider):
@@ -585,7 +586,8 @@ class EditableRangeSlider(CompositeWidget, _SliderBase):
         super().__init__(**params)
         self._label = StaticText(margin=0, align='end')
         self._slider = RangeSlider(margin=(0, 0, 5, 0), show_value=False)
-        self._slider.param.watch(self._sync_value, ['value', 'value_throttled'])
+        self._slider.param.watch(self._sync_value, 'value')
+        self._slider.param.watch(self._sync_value, 'value_throttled')
         self._start_edit = FloatInput(min_width=50, margin=0, format=self.format,
                                       css_classes=['slider-edit'])
         self._end_edit = FloatInput(min_width=50, margin=(0, 0, 0, 10), format=self.format,
@@ -668,4 +670,5 @@ class EditableRangeSlider(CompositeWidget, _SliderBase):
         self._end_edit.value = self.value[1]
 
     def _sync_value(self, event):
-        self.param.set_param(**{event.name: event.new})
+        with param.edit_constant(self):
+            self.param.set_param(**{event.name: event.new})


### PR DESCRIPTION
Fixes #2204

The error in #2204 was related to a missing `edit_constant` and the possibility of multiple events in `_sync_value`, which should now be fixed for the three editable sliders.

When looking / testing the editable sliders I could not get `value_throttled` to work with the `_input_widget`. To fix this, I changed the communication from `jscallback` to `param.watch`. Furthermore, I don't completely understand why in the current design it is possible to exceed the limit of the bounds with the _input_widget like
| Current | This PR |
| ----| ----|
|![before](https://user-images.githubusercontent.com/19758978/115147393-0a49aa00-a05b-11eb-91f5-978323f6af98.gif)| ![after](https://user-images.githubusercontent.com/19758978/115147398-0d449a80-a05b-11eb-9501-eef50b9c42a9.gif)|

I would expect the bounds to set to newer be exceeded, but it seems to be possible by design. Therefore, I have only implemented it for `EditableIntSlider` and `EditableFloatSlider`.