### PR TITLE
Reset Models/ Components when resetting layout (#2576)

### DIFF
--- a/panel/template/fast/grid/fast_grid_template.html
+++ b/panel/template/fast/grid/fast_grid_template.html
@@ -392,6 +392,7 @@ class ResponsiveGrid extends React.PureComponent
         this.setState({
             layouts: {{ layouts }}
         });
+        window.location.href = window.location.protocol + "//" + window.location.host + window.location.pathname + window.location.search;
     }
     onLayoutChange(layout, layouts)
     {

--- a/panel/template/fast/grid/fast_grid_template.html
+++ b/panel/template/fast/grid/fast_grid_template.html
@@ -392,7 +392,7 @@ class ResponsiveGrid extends React.PureComponent
         this.setState({
             layouts: {{ layouts }}
         });
-        window.location.href = window.location.protocol + "//" + window.location.host + window.location.pathname + window.location.search;
+        window.location.href = window.location.href
     }
     onLayoutChange(layout, layouts)
     {

--- a/panel/template/fast/grid/fast_grid_template.html
+++ b/panel/template/fast/grid/fast_grid_template.html
@@ -392,7 +392,7 @@ class ResponsiveGrid extends React.PureComponent
         this.setState({
             layouts: {{ layouts }}
         });
-        window.location.href = window.location.href
+        window.dispatchEvent(new Event("resize"));
     }
     onLayoutChange(layout, layouts)
     {

--- a/panel/template/react/react.html
+++ b/panel/template/react/react.html
@@ -213,6 +213,7 @@
          this.setState({
              layouts: {{ layouts }}
          });
+         window.location.href = window.location.protocol + "//" + window.location.host + window.location.pathname + window.location.search;
      }
 
      onLayoutChange(layout, layouts)

--- a/panel/template/react/react.html
+++ b/panel/template/react/react.html
@@ -213,7 +213,7 @@
          this.setState({
              layouts: {{ layouts }}
          });
-         window.location.href = window.location.href
+         window.dispatchEvent(new Event("resize"))
      }
 
      onLayoutChange(layout, layouts)

--- a/panel/template/react/react.html
+++ b/panel/template/react/react.html
@@ -213,7 +213,7 @@
          this.setState({
              layouts: {{ layouts }}
          });
-         window.location.href = window.location.protocol + "//" + window.location.host + window.location.pathname + window.location.search;
+         window.location.href = window.location.href
      }
 
      onLayoutChange(layout, layouts)


### PR DESCRIPTION
Fixes #2576

Technically I reset the layout of the component/ models by refreshing the page. I don't know if it is possible just to trigger a full relayout using bokeh layout engine?

https://user-images.githubusercontent.com/42288570/127115347-02e3ef7a-e897-48c2-b5b8-ad4f088a200f.mp4

FYI. @nghenzi and @syamajala. I've also updated this for the `ReactTemplate`. Please take a look if you can find the time.