### PR TITLE
fix indicator line-height #2600

### DIFF
--- a/panel/widgets/indicators.py
+++ b/panel/widgets/indicators.py
@@ -193,10 +193,10 @@ class Number(ValueIndicator):
         if value is None:
             value = float('nan')
         value = format.format(value=value).replace('nan', nan_format)
-        text = f'<div style="font-size: {font_size}; color: {color}">{value}</div>'
+        text = f'<div style="font-size: {font_size}; color: {color};line-height:1.42857">{value}</div>'
         if self.name:
             title_font_size = msg.pop('title_size', self.title_size)
-            text = f'<div style="font-size: {title_font_size}; color: {color}">{name}</div>\n{text}'
+            text = f'<div style="font-size: {title_font_size}; color: {color};line-height:1.42857">{name}</div>\n{text}'
         msg['text'] = escape(text)
         return msg
 
@@ -753,7 +753,7 @@ class Tqdm(Indicator):
 
     def __init__(self, **params):
         layout = params.pop('layout', 'column')
-        layout = self._layouts.get(layout, layout) 
+        layout = self._layouts.get(layout, layout)
         if "text_pane" not in params:
             sizing_mode = 'stretch_width' if layout == 'column' else 'fixed'
             params["text_pane"] = Str(


### PR DESCRIPTION
Fixes #2600

## FastListTemplate 

```python
import panel as pn
pn.extension()

pn.template.FastListTemplate(
    main=[pn.indicators.Number(name="MyNumber", value=42)]
).show()
```
![image](https://user-images.githubusercontent.com/42288570/128083860-8a884d2d-cdbf-4e04-ae56-ae83ed368ecd.png)

## VanillaTemplate

![image](https://user-images.githubusercontent.com/42288570/128084154-d1ddb18a-4f50-4a8f-9501-710bb42171f8.png)

```python
import panel as pn
pn.extension()

pn.template.VanillaTemplate(
    main=[pn.indicators.Number(name="MyNumber", value=42)]
).show()
```

![image](https://user-images.githubusercontent.com/42288570/128083929-8aceb679-c28c-4039-9544-85e95b531999.png)



