### PR TITLE
Ensure config per session state works for resources

### DIFF
--- a/panel/config.py
+++ b/panel/config.py
@@ -207,7 +207,7 @@ class _config(_base_config):
         if not getattr(self, 'initialized', False) or (attr.startswith('_') and attr.endswith('_')) or attr == '_validating':
             return super().__setattr__(attr, value)
         value = getattr(self, f'_{attr}_hook', lambda x: x)(value)
-        if state.curdoc:
+        if state.curdoc is not None:
             if attr in self.param:
                 validate_config(self, attr, value)
             elif f'_{attr}' in self.param:
@@ -231,6 +231,14 @@ class _config(_base_config):
         else:
             params = []
         session_config = super().__getattribute__('_session_config')
+        if state.curdoc and state.curdoc not in session_config:
+            session_config[state.curdoc] = {}
+        if (attr in ('raw_css', 'css_files', 'js_files', 'js_modules') and
+            state.curdoc and attr not in session_config[state.curdoc]):
+            if 'css' in attr:
+                setattr(self, attr, [])
+            else:
+                setattr(self, attr, {})
         if state.curdoc and state.curdoc in session_config and attr in session_config[state.curdoc]:
             return session_config[state.curdoc][attr]
         elif f'_{attr}' in params and getattr(self, f'_{attr}_') is not None:

--- a/panel/tests/test_server.py
+++ b/panel/tests/test_server.py
@@ -162,6 +162,32 @@ def test_server_async_callbacks():
         server.stop()
 
 
+def test_serve_config_per_session_state():
+    CSS1 = 'body { background-color: red }'
+    CSS2 = 'body { background-color: green }'
+    def app1():
+        config.raw_css = [CSS1]
+    def app2():
+        config.raw_css = [CSS2]
+
+    server1 = serve(app1, port=6004, threaded=True, show=False)
+    server2 = serve(app2, port=6005, threaded=True, show=False)
+
+    r1 = requests.get("http://localhost:6004/").content.decode('utf-8')
+    r2 = requests.get("http://localhost:6005/").content.decode('utf-8')
+
+    try:
+        assert CSS1 not in config.raw_css
+        assert CSS2 not in config.raw_css
+        assert CSS1 in r1
+        assert CSS2 not in r1
+        assert CSS1 not in r2
+        assert CSS2 in r2
+    finally:
+        server1.stop()
+        server2.stop()
+    
+
 def test_server_session_info():
     with config.set(session_history=-1):
         html = Markdown('# Title')


### PR DESCRIPTION
While I recently added support for per-session state on `pn.config` this didn't fully work for the resource related parameters such as `css_files`, `js_files` etc. because a) they are mutable so they need to create entries on access and b) while the session handler is running `state.curdoc` was not set to the correct value.