### PR TITLE
Add ability to make only certain Tabulator rows selectable

### DIFF
--- a/examples/reference/widgets/Tabulator.ipynb
+++ b/examples/reference/widgets/Tabulator.ipynb
@@ -40,7 +40,8 @@
     "* **``page_size``** (``int``): Number of rows on each page.\n",
     "* **``pagination``** (`str`, `default=None`):  Set to 'local' or 'remote' to enable pagination; by default pagination is disabled with the value set to `None`.\n",
     "* **``selection``** (``list``): The currently selected rows.\n",
-    "* **``selectable``** (`boolean` or `str`): Whether to allow selection of rows. Can be `True`, `False`, `'checkbox'` or `'toggle'`. \n",
+    "* **``selectable``** (`boolean` or `str`): Whether to allow selection of rows. Can be `True`, `False`, `'checkbox'`, `'checkbox-single'` or `'toggle'`. \n",
+    "* **``selectable_rows``** (`callable`): A function that should return a list of integer indexes given a DataFrame indicating which rows may be selected.\n",
     "* **``show_index``** (``boolean``): Whether to show the index column.\n",
     "* **``text_align``** (``dict`` or ``str``): A mapping from column name to alignment or a fixed column alignment, which should be one of 'left', 'center', 'right'.\n",
     "* **`theme`** (``str``): The CSS theme to apply (note that changing the theme will restyle all tables on the page).\n",
@@ -441,6 +442,7 @@
     "- `True`: Selects rows on click. To select multiple use Ctrl-select, to select a range use Shift-select\n",
     "- `False`: Disables selection\n",
     "- `'checkbox'`: Adds a column of checkboxes to toggle selections\n",
+    "- `'checkbox-single'`: Same as `'checkbox'` but disables (de)select-all in the header\n",
     "- `'toggle'`: Selection toggles when clicked"
    ]
   },
@@ -451,6 +453,22 @@
    "outputs": [],
    "source": [
     "pn.widgets.Tabulator(sel_df, selection=[0, 3, 7], selectable='checkbox')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Additionally we can also disable selection for specific rows by providing a `selectable_rows` function. The function must accept a DataFrame and return a list of integer indexes indicating which rows are selectable, e.g. here we disable selection for every second row:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pn.widgets.Tabulator(sel_df, selectable_rows=lambda df: list(range(0, len(df), 2)))"
    ]
   },
   {

--- a/panel/models/tabulator.py
+++ b/panel/models/tabulator.py
@@ -63,6 +63,8 @@ class DataTabulator(HTMLBox):
 
     select_mode = Any(default=True)
 
+    selectable_rows = Nullable(List(Int))
+
     theme = Enum(*TABULATOR_THEMES, default="simple")
 
     theme_url = String(default=THEME_URL)

--- a/panel/reactive.py
+++ b/panel/reactive.py
@@ -675,6 +675,7 @@ class SyncableData(Reactive):
 
     @updating
     def _stream(self, stream, rollover=None):
+        self._processed, _ = self._get_data()
         for ref, (m, _) in self._models.items():
             if ref not in state._views or ref in state._fake_roots:
                 continue


### PR DESCRIPTION
- Adds `selectable='checkbox-single'` option to disable (de)select-all in the header
- Add `selectable_rows` parameter which accepts a function which should return the indexes of the selectable rows given a DataFrame.