### PR TITLE
fix #2896: Colorbar background for dark theme

### DIFF
--- a/panel/template/fast/theme.py
+++ b/panel/template/fast/theme.py
@@ -100,6 +100,7 @@ class FastStyle(param.Parameterized):
                     "background_fill_color": self.neutral_fill_card_rest,
                 },
                 "ColorBar": {
+                    "background_fill_color": self.background_color,
                     "title_text_color": self.neutral_foreground_rest,
                     "title_text_font": self.font,
                     "title_text_font_size": "1.025em",
@@ -107,7 +108,6 @@ class FastStyle(param.Parameterized):
                     "major_label_text_color": self.neutral_foreground_rest,
                     "major_label_text_font": self.font,
                     "major_label_text_font_size": "1.025em",
-                    # "background_fill_color": FAST_DARK_75,
                     "major_tick_line_alpha": 0,
                     "bar_line_alpha": 0,
                 },


### PR DESCRIPTION
Fixes fix #2896.

The `ColorBar` is now readible when using the Fast dark themed templates. 

I need this for an example for the `scikit-image` docs.

![image](https://user-images.githubusercontent.com/42288570/140879718-97e98cc1-89da-4636-bbcf-6742651fa833.png)


```python
import holoviews as hv
import panel as pn
from skimage import data, filters

pn.extension()

image = data.coins()
edges = filters.sobel(image)*256
bounds = (-1, -1, 1, 1)

after_img = hv.Image(edges, bounds=bounds).apply.opts(
    cmap="binary_r", responsive=True, title="After", active_tools=["box_zoom"], tools=["hover"], colorbar=True
)

layout=pn.panel(after_img, height=800, aspect_ratio=1)

pn.template.FastListTemplate(
    site="Panel and Scikit-Image",
    main=[layout],
    header_background="#292929",
    theme="dark",
).servable()
```