### PR TITLE
Fix DiscreteSlider uses '%.3g' formatter for numpy64 ints

### DIFF
--- a/examples/reference/widgets/DiscreteSlider.ipynb
+++ b/examples/reference/widgets/DiscreteSlider.ipynb
@@ -27,6 +27,7 @@
     "* **``options``** (list or dict): A list or dictionary of options to select from\n",
     "* **``value``** (object): The current value; must be one of the option values\n",
     "* **``value_throttled ``** (object): The current value; must be one of the option values, throttled until mouseup\n",
+    "* **``formatter``** (str): Allows setting a string formatter, default is '.3g'. If the options specified are integers this is changed to '0,.0f'.\n",
     "\n",
     "##### Display\n",
     "\n",
@@ -69,11 +70,24 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
    "name": "python",
-   "pygments_lexer": "ipython3"
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.4"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/panel/tests/widgets/test_slider.py
+++ b/panel/tests/widgets/test_slider.py
@@ -1,10 +1,13 @@
-from datetime import datetime, date
 from collections import OrderedDict
+from datetime import date, datetime
 
-from bokeh.models import Div as BkDiv, Slider as BkSlider, Column as BkColumn
-
-from panel.widgets import (DateSlider, DateRangeSlider, DiscreteSlider,
+import numpy as np
+from bokeh.models import Column as BkColumn
+from bokeh.models import Div as BkDiv
+from bokeh.models import Slider as BkSlider
+from panel.widgets import (DateRangeSlider, DateSlider, DiscreteSlider,
                            FloatSlider, IntSlider, RangeSlider)
+from panel.widgets.slider import INT_FORMATTER, FLOAT_FORMATTER
 
 
 def test_float_slider(document, comm):
@@ -226,3 +229,33 @@ def test_discrete_slider_options_dict(document, comm):
 
     discrete_slider.value = 100
     assert widget.value == 3
+
+def test_discrete_slider_with_numpy64_options2():
+    options = [np.int64(1), np.int64(1)]
+    slider = DiscreteSlider(value=options[-1], options=options)
+    assert slider.formatter != '%.3g'
+
+from panel.widgets import DiscreteSlider
+import numpy as np
+
+def test_discrete_slider_with_numpy64_options():
+    options = [np.int64(1), np.int64(1)]
+    slider = DiscreteSlider(value=options[-1], options=options)
+    assert slider.formatter == '0,.0f'
+
+def test_format_as_value():
+    assert DiscreteSlider._format_value(2, '0,.0f')=='2'
+    assert DiscreteSlider._format_value(2, '0.2f')=='2.00'
+    assert DiscreteSlider._format_value(2000, '0,.0f')=='2,000'
+    assert DiscreteSlider._format_value(2000, '%.3g')=='2e+03'
+    assert DiscreteSlider._format_value(2000, '.3g')=='2e+03'
+
+
+def test_default_formatters():
+    assert INT_FORMATTER == '0,.0f'
+    assert FLOAT_FORMATTER == '.3g'
+
+def test_determine_formatter():
+    assert DiscreteSlider._determine_formatter([0,1,2])==INT_FORMATTER
+    assert DiscreteSlider._determine_formatter([np.int64(0),np.int64(1),np.int64(2)])==INT_FORMATTER
+    assert DiscreteSlider._determine_formatter([2.01, 2.02, 2.03])==DiscreteSlider.param.formatter.default

--- a/panel/widgets/slider.py
+++ b/panel/widgets/slider.py
@@ -22,6 +22,8 @@ from .base import Widget, CompositeWidget
 from ..layout import Column, Row
 from .input import IntInput, FloatInput, StaticText
 
+INT_FORMATTER = '0,.0f'
+FLOAT_FORMATTER = '.3g'
 
 class _SliderBase(Widget):
 
@@ -190,7 +192,7 @@ class DiscreteSlider(CompositeWidget, _SliderBase):
 
     value_throttled = param.Parameter(constant=True)
 
-    formatter = param.String(default='%.3g')
+    formatter = param.String(default=FLOAT_FORMATTER)
 
     _source_transforms = {'value': None, 'value_throttled': None, 'options': None}
 
@@ -208,8 +210,8 @@ class DiscreteSlider(CompositeWidget, _SliderBase):
     def __init__(self, **params):
         self._syncing = False
         super().__init__(**params)
-        if 'formatter' not in params and all(isinstance(v, (int, np.int_)) for v in self.values):
-            self.formatter = '%d'
+        if 'formatter' not in params:
+            self.formatter = self._determine_formatter(self.values)
         if self.value is None and None not in self.values and self.options:
             self.value = self.values[0]
         elif self.value not in self.values:
@@ -226,6 +228,13 @@ class DiscreteSlider(CompositeWidget, _SliderBase):
         self.param.watch(self._update_value, 'value')
         self.param.watch(self._update_value, 'value_throttled')
         self.param.watch(self._update_style, self._style_params)
+
+    @classmethod
+    def _determine_formatter(cls, values):
+        if all(isinstance(v, (int, np.integer)) for v in values):
+            return INT_FORMATTER
+        else:
+            return cls.param.formatter.default
 
     def _update_options(self, *events):
         values, labels = self.values, self.labels
@@ -330,14 +339,19 @@ class DiscreteSlider(CompositeWidget, _SliderBase):
                              "in the %s widgets' values list." % type(self).__name__)
         return self, model, values, lambda x: x.value, 'value', 'cb_obj.value'
 
+    @staticmethod
+    def _format_value(value, formatter):
+        if formatter.startswith("%"):
+            return formatter % value
+        return f'{{:{formatter}}}'.format(value)
+
     @property
     def labels(self):
         title = (self.name + ': ' if self.name else '')
-        if isinstance(self.options, dict):
-            return [title + ('<b>%s</b>' % o) for o in self.options]
-        else:
-            return [title + ('<b>%s</b>' % (o if isinstance(o, string_types) else (self.formatter % o)))
-                    for o in self.options]
+        return [title + ('<b>%s</b>' % (o if isinstance(o, string_types)
+            else self._format_value(o, self.formatter)))
+            for o in self.options]
+
     @property
     def values(self):
         return list(self.options.values()) if isinstance(self.options, dict) else self.options

--- a/panel/widgets/slider.py
+++ b/panel/widgets/slider.py
@@ -192,7 +192,10 @@ class DiscreteSlider(CompositeWidget, _SliderBase):
 
     value_throttled = param.Parameter(constant=True)
 
-    formatter = param.String(default=FLOAT_FORMATTER)
+    formatter = param.String(default=FLOAT_FORMATTER, doc=f"""
+    Allows setting a string formatter, default is '{FLOAT_FORMATTER}'. If the options specified
+    are integers this is changed to '{INT_FORMATTER}'.
+    """)
 
     _source_transforms = {'value': None, 'value_throttled': None, 'options': None}
 


### PR DESCRIPTION
This Addresses #2297

I've changed from old school python 2.6 and below format string to modern format string also. See https://mkaz.blog/code/python-string-format-cookbook/

You could consider renaming `formatter` to `format` also to align with other widgets. C.f. below

![image](https://user-images.githubusercontent.com/42288570/117527620-b08b2e80-afcd-11eb-97f8-5c0ebe2a4f9d.png)
