### PR TITLE
Editable sliders' `name` can be changed

### DIFF
--- a/panel/tests/widgets/test_slider.py
+++ b/panel/tests/widgets/test_slider.py
@@ -375,3 +375,7 @@ def test_editable_float_slider(document, comm,
 
         slider.value = val3
         assert input_widget.value == slider_widget.value == val3
+
+    slider.name = 'New Slider'
+
+    assert static_widget.text == 'New Slider:' 

--- a/panel/widgets/base.py
+++ b/panel/widgets/base.py
@@ -130,13 +130,14 @@ class CompositeWidget(Widget):
 
     def __init__(self, **params):
         super().__init__(**params)
-        layout = {p: getattr(self, p) for p in Layoutable.param
+        layout_params = [p for p in Layoutable.param if p != 'name']
+        layout = {p: getattr(self, p) for p in layout_params
                   if getattr(self, p) is not None}
         if layout.get('width', self.width) is None and not 'sizing_mode' in layout:
             layout['sizing_mode'] = 'stretch_width'
         self._composite = self._composite_type(**layout)
         self._models = self._composite._models
-        self.param.watch(self._update_layout_params, list(Layoutable.param))
+        self.param.watch(self._update_layout_params, layout_params)
 
     def _update_layout_params(self, *events):
         updates = {event.name: event.new for event in events}


### PR DESCRIPTION
Fixes #2663 
