### PR TITLE
Add support for scheduling global callbacks

### DIFF
--- a/panel/io/state.py
+++ b/panel/io/state.py
@@ -7,6 +7,7 @@ import json
 import threading
 
 from collections import OrderedDict, defaultdict
+from functools import partial
 from weakref import WeakKeyDictionary, WeakSet
 from urllib.parse import urljoin
 
@@ -15,9 +16,10 @@ import param
 from bokeh.document import Document
 from bokeh.io import curdoc as _curdoc
 from pyviz_comms import CommManager as _CommManager
+from tornado.ioloop import IOLoop
 from tornado.web import decode_signed_value
 
-from ..util import base64url_decode
+from ..util import base64url_decode, parse_timedelta
 
 _state_logger = logging.getLogger('panel.state')
 
@@ -91,6 +93,9 @@ class _state(param.Parameterized):
     # Dictionary of callbacks to be triggered on app load
     _onload = WeakKeyDictionary()
     _on_session_created = []
+
+    # Scheduled callbacks
+    _scheduled = {}
 
     # Stores a set of locked Websockets, reset after every change event
     _locks = WeakSet()
@@ -173,6 +178,21 @@ class _state(param.Parameterized):
     def _on_load(self, event):
         for cb in self._onload.pop(self.curdoc, []):
             cb()
+
+    def _scheduled_cb(self, name):
+        if name not in self._scheduled:
+            return
+        diter, cb = self._scheduled[name]
+        try:
+            at = next(diter)
+        except StopIteration:
+            at = None
+        if at is not None:
+            ioloop = IOLoop.current()
+            now = dt.datetime.now().timestamp()
+            call_time_seconds = (at - now)
+            ioloop.call_later(delay=call_time_seconds, callback=partial(self._scheduled_cb, name))
+        cb()
 
     #----------------------------------------------------------------
     # Public Methods
@@ -343,6 +363,63 @@ class _state(param.Parameterized):
             cb = self._get_callback(endpoint)
             self._rest_endpoints[endpoint] = ([parameterized], parameters, cb)
         parameterized.param.watch(cb, parameters)
+
+    def schedule(self, name, callback, at=None, period=None, cron=None):
+        """
+        Schedule a callback periodically at a specific
+        time. Scheduling is idempotent, i.e. if a callback has already
+        been scheduled under the same name subsequent calls will have
+        no effect. By default the starting time is immediate but may
+        be overridden with the `at` keyword argument. The period may
+        be declared using the `period` argument or a cron expression
+        (which requires the `croniter` library).
+
+        Arguments
+        ---------
+        name: str
+          Name of the scheduled task
+        callback: callable
+          Callback to schedule
+        at: datetime.datetime
+          Datetime to schedule the task at
+        period: str or datetime.timedelta
+          The period between executions, may be expressed as a timedelta
+          or a string:
+
+            - Week:   '1w'
+            - Day:    '1d'
+            - Hour:   '1h'
+            - Minute: '1m'
+            - Second: '1s'
+
+        cron: str
+          A cron expression (requires croniter to parse)
+        """
+        if name in self._scheduled:
+            return
+        ioloop = IOLoop.current()
+        if not ioloop.asyncio_loop.is_running():
+            raise RuntimeError("Cannot schedule task, event loop is not running.")
+        if cron is None:
+            if isinstance(period, str):
+                period = parse_timedelta(period)
+            def dgen():
+                if period is None:
+                    yield at
+                    raise StopIteration
+                new_time = at or dt.datetime.now()
+                while True:
+                    yield new_time.timestamp()
+                    new_time += period
+            diter = dgen()
+        else:
+            import croniter
+            base = dt.datetime.now() if at is None else at
+            diter = croniter(cron, base)
+        now = dt.datetime.now().timestamp()
+        call_time_seconds = (next(diter) - now)
+        self._scheduled[name] = (diter, callback)
+        ioloop.call_later(delay=call_time_seconds, callback=partial(self._scheduled_cb, name))
 
     def sync_busy(self, indicator):
         """

--- a/panel/util.py
+++ b/panel/util.py
@@ -384,3 +384,17 @@ def clone_model(bokeh_model, include_defaults=False, include_undefined=False):
         include_defaults=include_defaults, include_undefined=include_undefined
     )
     return type(bokeh_model)(**properties)
+
+
+_period_regex = re.compile(r'((?P<weeks>\d+?)w)?((?P<days>\d+?)d)?((?P<hours>\d+?)h)?((?P<minutes>\d+?)m)?((?P<seconds>\d+?)s)?')
+
+def parse_timedelta(time_str):
+    parts = _period_regex.match(time_str)
+    if not parts:
+        return
+    parts = parts.groupdict()
+    time_params = {}
+    for (name, p) in parts.items():
+        if p:
+            time_params[name] = int(p)
+    return dt.timedelta(**time_params)


### PR DESCRIPTION
Implements #2657

```
        Schedule a callback periodically at a specific
        time. Scheduling is idempotent, i.e. if a callback has already
        been scheduled under the same name subsequent calls will have
        no effect. By default the starting time is immediate but may
        be overridden with the `at` keyword argument. The period may
        be declared using the `period` argument or a cron expression
        (which requires the `croniter` library).

        Arguments
        ---------
        name: str
          Name of the scheduled task
        callback: callable
          Callback to schedule
        at: datetime.datetime
          Datetime to schedule the task at
        period: str or datetime.timedelta
          The period between executions, may be expressed as a timedelta
          or a string:

            - Week:   '1w'
            - Day:    '1d'
            - Hour:   '1h'
            - Minute: '1m'
            - Second: '1s'

        cron: str
          A cron expression (requires croniter to parse)
```