### PR TITLE
Fixed UTF-8 decoding in Terminal widget

### DIFF
--- a/panel/widgets/terminal.py
+++ b/panel/widgets/terminal.py
@@ -171,7 +171,7 @@ class TerminalSubprocess(param.Parameterized):
                 return data.decode('utf-8')
             except UnicodeDecodeError:
                 data = data + os.read(fd, 1)
-        raise Exception('Could not find decode boundary for UTF-8')
+        raise UnicodeError('Could not find decode boundary for UTF-8')
 
     def _forward_subprocess_output_to_terminal(self):
         if not self._fd:

--- a/panel/widgets/terminal.py
+++ b/panel/widgets/terminal.py
@@ -174,6 +174,7 @@ class TerminalSubprocess(param.Parameterized):
         try:
             output = raw.decode('utf-8')
         except UnicodeDecodeError:
+            # UTF8 characters may be one or two bytes long
             extra_byte = os.read(self._fd, 1)
             data = (raw + extra_byte)
             try:


### PR DESCRIPTION
Thanks @philippjfr for the recent fixes to the Terminal widget! And here is another one...

When the subprocess output is in ASCII range, the unicode characters are one byte which means you can read any length of bytes from the file descriptor and decode. When you are out the range, the characters can be two bytes long. This resulted in unicode decode errors for any subprocess using more of UTF8 than just ASCII.

This PR fixes this by trying to decode and reading an extra byte on failure and trying to decode that (and one more time). I no longer get any decode errors without needing to use 'ignore' to drop bytes that can't be decoded.