### PR TITLE
FastGridTemplate: Don't use persisted layout if save_layout=False

### DIFF
--- a/panel/template/fast/grid/fast_grid_template.html
+++ b/panel/template/fast/grid/fast_grid_template.html
@@ -342,7 +342,11 @@
 <script type="text/babel">
 const divStyle = {borderRadius: '5px'};
 const ResponsiveGridLayout = ReactGridLayout.WidthProvider(ReactGridLayout.Responsive);
+{% if saveLayout %}
 const originalLayout = getFromLS("layouts") || {{ layouts }};
+{% else %}
+const originalLayout = {{ layouts }};
+{% endif %}
 function resize_layout(obj, old_, new_, p, e, element) {
     window.dispatchEvent(new Event("resize"))
 }

--- a/panel/template/react/react.html
+++ b/panel/template/react/react.html
@@ -154,7 +154,11 @@
  const divStyle = {borderRadius: '5px'};
 
  const ResponsiveGridLayout = ReactGridLayout.WidthProvider(ReactGridLayout.Responsive);
+ {% if saveLayout %}
  const originalLayout = getFromLS("layouts") || {{ layouts }};
+ {% else %}
+ const originalLayout = {{ layouts }};
+ {% endif %}
 
  function resize_layout(obj, old_, new_, p, e, element) {
      window.dispatchEvent(new Event("resize"))


### PR DESCRIPTION
Fixes #2579

In the below video the LocalStorage contains a persisted layout. As you can see it's now only used when `save_layout=True`.

https://user-images.githubusercontent.com/42288570/127118887-4d22ce74-cd07-46e1-be8a-e2d7995c49ab.mp4

FYI. @nghenzi and @syamajala I've also added this change to the `ReactTemplate`. Please review if you can find the time. Thanks.