### PR TITLE
Add sphinx-copybutton to the docs build

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -60,7 +60,7 @@ jobs:
           conda install ${{ env.CHANS_DEV }} "pip<21.2.1" 
           conda list
           doit develop_install ${{ env.CHANS_DEV}} -o doc -o examples
-          pip install pydeck sphinxcontrib-napoleon pyecharts
+          pip install pydeck sphinxcontrib-napoleon sphinx-copybutton pyecharts
           pip install idom pydata_sphinx_theme
       - name: opengl
         run: |

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -42,7 +42,11 @@ html_theme_options = {
     ]
 }
 
-extensions += ['sphinx.ext.napoleon', 'nbsite.gallery']
+extensions += [
+    'sphinx.ext.napoleon',
+    'nbsite.gallery',
+    'sphinx_copybutton',
+]
 napoleon_numpy_docstring = True
 
 nbsite_gallery_conf = {


### PR DESCRIPTION
This sphinx extension adds a button for easily copying code snippets: https://sphinx-copybutton.readthedocs.io/en/latest/.

@philippjfr would you like me to try to build the site locally?