### PR TITLE
Ensure PeriodicCallback robustly logs the function name

### DIFF
--- a/panel/io/callbacks.py
+++ b/panel/io/callbacks.py
@@ -9,7 +9,7 @@ import param
 
 from bokeh.io import curdoc as _curdoc
 
-from ..util import edit_readonly
+from ..util import edit_readonly, function_name
 from .logging import LOG_PERIODIC_START, LOG_PERIODIC_END
 from .state import state
 
@@ -73,7 +73,7 @@ class PeriodicCallback(param.Parameterized):
     def _periodic_callback(self):
         with edit_readonly(state):
             state.busy = True
-        cbname = self.callback.__name__
+        cbname = function_name(self.callback)
         if self._doc:
             _periodic_logger.info(
                 LOG_PERIODIC_START, id(self._doc), cbname, self._counter

--- a/panel/util.py
+++ b/panel/util.py
@@ -16,6 +16,7 @@ from collections import defaultdict, OrderedDict
 from contextlib import contextmanager
 from datetime import datetime
 from distutils.version import LooseVersion
+from functools import partial
 from html import escape # noqa
 from importlib import import_module
 from six import string_types
@@ -391,3 +392,14 @@ def doc_event_obj(doc):
     Temporary helper for Bokeh 2.3/2.4 compatibility
     """
     return doc.callbacks if bokeh_version >= '2.4' and hasattr(doc, 'callbacks') else doc
+
+
+def function_name(func):
+    """
+    Returns the name of a function (or its string repr)
+    """
+    while isinstance(func, partial):
+        func = func.func
+    if hasattr(func, '__name__'):
+        return func.__name__
+    return str(func)


### PR DESCRIPTION
Small fix for periodic callbacks which don't have a `__name__` attribute.