### PR TITLE
Scroll on Tabulator selection

### DIFF
--- a/panel/models/tabulator.ts
+++ b/panel/models/tabulator.ts
@@ -470,6 +470,8 @@ export class DataTabulatorView extends PanelHTMLBoxView {
     this._selection_updating = true
     this.tabulator.deselectRow()
     this.tabulator.selectRow(indices)
+    // This actually places the selected row at the top of the table
+    this.tabulator.scrollToRow(indices[0], "bottom", false)
     this._selection_updating = false
   }
 


### PR DESCRIPTION
Scroll automatically to the selected rows when the selection is updated,
just like the DataFrame widget.

Closes #2485