### PR TITLE
Add support for vtkCornerAnnotations

### DIFF
--- a/panel/models/vtk.py
+++ b/panel/models/vtk.py
@@ -78,6 +78,9 @@ class AbstractVTKPlot(HTMLBox):
 
     width = Override(default=300)
 
+    annotations = List(Dict(String, Any))
+
+
 
 class VTKSynchronizedPlot(AbstractVTKPlot):
     """

--- a/panel/models/vtk/util.ts
+++ b/panel/models/vtk/util.ts
@@ -111,6 +111,22 @@ export type ColorMapper = {
 export const Interpolation = Enum("fast_linear", "linear", "nearest")
 export type Interpolation = typeof Interpolation["__type__"]
 
+export type Annotation = {
+  id: string
+  viewport: number[]
+  fontSize: number
+  fontFamily: string
+  color: number[]
+  LowerLeft?: string
+  LowerRight?: string
+  UpperLeft?: string
+  UpperRight?: string
+  LowerEdge?: string
+  RightEdge?: string
+  LeftEdge?: string
+  UpperEdge?: string
+}
+
 export declare type CSSProperties = {[key: string]: string}
 
 export declare type VolumeType = {

--- a/panel/pane/vtk/enums.py
+++ b/panel/pane/vtk/enums.py
@@ -1,4 +1,15 @@
+from enum import Enum
 from collections import namedtuple
+
+class TextPosition(Enum):
+    LowerLeft = 0 
+    LowerRight = 1  
+    UpperLeft = 2 
+    UpperRight = 3  
+    LowerEdge = 4 
+    RightEdge = 5  
+    LeftEdge = 6  
+    UpperEdge = 7   
 
 SCALAR_MODE = namedtuple("SCALAR_MODE",
     "Default UsePointData UseCellData UsePointFieldData UseCellFieldData UseFieldData"

--- a/panel/pane/vtk/vtk.py
+++ b/panel/pane/vtk/vtk.py
@@ -296,12 +296,13 @@ class BaseVTKRenderWindow(AbstractVTK):
             filename += '.synch'
         import panel.pane.vtk.synchronizable_serializer as rws
         context = rws.SynchronizationContext(serialize_all_data_arrays=all_data_arrays, debug=self._debug_serializer)
-        scene, arrays = self._serialize_ren_win(self.object, context, binary=True, compression=False)
+        scene, arrays, annotations = self._serialize_ren_win(self.object, context, binary=True, compression=False)
 
         with zipfile.ZipFile(filename, mode='w') as zf:
             zf.writestr('index.json', json.dumps(scene))
             for name, data in arrays.items():
                 zf.writestr('data/%s' % name, data, zipfile.ZIP_DEFLATED)
+            zf.writestr('annotations.json', json.dumps(annotations))
         return filename
 
     def _update_color_mappers(self):

--- a/panel/pane/vtk/vtk.py
+++ b/panel/pane/vtk/vtk.py
@@ -321,7 +321,8 @@ class BaseVTKRenderWindow(AbstractVTK):
         arrays = {name: context.getCachedDataArray(name, binary=binary, compression=compression)
                     for name in context.dataArrayCache.keys()
                     if name not in exclude_arrays}
-        return scene, arrays
+        annotations = context.getAnnotations()
+        return scene, arrays, annotations
 
     @staticmethod
     def _rgb2hex(r, g, b):
@@ -379,14 +380,12 @@ class VTKRenderWindow(BaseVTKRenderWindow):
             serialize_all_data_arrays=self.serialize_all_data_arrays,
             debug=self._debug_serializer
         )
-        self._scene, self._arrays = self._serialize_ren_win(
+        self._scene, self._arrays, self._annotations = self._serialize_ren_win(
             self.object,
             context,
         )
         if model is not None:
-            model.update(rebuild=True)
-            model.update(arrays=self._arrays)
-            model.update(scene=self._scene)
+            model.update(rebuild=True, arrays=self._arrays, scene=self._scene, annotations=self._annotations)
 
 
 class VTKRenderWindowSynchronized(BaseVTKRenderWindow, SyncHelpers):
@@ -427,10 +426,10 @@ class VTKRenderWindowSynchronized(BaseVTKRenderWindow, SyncHelpers):
             serialize_all_data_arrays=self.serialize_all_data_arrays,
             debug=self._debug_serializer
         )
-        scene, arrays = self._serialize_ren_win(self.object, context)
+        scene, arrays, annotations = self._serialize_ren_win(self.object, context)
         self._update_color_mappers()
         props = self._process_param_change(self._init_params())
-        props.update(scene=scene, arrays=arrays, color_mappers=self.color_mappers)
+        props.update(scene=scene, arrays=arrays, annotations=annotations, color_mappers=self.color_mappers)
         model = VTKSynchronizedPlot(**props)
 
         if root is None:
@@ -450,14 +449,13 @@ class VTKRenderWindowSynchronized(BaseVTKRenderWindow, SyncHelpers):
 
     def _update(self, ref=None, model=None):
         context = self._contexts[model.id]
-        scene, arrays = self._serialize_ren_win(
+        scene, arrays, annotations = self._serialize_ren_win(
             self.object,
             context,
             exclude_arrays=model.arrays_processed
         )
         context.checkForArraysToRelease()
-        model.update(arrays=arrays)
-        model.update(scene=scene)
+        model.update(arrays=arrays, scene=scene, annotations=annotations)
 
     def synchronize(self):
         self.param.trigger('object')


### PR DESCRIPTION
```python
plotter = pv.Plotter(shape=(2, 2))

plotter.subplot(0, 0)
plotter.add_text("Render Window 0", font_size=30, position="upper_edge")
plotter.add_text("Upper_Left", font_size=20, position="upper_left", color=(1,1,1))
plotter.add_text("Upper_Right", font_size=20, position="upper_right", color="green")
plotter.add_text("Lower_Left", font_size=20, position="lower_left", color="blue")
plotter.add_text("Lower_Right", font_size=20, position="lower_right", color="red")
plotter.add_mesh(examples.load_globe())

plotter.subplot(0, 1)
plotter.add_text("Upper_Edge", font_size=20, position="upper_edge")
plotter.add_text("Lower_Edge", font_size=20, position="lower_edge", font="courier")
plotter.add_text("Left_Edge", font_size=20, position="left_edge", font="times")
plotter.add_text("Right_Edge", font_size=20, position="right_edge", color=(0.9,0.9,0.5))
plotter.add_mesh(pv.Cube(), show_edges=True, color="tan")

plotter.subplot(1, 0)
plotter.add_text("Render Window 2", font_size=30, position="upper_edge")
sphere = pv.Sphere()
plotter.add_mesh(sphere, scalars=sphere.points[:, 2])
plotter.add_axes(interactive=True)

plotter.subplot(1, 1)
plotter.add_text("Render Window 3", font_size=30, position="left_edge")
plotter.add_mesh(pv.Cone(), color="g", show_edges=True)

# Display the window
pn.panel(plotter.ren_win, sizing_mode="stretch_both", height=400)

```
![image](https://user-images.githubusercontent.com/18531147/116252902-48884d00-a770-11eb-9ce8-a983fa6be97e.png)
