### PR TITLE
Change binder link from master to binder branch for robustness

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 | Latest dev release | [![Github tag](https://img.shields.io/github/v/tag/holoviz/panel.svg?label=tag&colorB=11ccbb)](https://github.com/holoviz/panel/tags) [![dev-site](https://img.shields.io/website-up-down-green-red/https/pyviz-dev.github.io/panel.svg?label=dev%20website)](https://pyviz-dev.github.io/panel/) |
 | Latest release | [![Github release](https://img.shields.io/github/release/holoviz/panel.svg?label=tag&colorB=11ccbb)](https://github.com/holoviz/panel/releases) [![PyPI version](https://img.shields.io/pypi/v/panel.svg?colorB=cc77dd)](https://pypi.python.org/pypi/panel) [![panel version](https://img.shields.io/conda/v/pyviz/panel.svg?colorB=4488ff&style=flat)](https://anaconda.org/pyviz/panel) [![conda-forge version](https://img.shields.io/conda/v/conda-forge/panel.svg?label=conda%7Cconda-forge&colorB=4488ff)](https://anaconda.org/conda-forge/panel) [![defaults version](https://img.shields.io/conda/v/anaconda/panel.svg?label=conda%7Cdefaults&style=flat&colorB=4488ff)](https://anaconda.org/anaconda/panel) |
 | Docs | [![gh-pages](https://img.shields.io/github/last-commit/holoviz/panel/gh-pages.svg)](https://github.com/holoviz/panel/tree/gh-pages) [![site](https://img.shields.io/website-up-down-green-red/https/panel.holoviz.org.svg)](https://panel.holoviz.org) |
-| Binder | [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/holoviz/panel/master?urlpath=lab/tree/examples) |
+| Binder | [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/holoviz/panel/binder?urlpath=lab/tree/examples) |
 | Support | [![Discourse](https://img.shields.io/discourse/status?server=https%3A%2F%2Fdiscourse.holoviz.org)](https://discourse.holoviz.org/) |
 
 ## What is it?

--- a/doc/_templates/layout.html
+++ b/doc/_templates/layout.html
@@ -29,7 +29,7 @@
   {% endfor %}
   {% endif %}
   {% if ('gallery' in pagename or 'reference' in pagename or 'user_guide' in pagename) and not pagename.endswith('index') %}
-  <a href="https://mybinder.org/v2/gh/holoviz/panel/master?urlpath=lab/tree/examples/{{ pagename }}.ipynb">Open this example in Binder</a>
+  <a href="https://mybinder.org/v2/gh/holoviz/panel/binder?urlpath=lab/tree/examples/{{ pagename }}.ipynb">Open this example in Binder</a>
   {% endif %}
 </div>
 {% endblock %}


### PR DESCRIPTION
Addresses suggestion 2 of https://github.com/holoviz/panel/issues/2702
-----

The master branch is always changing which means

- its not consistent with the docs for the current release
- Starting Binder takes a long time because it has to build a new image
- might not work because the master branch does not work.

I suggest changing to a branch called `binder`.

I've already created the `binder` branch from the `v0.12.1` (`git checkout tags/v0.12.1`) and tested that it works.

You can test binder via https://mybinder.org/v2/gh/holoviz/panel/binder?urlpath=lab/tree/examples

## Release Procedure

Please note that when ever a new version of Panel is released a step in that process is to merge the release into the `binder` branch and manually test that binder can build the image and that things works. But it would be a good test anyways that Panel indeed works in a fresh environment and that all the gallery apps works etc.

## Improvements to binder branch

Any improvements to the binder branch during releases should start from the binder branch and not from master.