### PR TITLE
Add option to hide constant parameters

### DIFF
--- a/panel/param.py
+++ b/panel/param.py
@@ -216,7 +216,8 @@ class Param(PaneBase):
                              type(layout).__name__)
         self.param.watch(self._update_widgets, [
             'object', 'parameters', 'name', 'display_threshold', 'expand_button',
-            'expand', 'expand_layout', 'widgets', 'show_labels', 'show_name'])
+            'expand', 'expand_layout', 'widgets', 'show_labels', 'show_name',
+            'hide_constant'])
         self._update_widgets()
 
     def __repr__(self, depth=0):

--- a/panel/param.py
+++ b/panel/param.py
@@ -115,6 +115,9 @@ class Param(PaneBase):
     height = param.Integer(default=None, bounds=(0, None), doc="""
         Height of widgetbox the parameter widgets are displayed in.""")
 
+    hide_constant = param.Boolean(default=False, doc="""
+        Whether to hide widgets of constant parameters.""")
+
     initializer = param.Callable(default=None, doc="""
         User-supplied function that will be called on initialization,
         usually to update the default Parameter values of the
@@ -384,6 +387,8 @@ class Param(PaneBase):
         else:
             label = p_obj.label
         kw = dict(disabled=p_obj.constant, name=label)
+        if self.hide_constant:
+            kw['visible'] = not p_obj.constant
 
         value = getattr(self.object, p_name)
         if value is not None:
@@ -460,6 +465,8 @@ class Param(PaneBase):
             widget = self._widgets[p_name]
             if change.what == 'constant':
                 updates['disabled'] = change.new
+                if self.hide_constant:
+                    updates['visible'] = not change.new
             elif change.what == 'precedence':
                 if change.new is change.old:
                     return

--- a/panel/tests/test_param.py
+++ b/panel/tests/test_param.py
@@ -410,6 +410,22 @@ def test_param_precedence(document, comm):
     assert test_pane._widgets['a'] in test_pane._widget_box.objects
 
 
+def test_hide_constant(document, comm):
+    class Test(param.Parameterized):
+        a = param.Number(default=1.2, bounds=(0, 5), constant=True)
+
+    test = Test()
+    test_pane = Pane(test, parameters=['a'], hide_constant=True)
+    model = test_pane.get_root(document, comm=comm)
+
+    slider = model.children[1]
+    assert not slider.visible
+
+    test.param.a.constant = False
+
+    assert slider.visible
+
+
 def test_param_label(document, comm):
     class Test(param.Parameterized):
         a = param.Number(default=1.2, bounds=(0, 5), label='A')


### PR DESCRIPTION
Instead of simply disabling the parameters this option allows you to hide it.