### PR TITLE
Ensure loading of MathJax bundle is optional

### DIFF
--- a/panel/io/notebook.py
+++ b/panel/io/notebook.py
@@ -241,7 +241,7 @@ def load_notebook(inline=True, load_timeout=5000):
     user_resources = settings.resources._user_value is not _Unset
     resources = Resources.from_bokeh(resources)
     try:
-        bundle = bundle_resources(resources)
+        bundle = bundle_resources(None, resources)
         bundle = Bundle.from_bokeh(bundle)
         configs, requirements, exports, skip_imports = require_components()
         ipywidget = 'ipywidgets_bokeh' in sys.modules

--- a/panel/io/save.py
+++ b/panel/io/save.py
@@ -8,7 +8,6 @@ from six import string_types
 import bokeh
 
 from bokeh.document.document import Document
-from bokeh.embed.bundle import bundle_for_objs_and_resources
 from bokeh.embed.elements import html_page_for_render_items
 from bokeh.embed.util import OutputDocumentFor, standalone_docs_json_and_render_items
 from bokeh.io.export import get_screenshot_as_png

--- a/panel/io/save.py
+++ b/panel/io/save.py
@@ -19,7 +19,10 @@ from pyviz_comms import Comm
 from ..config import config
 from .embed import embed_state
 from .model import add_to_doc
-from .resources import BASE_TEMPLATE, DEFAULT_TITLE, Bundle, Resources, set_resource_mode
+from .resources import (
+    BASE_TEMPLATE, DEFAULT_TITLE, Bundle, Resources, bundle_resources,
+    set_resource_mode
+)
 from .state import state
 
 #---------------------------------------------------------------------
@@ -134,7 +137,7 @@ def file_html(models, resources, title=None, template=BASE_TEMPLATE,
             models_seq, suppress_callback_warning=True
         )
         title = _title_from_models(models_seq, title)
-        bundle = bundle_for_objs_and_resources(None, resources)
+        bundle = bundle_resources(models_seq, resources)
         bundle = Bundle.from_bokeh(bundle)
         return html_page_for_render_items(
             bundle, docs_json, render_items, title=title, template=template,

--- a/panel/io/server.py
+++ b/panel/io/server.py
@@ -155,7 +155,7 @@ def server_html_page_for_session(session, resources, title, template=BASE_TEMPLA
     if template_variables is None:
         template_variables = {}
 
-    bundle = bundle_resources(resources)
+    bundle = bundle_resources(session.document.roots, resources)
     return html_page_for_render_items(bundle, {}, [render_item], title,
         template=template, template_variables=template_variables)
 

--- a/panel/io/server.py
+++ b/panel/io/server.py
@@ -159,9 +159,9 @@ def server_html_page_for_session(session, resources, title, template=BASE_TEMPLA
     return html_page_for_render_items(bundle, {}, [render_item], title,
         template=template, template_variables=template_variables)
 
-def autoload_js_script(resources, token, element_id, app_path, absolute_url):
+def autoload_js_script(doc, resources, token, element_id, app_path, absolute_url):
     resources = Resources.from_bokeh(resources)
-    bundle = bundle_resources(resources)
+    bundle = bundle_resources(doc.roots, resources)
 
     render_items = [RenderItem(token=token, elementid=element_id, use_for_title=False)]
     bundle.add(Script(script_for_render_items({}, render_items, app_path=app_path, absolute_url=absolute_url)))
@@ -260,7 +260,10 @@ class AutoloadJsHandler(BkAutoloadJsHandler, SessionPrefixHandler):
             state.curdoc = session.document
             try:
                 resources = Resources.from_bokeh(self.application.resources(server_url))
-                js = autoload_js_script(resources, session.token, element_id, app_path, absolute_url)
+                js = autoload_js_script(
+                    session.document, resources, session.token, element_id,
+                    app_path, absolute_url
+                )
             finally:
                 state.curdoc = None
 


### PR DESCRIPTION
Since the release of Bokeh 2.4 we are now always shipping the 1.8 MB MathJax bundle, whether that's on the server, in the notebook or in an exported file. 

To avoid this we now have the policy on both server and saved file exports that we only load the MathJax bundle if either:

- Some component is actually making use of the Bokeh mathjax support in the initially rendered app
- A user explicitly requests mathjax support with `pn.extension('mathjax')`

This will cause a slight regression because users that added a plot with mathjax handling after the initial render in a server context will now have to explicitly enable the mathjax support. Nonetheless I really would like to get this out in 0.12.5 because the 1.8 MB additional bundle loaded for everyone is a much larger issue.

In the notebook we **always** load all the bundles.

(Partially) fixes https://github.com/holoviz/panel/issues/2796
