### PR TITLE
Revert broken optimization in Tabulator streaming implementation

### DIFF
--- a/panel/models/tabulator.ts
+++ b/panel/models/tabulator.ts
@@ -645,9 +645,8 @@ export class DataTabulatorView extends PanelHTMLBoxView {
   addData(): void {
     const rows = this.tabulator.rowManager.getRows()
     const last_row = rows[rows.length-1]
-    const start = ((last_row?.data._index + 1) || 0)
-    let data = transform_cds_to_records(this.model.source, true, start)
-    this.tabulator.addData(data)
+    const start = ((last_row?.data._index) || 0)
+    this.setData()
     if (this.model.follow && last_row)
       this.tabulator.scrollToRow(start, "top", false)
     this.postUpdate()


### PR DESCRIPTION
The approach I tried for detecting newly added rows in Tabulator was incorrect for a number of reasons so for now we simply update all the data.