### PR TITLE
fix(vega): allow data item to miss optional field

### DIFF
--- a/panel/pane/vega.py
+++ b/panel/pane/vega.py
@@ -18,8 +18,7 @@ def ds_as_cds(dataset):
     if len(dataset) == 0:
         return {}
     # create a list of unique keys from all items as some items may not include optional fields
-    keys = list(set(k for d in dataset for k in d.keys()))
-    keys.sort()
+    keys = sorted(set(k for d in dataset for k in d.keys()))
     data = {k: [] for k in keys}
     for item in dataset:
         for k in keys:

--- a/panel/pane/vega.py
+++ b/panel/pane/vega.py
@@ -17,10 +17,13 @@ def ds_as_cds(dataset):
     """
     if len(dataset) == 0:
         return {}
-    data = {k: [] for k, v in dataset[0].items()}
+    # create a list of unique keys from all items as some items may not include optional fields
+    keys = list(set(k for d in dataset for k in d.keys()))
+    keys.sort()
+    data = {k: [] for k in keys}
     for item in dataset:
-        for k, v in item.items():
-            data[k].append(v)
+        for k in keys:
+            data[k].append(item.get(v))
     data = {k: np.asarray(v) for k, v in data.items()}
     return data
 

--- a/panel/pane/vega.py
+++ b/panel/pane/vega.py
@@ -22,7 +22,7 @@ def ds_as_cds(dataset):
     data = {k: [] for k in keys}
     for item in dataset:
         for k in keys:
-            data[k].append(item.get(v))
+            data[k].append(item.get(k))
     data = {k: np.asarray(v) for k, v in data.items()}
     return data
 


### PR DESCRIPTION
This fix the following bug with data passed to `pn.pane.Vega`.

#### Example
```py
dataset = [{"id": 1}, {"id":2, "parent": 1}, {"id": 3, "parent": 1}]
```

### Expected behavior
The sample dataset that work in Vega examples works in Panel.

### What happen
Panel app will crash with `KeyError`.

### Why
The list of keys are extracted from the first item in the dataset only. (`["id"]` when it should be `["id", "parent"]`),
This has to assume that all items in the dataset has the exact same fields, which is not always the case.
Therefore, when iterating through the 2nd and 3rd item, it cannot find `data["parent"]` to append the value to and  throw `KeyError`.

### Solution
Iterate through all items and compute the list of unique keys first.