### PR TITLE
Refactored config to hold per session state

### DIFF
--- a/panel/config.py
+++ b/panel/config.py
@@ -198,7 +198,7 @@ class _config(_base_config):
 
     def __setattr__(self, attr, value):
         from .io.state import state
-        if not getattr(self, 'initialized', False) or (attr.startswith('_') and attr.endswith('_')):
+        if not getattr(self, 'initialized', False) or (attr.startswith('_') and attr.endswith('_')) or attr == '_validating':
             return super().__setattr__(attr, value)
         value = getattr(self, f'_{attr}_hook', lambda x: x)(value)
         if state.curdoc:
@@ -206,6 +206,8 @@ class _config(_base_config):
                 validate_config(self, attr, value)
             elif f'_{attr}' in self.param:
                 validate_config(self, f'_{attr}', value)
+            else:
+                raise AttributeError(f'{attr!r} is not a valid config parameter.')
             if state.curdoc not in self._session_config:
                 self._session_config[state.curdoc] = {}
             self._session_config[state.curdoc][attr] = value

--- a/panel/tests/conftest.py
+++ b/panel/tests/conftest.py
@@ -146,6 +146,14 @@ def multiple_apps_server_sessions():
             continue  # tests may already close this
 
 
+@pytest.fixture
+def with_curdoc():
+    old_curdoc = state.curdoc
+    state.curdoc = Document()
+    yield
+    state.curdoc = old_curdoc
+        
+
 @contextmanager
 def set_env_var(env_var, value):
     old_value = os.environ.get(env_var)
@@ -155,4 +163,3 @@ def set_env_var(env_var, value):
         del os.environ[env_var]
     else:
         os.environ[env_var] = old_value
-

--- a/panel/tests/test_config.py
+++ b/panel/tests/test_config.py
@@ -1,6 +1,8 @@
 """
 Tests pn.config variables
 """
+import pytest
+
 from panel import config, state
 from panel.pane import HTML
 
@@ -27,6 +29,16 @@ def test_config_set_console_output():
     with config.set(console_output='disable'):
         with config.set(console_output='accumulate'):
             assert config.console_output == 'accumulate'
+
+
+@pytest.mark.usefixtures("with_curdoc")
+def test_session_override():
+    config.sizing_mode = 'stretch_width'
+    assert config.sizing_mode == 'stretch_width'
+    assert state.curdoc in config._session_config
+    assert config._session_config[state.curdoc] == {'sizing_mode': 'stretch_width'}
+    state.curdoc = None
+    assert config.sizing_mode is None
 
 
 def test_console_output_replace_stdout(document, comm, get_display_handle):


### PR DESCRIPTION
The `config` object was already quite complicated because it had to handle these fallback conditions (in order):

- Getting an explicitly overridden value
- Getting the value from a environment variable
- Getting the default value

This PR additionally adds a `_session_config` dictionary which is used to store explicitly overridden config values. Instead of complicating all the property logic further this PR adds `__getattribute__` and `__setattr__` implementations which catch attempts to get and set explicit overrides. The properties therefore only have to implement lookups to get the value from the env variable or the default.

Fixes https://github.com/holoviz/panel/issues/2350