### PR TITLE
Improve codehilite look and feel in Fast Templates

### DIFF
--- a/panel/template/fast/css/fast_panel.css
+++ b/panel/template/fast/css/fast_panel.css
@@ -1,5 +1,10 @@
 .codehilite {
   background: var(--neutral-fill-active);
+  padding-top: 1px;
+  padding-bottom: 1px;
+  padding-left: 1em;
+  padding-right: 1em;
+  border-radius: calc(var(--corner-radius) * 1px);
 }
 p.bk.card-button {
   display: block;


### PR DESCRIPTION
Fixes #2487 

Now looks like

![image](https://user-images.githubusercontent.com/42288570/124373870-77ea9700-dc96-11eb-80e3-b0b0b4240e8f.png)

when running the script

![image](https://user-images.githubusercontent.com/42288570/124373873-7faa3b80-dc96-11eb-922b-3e03759b97a3.png)