### PR TITLE
Improve validation for ReactiveHTML validation

### DIFF
--- a/panel/models/reactive_html.py
+++ b/panel/models/reactive_html.py
@@ -81,6 +81,10 @@ class ReactiveHTMLParser(HTMLParser):
         elif nloops:
             loop = [loop for loop in (list_loop, values_loop, items_loop) if loop][0]
             var, obj = loop[0]
+            if var in self.cls.param:
+                raise ValueError(f'Loop variable {var} clashes with parameter name. '
+                                 'Ensure loop variables have a unique name. Relevant '
+                                 f'template section:\n\n{data}')
             self.loop_map[var] = obj
 
         if '{% for ' in data:

--- a/panel/reactive.py
+++ b/panel/reactive.py
@@ -1310,7 +1310,14 @@ class ReactiveHTML(Reactive, metaclass=ReactiveHTMLMetaclass):
             context[parameter] = value
             if parameter in self._child_names:
                 context[f'{parameter}_names'] = self._child_names[parameter]
-        html = template.render(context)
+        try:
+            html = template.render(context)
+        except Exception as e:
+            raise RuntimeError(
+                f"{type(self).__name__} could not render "
+                f"template, errored with:\n\n{type(e).__name__}: {e}.\n"
+                f"Full template:\n\n{template_string}"
+            )
 
         # Parse templated HTML
         parser = ReactiveHTMLParser(self.__class__, template=False)


### PR DESCRIPTION
- [x] Better error when jinja2 template rendering fails
- [x] Ensure loop variables are uniquely named 