### PR TITLE
WIP: Add ability to define custom tornado handler plugins

### DIFF
--- a/panel/plugins/tiles.py
+++ b/panel/plugins/tiles.py
@@ -1,0 +1,67 @@
+import io
+import importlib
+
+from collections import Counter
+from pathlib import Path
+
+from datashader import Canvas
+from datashader.tiles import TileRenderer, MercatorTileDefinition
+
+from tornado.web import RequestHandler, HTTPError
+
+CACHE = Path('tile_cache')
+
+class TileProvider:
+
+    def __init__(self, provider):
+        self._provider = provider
+        self._module = importlib.import_module(provider)
+        self._tile_size = getattr(self._module, 'tile_size', 256)
+        self._definition = MercatorTileDefinition(
+            self._module.x_range,
+            self._module.y_range,
+            self._tile_size
+        )
+
+    async def get(self, x, y, z):
+        path = CACHE / self._provider / str(x) / str(y) / f"{z}.png"
+        if path.exists():
+            with open(path, 'rb') as f:
+                return f.read()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        x0, y0, x1, y1 = self._definition.get_tile_meters(x, y, z)
+        agg = self._module.aggregate(
+            x_range=(x0, x1), y_range=(y0, y1),
+            width=self._tile_size, height=self._tile_size
+        )
+        img = agg.to_pil()
+        bio = io.BytesIO()
+        img.save(bio, 'png')
+        img.save(path)
+        bio.seek(0)
+        return bio.read()
+
+
+class TileHandler(RequestHandler):
+
+    _providers = {}
+
+    @classmethod
+    def _get_provider(cls, provider):
+        if provider not in cls._providers:
+            cls._providers[provider] = pobj = TileProvider(provider)
+        else:
+            pobj = cls._providers[provider]
+        return pobj
+
+    async def get(self, path):
+        print(path)
+        if not path.endswith('.png'):
+            raise HTTPError(400, 'Must request png')
+        elif not Counter(path)['/'] <= 3:
+            raise HTTPError(400, 'Request must be of format provider/x/y/z.png')
+        *provider, x, y, z = path.split('/')
+        provider = self._get_provider('.'.join(provider))
+        x, y, z = int(x), int(y), int(z.split('.')[0])
+        self.set_header('Content-Type', 'image/png')
+        self.write(await provider.get(x, y, z))


### PR DESCRIPTION
Allows defining custom Tornado handler plugins via the `panel serve` CLI.

As a demo this also declares a `TileHandler` which allows users to ship a file alongside an app which renders tiles when given a request.

## Example

### nyc_taxi_tiles.py

```python
import datashader as ds

import dask.dataframe as dd

ddf = dd.read_parquet('~/development/datashader/examples/data/nyc_taxi.parq/').persist()

x_range = dd.compute(ddf.pickup_x.min(), ddf.pickup_x.max())
y_range = dd.compute(ddf.pickup_y.min(), ddf.pickup_y.max())

def aggregate(x_range, y_range, width, height):
    cvs = ds.Canvas(
        width, height, x_range, y_range, 
    )
    agg = cvs.points(ddf, 'pickup_x', 'pickup_y')
    img = ds.tf.dynspread(ds.tf.shade(agg))
    return img 
```

### nyc_tile_viewer.py


```python
import holoviews as hv
import panel as pn

hv.extension('bokeh')

pn.Row(
    hv.Tiles('http://localhost:5006/tiles/nyc_taxi_tiles/{X}/{Y}/{Z}.png').opts(
        responsive=True,
        xlim=(-20037508.34, 20037508.34),
        ylim=(-20037508.34, 20037508.34)
    ),
    sizing_mode='stretch_both'
).servable()
```

Now this can be run with:

```
panel serve nyc_tile_viewer.py --plugins="{'/tiles/(.*)':'panel.plugins.tiles.TileHandler'}"
```

<img width="1680" alt="Screen Shot 2021-09-17 at 11 16 33 PM" src="https://user-images.githubusercontent.com/1550771/133859350-04f0b5b8-4b96-414f-b35a-aef28f839708.png">


