### PR TITLE
Add FlexBox layout

### DIFF
--- a/examples/reference/layouts/FlexBox.ipynb
+++ b/examples/reference/layouts/FlexBox.ipynb
@@ -1,0 +1,158 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import panel as pn\n",
+    "pn.extension()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The ``FlexBox`` is a list-like layout (unlike ``GridSpec``) that wraps objects into a CSS flex container. It has a list-like API with methods to ``append``, ``extend``, ``clear``, ``insert``, ``pop``, ``remove`` and ``__setitem__``, which make it possible to interactively update and modify the layout and exposes all the CSS options for controlling the behavior and layout of the flex box.\n",
+    "\n",
+    "For a detailed introduction to CSS flex boxes, see [this guide](https://css-tricks.com/snippets/css/a-guide-to-flexbox/).\n",
+    "\n",
+    "#### Parameters:\n",
+    "\n",
+    "For layout and styling related parameters see the [customization user guide](../../user_guide/Customization.ipynb).\n",
+    "\n",
+    "* **``align_content``** (str): Defines how a flex container's lines align when there is extra space in the cross-axis. One of 'normal', 'flex-start', 'flex-end', 'center', 'space-between', 'space-around', 'space-evenly', 'stretch', 'start', 'end', 'baseline', 'first baseline' and 'last baseline'.\n",
+    "* **``align_items``** (str): Defines the default behavior for how flex items are laid out along the cross axis on the current line. Same options as `align_content`.\n",
+    "* **``flex_direction``** (str): This establishes the main-axis, thus defining the direction flex items are placed in the flex container. One of 'row', 'row-reverse', 'column', 'column-reverse'.\n",
+    "* **``flex_wrap``** (str): Whether and how to wrap items in the flex container. One of 'nowrap', 'wrap', 'wrap-reverse'.\n",
+    "* **``justify_content``** (str): Defines the alignment along the main axis. One of 'flex-start', 'flex-end', 'center', 'space-between', 'space-around', 'space-evenly', 'start', 'end', 'left', 'right'.\n",
+    "* **``objects``** (list): The list of objects to display in the WidgetBox. Should not generally be modified directly except when replaced in its entirety.\n",
+    "\n",
+    "___"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "A ``FlexBox`` layout can either be instantiated as empty and populated after the fact or using a list of objects provided as positional arguments. If the objects are not already panel components they will each be converted to one using the ``pn.panel`` conversion method. By default the `FlexBox` has a `flex_direction='row'` and uses `flex_wrap='wrap'`, which means items will flow in a row-wise manner"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import random\n",
+    "\n",
+    "rcolor = lambda: \"#%06x\" % random.randint(0, 0xFFFFFF)\n",
+    "\n",
+    "box = pn.FlexBox(*[pn.pane.HTML(str(i), background=rcolor(), width=100, height=100) for i in range(24)])\n",
+    "box"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can flip the direction by setting the `flex_direction` parameter to `'column'`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "column_box = box.clone(flex_direction='column', height=450)\n",
+    "column_box"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The other options including `align_content`, `align_items`, and `justify_content` control how items are spaced on the page, e.g. `align_content` declares how to distribute items along the cross-axis (i.e. along the row direction for a column based flexbox):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "column_box.clone(align_content='space-evenly')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In general it is preferred to modify layouts only through the provided methods and avoid modifying the ``objects`` parameter directly. The one exception is when replacing the list of ``objects`` entirely, otherwise it is recommended to use the methods on the ``FlexBox`` itself to ensure that the rendered views of the ``FlexBox`` are rerendered in response to the change. As a simple example we might assign a new item to the ``box`` using a setitem operation:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "color = pn.pane.HTML(str(5), background=rcolor(), width=100, height=100)\n",
+    "column_box[5] = color"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To see the effect in a statically rendered page, we will display the box a second time:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "column_box"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In general a ``FlexBox`` does not have to be given a ``width``, ``height`` or ``sizing_mode``, allowing it to adapt to the size of its contents."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.8"
+  },
+  "widgets": {
+   "application/vnd.jupyter.widget-state+json": {
+    "state": {},
+    "version_major": 2,
+    "version_minor": 0
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/panel/__init__.py
+++ b/panel/__init__.py
@@ -10,8 +10,8 @@ from .depends import bind, depends # noqa
 from .interact import interact # noqa
 from .io import _jupyter_server_extension_paths, ipywidget, serve, state # noqa
 from .layout import ( # noqa
-    Accordion, Card, Row, Column, WidgetBox, Tabs, Spacer, 
-    GridSpec, GridBox
+    Accordion, Card, Column, GridSpec, GridBox, FlexBox, Tabs, Row,
+    Spacer, WidgetBox
 )
 from .pane import panel, Pane # noqa
 from .param import Param # noqa

--- a/panel/layout/__init__.py
+++ b/panel/layout/__init__.py
@@ -1,6 +1,7 @@
 from .accordion import Accordion # noqa
 from .base import Column, ListLike, ListPanel, Panel, Row, WidgetBox # noqa
 from .card import Card # noqa
+from .flex import FlexBox # noqa
 from .grid import GridBox, GridSpec # noqa
 from .spacer import Divider, HSpacer, Spacer, VSpacer # noqa
 from .tabs import Tabs # noqa

--- a/panel/layout/flex.py
+++ b/panel/layout/flex.py
@@ -1,0 +1,54 @@
+import param
+
+from ..reactive import ReactiveHTML
+from .base import ListLike
+
+class FlexBox(ListLike, ReactiveHTML):
+
+    align_content = param.Selector(default='flex-start', objects=[
+        'normal', 'flex-start', 'flex-end', 'center', 'space-between',
+        'space-around', 'space-evenly', 'stretch', 'start', 'end',
+        'baseline', 'first baseline', 'last baseline'], doc="""
+        Defines how a flex container's lines align when there is extra
+        space in the cross-axis.""")
+
+    align_items = param.Selector(default='flex-start', objects=[
+        'stretch', 'flex-start', 'flex-end', 'center', 'baseline',
+        'first baseline', 'last baseline', 'start', 'end',
+        'self-start', 'self-end'], doc="""
+        Defines the default behavior for how flex items are laid
+        out along the cross axis on the current line.""")
+
+    flex_direction = param.Selector(default='row', objects=[
+        'row', 'row-reverse', 'column', 'column-reverse'], doc="""
+        This establishes the main-axis, thus defining the direction
+        flex items are placed in the flex container.""")
+
+    flex_wrap = param.Selector(default='wrap', objects=[
+        'nowrap', 'wrap', 'wrap-reverse'], doc="""
+        Whether and how to wrap items in the flex container.""")
+
+    justify_content = param.Selector(default='flex-start', objects=[
+        'flex-start', 'flex-end', 'center', 'space-between', 'space-around',
+        'space-evenly', 'start', 'end', 'left', 'right'], doc="""
+        Defines the alignment along the main axis.""")
+
+    _template = """
+    <div id="flexbox" style="display: flex; flex-wrap: ${flex_wrap}; justify-content: ${justify_content}; flex-direction: ${flex_direction}; align-content: ${align_content};">
+    {% for obj in objects %}
+      <div id="flex-item-{{ loop.index0 }}">
+       ${objects[{{ loop.index0 }}]}
+      </div>
+    {% endfor %}
+    </div>
+    """
+
+    def __init__(self, *objects, **params):
+        if 'sizing_mode' not in params:
+            direction = params.get('flex_direction', self.flex_direction)
+            if direction.startswith('row'):
+                params['sizing_mode'] = 'stretch_width'
+            else:
+                params['sizing_mode'] = 'stretch_height'
+        super().__init__(objects=list(objects), **params)
+    

--- a/panel/layout/flex.py
+++ b/panel/layout/flex.py
@@ -36,7 +36,7 @@ class FlexBox(ListLike, ReactiveHTML):
         'space-evenly', 'start', 'end', 'left', 'right'], doc="""
         Defines the alignment along the main axis.""")
 
-    _template = (Path(__file__).parent / 'flexbox.html').read_text('utf-8'0)
+    _template = (Path(__file__).parent / 'flexbox.html').read_text('utf-8')
 
     def __init__(self, *objects, **params):
         if 'sizing_mode' not in params:

--- a/panel/layout/flex.py
+++ b/panel/layout/flex.py
@@ -1,7 +1,10 @@
+from pathlib import Path
+
 import param
 
 from ..reactive import ReactiveHTML
 from .base import ListLike
+
 
 class FlexBox(ListLike, ReactiveHTML):
 
@@ -33,15 +36,7 @@ class FlexBox(ListLike, ReactiveHTML):
         'space-evenly', 'start', 'end', 'left', 'right'], doc="""
         Defines the alignment along the main axis.""")
 
-    _template = """
-    <div id="flexbox" style="display: flex; flex-wrap: ${flex_wrap}; justify-content: ${justify_content}; flex-direction: ${flex_direction}; align-content: ${align_content};">
-    {% for obj in objects %}
-      <div id="flex-item-{{ loop.index0 }}">
-       ${objects[{{ loop.index0 }}]}
-      </div>
-    {% endfor %}
-    </div>
-    """
+    _template = (Path(__file__).parent / 'flexbox.html').read_text('utf-8'0)
 
     def __init__(self, *objects, **params):
         if 'sizing_mode' not in params:
@@ -51,4 +46,4 @@ class FlexBox(ListLike, ReactiveHTML):
             else:
                 params['sizing_mode'] = 'stretch_height'
         super().__init__(objects=list(objects), **params)
-    
+

--- a/panel/layout/flexbox.html
+++ b/panel/layout/flexbox.html
@@ -1,0 +1,7 @@
+<div id="flexbox" style="display: flex; flex-wrap: ${flex_wrap}; justify-content: ${justify_content}; flex-direction: ${flex_direction}; align-content: ${align_content};">
+  {% for obj in objects %}
+  <div id="flex-item-{{ loop.index0 }}">
+    ${objects[{{ loop.index0 }}]}
+  </div>
+  {% endfor %}
+</div>

--- a/panel/reactive.py
+++ b/panel/reactive.py
@@ -1232,15 +1232,15 @@ class ReactiveHTML(Reactive, metaclass=ReactiveHTMLMetaclass):
             mode = self._child_config.get(children_param, 'model')
             if mode == 'literal':
                 continue
-            new_panes = getattr(self, children_param)
-            if not isinstance(new_panes, (list, dict)):
-                new_panes = [new_panes]
+            panes = getattr(self, children_param)
+            if not isinstance(panes, (list, dict)):
+                panes = [panes]
                 old_panes = [old_panes]
-            elif isinstance(new_panes, dict):
-                new_panes = new_panes.values()
+            elif isinstance(panes, dict):
+                panes = panes.values()
                 old_panes = old_panes.values()
             for old_pane in old_panes:
-                if old_pane not in new_panes:
+                if old_pane not in panes:
                     old_pane._cleanup(root)
 
         for parent, child_panes in new_panes.items():

--- a/panel/reactive.py
+++ b/panel/reactive.py
@@ -1131,6 +1131,11 @@ class ReactiveHTML(Reactive, metaclass=ReactiveHTMLMetaclass):
                     else:
                         children.append(panel(pane))
                 params[children_param] = children
+            elif isinstance(child_value, dict):
+                children = {}
+                for key, pane in child_value.items():
+                    children[key] = panel(pane)
+                params[children_param] = children
             else:
                 params[children_param] = panel(child_value)
         super().__init__(**params)
@@ -1206,20 +1211,22 @@ class ReactiveHTML(Reactive, metaclass=ReactiveHTMLMetaclass):
         old_children = old_children or {}
         old_models = model.children
         new_models = {parent: [] for parent in self._parser.children}
+        new_panes = {}
 
         for parent, children_param in self._parser.children.items():
             mode = self._child_config.get(children_param, 'model')
             if mode == 'literal':
                 continue
             panes = getattr(self, children_param)
-            if not isinstance(panes, (list, dict)):
-                panes = [panes]
             if isinstance(panes, dict):
                 for key, value in panes.items():
                     panes[key] = panel(value)
-            else:
+            elif isinstance(panes, list):
                 for i, pane in enumerate(panes):
                     panes[i] = panel(pane)
+            else:
+                panes = [panel(panes)]
+            new_panes[parent] = panes
 
         for children_param, old_panes in old_children.items():
             mode = self._child_config.get(children_param, 'model')
@@ -1231,25 +1238,24 @@ class ReactiveHTML(Reactive, metaclass=ReactiveHTMLMetaclass):
                 old_panes = [old_panes]
             elif isinstance(new_panes, dict):
                 new_panes = new_panes.values()
+                old_panes = old_panes.values()
             for old_pane in old_panes:
                 if old_pane not in new_panes:
                     old_pane._cleanup(root)
 
-        for parent, children_param in self._parser.children.items():
-            new_panes = getattr(self, children_param)
-            if not isinstance(new_panes, (list, dict)):
-                new_panes = [new_panes]
-            if isinstance(new_panes, dict):
-                new_panes = (new_panes.values())
+        for parent, child_panes in new_panes.items():
+            children_param = self._parser.children[parent]
+            if isinstance(child_panes, dict):
+                child_panes = child_panes.values()
             mode = self._child_config.get(children_param, 'model')
             if mode == 'literal':
-                new_models[parent] = new_panes
+                new_models[parent] = child_panes
             elif children_param in old_children:
                 # Find existing models
                 old_panes = old_children[children_param]
                 if not isinstance(old_panes, (list, dict)):
                     old_panes = [old_panes]
-                for i, pane in enumerate(new_panes):
+                for i, pane in enumerate(child_panes):
                     if pane in old_panes and root.ref['id'] in pane._models:
                         child, _ = pane._models[root.ref['id']]
                     else:
@@ -1261,7 +1267,7 @@ class ReactiveHTML(Reactive, metaclass=ReactiveHTMLMetaclass):
             else:
                 new_models[parent] = [
                     pane._get_model(doc, root, model, comm)
-                    for pane in new_panes
+                    for pane in child_panes
                 ]
         return self._process_children(doc, root, model, comm, new_models)
 

--- a/setup.py
+++ b/setup.py
@@ -138,7 +138,7 @@ extras_require = {
         'altair',
         'streamz',
         'vega_datasets',
-        'vtk',
+        'vtk ==9.0.1',
         'scikit-learn',
         'datashader',
         'jupyter_bokeh',


### PR DESCRIPTION
Adds a `FlexBox` layout container which is the first ReactiveHTML based layout component added to panel. Exposes the power of CSS flex boxes in panel, which unlike our other containers responsively wrap depending on the size of the contents and the container.

![flexbox](https://user-images.githubusercontent.com/1550771/115877614-ed8ce800-a447-11eb-9b55-de0a91d88f83.gif)
