### PR TITLE
Fixes for Card rendering in MaterialTemplate

### DIFF
--- a/panel/template/material/material.css
+++ b/panel/template/material/material.css
@@ -135,8 +135,8 @@ div.bk.mdc-card {
   font-weight: bold;
   align-items: center;
   display: flex !important;
-  padding: 0.25em;
   position: relative !important;
+  margin-left: -1.4em;
 }
 
 .pn-modal {


### PR DESCRIPTION
Previous changes to the Card header caused some weirdness rendering the card header in the `MaterialTemplate`.