### PR TITLE
Fix Perspective Filter Errors

### DIFF
--- a/panel/pane/perspective.py
+++ b/panel/pane/perspective.py
@@ -369,9 +369,9 @@ class Perspective(PaneBase, ReactiveData):
             if msg.get(p):
                 msg[p] = [str(col) for col in msg[p]]
         if msg.get('sort'):
-            msg['sort'] = [[str(col), d] for col, d in msg['sort']]
+            msg['sort'] = [[str(col), *args] for col, *args in msg['sort']]
         if msg.get('filters'):
-            msg['filters'] = [[str(col), e, val] for col, e, val in msg['filters']]
+            msg['filters'] = [[str(col), *args] for col, *args in msg['filters']]
         if msg.get('aggregates'):
             msg['aggregates'] = {str(col): agg for col, agg in msg['aggregates'].items()}
         return msg


### PR DESCRIPTION
I noticed at work that when I drag a column to the "Filter" it raises errors.

I can see its because the fix applied to the `_process_property_change` in #2300 needs to be applied to the `_process_param_change` method as well.

Because of #2518 I'm not able to show the behaviour before and after this fix is applied

@philippjfr . Is it possible to get this in Panel 0.12?