### PR TITLE
Fix keyerror when reloading

### DIFF
--- a/panel/io/reload.py
+++ b/panel/io/reload.py
@@ -112,7 +112,8 @@ def record_modules():
 def _reload(module=None):
     if module is not None:
         for module in _modules:
-            del sys.modules[module]
+            if module in sys.modules:
+                del sys.modules[module]
     for cb in _callbacks.values():
         cb.stop()
     _callbacks.clear()


### PR DESCRIPTION
Fixes errors like

```bash
KeyError: 'analytics_workspace.mail'

2021-08-31 13:15:55,562 Error thrown from periodic callback:
2021-08-31 13:15:55,562 Traceback (most recent call last):
  File "c:\repos\analytics-workspace\aw-lib\.venv\lib\site-packages\tornado\gen.py", line 526, in callback
    result_list.append(f.result())
  File "c:\repos\analytics-workspace\aw-lib\.venv\lib\site-packages\bokeh\server\session.py", line 67, in _needs_document_lock_wrapper
    result = func(self, *args, **kwargs)
  File "c:\repos\analytics-workspace\aw-lib\.venv\lib\site-packages\bokeh\server\session.py", line 195, in with_document_locked
    return func(*args, **kwargs)
  File "c:\repos\analytics-workspace\aw-lib\.venv\lib\site-packages\bokeh\document\document.py", line 1212, in wrapper
    return doc._with_self_as_curdoc(invoke)
  File "c:\repos\analytics-workspace\aw-lib\.venv\lib\site-packages\bokeh\document\document.py", line 1198, in _with_self_as_curdoc
    return f()
  File "c:\repos\analytics-workspace\aw-lib\.venv\lib\site-packages\bokeh\document\document.py", line 1211, in invoke
    return f(*args, **kwargs)
  File "c:\repos\analytics-workspace\aw-lib\.venv\lib\site-packages\panel\io\callbacks.py", line 72, in _periodic_callback
    self.callback()
  File "c:\repos\analytics-workspace\aw-lib\.venv\lib\site-packages\panel\io\reload.py", line 153, in _reload_on_update
    _check_file(modify_times, path, module_name)
  File "c:\repos\analytics-workspace\aw-lib\.venv\lib\site-packages\panel\io\reload.py", line 134, in _check_file
    _reload(module)
  File "c:\repos\analytics-workspace\aw-lib\.venv\lib\site-packages\panel\io\reload.py", line 115, in _reload
    del sys.modules[module]
KeyError: 'analytics_workspace.mail'
```