### PR TITLE
Allow setting a maximum height for the loading indicator

### DIFF
--- a/panel/config.py
+++ b/panel/config.py
@@ -96,6 +96,9 @@ class _config(_base_config):
     loading_color = param.Color(default='#c3c3c3', doc="""
         Color of the loading indicator.""")
 
+    loading_max_height = param.Integer(default=400, doc="""
+        Maximum height of the loading indicator.""")
+
     profiler = param.Selector(default=None, allow_None=True, objects=[
         'pyinstrument', 'snakeviz'], doc="""
         The profiler engine to enable.""")

--- a/panel/io/resources.py
+++ b/panel/io/resources.py
@@ -77,7 +77,8 @@ def loading_css():
     b64 = b64encode(svg.encode('utf-8')).decode('utf-8')
     return f"""
     .bk.pn-loading.{config.loading_spinner}:before {{
-      background-image: url("data:image/svg+xml;base64,{b64}")
+      background-image: url("data:image/svg+xml;base64,{b64}");
+      max-height: {config.loading_max_height}px;
     }}
     """
 


### PR DESCRIPTION
Since the loading indicator scales with the size of the object it's being rendered on we really need to be able to set a maximum height because you don't want a loading indicator to fill half your screen.