### PR TITLE
Fix JPG example

### DIFF
--- a/examples/reference/panes/JPG.ipynb
+++ b/examples/reference/panes/JPG.ipynb
@@ -43,7 +43,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "jpg_pane = pn.pane.JPG('https://upload.wikimedia.org/wikipedia/commons/3/38/JPEG_example_JPG_RIP_001.jpg', width=500)\n",
+    "jpg_pane = pn.pane.JPG('https://www.gstatic.com/webp/gallery/4.sm.jpg', width=500)\n",
     "\n",
     "jpg_pane"
    ]
@@ -61,7 +61,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "jpg_pane.object = 'https://upload.wikimedia.org/wikipedia/commons/b/b2/JPEG_compression_Example.jpg'"
+    "jpg_pane.object = 'https://www.gstatic.com/webp/gallery/1.sm.jpg'"
    ]
   }
  ],


### PR DESCRIPTION
Wikipedia was restricting access to the old examples somehow