### PR TITLE
Allow bundling and loading JS and CSS for ReactiveHTML components

### DIFF
--- a/panel/compiler.py
+++ b/panel/compiler.py
@@ -138,6 +138,7 @@ def write_bundled_tarball(name, tarball, bundle_dir, module=False):
             
 def bundle_resources():
     from .config import panel_extension
+    from .reactive import ReactiveHTML
     from .template.base import BasicTemplate
     from .template.theme import Theme
 
@@ -150,7 +151,12 @@ def bundle_resources():
     # Extract Model dependencies
     js_files = {}
     css_files = {}
-    for name, model in Model.model_class_reverse_map.items():
+    reactive = param.concrete_descendents(ReactiveHTML).values()
+    models = (
+        list(Model.model_class_reverse_map.items()) +
+        [(f'{m.__module__}.{m.__name__}', m) for m in reactive]
+    )
+    for name, model in models:
         if not name.startswith('panel.'):
             continue
         prev_jsfiles = getattr(model, '__javascript_raw__', None)

--- a/panel/io/resources.py
+++ b/panel/io/resources.py
@@ -10,6 +10,8 @@ from base64 import b64encode
 from collections import OrderedDict
 from pathlib import Path
 
+import param
+
 from bokeh.embed.bundle import (
     Bundle as BkBundle, _bundle_extensions, extension_dirs,
     bundle_models
@@ -159,7 +161,14 @@ class Resources(BkResources):
     @property
     def js_files(self):
         from ..config import config
+        from ..reactive import ReactiveHTML
+
         files = super(Resources, self).js_files
+
+        for model in param.concrete_descendents(ReactiveHTML).values():
+            if hasattr(model, '__javascript__'):
+                files += model.__javascript__
+
         js_files = []
         for js_file in files:
             if (js_file.startswith(state.base_url) or js_file.startswith('static/')):
@@ -196,8 +205,14 @@ class Resources(BkResources):
     @property
     def css_files(self):
         from ..config import config
+        from ..reactive import ReactiveHTML
 
         files = super(Resources, self).css_files
+
+        for model in param.concrete_descendents(ReactiveHTML).values():
+            if hasattr(model, '__css__'):
+                files += model.__css__
+
         for cssf in config.css_files:
             if os.path.isfile(cssf) or cssf in files:
                 continue


### PR DESCRIPTION
Allows a `ReactiveHTML` component to declare `__css__` and `__javascript__` like ordinary Bokeh models, which can be bundled and loaded as part of the resource bundle.