### PR TITLE
Tabs cache dynamic contents

### DIFF
--- a/panel/io/state.py
+++ b/panel/io/state.py
@@ -177,7 +177,7 @@ class _state(param.Parameterized):
     def _on_load(self, event):
         callbacks = self._onload.pop(self.curdoc, [])
         if not callbacks:
-             return
+            return
 
         from ..config import config
         from .profile import profile_ctx

--- a/panel/package-lock.json
+++ b/panel/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@holoviz/panel",
-  "version": "0.13.0-a.14",
+  "version": "0.13.0-a.15",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@holoviz/panel",
-      "version": "0.13.0-a.14",
+      "version": "0.13.0-a.15",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@bokeh/bokehjs": "^2.4.1",

--- a/panel/package.json
+++ b/panel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@holoviz/panel",
-  "version": "0.13.0-a.14",
+  "version": "0.13.0-a.15",
   "description": "A high level dashboarding library for python visualization libraries.",
   "license": "BSD-3-Clause",
   "repository": {


### PR DESCRIPTION
Previously Tabs set to dynamic would re-render bokeh models every time a particular panel switched from hidden to shown state. There's no good reason not to just cache even the hidden rendered models.