### PR TITLE
Add CSS for active item of menu in Fast Template #2604

### DIFF
--- a/panel/template/fast/css/fast_root.css
+++ b/panel/template/fast/css/fast_root.css
@@ -35,3 +35,7 @@ h1, h2, h3, h4, h5, h6 {
   line-height: 1.5em;
 }
 ::-webkit-scrollbar { width: 12px; height: 12px;}
+#menu .menu-item-active a {
+  background: var(--accent-fill-active);
+  color: var(--accent-foreground-cut-rest);
+}


### PR DESCRIPTION
Implements https://github.com/holoviz/panel/issues/2604

If you run the script in #2604 you get the nice active "ML Explainability" visually identified as active

![image](https://user-images.githubusercontent.com/42288570/128081664-168265f2-9512-48f4-9305-0da769d9acaa.png)
