### PR TITLE
Disable nested field separators on Tabulator

### DIFF
--- a/panel/models/tabulator.ts
+++ b/panel/models/tabulator.ts
@@ -168,6 +168,7 @@ export class DataTabulatorView extends PanelHTMLBoxView {
     let configuration = {
       ...this.model.configuration,
       index: "_index",
+      nestedFieldSeparator: false,
       selectable: selectable,
       tableBuilding: function() { that.tableInit(that, this) },
       renderComplete: () => this.renderComplete(),


### PR DESCRIPTION
By default Tabulator uses `.` as the nested field separator, which means that any columns containing periods will be treated as a nested field. Since we do not support nested fields anyway we simply disable this.