### PR TITLE
Allow to update the completions options from a parameter

### DIFF
--- a/panel/param.py
+++ b/panel/param.py
@@ -485,7 +485,11 @@ class Param(PaneBase):
                     self._rerender()
                 return
             elif change.what == 'objects':
-                updates['options'] = p_obj.get_range()
+                options = p_obj.get_range()
+                if ('options' in widget.param and
+                    isinstance(widget.param['options'], param.List)):
+                    options = list(options)
+                updates['options'] = options
             elif change.what == 'bounds':
                 start, end = p_obj.get_soft_bounds()
                 supports_bounds = hasattr(widget, 'start')

--- a/panel/widgets/select.py
+++ b/panel/widgets/select.py
@@ -242,6 +242,13 @@ class AutocompleteInput(Widget):
 
     _rename = _AutocompleteInput_rename
 
+    def _process_param_change(self, msg):
+        msg = super()._process_param_change(msg)
+        if 'completions' in msg:
+            if self.restrict and not isIn(self.value, msg['completions']):
+                msg['value'] = self.value = ''
+        return msg
+
 
 class _RadioGroupBase(SingleSelectBase):
 


### PR DESCRIPTION
I took care of allowing an `AutocompleteInput` widget to be created from a Parameter in https://github.com/holoviz/panel/pull/2874 but missed allowing to update its options/completions.

In this PR I also reset the widget's value to `''` if the current one is not in the new options/completions.