### PR TITLE
fix videostream unpause

### DIFF
--- a/panel/models/videostream.ts
+++ b/panel/models/videostream.ts
@@ -33,7 +33,7 @@ export class VideoStreamView extends PanelHTMLBoxView {
         this.timer = null;
       }
       this.videoEl.pause()
-    }
+    } else this.videoEl.play()
     this.set_timeout()
   }
 


### PR DESCRIPTION
Fixes https://discourse.holoviz.org/t/videostream-does-not-show-video-after-setting-paused-to-false/2525.

I.e. you can pause and the un-pause again.

https://user-images.githubusercontent.com/42288570/124864463-3705c180-dfb9-11eb-927e-021ebd0d43d7.mp4

```python
import panel as pn
import time
pn.extension()
video = pn.widgets.VideoStream(timeout=100, paused=False)

pn.Column(video, video.param.paused).servable()
```