### PR TITLE
Allow to set AutoCompleteInput in a Param pane

### DIFF
--- a/examples/user_guide/Param.ipynb
+++ b/examples/user_guide/Param.ipynb
@@ -192,11 +192,13 @@
     "    \"\"\"An example Parameterized class\"\"\"\n",
     "\n",
     "    select_string = param.Selector(objects=[\"red\", \"yellow\", \"green\"])\n",
+    "    autocomplete_string = param.Selector(default='', objects=[\"red\", \"yellow\", \"green\"], check_on_set=False)\n",
     "    select_number = param.Selector(objects=[0, 1, 10, 100])\n",
     "\n",
     "\n",
     "pn.Param(CustomExample.param, widgets={\n",
     "    'select_string': pn.widgets.RadioButtonGroup,\n",
+    "    'autocomplete_string': pn.widgets.AutocompleteInput,\n",
     "    'select_number': pn.widgets.DiscretePlayer}\n",
     ")"
    ]
@@ -218,6 +220,7 @@
    "source": [
     "pn.Param(CustomExample.param, widgets={\n",
     "    'select_string': {'widget_type': pn.widgets.RadioButtonGroup, 'button_type': 'success'},\n",
+    "    'autocomplete_string': {'widget_type': pn.widgets.AutocompleteInput, 'placeholder': 'Find a color...'},\n",
     "    'select_number': pn.widgets.DiscretePlayer}\n",
     ")"
    ]

--- a/panel/param.py
+++ b/panel/param.py
@@ -402,6 +402,11 @@ class Param(PaneBase):
             options = p_obj.get_range()
             if not options and value is not None:
                 options = [value]
+            # This applies to widgets whose `options` Parameter is a List type,
+            # such as AutoCompleteInput.
+            if ('options' in widget_class.param
+                and isinstance(widget_class.param['options'], param.List)):
+                options = list(options.values())
             kw['options'] = options
         if hasattr(p_obj, 'get_soft_bounds'):
             bounds = p_obj.get_soft_bounds()

--- a/panel/tests/test_param.py
+++ b/panel/tests/test_param.py
@@ -9,7 +9,7 @@ from bokeh.models import (
 from panel.pane import Pane, PaneBase, Matplotlib, Bokeh, HTML
 from panel.layout import Tabs, Row
 from panel.param import Param, ParamMethod, ParamFunction, JSONInit
-from panel.widgets import LiteralInput, NumberInput, RangeSlider
+from panel.widgets import AutocompleteInput, LiteralInput, NumberInput, RangeSlider
 from panel.tests.util import mpl_available, mpl_figure
 
 
@@ -1234,3 +1234,16 @@ def test_numberinput_bounds():
 
     assert numinput.start == 0
     assert numinput.end == 5
+
+def test_set_widget_autocompleteinput():
+
+    class Test(param.Parameterized):
+        choice = param.Selector(objects=['a', 'b'])
+
+    test = Test()
+    p = Param(test, widgets={'choice': AutocompleteInput})
+
+    autocompleteinput = p.layout[1]
+
+    assert autocompleteinput.value == 'a'
+    assert autocompleteinput.options == ['a', 'b']


### PR DESCRIPTION
Fixes https://github.com/holoviz/panel/issues/1460

I did not integrate `AutoCompleteInput` into the *Select* model as suggested in the issue since its model is actually halfway through a text input (the value doesn't have to be one of the options with `restrict=False`) and a select widget.