### PR TITLE
pn.viewable.Viewer can now be used with pn.serve

### DIFF
--- a/panel/pane/base.py
+++ b/panel/pane/base.py
@@ -13,7 +13,7 @@ from ..layout import Panel, Row
 from ..links import Link
 from ..models import ReactiveHTML as _BkReactiveHTML
 from ..reactive import Reactive
-from ..viewable import Layoutable, Viewable
+from ..viewable import Layoutable, Viewable, Viewer
 from ..util import param_reprs
 
 
@@ -46,6 +46,8 @@ def panel(obj, **kwargs):
     if isinstance(obj, Viewable):
         return obj
     elif hasattr(obj, '__panel__'):
+        if not isinstance(obj, Viewer) and issubclass(obj, Viewer):
+            return panel(obj().__panel__())
         return panel(obj.__panel__())
     if kwargs.get('name', False) is None:
         kwargs.pop('name')

--- a/panel/tests/test_viewable.py
+++ b/panel/tests/test_viewable.py
@@ -3,8 +3,8 @@ import pytest
 
 from panel import config
 from panel.interact import interactive
-from panel.pane import Str
-from panel.viewable import Viewable
+from panel.pane import Str, panel
+from panel.viewable import Viewable, Viewer
 
 from .util import jb_available, py3_only
 
@@ -27,3 +27,16 @@ def test_viewable_signature(viewable):
     parameters = signature(viewable).parameters
     assert 'params' in parameters
     assert parameters['params'] == Parameter('params', Parameter.VAR_KEYWORD)
+
+
+def test_Viewer_not_initialized():
+    class Test(Viewer):
+        def __panel__(self):
+            return "# Test"
+
+    test = panel(Test)
+    assert test.object == "# Test"
+
+    # Confirm that initialized also work
+    test = panel(Test())
+    assert test.object == "# Test"


### PR DESCRIPTION
Resolves #2768

I don't know if there should be a more advanced unit test involving calling `pn.serve`.