### PR TITLE
Unescape child literal HTML in ReactiveHTML

### DIFF
--- a/panel/models/reactive_html.ts
+++ b/panel/models/reactive_html.ts
@@ -290,7 +290,7 @@ export class ReactiveHTMLView extends PanelHTMLBoxView {
   private _render_child(model: any, el: Element): void {
     const view: any = this._child_views.get(model)
     if (view == null)
-      el.innerHTML = model
+      el.innerHTML = htmlDecode(model) || model
     else {
       view._parent = this
       view.renderTo(el)


### PR DESCRIPTION
Fixes https://github.com/holoviz/panel/issues/2681