### PR TITLE
Allow using loop variables in ReactiveHTML templates

### DIFF
--- a/examples/user_guide/Custom_Components.ipynb
+++ b/examples/user_guide/Custom_Components.ipynb
@@ -154,7 +154,7 @@
     "Instead of declaring explicit DOM events Python callbacks can also be declared inline, e.g.:\n",
     "\n",
     "```html\n",
-    "    _html = '<input id=\"input\" onchange=\"${_input_change}\"></input>'\n",
+    "    _template = '<input id=\"input\" onchange=\"${_input_change}\"></input>'\n",
     "```\n",
     "\n",
     "will look for an `_input_change` method on the `ReactiveHTML` component and call it when the event is fired.\n",
@@ -164,7 +164,7 @@
     "In addition to declaring callbacks in Python it is also possible to declare Javascript callbacks to execute when any sync attribute changes. Let us say we have declared an input element with a synced value parameter:\n",
     "\n",
     "```html\n",
-    "    _html = '<input id=\"input\" value=\"${value}\"></input>'\n",
+    "    _template = '<input id=\"input\" value=\"${value}\"></input>'\n",
     "```\n",
     "\n",
     "We can now declare a set of `_scripts`, which will fire whenever the value updates:\n",
@@ -236,7 +236,7 @@
    "source": [
     "#### Child templates\n",
     "\n",
-    "If we want to provide a template for the children of an HTML node we have to use Jinja2 to loop over the parameter and use the `{{ loop.index0 }}` variable to enumerate the child `id`s and index into the options:"
+    "If we want to provide a template for the children of an HTML node we have to use Jinja2 to loop over the parameter and use the `{{ loop.index0 }}` variable to enumerate the child `id`s:"
    ]
   },
   {
@@ -254,7 +254,7 @@
     "    _template = \"\"\"\n",
     "    <select id=\"select\" value=\"${value}\">\n",
     "      {% for obj in options %}\n",
-    "      <option id=\"option-{{ loop.index0 }}\">${options[{{ loop.index0 }}]}</option>\n",
+    "      <option id=\"option-{{ loop.index0 }}\">${obj}</option>\n",
     "      {% endfor %}\n",
     "    </select>\n",
     "    \"\"\"\n",

--- a/examples/user_guide/Custom_Components.ipynb
+++ b/examples/user_guide/Custom_Components.ipynb
@@ -236,7 +236,7 @@
    "source": [
     "#### Child templates\n",
     "\n",
-    "If we want to provide a template for the children of an HTML node we have to use Jinja2 to loop over the parameter and use the `{{ loop.index0 }}` variable to enumerate the child `id`s:"
+    "If we want to provide a template for the children of an HTML node we have to use Jinja2 syntax to loop over the parameter. The component will automatically assign each `<option>` tag a unique id and insert the loop variable `obj` into each of the tags:"
    ]
   },
   {
@@ -254,7 +254,7 @@
     "    _template = \"\"\"\n",
     "    <select id=\"select\" value=\"${value}\">\n",
     "      {% for obj in options %}\n",
-    "      <option id=\"option-{{ loop.index0 }}\">${obj}</option>\n",
+    "      <option id=\"option\">${obj}</option>\n",
     "      {% endfor %}\n",
     "    </select>\n",
     "    \"\"\"\n",

--- a/panel/tests/test_reactive.py
+++ b/panel/tests/test_reactive.py
@@ -301,6 +301,7 @@ def test_reactive_html_templated_children():
     widget = TextInput()
     test = TestTemplatedChildren(children=[widget])
     root = test.get_root()
+    assert root.looped == ['option']
     assert root.children == {'option': [widget._models[root.ref['id']][0]]}
 
     widget_new = TextInput()
@@ -308,3 +309,77 @@ def test_reactive_html_templated_children():
     assert len(widget._models) == 0
     assert root.children == {'option': [widget_new._models[root.ref['id']][0]]}
 
+
+
+def test_reactive_html_templated_children_add_loop_id():
+
+    class TestTemplatedChildren(ReactiveHTML):
+
+        children = param.List(default=[])
+
+        _template = """
+        <select id="select">
+        {% for option in children %}
+          <option id="option">${children[{{ loop.index0 }}]}</option>
+        {% endfor %}
+        </select>
+        """
+
+    assert TestTemplatedChildren._attrs == {}
+    assert TestTemplatedChildren._node_callbacks == {}
+    assert TestTemplatedChildren._inline_callbacks == []
+    assert TestTemplatedChildren._parser.children == {'option': 'children'}
+
+    test = TestTemplatedChildren(children=['A', 'B', 'C'])
+
+    assert test._get_template() == """
+        <select id="select-${id}">
+        
+          <option id="option-0-${id}"></option>
+        
+          <option id="option-1-${id}"></option>
+        
+          <option id="option-2-${id}"></option>
+        
+        </select>
+        """
+
+    model = test.get_root()
+    assert model.looped == ['option']
+
+
+
+def test_reactive_html_templated_children_add_loop_id_and_for_loop_var():
+
+    class TestTemplatedChildren(ReactiveHTML):
+
+        children = param.List(default=[])
+
+        _template = """
+        <select id="select">
+        {% for option in children %}
+          <option id="option">${option}</option>
+        {% endfor %}
+        </select>
+        """
+
+    assert TestTemplatedChildren._attrs == {}
+    assert TestTemplatedChildren._node_callbacks == {}
+    assert TestTemplatedChildren._inline_callbacks == []
+    assert TestTemplatedChildren._parser.children == {'option': 'children'}
+
+    test = TestTemplatedChildren(children=['A', 'B', 'C'])
+
+    assert test._get_template() == """
+        <select id="select-${id}">
+        
+          <option id="option-0-${id}"></option>
+        
+          <option id="option-1-${id}"></option>
+        
+          <option id="option-2-${id}"></option>
+        
+        </select>
+        """
+    model = test.get_root()
+    assert model.looped == ['option']


### PR DESCRIPTION
Allows making use of loop variables instead of the more cumbersome indexing syntax, e.g. this:

```python
class Select(ReactiveHTML):

    options = param.List(doc="Options to choose from.")
    
    value = param.String(doc="Current selected option")
    
    _template = """
    <select id="select" value="${value}">
      {% for obj in options %}
      <option id="option-{{ loop.index0 }}">${objects[{{ loop.index0 }}]}</option>
      {% endfor %}
    </select>
    """
```

Can now be written as:

```python
class Select(ReactiveHTML):

    options = param.List(doc="Options to choose from.")
    
    value = param.String(doc="Current selected option")
    
    _template = """
    <select id="select" value="${value}">
      {% for obj in options %}
      <option id="option">${obj}</option>
      {% endfor %}
    </select>
    """
```