### PR TITLE
Update Tabulator styles on scroll

### DIFF
--- a/panel/models/tabulator.ts
+++ b/panel/models/tabulator.ts
@@ -7,6 +7,8 @@ import * as p from "@bokehjs/core/properties";
 import {ColumnDataSource} from "@bokehjs/models/sources/column_data_source";
 import {TableColumn} from "@bokehjs/models/widgets/tables"
 
+import {debounce} from  "debounce"
+
 import {transform_cds_to_records} from "./data"
 import {PanelHTMLBoxView, set_size} from "./layout"
 
@@ -289,6 +291,9 @@ export class DataTabulatorView extends PanelHTMLBoxView {
       tooltips: (cell: any) => {
         return  cell.getColumn().getField() + ": " + cell.getValue();
       },
+      scrollVertical: debounce(() => {
+        this.updateStyles()
+      }, 50, false),
       rowFormatter: (row: any) => this._render_row(row),
       dataFiltering: () => {
         if (this.tabulator != null)


### PR DESCRIPTION
On scroll we have to update styles since Tabulator employs progressive rendering (i.e. cells are only rendered when they are in view plus some offset).

Fixes https://github.com/holoviz/panel/issues/2851