### PR TITLE
Improve request handling for remote pagination on Tabulator

### DIFF
--- a/panel/models/tabulator.ts
+++ b/panel/models/tabulator.ts
@@ -87,13 +87,6 @@ export class DataTabulatorView extends PanelHTMLBoxView {
 
     this.tabulator = new Tabulator(container, configuration)
 
-    // Patch the ajax request method
-    this.tabulator.modules = {...this.tabulator.modules}
-    const ajax = this.tabulator.modules.ajax
-    this.tabulator.modules.ajax.sendRequest = () => {
-      this.requestPage(ajax.params.page, ajax.params.sorters)
-    }
-
     // Swap pagination mode
     if (this.model.pagination === 'remote') {
       this.tabulator.options.pagination = this.model.pagination
@@ -114,12 +107,23 @@ export class DataTabulatorView extends PanelHTMLBoxView {
     this.el.appendChild(container)
   }
 
+  tableInit(view: DataTabulatorView, tabulator: any): void {
+    // Patch the ajax request and page data parsing methods
+    const ajax = tabulator.modules.ajax
+    ajax.sendRequest = () => {
+      return view.requestPage(ajax.params.page, ajax.params.sorters)
+    }
+    tabulator.modules.page._parseRemoteData = (data: any) => {}
+  }
+
   requestPage(page: number, sorters: any[]): Promise<void> {
     return new Promise((resolve: any, reject: any) => {
       try {
-        this.model.page = page || 1
-        this.model.sorters = sorters
-        resolve({data: [], last_page: this.model.max_page})
+	if (page != null && sorters != null) {
+          this.model.page = page || 1
+          this.model.sorters = sorters
+	}
+        resolve([])
       } catch(err) {
         reject(err)
       }
@@ -160,10 +164,12 @@ export class DataTabulatorView extends PanelHTMLBoxView {
   getConfiguration(): any {
     const pagination = this.model.pagination == 'remote' ? 'local': (this.model.pagination || false)
     let selectable = !(typeof this.model.select_mode === 'boolean')
+    const that = this
     let configuration = {
       ...this.model.configuration,
       index: "_index",
       selectable: selectable,
+      tableBuilding: function() { that.tableInit(that, this) },
       renderComplete: () => this.renderComplete(),
       rowSelectionChanged: (data: any, rows: any) => this.rowSelectionChanged(data, rows),
       rowClick: (e: any, row: any) => this.rowClicked(e, row),

--- a/panel/widgets/tables.py
+++ b/panel/widgets/tables.py
@@ -896,7 +896,7 @@ class Tabulator(BaseTable):
 
     def _update_selected(self, *events, indices=None):
         kwargs = {}
-        if self.pagination == 'remote':
+        if self.pagination == 'remote' and self.value is not None:
             index = self.value.iloc[self.selection].index
             indices = []
             for v in index.values:


### PR DESCRIPTION
Patches ajax requests handling during initialization of the Tabulator so no request is **ever** sent and ensures Tabulator initialized with None works when paginated.