### PR TITLE
Fix broken serialisation in panel.io.location

### DIFF
--- a/panel/io/location.py
+++ b/panel/io/location.py
@@ -169,7 +169,7 @@ class Location(Syncable):
             if v is None:
                 continue
             try:
-                parameterized.param[p].serialize(v)
+                v = parameterized.param[p].serialize(v)
             except Exception:
                 pass
             if not isinstance(v, str):


### PR DESCRIPTION
The serialised value was never actually captured, which would invariably lead to JSON serialisation errors for any value other than a simple string