### PR TITLE
Fix #2631 - handle RuntimeError: dictionary changed size during iteration

### DIFF
--- a/panel/reactive.py
+++ b/panel/reactive.py
@@ -248,7 +248,7 @@ class Syncable(Renderable):
         if not msg:
             return
 
-        for ref, (model, parent) in self._models.items():
+        for ref, (model, _) in list(self._models.items()):
             self._apply_update(events, msg, model, ref)
 
     def _process_events(self, events):
@@ -939,7 +939,7 @@ class ReactiveData(SyncableData):
                 finally:
                     self._updating = False
                 # Ensure that if the data was changed in a user
-                # callback, we still send the updated data 
+                # callback, we still send the updated data
                 if old_data is not self.value:
                     self._update_cds()
         if 'indices' in events:

--- a/panel/reactive.py
+++ b/panel/reactive.py
@@ -248,7 +248,7 @@ class Syncable(Renderable):
         if not msg:
             return
 
-        for ref, (model, _) in list(self._models.items()):
+        for ref, (model, _) in self._models.copy().items():
             self._apply_update(events, msg, model, ref)
 
     def _process_events(self, events):


### PR DESCRIPTION
Fixes #2631. Probably also needed for #2597 to work in practice.

I don't know if

- There are any side effects. For example is it always good to `_apply_update` if  `self._models.items()` has changed?
- It would be more efficient to use `.copy` instead of `list`? But according to https://www.geeksforgeeks.org/python-cloning-copying-list/ list seems like an efficient solution. And using `list` is also what is mostly recommended here https://stackoverflow.com/questions/11941817/how-to-avoid-runtimeerror-dictionary-changed-size-during-iteration-error.