### PR TITLE
Make Plotly pane resize when window resizes

### DIFF
--- a/panel/models/plotly.ts
+++ b/panel/models/plotly.ts
@@ -271,6 +271,13 @@ export class PlotlyPlotView extends PanelHTMLBoxView {
     );
   }
 
+  after_layout(): void{
+    super.after_layout()
+    if ((window as any).Plotly) {
+      (window as any).Plotly.Plots.resize(this._layout_wrapper);
+    }
+  }
+
   _get_trace(index: number, update: boolean): any {
     const trace = clone(this.model.data[index]);
     const cds = this.model.data_sources[index];


### PR DESCRIPTION
Fixes https://github.com/holoviz/panel/issues/1514

I've implemented the fix and tested that it works

https://user-images.githubusercontent.com/42288570/131785863-c23d5c29-0eea-4292-b594-e38965f58220.mp4