### PR TITLE
Patch bokeh create_static_handler

### DIFF
--- a/panel/io/server.py
+++ b/panel/io/server.py
@@ -39,6 +39,7 @@ from bokeh.server.urls import per_app_patterns, toplevel_patterns
 from bokeh.server.views.autoload_js_handler import AutoloadJsHandler as BkAutoloadJsHandler
 from bokeh.server.views.doc_handler import DocHandler as BkDocHandler
 from bokeh.server.views.root_handler import RootHandler as BkRootHandler
+from bokeh.server.views.static_handler import StaticHandler
 
 # Tornado imports
 from tornado.ioloop import IOLoop
@@ -367,6 +368,19 @@ def modify_document(self, doc):
         bk_set_curdoc(old_doc)
 
 CodeHandler.modify_document = modify_document
+
+# Copied from bokeh 2.4.0, to fix directly in bokeh at some point.
+def create_static_handler(prefix, key, app):
+    # patch
+    key = '/__patchedroot' if key == '/' else key
+
+    route = prefix
+    route += "/static/(.*)" if key == "/" else key + "/static/(.*)"
+    if app.static_path is not None:
+        return (route, StaticFileHandler, {"path" : app.static_path})
+    return (route, StaticHandler, {})
+
+bokeh.server.tornado.create_static_handler = create_static_handler
 
 #---------------------------------------------------------------------
 # Public API

--- a/panel/tests/test_server.py
+++ b/panel/tests/test_server.py
@@ -127,6 +127,21 @@ def test_server_template_static_resources_with_subpath_and_prefix_relative_url()
         server.stop()
 
 
+def test_server_extensions_on_root():
+    html = Markdown('# Title')
+
+    server = serve(html, port=6006, threaded=True, show=False)
+
+    # Wait for server to start
+    time.sleep(1)
+
+    try:
+        r = requests.get("http://localhost:6006/static/extensions/panel/css/loading.css")
+        assert r.ok
+    finally:
+        server.stop()
+
+
 def test_server_async_callbacks():
     button = Button(name='Click')
 


### PR DESCRIPTION
Fixes https://github.com/holoviz/panel/issues/2726

Patch bokeh to get `.show()` to work again, this is possibly due to https://github.com/bokeh/bokeh/pull/11531.