### PR TITLE
Fix race condition in autoreload

### DIFF
--- a/panel/io/reload.py
+++ b/panel/io/reload.py
@@ -116,6 +116,7 @@ def _reload(module=None):
     for cb in _callbacks.values():
         cb.stop()
     _callbacks.clear()
+    state.location.reload = True
     for loc in state._locations.values():
         loc.reload = True
 

--- a/panel/io/reload.py
+++ b/panel/io/reload.py
@@ -113,11 +113,11 @@ def _reload(module=None):
     if module is not None:
         for module in _modules:
             del sys.modules[module]
-    if state.curdoc in _callbacks:
-        _callbacks[state.curdoc].stop()
-        del _callbacks[state.curdoc]
-    if state.location:
-        state.location.reload = True
+    for cb in _callbacks.values():
+        cb.stop()
+    _callbacks.clear()
+    for loc in state._locations.values():
+        loc.reload = True
 
 def _check_file(modify_times, path, module=None):
     try:


### PR DESCRIPTION
When autoreload detects a modified file it clears out the `sys.modules` and then reloads just the session that detected the changed file. Subsequent sessions that try to detect the changed file will then no longer find the changed module in the `sys.modules` (meaning they can't detect a change), or they will find that the already restarted sessions has already repopulated `sys.modules`  and delete that newly loaded module (which will potentially break the already restarted session). In the new setup whenever **any** session detects that a module was changed it immediately halts the watchers on other threads and then reloads **all** sessions.

This has the potential to fail for sessions that do not have a frontend connected (since the reload mechanism is triggered by refreshing the browser window) and those sessions will stick around. Someone could in theory reconnect to such an old session programmatically but since autoreload is meant for interactive use this does not seem like a big worry.

Fixes #2531 