### PR TITLE
Improve and standardize selection behavior of Tabulator

### DIFF
--- a/examples/reference/widgets/Tabulator.ipynb
+++ b/examples/reference/widgets/Tabulator.ipynb
@@ -39,7 +39,7 @@
     "* **``page_size``** (``int``): Number of rows on each page.\n",
     "* **``pagination``** (`str`, `default=None`):  Set to 'local' or 'remote' to enable pagination; by default pagination is disabled with the value set to `None`.\n",
     "* **``selection``** (``list``): The currently selected rows.\n",
-    "* **``selectable``** (`boolean` or `str`): Whether to allow selection of rows. Can be `True`, `False` or `'checkbox'. \n",
+    "* **``selectable``** (`boolean` or `str`): Whether to allow selection of rows. Can be `True`, `False`, `'checkbox'` or `'toggle'`. \n",
     "* **``show_index``** (``boolean``): Whether to show the index column.\n",
     "* **`theme`** (``str``): The CSS theme to apply (note that changing the theme will restyle all tables on the page).\n",
     "* **`titles`** (``dict``): A mapping from column name to a title to override the name with.\n",
@@ -434,7 +434,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The `selectable` parameter can also be used to control how the selection works. Setting it to `False` will disable selecting entirely, while setting `selectable='checkbox'` will add checkboxes to perform the selection:"
+    "The `selectable` parameter declares how the selections work. \n",
+    "\n",
+    "- `True`: Selects rows on click. To select multiple use Ctrl-select, to select a range use Shift-select\n",
+    "- `False`: Disables selection\n",
+    "- `'checkbox'`: Adds a column of checkboxes to toggle selections\n",
+    "- `'toggle'`: Selection toggles when clicked"
    ]
   },
   {

--- a/panel/models/tabulator.py
+++ b/panel/models/tabulator.py
@@ -61,6 +61,8 @@ class DataTabulator(HTMLBox):
 
     sorters = List(Dict(String, String))
 
+    select_mode = Any(default=True)
+
     theme = Enum(*TABULATOR_THEMES, default="simple")
 
     theme_url = String(default=THEME_URL)

--- a/panel/models/tabulator.ts
+++ b/panel/models/tabulator.ts
@@ -159,11 +159,7 @@ export class DataTabulatorView extends PanelHTMLBoxView {
 
   getConfiguration(): any {
     const pagination = this.model.pagination == 'remote' ? 'local': (this.model.pagination || false)
-    let selectable: any
-    if (typeof this.model.select_mode === 'boolean')
-      selectable = false
-    else
-      selectable = true
+    let selectable = !typeof this.model.select_mode === 'boolean'
     let configuration = {
       ...this.model.configuration,
       index: "_index",

--- a/panel/models/tabulator.ts
+++ b/panel/models/tabulator.ts
@@ -160,11 +160,7 @@ export class DataTabulatorView extends PanelHTMLBoxView {
   getConfiguration(): any {
     const pagination = this.model.pagination == 'remote' ? 'local': (this.model.pagination || false)
     let selectable: any
-    if (this.model.select_mode === true)
-      selectable = false
-    else if (this.model.select_mode === 'toggle')
-      selectable = true
-    else if (this.model.select_mode === false)
+    if (typeof this.model.select_mode === 'boolean')
       selectable = false
     else
       selectable = true

--- a/panel/models/tabulator.ts
+++ b/panel/models/tabulator.ts
@@ -471,11 +471,11 @@ export class DataTabulatorView extends PanelHTMLBoxView {
     } else if (e.shiftKey && selected.indices.length) {
       const start = selected.indices[selected.indices.length-1]
       if (index>start) {
-	for (let i = start; i<index; i++)
-	  indices.push(i)
+        for (let i = start; i<index; i++)
+          indices.push(i)
       } else {
-	for (let i = start; i>index; i--)
-	  indices.push(i)
+        for (let i = start; i>index; i--)
+          indices.push(i)
       }
     }
     if (indices.indexOf(index) < 0)

--- a/panel/widgets/tables.py
+++ b/panel/widgets/tables.py
@@ -714,11 +714,15 @@ class Tabulator(BaseTable):
         The height of each table row.""")
 
     selectable = param.ObjectSelector(
-        default=True, objects=[True, False, 'checkbox'], doc="""
-        Whether a table's rows can be selected or not. Multiple
-        selection is allowed and can be achieved by either clicking
-        multiple checkboxes (if enabled) or using Shift + click on
-        rows.""")
+        default=True, objects=[True, False, 'checkbox', 'toggle'], doc="""
+        Defines the selection mode of the Tabulator.
+
+          - True: Selects rows on click. To select multiple use
+                  Ctrl-select, to select a range use Shift-select
+          - checkbox: Adds a column of checkboxes to toggle selections
+          - toggle: Selection toggles when clicked
+          - False: Disables selection
+        """)
 
     sorters = param.List(default=[], doc="""
         A list of sorters to apply during pagination.""")
@@ -734,6 +738,8 @@ class Tabulator(BaseTable):
     _config_params = ['frozen_columns', 'groups', 'selectable']
 
     _manual_params = BaseTable._manual_params + _config_params
+
+    _rename = {'disabled': 'editable', 'selection': None, 'selectable': 'select_mode'}
 
     def __init__(self, value=None, **params):
         configuration = params.pop('configuration', {})
@@ -954,6 +960,7 @@ class Tabulator(BaseTable):
         props['groupby'] = self.groupby
         props['hidden_columns'] = self.hidden_columns
         props['editable'] = not self.disabled
+        props['select_mode'] = self.selectable
         process = {'theme': self.theme, 'frozen_rows': self.frozen_rows}
         props.update(self._process_param_change(process))
         if self.pagination:


### PR DESCRIPTION
The old table had a more intuitive selection behavior which used Ctrl/Meta keys to toggle selection of multiple rows and the shift key for range selection. The Tabulator has a default behavior where clicking on rows simply toggles selection on and off. This changes the Tabulator selection behavior to be consistent with the old behavior but also allowing users to toggle the previous behavior by setting `selectable='toggle'`.

Fixes https://github.com/holoviz/panel/issues/2089