### PR TITLE
Bundle .map files during build

### DIFF
--- a/panel/compiler.py
+++ b/panel/compiler.py
@@ -102,7 +102,7 @@ def write_bundled_files(name, files, bundle_dir, explicit_dir=None, ext=None):
         except Exception:
             try:
                 map_response = requests.get(map_file, verify=False)
-            except Exception as e:
+            except Exception:
                 map_response = None
         bundle_path = os.path.join(*os.path.join(*bundle_file.split('//')[1:]).split('/')[1:])
         obj_dir = explicit_dir or model_name

--- a/panel/compiler.py
+++ b/panel/compiler.py
@@ -83,7 +83,6 @@ def require_components():
                     exports.append(export)
     return configs, requirements, exports, skip_import
 
-
 def write_bundled_files(name, files, bundle_dir, explicit_dir=None, ext=None):
     model_name = name.split('.')[-1].lower()
     for bundle_file in files:
@@ -94,8 +93,17 @@ def write_bundled_files(name, files, bundle_dir, explicit_dir=None, ext=None):
             try:
                 response = requests.get(bundle_file, verify=False)
             except Exception as e:
-                print(f"Failed to fetch {name} dependency: {bundle_file}. Errored with {e}.")
-                continue
+                raise ConnectionError(
+                    f"Failed to fetch {name} dependency: {bundle_file}. Errored with {e}."
+                )
+        try:
+            map_file = f'{bundle_file}.map'
+            map_response = requests.get(map_file)
+        except Exception:
+            try:
+                map_response = requests.get(map_file, verify=False)
+            except Exception as e:
+                map_response = None
         bundle_path = os.path.join(*os.path.join(*bundle_file.split('//')[1:]).split('/')[1:])
         obj_dir = explicit_dir or model_name
         filename = bundle_dir.joinpath(obj_dir, bundle_path)
@@ -105,6 +113,9 @@ def write_bundled_files(name, files, bundle_dir, explicit_dir=None, ext=None):
             filename += f'.{ext}'
         with open(filename, 'w', encoding="utf-8") as f:
             f.write(response.content.decode('utf-8'))
+        if map_response:
+            with open(f'{filename}.map', 'w', encoding="utf-8") as f:
+                f.write(map_response.content.decode('utf-8'))
 
 def write_bundled_tarball(name, tarball, bundle_dir, module=False):
     model_name = name.split('.')[-1].lower()


### PR DESCRIPTION
Various debuggers and browser consoles look for sourcemap files which were previously not bundled. This raised errors in the JS console which would be distracting and cause users to think there was something wrong. During the bundling step we now simply try to make a request to the CDN to check if there's a `.map` file that we should bundle alongside the CSS and JS files.