### PR TITLE
Ensure admin timeline is robust to load balance setup

### DIFF
--- a/panel/io/admin.py
+++ b/panel/io/admin.py
@@ -165,10 +165,14 @@ def get_timeline(doc=None):
             }
             cds.patch(patch)
         elif new.msg.endswith('rendered'):
-            index = cds.data['msg'].index(f'Session {sid} initializing')
+            try:
+                index = cds.data['msg'].index(f'Session {sid} initializing')
+                x0 = cds.data['x1'][index]
+            except ValueError:
+                x0 = new.created*1000
             etype = 'rendering'
             event = {
-                'x0': [cds.data['x1'][index]],
+                'x0': [x0],
                 'x1': [new.created*1000],
                 'y0': [(sid, -.25)],
                 'y1': [(sid, .25)],


### PR DESCRIPTION
When running multiple processes or running in a load balanced setup not all requests may arrive on the same server. This ensures that the timeline graph is robust to that.