### PR TITLE
Allow setting Param precedence to None

### DIFF
--- a/panel/param.py
+++ b/panel/param.py
@@ -459,8 +459,12 @@ class Param(PaneBase):
             if change.what == 'constant':
                 updates['disabled'] = change.new
             elif change.what == 'precedence':
-                if (change.new < self.display_threshold and
-                    widget in self._widget_box.objects):
+                if change.new is change.old:
+                    return
+                elif change.new is None:
+                    self._rerender()
+                elif (change.new < self.display_threshold and
+                      widget in self._widget_box.objects):
                     self._widget_box.pop(widget)
                 elif change.new >= self.display_threshold:
                     self._rerender()

--- a/panel/tests/test_param.py
+++ b/panel/tests/test_param.py
@@ -406,6 +406,9 @@ def test_param_precedence(document, comm):
     a_param.precedence = 1
     assert test_pane._widgets['a'] in test_pane._widget_box.objects
 
+    a_param.precedence = None
+    assert test_pane._widgets['a'] in test_pane._widget_box.objects
+
 
 def test_param_label(document, comm):
     class Test(param.Parameterized):


### PR DESCRIPTION
As the title says, (re)setting the precedence to None triggered an error. It now correctly renders the widget.