### PR TITLE
add slider horizontal bar back

### DIFF
--- a/panel/template/fast/css/fast_root.css
+++ b/panel/template/fast/css/fast_root.css
@@ -1,4 +1,7 @@
 /* fast_root.css */
+:root {
+  --track-width: 2;
+}
 #menu * {
   width: 100%;
 }


### PR DESCRIPTION
Fixes https://github.com/holoviz/panel/issues/2369

![image](https://user-images.githubusercontent.com/42288570/121841890-8f5de200-ccdf-11eb-80fa-f288bdd83907.png)

```python
import panel as pn

slider = pn.widgets.FloatSlider(value=2, start=0, end=10, step=0.1)

pn.template.FastListTemplate(site="Panel", title="FloatSliderFix", sidebar=[slider]).servable()
```