### PR TITLE
Add a groups (aka optgroup) parameter to Select

### DIFF
--- a/examples/reference/widgets/Select.ipynb
+++ b/examples/reference/widgets/Select.ipynb
@@ -25,6 +25,7 @@
     "##### Core\n",
     "\n",
     "* **``options``** (list or dict): A list or dictionary of options to select from\n",
+    "* **``groups``** (dict): A dictionary whose keys are used to visually group the options and whose values are either a list or a dictionary of options to select from. Mutually exclusive with ``options``\n",
     "* **``size``** (int): Declares how many options are displayed at the same time. If set to 1 displays options as dropdown otherwise displays scrollable area.\n",
     "* **``value``** (object): The current value; must be one of the option values\n",
     "\n",
@@ -104,6 +105,33 @@
    "outputs": [],
    "source": [
     "select.value = 2"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The items displayed in the dropdown menu can be grouped visually (also known as *optgroup*) by setting the `groups` parameter **instead of** `options`. `groups` accepts a dictionary whose keys are used to group the options and whose values are defined similarly to how `options` are defined."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "select = pn.widgets.Select(name='Select', groups={'Europe': ['Greece', 'France'], 'Africa': ['Algeria', 'Congo']})\n",
+    "\n",
+    "select"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "select.value"
    ]
   },
   {

--- a/examples/reference/widgets/Select.ipynb
+++ b/examples/reference/widgets/Select.ipynb
@@ -67,6 +67,49 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "The `options` parameter also accepts a dictionary whose keys are going to be the labels of the dropdown menu. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "select = pn.widgets.Select(name='Select', options={'Biology': 1, 'Chemistry': 2})\n",
+    "\n",
+    "select"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "select.value"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Updating the value will display the right label."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "select.value = 2"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "Instead of a dropdown menu we can also select one option from a list by rendering multiple options at once using the `size` parameter:"
    ]
   },
@@ -101,9 +144,22 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
    "name": "python",
-   "pygments_lexer": "ipython3"
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.11"
   }
  },
  "nbformat": 4,

--- a/examples/reference/widgets/Select.ipynb
+++ b/examples/reference/widgets/Select.ipynb
@@ -172,22 +172,9 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
    "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.7.11"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/panel/tests/widgets/test_select.py
+++ b/panel/tests/widgets/test_select.py
@@ -60,6 +60,91 @@ def test_select(document, comm):
     assert widget.value == as_unicode(opts['A'])
 
 
+def test_select_groups_list_options(document, comm):
+    opts = [1, 2, 3]
+    groups = dict(a=[1, 2], b=[3])
+    select = Select(options=opts, value=opts[0], groups=groups, name='Select')
+
+    widget = select.get_root(document, comm=comm)
+
+    assert isinstance(widget, select._widget_type)
+    assert widget.title == 'Select'
+    assert widget.value == as_unicode(opts[0])
+    assert widget.options == {gr: [(as_unicode(v), as_unicode(v)) for v in values] for gr, values in groups.items()}
+
+    select._process_events({'value': as_unicode(opts[1])})
+    assert select.value == opts[1]
+
+    widget.value = as_unicode(opts[0])
+    select.value = opts[0]
+    assert select.value == opts[0]
+
+    select.value = opts[1]
+    assert widget.value == as_unicode(opts[1])
+
+
+def test_select_groups_dict_options(document, comm):
+    opts = dict(a=1, b=2, c=3)
+    groups = dict(A=['a', 'b'], B=['c'])
+    select = Select(options=opts, value=opts['a'], groups=groups, name='Select')
+
+    widget = select.get_root(document, comm=comm)
+
+    assert isinstance(widget, select._widget_type)
+    assert widget.title == 'Select'
+    assert widget.value == as_unicode(opts['a'])
+    assert widget.options == {gr: [(as_unicode(opts[v]), v) for v in values] for gr, values in groups.items()}
+
+    select._process_events({'value': as_unicode(opts['c'])})
+    assert select.value == opts['c']
+
+    widget.value = as_unicode(opts['b'])
+    select.value = opts['b']
+    assert select.value == opts['b']
+
+    select.value = opts['a']
+    assert widget.value == as_unicode(opts['a'])
+
+
+def test_select_change_groups_and_options(document, comm):
+    opts = dict(a=1, b=2, c=3)
+    groups = dict(A=['a', 'b'], B=['c'])
+    select = Select(options=opts, value=opts['a'], groups=groups, name='Select')
+
+    widget = select.get_root(document, comm=comm)
+
+    new_groups = dict(C=['a'], D=['b', 'c'])
+    select.groups = new_groups
+    assert select.value == opts['a']
+    assert widget.value == as_unicode(opts['a'])
+    assert widget.options == {gr: [(as_unicode(opts[v]), v) for v in values] for gr, values in new_groups.items()}
+
+    select.options = dict(a=1, b=2)
+    new_groups = dict(A=['a'], B=['b'])
+    select.groups = new_groups
+    assert select.value == opts['a']
+    assert widget.value == as_unicode(opts['a'])
+    assert widget.options == {gr: [(as_unicode(opts[v]), v) for v in values] for gr, values in new_groups.items()}
+
+    select.options = {}
+    assert select.value == None
+    assert widget.value == ''
+
+
+def test_select_groups_error_not_maching_options(document, comm):
+    opts = dict(a=1, b=2, c=3)
+    groups = dict(A=['a', 'b'], B=['c', 'one_more'])
+    select = Select(options=opts, value=opts['a'], groups=groups, name='Select')
+    with pytest.raises(ValueError):
+        select.get_root(document, comm=comm)
+    
+    opts = [1, 2, 3]
+    groups = dict(a=[1, 2], b=[3, 999])
+    Select(options=opts, value=opts[0], groups=groups, name='Select')
+    with pytest.raises(ValueError):
+        select.get_root(document, comm=comm)
+
+
 def test_select_change_options(document, comm):
     opts = {'A': 'a', '1': 1}
     select = Select(options=opts, value=opts['1'], name='Select')

--- a/panel/tests/widgets/test_select.py
+++ b/panel/tests/widgets/test_select.py
@@ -61,88 +61,81 @@ def test_select(document, comm):
 
 
 def test_select_groups_list_options(document, comm):
-    opts = [1, 2, 3]
     groups = dict(a=[1, 2], b=[3])
-    select = Select(options=opts, value=opts[0], groups=groups, name='Select')
+    select = Select(value=groups['a'][0], groups=groups, name='Select')
 
     widget = select.get_root(document, comm=comm)
 
     assert isinstance(widget, select._widget_type)
     assert widget.title == 'Select'
-    assert widget.value == as_unicode(opts[0])
+    assert widget.value == as_unicode(groups['a'][0])
     assert widget.options == {gr: [(as_unicode(v), as_unicode(v)) for v in values] for gr, values in groups.items()}
 
-    select._process_events({'value': as_unicode(opts[1])})
-    assert select.value == opts[1]
+    select._process_events({'value': as_unicode(groups['a'][1])})
+    assert select.value == groups['a'][1]
 
-    widget.value = as_unicode(opts[0])
-    select.value = opts[0]
-    assert select.value == opts[0]
+    widget.value = as_unicode(groups['a'][0])
+    assert select.value == groups['a'][0]
 
-    select.value = opts[1]
-    assert widget.value == as_unicode(opts[1])
+    select.value = groups['a'][1]
+    assert widget.value == as_unicode(groups['a'][1])
 
 
 def test_select_groups_dict_options(document, comm):
-    opts = dict(a=1, b=2, c=3)
-    groups = dict(A=['a', 'b'], B=['c'])
-    select = Select(options=opts, value=opts['a'], groups=groups, name='Select')
+    groups = dict(A=dict(a=1, b=2), B=dict(c=3))
+    select = Select(value=groups['A']['a'], groups=groups, name='Select')
 
     widget = select.get_root(document, comm=comm)
 
     assert isinstance(widget, select._widget_type)
     assert widget.title == 'Select'
-    assert widget.value == as_unicode(opts['a'])
-    assert widget.options == {gr: [(as_unicode(opts[v]), v) for v in values] for gr, values in groups.items()}
+    assert widget.value == as_unicode(groups['A']['a'])
+    assert widget.options == {'A': [('1', 'a'), ('2', 'b')], 'B': [('3', 'c')]}
 
-    select._process_events({'value': as_unicode(opts['c'])})
-    assert select.value == opts['c']
+    select._process_events({'value': as_unicode(groups['B']['c'])})
+    assert select.value == groups['B']['c']
 
-    widget.value = as_unicode(opts['b'])
-    select.value = opts['b']
-    assert select.value == opts['b']
+    widget.value = as_unicode(groups['A']['b'])
+    assert select.value == groups['A']['b']
 
-    select.value = opts['a']
-    assert widget.value == as_unicode(opts['a'])
+    select.value = groups['A']['a']
+    assert widget.value == as_unicode(groups['A']['a'])
 
 
-def test_select_change_groups_and_options(document, comm):
-    opts = dict(a=1, b=2, c=3)
-    groups = dict(A=['a', 'b'], B=['c'])
-    select = Select(options=opts, value=opts['a'], groups=groups, name='Select')
+def test_select_change_groups(document, comm):
+    groups = dict(A=dict(a=1, b=2), B=dict(c=3))
+    select = Select(value=groups['A']['a'], groups=groups, name='Select')
 
     widget = select.get_root(document, comm=comm)
 
-    new_groups = dict(C=['a'], D=['b', 'c'])
+    new_groups = dict(C=dict(d=4), D=dict(e=5, f=6))
     select.groups = new_groups
-    assert select.value == opts['a']
-    assert widget.value == as_unicode(opts['a'])
-    assert widget.options == {gr: [(as_unicode(opts[v]), v) for v in values] for gr, values in new_groups.items()}
+    assert select.value == new_groups['C']['d']
+    assert widget.value == as_unicode(new_groups['C']['d'])
+    assert widget.options == {'C': [('4', 'd')], 'D': [('5', 'e'), ('6', 'f')]}
 
-    select.options = dict(a=1, b=2)
-    new_groups = dict(A=['a'], B=['b'])
-    select.groups = new_groups
-    assert select.value == opts['a']
-    assert widget.value == as_unicode(opts['a'])
-    assert widget.options == {gr: [(as_unicode(opts[v]), v) for v in values] for gr, values in new_groups.items()}
-
-    select.options = {}
+    select.groups = {}
     assert select.value == None
     assert widget.value == ''
 
 
-def test_select_groups_error_not_maching_options(document, comm):
-    opts = dict(a=1, b=2, c=3)
-    groups = dict(A=['a', 'b'], B=['c', 'one_more'])
-    select = Select(options=opts, value=opts['a'], groups=groups, name='Select')
+def test_select_groups_error_with_options():
+    # Instantiate with groups and options
     with pytest.raises(ValueError):
-        select.get_root(document, comm=comm)
-    
+        Select(options=[1, 2], groups=dict(a=[1], b=[2]), name='Select')
+
     opts = [1, 2, 3]
-    groups = dict(a=[1, 2], b=[3, 999])
-    Select(options=opts, value=opts[0], groups=groups, name='Select')
+    groups = dict(a=[1, 2], b=[3])
+
+    # Instamtiate with options and then update groups
+    select = Select(options=opts, name='Select')
     with pytest.raises(ValueError):
-        select.get_root(document, comm=comm)
+        select.groups = groups
+
+    # Instantiate with groups and then update options
+    select = Select(groups=groups, name='Select')
+    with pytest.raises(ValueError):
+        select.options = opts
 
 
 def test_select_change_options(document, comm):

--- a/panel/widgets/select.py
+++ b/panel/widgets/select.py
@@ -161,7 +161,7 @@ class Select(SingleSelectBase):
             if (all(isinstance(values, dict) for values in groups.values()) is False
                and  all(isinstance(values, list) for values in groups.values()) is False):
                 raise ValueError(
-                    'The values of the groups dictionnary must be all of '
+                    'The values of the groups dictionary must be all of '
                     'the dictionary or the list type.'
                 )
             labels, values = self.labels, self.values

--- a/panel/widgets/select.py
+++ b/panel/widgets/select.py
@@ -146,11 +146,16 @@ class Select(SingleSelectBase):
         super().__init__(**params)
         if self.size == 1:
             self.param.size.constant = True
+        watcher = self.param.watch(self._validate_options_groups, ['options', 'groups'])
+        self._callbacks.append(watcher)
+        self._validate_options_groups()
 
-    @param.depends('options', 'groups', watch=True, on_init=True)
-    def _validate_options_groups(self):
+    def _validate_options_groups(self, *events):
         if self.options and self.groups:
-            raise ValueError('options and groups are mutually exclusive.')
+            raise ValueError(
+                f'{type(self).__name__} options and groups parameters '
+                'are mutually exclusive.'
+            )
 
     def _process_param_change(self, msg):
         msg = super()._process_param_change(msg)

--- a/panel/widgets/select.py
+++ b/panel/widgets/select.py
@@ -146,9 +146,8 @@ class Select(SingleSelectBase):
         super().__init__(**params)
         if self.size == 1:
             self.param.size.constant = True
-        self._validate_options_groups()
 
-    @param.depends('options', 'groups', watch=True)
+    @param.depends('options', 'groups', watch=True, on_init=True)
     def _validate_options_groups(self):
         if self.options and self.groups:
             raise ValueError('options and groups are mutually exclusive.')
@@ -163,7 +162,7 @@ class Select(SingleSelectBase):
                and  all(isinstance(values, list) for values in groups.values()) is False):
                 raise ValueError(
                     'The values of the groups dictionnary must be all of '
-                    'the dictionnary or the list type.'
+                    'the dictionary or the list type.'
                 )
             labels, values = self.labels, self.values
             unique = len(set(self.unicode_values)) == len(labels)


### PR DESCRIPTION
The Select widget of Bokeh supports option groups (optgroup) that allow to visually group the elements of a dropdown menu.  The options of a Bokeh Select widget are grouped when they're declared in a dictionary, the keys of the dictionary being the groups labels. Panel already allows users to declare the options of its Select widget with a dictionary (the keys becoming the labels, and the values the values). Because of that this functionality is exposed in Panel by adding a `groups` parameter to the Select widget that is `None` by default (i.e. no groups) and accepts a dictionary that defines how the options should be grouped.

*When options is a list*
![image](https://user-images.githubusercontent.com/35924738/139958340-15bb6262-8576-4952-9df4-7c9794732946.png)

*When options is a dict*
![image](https://user-images.githubusercontent.com/35924738/139958188-f66d3b3b-63a1-407f-a2ac-ed1941d789b5.png)

*Error raised when the values of groups don't match exactly with the options*
![image](https://user-images.githubusercontent.com/35924738/139958510-27108193-01b4-4a0e-a5c7-7b49d5ce8107.png)

* [x] Add tests
* [x] Add docs