### PR TITLE
fix slick grid index column background in Fast Templates

### DIFF
--- a/panel/template/fast/css/fast_bokeh_slickgrid.css
+++ b/panel/template/fast/css/fast_bokeh_slickgrid.css
@@ -42,7 +42,9 @@
   border-color: black;
   border-style: solid;
 }
-
+.bk-root .slick-cell.bk-cell-index {
+  background: transparent;
+}
 .bk-root .slick-reorder-proxy {
   background: blue;
   opacity: 0.15;


### PR DESCRIPTION
Fixes #2613, I.e. gives the index column the right background color in Fast Templates when using dark theme

![image](https://user-images.githubusercontent.com/42288570/128124242-996ad209-4085-45ce-97fb-7bfc7169518c.png)

Still looks fine in default theme

![image](https://user-images.githubusercontent.com/42288570/128124268-b166e5ee-8883-4d99-93f1-2b5d8bb17a94.png)

```python
import panel as pn

pn.extension()

import numpy as np
import holoviews as hv

from holoviews import opts, streams
from holoviews.plotting.links import DataLink

hv.extension('bokeh')
curve = hv.Curve(np.random.randn(10).cumsum()).opts(responsive=True, line_width=6)
table = hv.Table(curve).opts(editable=True)
component=pn.pane.HoloViews(table, height=500, sizing_mode="stretch_both")
pn.template.FastListTemplate(title="Table", main=[component]).servable()
```