### PR TITLE
Ensure each session is cleaned up after it is warm

### DIFF
--- a/panel/command/serve.py
+++ b/panel/command/serve.py
@@ -178,7 +178,6 @@ class Serve(_BkServe):
         if args.warm or args.autoreload:
             argvs = {f: args.args for f in files}
             applications = build_single_handler_applications(files, argvs)
-            docs = []
             if args.autoreload:
                 with record_modules():
                     for app in applications.values():

--- a/panel/command/serve.py
+++ b/panel/command/serve.py
@@ -22,6 +22,16 @@ from ..io.state import state
 log = logging.getLogger(__name__)
 
 
+def _cleanup_doc(doc):
+    for callback in doc.session_destroyed_callbacks:
+        try:
+            callback(None)
+        except Exception:
+            pass
+    doc._callbacks[None] = {}
+    doc.destroy(None)
+
+
 def parse_var(s):
     """
     Parse a key, value pair, separated by '='
@@ -173,20 +183,12 @@ class Serve(_BkServe):
                 with record_modules():
                     for app in applications.values():
                         doc = app.create_document()
-                        docs.append(doc)
+                        _cleanup_doc(doc)
             else:
                 for app in applications.values():
                     doc = app.create_document()
-                    docs.append(doc)
-            for doc in docs:
-                for callback in doc.session_destroyed_callbacks:
-                    try:
-                        callback(None)
-                    except Exception:
-                        pass
-                doc._callbacks[None] = {}
-                doc.destroy(None)
-
+                    _cleanup_doc(doc)
+                    
         config.session_history = args.session_history
         if args.rest_session_info:
             pattern = REST_PROVIDERS['param'](files, 'rest')


### PR DESCRIPTION
Makes sure that if there are memory spikes when warming up a session they are cleaned up immediately and don't accumulate until we are done warming up.