### PR TITLE
Allow nested parameterized objects on ReactiveHTML

### DIFF
--- a/panel/layout/tabs.py
+++ b/panel/layout/tabs.py
@@ -82,7 +82,7 @@ class Tabs(NamedListPanel):
             new = [old[i] for i in inds]
         return old, new
 
-    def _comm_change(self, doc, ref, comm, attr, old, new):
+    def _comm_change(self, doc, ref, comm, subpath, attr, old, new):
         if attr in self._changing.get(ref, []):
             self._changing[ref].remove(attr)
             return
@@ -90,9 +90,9 @@ class Tabs(NamedListPanel):
             old, new = self._process_close(ref, attr, old, new)
             if new is None:
                 return
-        super()._comm_change(doc, ref, comm, attr, old, new)
+        super()._comm_change(doc, ref, comm, subpath, attr, old, new)
 
-    def _server_change(self, doc, ref, attr, old, new):
+    def _server_change(self, doc, ref, subpath, attr, old, new):
         if attr in self._changing.get(ref, []):
             self._changing[ref].remove(attr)
             return
@@ -100,7 +100,7 @@ class Tabs(NamedListPanel):
             old, new = self._process_close(ref, attr, old, new)
             if new is None:
                 return
-        super()._server_change(doc, ref, attr, old, new)
+        super()._server_change(doc, ref, subpath, attr, old, new)
 
     def _update_active(self, *events):
         for event in events:

--- a/panel/links.py
+++ b/panel/links.py
@@ -47,7 +47,8 @@ PARAM_MAPPING = {
     pm.CalendarDateRange: lambda p, kwargs: bp.Tuple(bp.Date, bp.Date, **kwargs),
     pm.ClassSelector: lambda p, kwargs: (
         (bp.Instance(DataModel, **kwargs), [(Parameterized, create_linked_datamodel)])
-        if issubclass(p.class_, param.Parameterized) else bp.Any(**kwargs)
+        if isinstance(p.class_, type) and issubclass(p.class_, param.Parameterized) else
+        bp.Any(**kwargs)
     ),
     pm.Color: lambda p, kwargs: bp.Color(**kwargs),
     pm.DataFrame: lambda p, kwargs: (

--- a/panel/models/reactive_html.py
+++ b/panel/models/reactive_html.py
@@ -123,7 +123,7 @@ class ReactiveHTMLParser(HTMLParser):
             match = match[2:-1]
             if match.startswith('model.'):
                 continue
-            if match not in self.cls.param:
+            if match not in self.cls.param and '.' not in match:
                 params = difflib.get_close_matches(match, list(self.cls.param))
                 raise ValueError(f"{self.cls.__name__} HTML template references "
                                  f"unknown parameter '{match}', similar parameters "

--- a/panel/models/reactive_html.ts
+++ b/panel/models/reactive_html.ts
@@ -97,7 +97,7 @@ export class ReactiveHTMLView extends PanelHTMLBoxView {
     this.html = htmlDecode(this.model.html) || this.model.html
   }
 
-  _recursive_connect(model: any, children: boolean, path: string): void {
+  _recursive_connect(model: any, update_children: boolean, path: string): void {
     for (const prop in model.properties) {
       let subpath: string
       if (path.length)
@@ -108,7 +108,7 @@ export class ReactiveHTMLView extends PanelHTMLBoxView {
       if (obj.properties != null)
 	this._recursive_connect(obj, true, subpath)
       this.connect(model.properties[prop].change, () => {
-	if (children) {
+	if (update_children) {
           for (const node in this.model.children) {
             if (this.model.children[node] == prop) {
               let children = model[prop]
@@ -130,7 +130,6 @@ export class ReactiveHTMLView extends PanelHTMLBoxView {
 
   connect_signals(): void {
     super.connect_signals()
-
     this.connect(this.model.properties.children.change, async () => {
       this.html = htmlDecode(this.model.html) || this.model.html
       await this.rebuild()
@@ -166,7 +165,7 @@ export class ReactiveHTMLView extends PanelHTMLBoxView {
         if (property == null)
           continue
         this.connect(property.change, () => {
-          if (!this._changing)
+	  if (!this._changing)
             this.run_script(prop)
         })
       }

--- a/panel/models/reactive_html.ts
+++ b/panel/models/reactive_html.ts
@@ -101,25 +101,25 @@ export class ReactiveHTMLView extends PanelHTMLBoxView {
     for (const prop in model.properties) {
       let subpath: string
       if (path.length)
-	subpath = `${path}.${prop}`
+        subpath = `${path}.${prop}`
       else
-	subpath = prop
+        subpath = prop
       const obj = model[prop]
       if (obj.properties != null)
-	this._recursive_connect(obj, true, subpath)
+        this._recursive_connect(obj, true, subpath)
       this.connect(model.properties[prop].change, () => {
-	if (update_children) {
+        if (update_children) {
           for (const node in this.model.children) {
             if (this.model.children[node] == prop) {
               let children = model[prop]
               if (!isArray(children))
-		children = [children]
+                children = [children]
               this._render_node(node, children)
               this.invalidate_layout()
               return
             }
           }
-	}
+        }
         if (!this._changing) {
           this._update(subpath)
           this.invalidate_layout()
@@ -165,7 +165,7 @@ export class ReactiveHTMLView extends PanelHTMLBoxView {
         if (property == null)
           continue
         this.connect(property.change, () => {
-	  if (!this._changing)
+          if (!this._changing)
             this.run_script(prop)
         })
       }

--- a/panel/models/reactive_html.ts
+++ b/panel/models/reactive_html.ts
@@ -146,13 +146,23 @@ export class ReactiveHTMLView extends PanelHTMLBoxView {
 
   connect_scripts(): void {
     const id = this.model.data.id
-    for (const prop in this.model.scripts) {
+    for (let prop in this.model.scripts) {
       const scripts = this.model.scripts[prop]
+      let data_model = this.model.data
+      let attr: string
+      if (prop.indexOf('.') >= 0) {
+        const path = prop.split('.')
+        attr = path[path.length-1]
+        for (const p of path.slice(0, -1))
+          data_model = data_model[p]
+      } else {
+        attr = prop
+      }
       for (const script of scripts) {
         const decoded_script = htmlDecode(script) || script
         const script_fn = this._render_script(decoded_script, id)
         this._script_fns[prop] = script_fn
-        const property = this.model.data.properties[prop]
+        const property = data_model.properties[attr]
         if (property == null)
           continue
         this.connect(property.change, () => {

--- a/panel/reactive.py
+++ b/panel/reactive.py
@@ -1046,9 +1046,11 @@ class ReactiveHTMLMetaclass(ParameterizedMetaclass):
             if mcs._child_config.get(child) == 'literal':
                 types[child] = param.String
             elif (type(cparam) not in PARAM_MAPPING or
+                  isinstance(cparam, (param.List, param.Dict, param.Tuple)) or
                   (isinstance(cparam, param.ClassSelector) and
                    isinstance(cparam.class_, type) and
-                   issubclass(cparam.class_, Reactive))):
+                   (not issubclass(cparam.class_, param.Parameterized) or
+                    issubclass(cparam.class_, Reactive)))):
                 # Any parameter which can be consistently serialized
                 # (except) Panel Reactive objects can be reflected
                 # on the data model

--- a/panel/tests/layout/test_tabs.py
+++ b/panel/tests/layout/test_tabs.py
@@ -254,7 +254,7 @@ def test_tabs_close_tab_in_notebook(document, comm, tabs):
     old_tabs = list(model.tabs)
     _, div2 = tabs
 
-    tabs._comm_change(document, model.ref['id'], comm, 'tabs', old_tabs, [model.tabs[1]])
+    tabs._comm_change(document, model.ref['id'], comm, None, 'tabs', old_tabs, [model.tabs[1]])
 
     assert len(tabs.objects) == 1
     assert tabs.objects[0] is div2
@@ -264,7 +264,7 @@ def test_tabs_close_tab_on_server(document, comm, tabs):
     model = tabs.get_root(document, comm=comm)
     _, div2 = tabs
 
-    tabs._server_change(document, model.ref['id'], 'tabs', model.tabs, model.tabs[1:])
+    tabs._server_change(document, model.ref['id'], None, 'tabs', model.tabs, model.tabs[1:])
 
     assert len(tabs.objects) == 1
     assert tabs.objects[0] is div2

--- a/panel/tests/test_reactive.py
+++ b/panel/tests/test_reactive.py
@@ -60,7 +60,7 @@ def test_link_properties_nb(document, comm):
     # Assert callback is set up correctly
     cb = div._callbacks['text'][0]
     assert isinstance(cb, partial)
-    assert cb.args == (document, div.ref['id'], comm)
+    assert cb.args == (document, div.ref['id'], comm, None)
     assert cb.func == obj._comm_change
 
 
@@ -80,7 +80,7 @@ def test_link_properties_server(document):
     # Assert callback is set up correctly
     cb = div._callbacks['text'][0]
     assert isinstance(cb, partial)
-    assert cb.args == (document, div.ref['id'])
+    assert cb.args == (document, div.ref['id'], None)
     assert cb.func == obj._server_change
 
 

--- a/panel/tests/test_server.py
+++ b/panel/tests/test_server.py
@@ -42,7 +42,7 @@ def test_server_change_io_state(html_server_session):
         assert state.curdoc is session.document
 
     html.param.watch(handle_event, 'object')
-    html._server_change(session.document, None, 'text', '<h1>Title</h1>', '<h1>New Title</h1>')
+    html._server_change(session.document, None, None, 'text', '<h1>Title</h1>', '<h1>New Title</h1>')
 
 
 def test_server_static_dirs():


### PR DESCRIPTION
This means that ReactiveHTML objects can now declare parameters of type `ClassSelector(class_=Parameterized)` which are automatically reflected as DataModels on the JS side and automatically synced.