### PR TITLE
correctly accessing the filtered dataframe for selection of tabulator…

### DIFF
--- a/panel/tests/widgets/test_tables.py
+++ b/panel/tests/widgets/test_tables.py
@@ -216,6 +216,24 @@ def test_none_table(document, comm):
     assert model.source.data == {}
 
 
+def test_tabulator_selected_dataframe(dataframe):
+    df = makeMixedDataFrame()
+    table = Tabulator(df, selection=[0, 2])
+
+    pd.testing.assert_frame_equal(table.selected_dataframe, df.iloc[[0, 2]])
+
+
+def test_tabulator_selected_and_filtered_dataframe(document, comm):
+    df = makeMixedDataFrame()
+    table = Tabulator(df)
+
+    pd.testing.assert_frame_equal(table.selected_dataframe, df)
+
+    table.add_filter('foo3', 'C')
+
+    pd.testing.assert_frame_equal(table.selected_dataframe, df[df["C"] == "foo3"])
+
+
 def test_tabulator_config_defaults(document, comm):
     df = makeMixedDataFrame()
     table = Tabulator(df)

--- a/panel/tests/widgets/test_tables.py
+++ b/panel/tests/widgets/test_tables.py
@@ -216,7 +216,7 @@ def test_none_table(document, comm):
     assert model.source.data == {}
 
 
-def test_tabulator_selected_dataframe(dataframe):
+def test_tabulator_selected_dataframe():
     df = makeMixedDataFrame()
     table = Tabulator(df, selection=[0, 2])
 

--- a/panel/widgets/tables.py
+++ b/panel/widgets/tables.py
@@ -544,8 +544,8 @@ class BaseTable(ReactiveData, Widget):
         Returns a DataFrame of the currently selected rows.
         """
         if not self.selection:
-            return self.value
-        return self.value.iloc[self.selection]
+            return self._processed
+        return self._processed.iloc[self.selection]
 
 
 


### PR DESCRIPTION
Accessing now ._processed in the selected_dataframe property as discussed in #2642