### PR TITLE
Simplified styling of Card layout

### DIFF
--- a/panel/dist/css/card.css
+++ b/panel/dist/css/card.css
@@ -24,7 +24,7 @@
 .bk.card-button {
   background-color: transparent;
   position: absolute;
-  left: 6px;
+  left: 0.5em;
 }
 .bk.card-header-row {
   position: relative !important;

--- a/panel/dist/css/card.css
+++ b/panel/dist/css/card.css
@@ -11,7 +11,6 @@
   border-radius: 0.25rem;
   display: flex;
   justify-content: space-between;
-  padding: 0 1.25rem 0 0;
   width: 100%;
 }
 .bk.accordion-header {
@@ -20,15 +19,12 @@
   border-radius: 0;
   display: flex;
   justify-content: space-between;
-  padding: 0 1.25rem 0 0;
   width: 100%;
 }
-p.bk.card-button {
+.bk.card-button {
   background-color: transparent;
-  font-size: 1.25rem;
-  font-weight: 700;
-  margin: 0;
-  margin-left: -15px;
+  position: absolute;
+  left: 6px;
 }
 .bk.card-header-row {
   position: relative !important;
@@ -38,6 +34,5 @@ p.bk.card-button {
   display: flex !important;
   font-size: 1.4em;
   font-weight: bold;
-  padding: 0.25em;
   position: relative !important;
 }

--- a/panel/layout/card.py
+++ b/panel/layout/card.py
@@ -86,7 +86,7 @@ class Card(Column):
                 return
             else:
                 self._header = item = HTML(
-                    sizing_mode='stretch_width', margin=(2, 5), **params
+                    sizing_mode='stretch_width', **params
                 )
         else:
             item = panel(self.header)

--- a/panel/models/card.ts
+++ b/panel/models/card.ts
@@ -41,12 +41,13 @@ export class CardView extends ColumnView {
     let header_el
     if (this.model.collapsible) {
       this.button_el = DOM.createElement("button", {type: "button", class: header_css_classes})
+      const icon = DOM.createElement("div", {class: button_css_classes})
+      icon.innerHTML = this.model.collapsed ? "\u25b2" : "\u25bc"
+      this.button_el.appendChild(icon)
       this.button_el.style.backgroundColor = header_background != null ? header_background : ""
       header.el.style.backgroundColor = header_background != null ? header_background : ""
       this.button_el.appendChild(header.el)
-      const icon = DOM.createElement("p", {class: button_css_classes})
-      icon.innerHTML = this.model.collapsed ? "+" : "\u2212"
-      this.button_el.appendChild(icon)
+
       this.button_el.onclick = () => this._toggle_button()
       header_el = this.button_el
     } else {


### PR DESCRIPTION
The Card css was somewhat brittle and I did not much like the old +/- indicators for uncollapsed/collapsed states respectively. This PR changes the styling to use arrows as indicators instead and makes the CSS less brittle:

### Accordion

<img width="335" alt="Screen Shot 2021-06-02 at 6 06 50 PM" src="https://user-images.githubusercontent.com/1550771/120514187-4f3c5c80-c3cd-11eb-926e-df14e8eed1eb.png">

### Cards

<img width="1234" alt="Screen Shot 2021-06-02 at 6 07 35 PM" src="https://user-images.githubusercontent.com/1550771/120514292-6aa76780-c3cd-11eb-97d1-08834d62d5d7.png">
