### PR TITLE
Add support for rendering panels inside Tabulator rows

### DIFF
--- a/panel/models/tabulator.py
+++ b/panel/models/tabulator.py
@@ -7,7 +7,7 @@ from bokeh.core.properties import (
     Any, Bool, Dict, Either, Enum, Instance, Int, List, Nullable,
     String, Tuple
 )
-from bokeh.models import ColumnDataSource
+from bokeh.models import ColumnDataSource, LayoutDOM
 from bokeh.models.layouts import HTMLBox
 from bokeh.models.widgets.tables import TableColumn
 
@@ -65,7 +65,11 @@ class DataTabulator(HTMLBox):
 
     download = Bool(default=False)
 
+    children = Dict(Int, Instance(LayoutDOM))
+
     editable = Bool(default=True)
+
+    expanded = List(Int)
 
     filename = String(default="table.csv")
 

--- a/panel/models/tabulator.ts
+++ b/panel/models/tabulator.ts
@@ -1,5 +1,6 @@
 import {isArray} from "@bokehjs/core/util/types"
 import {HTMLBox} from "@bokehjs/models/layouts/html_box"
+import {build_views} from "@bokehjs/core/build_views"
 import {div} from "@bokehjs/core/dom"
 import {Enum} from "@bokehjs/core/kinds"
 import * as p from "@bokehjs/core/properties";
@@ -116,6 +117,14 @@ export class DataTabulatorView extends PanelHTMLBoxView {
       this.tabulator.download(ftype, this.model.filename)
     })
 
+    this.connect(this.model.properties.children.change, () => {
+      this._render_children()
+    })
+
+    this.connect(this.model.properties.expanded.change, () => {
+      //this.tabulator.redraw(true)
+    })
+
     this.connect(this.model.properties.hidden_columns.change, () => {
       this.hideColumns()
     })
@@ -168,6 +177,7 @@ export class DataTabulatorView extends PanelHTMLBoxView {
     let configuration = this.getConfiguration();
 
     this.tabulator = new Tabulator(container, configuration)
+    this._render_children()
 
     // Swap pagination mode
     if (this.model.pagination === 'remote') {
@@ -272,6 +282,7 @@ export class DataTabulatorView extends PanelHTMLBoxView {
       tooltips: (cell: any) => {
         return  cell.getColumn().getField() + ": " + cell.getValue();
       },
+      rowFormatter: (row: any) => this._render_row(row)
     }
     if (pagination) {
       configuration['ajaxURL'] = "http://panel.pyviz.org"
@@ -291,6 +302,55 @@ export class DataTabulatorView extends PanelHTMLBoxView {
     }
   }
 
+  _render_children(): void {
+    new Promise(async (resolve: any) => {
+      const children = []
+      for (const idx of this.model.expanded) {
+	if (idx in this.model.children)
+	  children.push(this.model.children[idx])
+      }
+      await build_views(this._child_views, children, {parent: (null as any)})
+      resolve(null)
+    }).then(() => {
+      for (const r of this.model.expanded) {
+	const row = this.tabulator.getRow(r)
+	this._render_row(row)
+      }
+    })
+  }
+
+  _render_row(row: any): void {
+    const index = row._row.data._index
+    if (this.model.expanded.indexOf(index) < 0 || !(index in this.model.children))
+      return
+    const model = this.model.children[index]
+    const view = this._child_views.get(model)
+    if (view == null)
+      return
+    const style = getComputedStyle(this.tabulator.element.children[1].children[0])
+    const bg = style.backgroundColor
+    const row_view = div({style: "height: 100%; width: 100%; background-color: " + bg})
+    view.renderTo(row_view)
+    row.getElement().appendChild(row_view)
+  }
+
+  _expand_render(cell: any): string {
+    const index = cell._cell.row.data._index
+    const icon = this.model.expanded.indexOf(index) < 0 ? "\u25ba" : "\u25bc"
+    return "<i>" + icon + "</i>"
+  }
+
+  _update_expand(cell: any): void {
+    const index = cell._cell.row.data._index
+    const exp_index = this.model.expanded.indexOf(index)
+    if (exp_index < 0)
+      this.model.expanded.push(index)
+    else
+      this.model.expanded.splice(exp_index, 1)
+    this.model.expanded = [...this.model.expanded]
+    cell._cell.row.reinitialize(true)
+  }
+
   getColumns(): any {
     const config_columns: (any[] | undefined) = this.model.configuration?.columns;
     let columns = []
@@ -301,7 +361,15 @@ export class DataTabulatorView extends PanelHTMLBoxView {
           for (const col of column.columns)
             group_columns.push({...col})
           columns.push({...column, columns: group_columns})
-        } else
+        } else if (column.formatter === "expand") {
+	  const expand = {
+	    align: "center",
+	    cellClick: (_: any, cell: any) => { this._update_expand(cell) },
+	    formatter: (cell: any) => { return this._expand_render(cell) },
+	    width:40
+	  }
+	  columns.push(expand)
+	} else
           columns.push({...column})
     }
     for (const column of this.model.columns) {
@@ -645,9 +713,11 @@ export namespace DataTabulator {
   export type Attrs = p.AttrsOf<Props>
   export type Props = HTMLBox.Props & {
     aggregators: p.Property<any>
+    children: p.Property<any>
     columns: p.Property<TableColumn[]>
     configuration: p.Property<any>
     download: p.Property<boolean>
+    expanded: p.Property<number[]>
     filename: p.Property<string>
     editable: p.Property<boolean>
     follow: p.Property<boolean>
@@ -687,10 +757,12 @@ export class DataTabulator extends HTMLBox {
 
     this.define<DataTabulator.Props>(({Any, Array, Boolean, Nullable, Number, Ref, String}) => ({
       aggregators:    [ Any,                     {} ],
+      children:       [ Any,                     {} ],
       configuration:  [ Any,                     {} ],
       columns:        [ Array(Ref(TableColumn)), [] ],
       download:       [ Boolean,               true ],
       editable:       [ Boolean,               true ],
+      expanded:       [ Array(Number),           [] ],
       filename:       [ String,         "table.csv" ],
       follow:         [ Boolean,               true ],
       frozen_rows:    [ Array(Number),           [] ],

--- a/panel/widgets/tables.py
+++ b/panel/widgets/tables.py
@@ -5,7 +5,7 @@ from types import FunctionType, MethodType
 import numpy as np
 import param
 
-from bokeh.models import ColumnDataSource
+from bokeh.models import ColumnDataSource, Div as BkDiv
 from bokeh.models.widgets.tables import (
     AvgAggregator, CellEditor, CellFormatter, CheckboxEditor,
     DataCube, DataTable, DateEditor, DateFormatter, GroupingInfo,
@@ -697,6 +697,10 @@ class Tabulator(BaseTable):
     table to provide a full-featured interactive table.
     """
 
+    expanded = param.List(default=[], doc="""
+        List of expanded rows, only applicable if a row_detail function
+        has been defined.""")
+
     frozen_columns = param.List(default=[], doc="""
         List indicating the columns to freeze. The column(s) may be
         selected by name or index.""")
@@ -728,6 +732,10 @@ class Tabulator(BaseTable):
 
     page_size = param.Integer(default=20, bounds=(1, None), doc="""
         Number of rows to render per page.""")
+
+    row_detail = param.Callable(doc="""
+        A function which is given the DataFrame row and should return
+        a Panel object to render as additional detail below the row.""")
 
     row_height = param.Integer(default=30, doc="""
         The height of each table row.""")
@@ -778,6 +786,7 @@ class Tabulator(BaseTable):
         self.style = None
         super().__init__(value=value, **params)
         self._configuration = configuration
+        self.param.watch(self._update_children, 'expanded')
 
     def _validate(self, *events):
         super()._validate(*events)
@@ -854,6 +863,15 @@ class Tabulator(BaseTable):
     def _length(self):
         return len(self._processed)
 
+    def _get_children(self):
+        if self.row_detail is None:
+            return {}
+        from ..pane import panel
+        df = self._processed
+        return {
+            i: panel(self.row_detail(df.iloc[i])) for i in self.expanded
+        }
+
     def _get_style_data(self):
         if self.value is None:
             return {}
@@ -868,7 +886,7 @@ class Tabulator(BaseTable):
             return {}
         styler._todo = self.style._todo
         styler._compute()
-        offset = len(self.indexes) + int(self.selectable in ('checkbox', 'checkbox-single'))
+        offset = len(self.indexes) + int(self.selectable in ('checkbox', 'checkbox-single')) + int(bool(self.row_detail))
 
         styles = {}
         for (r, c), s in styler.ctx.items():
@@ -891,6 +909,28 @@ class Tabulator(BaseTable):
         styles = self._get_style_data()
         msg = {'styles': styles}
         for ref, (m, _) in self._models.items():
+            self._apply_update([], msg, m, ref)
+
+    def _get_model_children(self, panels, doc, root, parent, comm=None):
+        ref = root.ref['id']
+        models = {}
+        for i, p in panels.items():
+            if ref in p._models:
+                model = p._models[ref][0]
+            else:
+                model = p._get_model(doc, root, parent, comm)
+            model.margin = (0, 5, 0, 10)
+            models[i] = model
+        return models
+
+    def _update_children(self, *event):
+        child_panels = self._get_children()
+        for ref, (m, _) in self._models.items():
+            root, doc, comm = state._views[ref][1:]
+            children = self._get_model_children(
+                child_panels, doc, root, m, comm
+            )
+            msg = {'children': children}
             self._apply_update([], msg, m, ref)
 
     @updating
@@ -1019,6 +1059,7 @@ class Tabulator(BaseTable):
             selectable = self.selectable
         props.update({
             'aggregators': self.aggregators,
+            'expanded': self.expanded,
             'source': source,
             'styles': self._get_style_data(),
             'columns': columns,
@@ -1053,7 +1094,11 @@ class Tabulator(BaseTable):
             model = super()._get_model(doc, root, parent, comm)
         if root is None:
             root = model
-        self._link_props(model, ['page', 'sorters'], doc, root, comm)
+        child_panels = self._get_children()
+        model.children = self._get_model_children(
+            child_panels, doc, root, parent, comm
+        )
+        self._link_props(model, ['page', 'sorters', 'expanded'], doc, root, comm)
         return model
 
     def _update_model(self, events, msg, root, model, doc, comm):
@@ -1068,6 +1113,10 @@ class Tabulator(BaseTable):
         groups = {}
         columns = []
         selectable = self.selectable
+        if self.row_detail:
+            columns.append({
+                "formatter": "expand"
+            })
         if isinstance(selectable, str) and selectable.startswith('checkbox'):
             title = "" if selectable.endswith('-single') else "rowSelection"
             columns.append({


### PR DESCRIPTION
Adds two parameters to `Tabulator` to support adding additional content inside a Tabulator row, which acts like an accordion.

- `expanded`: The currrently expanded rows
- `row_detail`: A function which is given a DataFrame row as input and should output a Panel object

```python
def row_detail(row):
    return row.to_frame()

pn.widgets.Tabulator(
    value=pd.DataFrame([(0, 1), (1, 2)]),
    row_detail=row_detail, sizing_mode='stretch_height'
)
```

![tabulator_nested](https://user-images.githubusercontent.com/1550771/134159077-d75252a6-4746-4111-b8c1-49fc2cacf496.gif)
