### PR TITLE
support packages in config of _autoload_js cf. #2571

### DIFF
--- a/panel/io/notebook.py
+++ b/panel/io/notebook.py
@@ -96,7 +96,7 @@ AUTOLOAD_NB_JS = _env.get_template("autoload_panel_js.js")
 NB_TEMPLATE_BASE = _env.get_template('nb_template.html')
 
 def _autoload_js(bundle, configs, requirements, exports, skip_imports, ipywidget, load_timeout=5000):
-    config = {'paths': {}, 'shim': {}}
+    config = {'packages': {}, 'paths': {}, 'shim': {}}
     for conf in configs:
         for key, c in conf.items():
             config[key].update(c)


### PR DESCRIPTION
Fixes #2571

@philippjfr . If you want to support `None` exports values. C.f. https://github.com/holoviz/panel/issues/2571#issuecomment-886083634 then I or you would have to change line 93 below and maybe more

![image](https://user-images.githubusercontent.com/42288570/126877175-798979af-3659-4e4f-880b-741c636c4fd9.png)

But this fix is ok for me.