### PR TITLE
Fix Card Header in Fast Templates

### DIFF
--- a/panel/template/fast/css/fast_panel.css
+++ b/panel/template/fast/css/fast_panel.css
@@ -15,6 +15,7 @@ p.bk.card-button {
 .bk.card-header {
   color: var(--neutral-foreground-rest);
   background-color: var(--neutral-fill-active) !important;
+  height: unset;
 }
 .bk.pn-loading:before {
   position: absolute;

--- a/panel/template/fast/css/fast_panel.css
+++ b/panel/template/fast/css/fast_panel.css
@@ -5,6 +5,9 @@ p.bk.card-button {
   display: block;
   padding-right: 1em;
 }
+.bk-root .bk.card-button {
+  margin-left: 0.5em;
+}
 .bk.card {
   color: var(--neutral-foreground-rest);
   background-color: var(--neutral-fill-rest);

--- a/panel/template/fast/css/fast_panel.css
+++ b/panel/template/fast/css/fast_panel.css
@@ -1,9 +1,6 @@
 .codehilite {
   background: var(--neutral-fill-active);
 }
-.bk.card button.bk.card-header {
-  height: 55px;
-}
 p.bk.card-button {
   display: block;
   padding-right: 1em;


### PR DESCRIPTION
Fixes #2379 as well as unreported height and margin issue discovered during testing.

![image](https://user-images.githubusercontent.com/42288570/123535379-cb536700-d723-11eb-83a8-9e114f8a8e01.png)

```python
import panel as pn

d = pn.Card(pn.widgets.FloatSlider(name='Slider'),'#Hola')
e = pn.Card(pn.widgets.FloatSlider(name='Slider'),'#Hola', header="Text")
f = pn.Card(pn.widgets.FloatSlider(name='Slider'),'#Hola', header="# Text")

tmpl = pn.template.FastListTemplate(
    theme=pn.template.DarkTheme,
    main=[d,e,f]
)
tmpl.servable()
```