### PR TITLE
Enable jupyterlab preview on binder

### DIFF
--- a/binder/postBuild
+++ b/binder/postBuild
@@ -7,4 +7,4 @@ SERVICE_URL=https://open-vsx.org/vscode/gallery ITEM_URL=https://open-vsx.org/vs
 SERVICE_URL=https://open-vsx.org/vscode/gallery ITEM_URL=https://open-vsx.org/vscode/item code-server --install-extension ritwickdey.liveserver
 bokeh sampledata
 panel build panel
-jupyter serverextension enable panel.io.serverextension
+jupyter serverextension enable panel.io.jupyter_server_extension

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -7,3 +7,4 @@ SERVICE_URL=https://open-vsx.org/vscode/gallery ITEM_URL=https://open-vsx.org/vs
 SERVICE_URL=https://open-vsx.org/vscode/gallery ITEM_URL=https://open-vsx.org/vscode/item code-server --install-extension ritwickdey.liveserver
 bokeh sampledata
 panel build panel
+jupyter serverextension enable panel.io.serverextension

--- a/panel/io/jupyter_server_extension.py
+++ b/panel/io/jupyter_server_extension.py
@@ -21,6 +21,7 @@ from tornado.web import StaticFileHandler
 
 from ..config import config
 from ..util import edit_readonly
+from . import resources
 from .state import state
 from .resources import DIST_DIR, Resources
 
@@ -170,8 +171,8 @@ def _load_jupyter_server_extension(notebook_app):
     )
     config.autoreload = True
     with edit_readonly(state):
-        state.base_url = '/panel-preview/'
-        state.rel_path = '/panel-preview'
+        state.base_url = urljoin(base_url, '/panel-preview/')
+        state.rel_path = urljoin(base_url, '/panel-preview/')
 
     # Set up handlers
     notebook_app.web_app.add_handlers(

--- a/panel/io/jupyter_server_extension.py
+++ b/panel/io/jupyter_server_extension.py
@@ -26,9 +26,22 @@ from .resources import DIST_DIR, Resources
 
 _RESOURCES = None
 
-_APPS = {
+_APPS = {}
 
-}
+
+def url_path_join(*pieces):
+    """Join components of url into a relative url
+    Use to prevent double slash when joining subpath. This will leave the
+    initial and final / in place
+    """
+    initial = pieces[0].startswith('/')
+    final = pieces[-1].endswith('/')
+    stripped = [s.strip('/') for s in pieces]
+    result = '/'.join(s for s in stripped if s)
+    if initial: result = '/' + result
+    if final: result = result + '/'
+    if result == '//': result = '/'
+    return result
 
 
 class ServerApplicationProxy:
@@ -148,7 +161,7 @@ class PanelWSHandler(WSHandler):
 def _load_jupyter_server_extension(notebook_app):
     global RESOURCES
 
-    base_url = notebook_app.web_app.settings["base_url"]
+    base_url = url_path_join(notebook_app.web_app.settings["base_url"])
 
     # Configure Panel
     RESOURCES = Resources(

--- a/panel/io/jupyter_server_extension.py
+++ b/panel/io/jupyter_server_extension.py
@@ -162,7 +162,7 @@ class PanelWSHandler(WSHandler):
 def _load_jupyter_server_extension(notebook_app):
     global RESOURCES
 
-    base_url = url_path_join(notebook_app.web_app.settings["base_url"])
+    base_url = notebook_app.web_app.settings["base_url"]
 
     # Configure Panel
     RESOURCES = Resources(
@@ -171,8 +171,10 @@ def _load_jupyter_server_extension(notebook_app):
     )
     config.autoreload = True
     with edit_readonly(state):
-        state.base_url = url_path_join(base_url, '/panel-preview')
+        state.base_url = url_path_join(base_url, '/panel-preview/')
         state.rel_path = url_path_join(base_url, '/panel-preview')
+
+    print(state.base_url, urljoin(base_url, 'panel-preview'))
 
     # Set up handlers
     notebook_app.web_app.add_handlers(

--- a/panel/io/jupyter_server_extension.py
+++ b/panel/io/jupyter_server_extension.py
@@ -21,7 +21,6 @@ from tornado.web import StaticFileHandler
 
 from ..config import config
 from ..util import edit_readonly
-from . import resources
 from .state import state
 from .resources import DIST_DIR, Resources
 

--- a/panel/io/jupyter_server_extension.py
+++ b/panel/io/jupyter_server_extension.py
@@ -171,8 +171,8 @@ def _load_jupyter_server_extension(notebook_app):
     )
     config.autoreload = True
     with edit_readonly(state):
-        state.base_url = urljoin(base_url, '/panel-preview/')
-        state.rel_path = urljoin(base_url, '/panel-preview/')
+        state.base_url = url_path_join(base_url, '/panel-preview')
+        state.rel_path = url_path_join(base_url, '/panel-preview')
 
     # Set up handlers
     notebook_app.web_app.add_handlers(


### PR DESCRIPTION
I would like to enable jupyterlab preview on binder.

When it works it should be available at https://mybinder.org/v2/gh/holoviz/panel/jupyterlab-preview-on-binder?urlpath=lab/tree/examples