### PR TITLE
Adds escape parameter to DataFrame pane to enable using html markup

### DIFF
--- a/examples/reference/panes/DataFrame.ipynb
+++ b/examples/reference/panes/DataFrame.ipynb
@@ -27,7 +27,7 @@
     "* **``classes``** (list[str]): CSS class(es) to apply to the resulting html table.\n",
     "* **``col_space``** (int or str): The minimum width of each column in CSS length units. An int is assumed to be px units.\n",
     "* **``decimal``** (str, default='.'): Character recognized as decimal separator, e.g. ',' in Europe.\n",
-    "* **``escape``** (boolean, default=False): Convert the characters <, >, and & to HTML-safe sequences.\n",
+    "* **``escape``** (boolean, default=True): Convert the characters <, >, and & to HTML-safe sequences.\n",
     "* **``float_format``** (function): Formatter function to apply to columns' elements if they are floats. The result of this function must be a unicode string.\n",
     "* **``formatters``** (dict or list): Formatter functions to apply to columns' elements by position or name. The result of each function must be a unicode string.\n",
     "* **``object``** (object): The HoloViews object being displayed\n",
@@ -61,7 +61,7 @@
    "source": [
     "df = pd._testing.makeMixedDataFrame()\n",
     "\n",
-    "df_pane = pn.pane.DataFrame(df)\n",
+    "df_pane = pn.pane.DataFrame(df, width=400)\n",
     "\n",
     "df_pane"
    ]
@@ -81,6 +81,27 @@
    "source": [
     "pn.panel(df_pane.param, parameters=['bold_rows', 'index', 'header', 'max_rows', 'show_dimensions'],\n",
     "         widgets={'max_rows': {'start': 1, 'end': len(df), 'value': len(df)}})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "By setting `escape` to True you can include *HTML markup* in your `Dataframe` pane"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "links = pd.DataFrame({\n",
+    "    \"site\": [\"Docs\", \"Discourse\", \"Github\", \"Twitter\"], \n",
+    "    \"url\": [\"https://panel.holoviz.org/\", \"https://discourse.holoviz.org/\", \"https://github.com/holoviz/panel\", \"https://twitter.com/Panel_org\"]\n",
+    "})\n",
+    "links[\"value\"]=\"<a href='\" + links[\"url\"] + \"' target='_blank'>\" + links[\"site\"] + \"</a>\"\n",
+    "pn.pane.DataFrame(links, escape=False, width=800, index=False)"
    ]
   },
   {
@@ -111,19 +132,25 @@
    "source": [
     "type(sdf.groupby('y').sum().x)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
    "name": "python",
-   "pygments_lexer": "ipython3"
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.3"
   }
  },
  "nbformat": 4,

--- a/panel/pane/markup.py
+++ b/panel/pane/markup.py
@@ -107,6 +107,10 @@ class DataFrame(HTML):
     decimal = param.String(default='.', doc="""
         Character recognized as decimal separator, e.g. ',' in Europe.""")
 
+    escape = param.Boolean(default=True, doc="""
+        Whether or not to escape the dataframe HTML. For security reasons
+        the default value is True.""")
+
     float_format = param.Callable(default=None, doc="""
         Formatter function to apply to columns' elements if they are
         floats. The result of this function must be a unicode string.""")
@@ -155,7 +159,7 @@ class DataFrame(HTML):
 
     _rerender_params = [
         'object', '_object', 'bold_rows', 'border', 'classes',
-        'col_space', 'decimal', 'float_format', 'formatters',
+        'col_space', 'decimal', 'escape', 'float_format', 'formatters',
         'header', 'index', 'index_names', 'justify', 'max_rows',
         'max_cols', 'na_rep', 'render_links', 'show_dimensions',
         'sparsify', 'sizing_mode'

--- a/panel/tests/pane/test_markup.py
+++ b/panel/tests/pane/test_markup.py
@@ -131,6 +131,26 @@ def test_dataframe_pane_pandas(document, comm):
     pane._cleanup(model)
     assert pane._models == {}
 
+@pd_available
+def test_dataframe_pane_supports_escape(document, comm):
+    import pandas as pd
+    url = "<a href='https://panel.holoviz.org/'>Panel</a>"
+    df = pd.DataFrame({"url": [url]})
+    pane = DataFrame(df)
+
+    # Create pane
+    model = pane.get_root(document, comm=comm)
+    assert pane._models[model.ref['id']][0] is model
+    assert pane.escape
+    assert "&lt;a href=&#x27;https://panel.holoviz.org/&#x27;&gt;Panel&lt;/a&gt;" not in model.text
+
+    pane.escape = False
+    assert "&lt;a href=&#x27;https://panel.holoviz.org/&#x27;&gt;Panel&lt;/a&gt;" in model.text
+
+    # Cleanup
+    pane._cleanup(model)
+    assert pane._models == {}
+
 
 @streamz_available
 def test_dataframe_pane_streamz(document, comm):


### PR DESCRIPTION
Adds the functionality requested in https://github.com/holoviz/panel/issues/2889

For example you can create an example like

```python
import panel as pn
import pandas as pd

pn.extension(sizing_mode="stretch_width")

# The urls depend on which row and column they are in
source = pd.DataFrame({
    "country": ["DE", "DK", "DE", "DK"],
    "date": ["2021-10-01", "2021-10-01","2021-10-02", "2021-10-02"],
    "value": [1,2,3,4]
})
target = source.copy()
target["value"]="<a href='?country=" + target["country"] + "&date=" + target["date"] + "'>" + target["value"].astype(str) + "</a>"
target = target.pivot(index="country", columns="date", values="value").reset_index()
target.columns.name=""
table = pn.pane.DataFrame(target, escape=False, index=False)

table.servable()
```

https://user-images.githubusercontent.com/42288570/140637284-00513b3f-2a84-4296-9233-627cdfd5acb0.mp4

which is the way the pandas community recommends, c.f. https://github.com/pandas-dev/pandas/issues/28013


