### PR TITLE
Add a header_align parameter to the Tabulator widget

### DIFF
--- a/examples/reference/widgets/Tabulator.ipynb
+++ b/examples/reference/widgets/Tabulator.ipynb
@@ -36,6 +36,7 @@
     "* **``filters``** (``list``): A list of client-side filter definitions that are applied to the table.\n",
     "* **``formatters``** (``dict``): A dictionary mapping from column name to a bokeh `CellFormatter` instance or tabulator formatter specification.\n",
     "* **``groupby``** (`list`): Groups rows in the table by one or more columns.\n",
+    "* **``header_align``** (``dict`` or ``str``): A mapping from column name to header alignment or a fixed header alignment, which should be one of `'left'`, `'center'`, `'right'`.\n",
     "* **``header_filters``** (``boolean``/``dict``): A boolean enabling filters in the column headers or a dictionary providing filter definitions for specific columns.\n",
     "* **``hierarchical``** (boolean, default=False): Whether to render multi-indexes as hierarchical index (note hierarchical must be enabled during instantiation and cannot be modified later)\n",
     "* **``hidden_columns``** (`list`): List of columns to hide.\n",
@@ -336,6 +337,24 @@
    "outputs": [],
    "source": [
     "pn.widgets.Tabulator(custom_df, layout='fit_columns', width=650)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Alignment\n",
+    "\n",
+    "The content of a column or its header can be horizontally aligned with `text_align` and `header_align`. These two parameters accept either a string that globally defines the alignment or a dictionnary that declares which particular columns are meant to be aligned and how."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pn.widgets.Tabulator(df, header_align='center', text_align={'str': 'right', 'bool': 'center' }, widths=200)"
    ]
   },
   {

--- a/panel/widgets/tables.py
+++ b/panel/widgets/tables.py
@@ -784,6 +784,10 @@ class Tabulator(BaseTable):
     groupby = param.List(default=[], doc="""
         Groups rows in the table by one or more columns.""")
 
+    header_align = param.ClassSelector(default={}, class_=(dict, str), doc="""
+        A mapping from column name to alignment or a fixed column
+        alignment, which should be one of 'left', 'center', 'right'.""")
+
     header_filters = param.ClassSelector(class_=(bool, dict), doc="""
         Whether to enable filters in the header or dictionary
         configuring filters for each column.""")
@@ -1294,6 +1298,10 @@ class Tabulator(BaseTable):
                 col_dict['hozAlign'] = self.text_align
             elif column.field in self.text_align:
                 col_dict['hozAlign'] = self.text_align[column.field]
+            if isinstance(self.header_align, str):
+                col_dict['headerHozAlign'] = self.header_align
+            elif column.field in self.header_align:
+                col_dict['headerHozAlign'] = self.header_align[column.field]
             formatter = self.formatters.get(column.field)
             if isinstance(formatter, str):
                 col_dict['formatter'] = formatter


### PR DESCRIPTION
It works exactly as `text_align`, by accepting either a string or a dictionary. I didn't see any option to do that for the Bokeh table, so it's just implemented for the Tabulator widget.

Also didn't find any other way to set the header alignment with the current implementation, but happy to close this PR if there's already a way!