### PR TITLE
Ensure Card collapsible icon offset is computed robustly

### DIFF
--- a/panel/models/card.ts
+++ b/panel/models/card.ts
@@ -32,8 +32,13 @@ export class CardView extends ColumnView {
       const obbox = header.layout.bbox
       const ibbox = header.layout.inner_bbox
       if (obbox.x1 != 0) {
-	const icon_style = getComputedStyle(this.button_el.children[0])
-	const offset = parseFloat(icon_style.width) + parseFloat(icon_style.marginLeft)
+	let offset: number
+	if (this.model.collapsible) {
+	  const icon_style = getComputedStyle(this.button_el.children[0])
+	  offset = (parseFloat(icon_style.width) + parseFloat(icon_style.marginLeft)) || 0
+        } else {
+	  offset = 0
+	}
 	const outer = new BBox({x0: obbox.x0, x1: obbox.x1-offset, y0: obbox.y0, y1: obbox.y1})
 	const inner = new BBox({x0: ibbox.x0, x1: ibbox.x1-offset, y0: ibbox.y0, y1: ibbox.y1})
 	header.layout.set_geometry(outer, inner)


### PR DESCRIPTION
Computation of the positioning requires robust detection of the collapsible icon. This PR ensures that this happens even if `collapsible=False` or the icon is hidden.