### PR TITLE
Adding ICO and pathlib support for image

### DIFF
--- a/panel/pane/__init__.py
+++ b/panel/pane/__init__.py
@@ -13,7 +13,7 @@ from .echarts import ECharts # noqa
 from .holoviews import HoloViews, Interactive # noqa
 from .idom import IDOM # noqa0
 from .ipywidget import IPyWidget # noqa
-from .image import GIF, JPG, PDF, PNG, SVG # noqa
+from .image import GIF, ICO, JPG, PDF, PNG, SVG # noqa
 from .markup import DataFrame, HTML, JSON, Markdown, Str # noqa
 from .media import Audio, Video # noqa
 from .perspective import Perspective # noqa

--- a/panel/pane/image.py
+++ b/panel/pane/image.py
@@ -171,6 +171,17 @@ class GIF(ImageBase):
         return int(w), int(h)
 
 
+class ICO(ImageBase):
+
+    filetype = 'ico'
+
+    @classmethod
+    def _imgshape(cls, data):
+        import struct
+        w, h = struct.unpack("<BB" , data[6:8])
+        return int(w or 256), int(h or 256)
+
+
 class JPG(ImageBase):
 
     filetype = 'jpg'

--- a/panel/pane/image.py
+++ b/panel/pane/image.py
@@ -3,6 +3,7 @@ Contains Image panes including renderers for PNG, SVG, GIF and JPG
 file types.
 """
 import base64
+from pathlib import PurePath
 
 from io import BytesIO
 from six import string_types
@@ -21,6 +22,11 @@ class FileBase(DivPaneBase):
     _rerender_params = ['embed', 'object', 'style', 'width', 'height']
 
     __abstract = True
+
+    def __init__(self, object=None, **params):
+        if isinstance(object, PurePath):
+            object = str(object)
+        super().__init__(object=object, **params)
 
     def _type_error(self, object):
         if isinstance(object, string_types):

--- a/panel/template/base.py
+++ b/panel/template/base.py
@@ -8,6 +8,7 @@ import uuid
 
 from collections import OrderedDict
 from functools import partial
+from pathlib import PurePath
 
 import param
 
@@ -483,6 +484,8 @@ class BasicTemplate(BaseTemplate):
             params['modal'] = self._get_params(params['modal'], self.param.modal.class_)
         if 'theme' in params and isinstance(params['theme'], str):
             params['theme'] = THEMES[params['theme']]
+        if 'favicon' in params and isinstance(params['favicon'], PurePath):
+            params['favicon'] = str(params['favicon'])
         super().__init__(template=template, **params)
         self._js_area = HTML(margin=0, width=0, height=0)
         if '{{ embed(roots.js_area) }}' in template:

--- a/panel/template/base.py
+++ b/panel/template/base.py
@@ -639,14 +639,14 @@ class BasicTemplate(BaseTemplate):
         if os.path.isfile(self.logo):
             img = _panel(self.logo)
             if not isinstance(img, ImageBase):
-                raise ValueError("Could not determine file type of logo: {self.logo}.")
+                raise ValueError(f"Could not determine file type of logo: {self.logo}.")
             logo = img._b64()
         else:
             logo = self.logo
         if os.path.isfile(self.favicon):
             img = _panel(self.favicon)
             if not isinstance(img, ImageBase):
-                raise ValueError("Could not determine file type of favicon: {self.favicon}.")
+                raise ValueError(f"Could not determine file type of favicon: {self.favicon}.")
             favicon = img._b64()
         else:
             if _settings.resources(default='server') == 'cdn' and self.favicon == FAVICON_URL:

--- a/panel/tests/pane/test_image.py
+++ b/panel/tests/pane/test_image.py
@@ -3,8 +3,9 @@ import sys
 import pytest
 
 from base64 import b64decode, b64encode
+from pathlib import Path
 
-from panel.pane import GIF, JPG, PDF, PNG, SVG
+from panel.pane import GIF, ICO, JPG, PDF, PNG, SVG
 from panel.pane.markup import escape
 from io import BytesIO, StringIO
 
@@ -53,10 +54,13 @@ twopixel = dict(\
           b'QEBAQEBAQEBAQEBAQEBAQH/wAARCAABAAIDAREAAhEBAxEB/8QAFAABAAAAAAAA' + \
           b'AAAAAAAAAAAACf/EABoQAAEFAQAAAAAAAAAAAAAAAAYABAU2dbX/xAAVAQEBAAA' + \
           b'AAAAAAAAAAAAAAAAFBv/EABkRAAEFAAAAAAAAAAAAAAAAAAEAAjFxsf/aAAwDAQ' + \
-          b'ACEQMRAD8AA0qs5HvTHQcJdsChioXSbOr/2Q==')
+          b'ACEQMRAD8AA0qs5HvTHQcJdsChioXSbOr/2Q==',
+    ico = b'AAABAAEAAgEAAAEAIAA0AAAAFgAAACgAAAACAAAAAgAAAAEAIAAAAAAACAAAAHQ' + \
+          b'SAAB0EgAAAAAAAAAAAAD//////////wAAAAA=')
+
 
 def test_imgshape():
-    for t in [PNG, JPG, GIF]:
+    for t in [PNG, JPG, GIF, ICO]:
         w,h = t._imgshape(b64decode(twopixel[t.name.lower()]))
         assert w == 2
         assert h == 1
@@ -91,6 +95,15 @@ def test_loading_a_image_from_url():
     url = 'https://file-examples-com.github.io/uploads/2017/10/file_example_PNG_500kB.png'
 
     image_pane = PNG(url)
+    image_data = image_pane._data()
+    assert b'PNG' in image_data
+
+
+def test_loading_a_image_from_pathlib():
+    """Tests the loading of a image from a pathlib"""
+    filepath = Path(__file__).parent.parent / "test_data" / "logo.png"
+
+    image_pane = PNG(filepath)
     image_data = image_pane._data()
     assert b'PNG' in image_data
 

--- a/panel/tests/test_docs.py
+++ b/panel/tests/test_docs.py
@@ -42,7 +42,7 @@ def test_widgets_are_in_reference_gallery():
 
 @docs_available
 def test_panes_are_in_reference_gallery():
-    exceptions = set(['PaneBase', 'YT', 'RGGPlot', 'Interactive'])
+    exceptions = set(['PaneBase', 'YT', 'RGGPlot', 'Interactive', 'ICO'])
     docs = {os.path.splitext(f)[0] for f in os.listdir(os.path.join(ref, 'panes'))}
 
     def is_panel_pane(attr):


### PR DESCRIPTION
Added a `ICO` class to `pane.image` and `pathlib` conversion to pane.image and favicon in templates. 