### PR TITLE
Branch 0.12.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Version 0.12.6
 
-Date: 2021-12-07
+Date: 2021-12-08
 
 The 0.12.6 release fixes a major regression introduced in the last release along with a small number of pre-existing bugs.
 
@@ -14,11 +14,12 @@ Regressions:
 Bug fixes:
 
 - Do not run `Ace` import on initialization ([#2959](https://github.com/holoviz/panel/pull/2959))
-- Improve handling of `ReactiveHTML` cleanup ([#2974](https://github.com/holoviz/panel/pull/2974))
+- Improve handling of `ReactiveHTML` cleanup ([#2974](https://github.com/holoviz/panel/pull/2974), [#2993](https://github.com/holoviz/panel/pull/2993))
 - Ensure empty `Str` has same height as non-empty ([#2981](https://github.com/holoviz/panel/pull/2981))
 - Ensure `Tabulator` supports grouping on numeric columns ([#2987](https://github.com/holoviz/panel/pull/2987))
 - Fix `Tabulator` with multi-index and pagination ([#2989](https://github.com/holoviz/panel/pull/2989))
 - Allow index as column name in table widgets ([#2990](https://github.com/holoviz/panel/pull/2990))
+- Ensure TemplateActions component does not have height ([#2997](https://github.com/holoviz/panel/pull/2997))
 
 ## Version 0.12.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Releases
 
+## Version 0.12.6
+
+Date: 2021-12-07
+
+The 0.12.6 release fixes a major regression introduced in the last release along with a small number of pre-existing bugs.
+
+Regressions:
+
+- Always load imported bokeh extensions ([#2957](https://github.com/holoviz/panel/pull/2957))
+- Fix regression rendering `HoloViews` plotly backend ([#2961](https://github.com/holoviz/panel/pull/2961))
+
+Bug fixes:
+
+- Do not run `Ace` import on initialization ([#2959](https://github.com/holoviz/panel/pull/2959))
+- Improve handling of `ReactiveHTML` cleanup ([#2974](https://github.com/holoviz/panel/pull/2974))
+- Ensure empty `Str` has same height as non-empty ([#2981](https://github.com/holoviz/panel/pull/2981))
+- Ensure `Tabulator` supports grouping on numeric columns ([#2987](https://github.com/holoviz/panel/pull/2987()
+- Fix `Tabulator` with multi-index and pagination ([#2989](https://github.com/holoviz/panel/pull/2989))
+- Allow index as column name in table widgets ([#2990](https://github.com/holoviz/panel/pull/2990))
+
 ## Version 0.12.5
 
 Date: 2021-11-23
@@ -13,7 +33,7 @@ Compatibility:
 
 Enhancements:
 
-- Add 'light' to list of button types ([#2814, [#2816](https://github.com/holoviz/panel/pull/2816))
+- Add 'light' to list of button types ([#2814](https://github.com/holoviz/panel/pull/2814), [#2816](https://github.com/holoviz/panel/pull/2816))
 - Make OAuth cookie expiry configurable ([#2724](https://github.com/holoviz/panel/pull/2724))
 - Run `onload` callbacks with `--warm` option ([#2844](https://github.com/holoviz/panel/pull/2844))
 - Improve Plotly responsive sizing behavior ([#2838](https://github.com/holoviz/panel/pull/2838))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ Bug fixes:
 - Do not run `Ace` import on initialization ([#2959](https://github.com/holoviz/panel/pull/2959))
 - Improve handling of `ReactiveHTML` cleanup ([#2974](https://github.com/holoviz/panel/pull/2974))
 - Ensure empty `Str` has same height as non-empty ([#2981](https://github.com/holoviz/panel/pull/2981))
-- Ensure `Tabulator` supports grouping on numeric columns ([#2987](https://github.com/holoviz/panel/pull/2987()
+- Ensure `Tabulator` supports grouping on numeric columns ([#2987](https://github.com/holoviz/panel/pull/2987))
 - Fix `Tabulator` with multi-index and pagination ([#2989](https://github.com/holoviz/panel/pull/2989))
 - Allow index as column name in table widgets ([#2990](https://github.com/holoviz/panel/pull/2990))
 

--- a/doc/releases.md
+++ b/doc/releases.md
@@ -16,7 +16,7 @@ Bug fixes:
 - Do not run `Ace` import on initialization ([#2959](https://github.com/holoviz/panel/pull/2959))
 - Improve handling of `ReactiveHTML` cleanup ([#2974](https://github.com/holoviz/panel/pull/2974))
 - Ensure empty `Str` has same height as non-empty ([#2981](https://github.com/holoviz/panel/pull/2981))
-- Ensure `Tabulator` supports grouping on numeric columns ([#2987](https://github.com/holoviz/panel/pull/2987()
+- Ensure `Tabulator` supports grouping on numeric columns ([#2987](https://github.com/holoviz/panel/pull/2987))
 - Fix `Tabulator` with multi-index and pagination ([#2989](https://github.com/holoviz/panel/pull/2989))
 - Allow index as column name in table widgets ([#2990](https://github.com/holoviz/panel/pull/2990))
 
@@ -33,7 +33,7 @@ Compatibility:
 
 Enhancements:
 
-- Add 'light' to list of button types ([#2814, [#2816](https://github.com/holoviz/panel/pull/2816))
+- Add 'light' to list of button types ([#2814](https://github.com/holoviz/panel/pull/2814), [#2816](https://github.com/holoviz/panel/pull/2816))
 - Make OAuth cookie expiry configurable ([#2724](https://github.com/holoviz/panel/pull/2724))
 - Run `onload` callbacks with `--warm` option ([#2844](https://github.com/holoviz/panel/pull/2844))
 - Improve Plotly responsive sizing behavior ([#2838](https://github.com/holoviz/panel/pull/2838))

--- a/doc/releases.md
+++ b/doc/releases.md
@@ -4,7 +4,7 @@
 
 Date: 2021-12-07
 
-The 0.12.6 release fixes a major regression introduced in the last release along with a small number of pre-existing bugs.
+The 0.12.6 release fixes a major regression introduced in the last release along with a small number of pre-existing bugs. 
 
 Regressions:
 
@@ -14,11 +14,12 @@ Regressions:
 Bug fixes:
 
 - Do not run `Ace` import on initialization ([#2959](https://github.com/holoviz/panel/pull/2959))
-- Improve handling of `ReactiveHTML` cleanup ([#2974](https://github.com/holoviz/panel/pull/2974))
+- Improve handling of `ReactiveHTML` cleanup ([#2974](https://github.com/holoviz/panel/pull/2974), [#2993](https://github.com/holoviz/panel/pull/2993))
 - Ensure empty `Str` has same height as non-empty ([#2981](https://github.com/holoviz/panel/pull/2981))
 - Ensure `Tabulator` supports grouping on numeric columns ([#2987](https://github.com/holoviz/panel/pull/2987))
 - Fix `Tabulator` with multi-index and pagination ([#2989](https://github.com/holoviz/panel/pull/2989))
 - Allow index as column name in table widgets ([#2990](https://github.com/holoviz/panel/pull/2990))
+- Ensure TemplateActions component does not have height ([#2997](https://github.com/holoviz/panel/pull/2997))
 
 ## Version 0.12.5
 

--- a/doc/releases.md
+++ b/doc/releases.md
@@ -1,5 +1,25 @@
 # Releases
 
+## Version 0.12.6
+
+Date: 2021-12-07
+
+The 0.12.6 release fixes a major regression introduced in the last release along with a small number of pre-existing bugs.
+
+Regressions:
+
+- Always load imported bokeh extensions ([#2957](https://github.com/holoviz/panel/pull/2957))
+- Fix regression rendering `HoloViews` plotly backend ([#2961](https://github.com/holoviz/panel/pull/2961))
+
+Bug fixes:
+
+- Do not run `Ace` import on initialization ([#2959](https://github.com/holoviz/panel/pull/2959))
+- Improve handling of `ReactiveHTML` cleanup ([#2974](https://github.com/holoviz/panel/pull/2974))
+- Ensure empty `Str` has same height as non-empty ([#2981](https://github.com/holoviz/panel/pull/2981))
+- Ensure `Tabulator` supports grouping on numeric columns ([#2987](https://github.com/holoviz/panel/pull/2987()
+- Fix `Tabulator` with multi-index and pagination ([#2989](https://github.com/holoviz/panel/pull/2989))
+- Allow index as column name in table widgets ([#2990](https://github.com/holoviz/panel/pull/2990))
+
 ## Version 0.12.5
 
 Date: 2021-11-23

--- a/panel/io/resources.py
+++ b/panel/io/resources.py
@@ -123,7 +123,7 @@ def bundle_resources(roots, resources):
     css_files.extend(css_resources.css_files)
     css_raw.extend(css_resources.css_raw)
 
-    extensions = _bundle_extensions(roots, js_resources)
+    extensions = _bundle_extensions(None, js_resources)
     if mode == "inline":
         js_raw.extend([ Resources._inline(bundle.artifact_path) for bundle in extensions ])
     elif mode == "server":

--- a/panel/models/ace.ts
+++ b/panel/models/ace.ts
@@ -14,7 +14,6 @@ function ID() {
 
 export class AcePlotView extends PanelHTMLBoxView {
   model: AcePlot
-  protected _ace: any
   protected _editor: any
   protected _langTools: any
   protected _modelist: any
@@ -22,7 +21,6 @@ export class AcePlotView extends PanelHTMLBoxView {
 
   initialize(): void {
     super.initialize()
-    this._ace = (window as any).ace
     this._container = div({
       id: ID(),
       style: {
@@ -51,9 +49,9 @@ export class AcePlotView extends PanelHTMLBoxView {
     if (!(this._container === this.el.childNodes[0]))
       this.el.appendChild(this._container)
       this._container.textContent = this.model.code
-      this._editor = this._ace.edit(this._container.id)
-      this._langTools = this._ace.require('ace/ext/language_tools')
-      this._modelist = this._ace.require("ace/ext/modelist")
+      this._editor = (window as any).ace.edit(this._container.id)
+      this._langTools = (window as any).ace.require('ace/ext/language_tools')
+      this._modelist = (window as any).ace.require("ace/ext/modelist")
       this._editor.setOptions({
         enableBasicAutocompletion: true,
         enableSnippets: true,

--- a/panel/pane/holoviews.py
+++ b/panel/pane/holoviews.py
@@ -259,10 +259,7 @@ class HoloViews(PaneBase):
 
         kwargs = {p: v for p, v in self.param.get_param_values()
                   if p in Layoutable.param and p != 'name'}
-        pane_type = self._panes.get(backend, Pane)
-        if 'tight' in pane_type.param:
-            kwargs['tight'] = True
-        child_pane = pane_type(state, **kwargs)
+        child_pane = self._get_pane(backend, state, **kwargs)
         self._update_plot(plot, child_pane)
         model = child_pane._get_model(doc, root, parent, comm)
         if ref in self._plots:
@@ -272,6 +269,12 @@ class HoloViews(PaneBase):
         self._plots[ref] = (plot, child_pane)
         self._models[ref] = (model, parent)
         return model
+
+    def _get_pane(self, backend, state, **kwargs):
+        pane_type = self._panes.get(backend, Pane)
+        if isinstance(pane_type, type) and issubclass(pane_type, Matplotlib):
+            kwargs['tight'] = True
+        return pane_type(state, **kwargs)
 
     def _render(self, doc, comm, root):
         import holoviews as hv

--- a/panel/pane/markup.py
+++ b/panel/pane/markup.py
@@ -243,8 +243,8 @@ class Str(DivPaneBase):
 
     def _get_properties(self):
         properties = super()._get_properties()
-        if self.object is None:
-            text = ''
+        if self.object is None or (isinstance(self.object, str) and self.object == ''):
+            text = '<pre> </pre>'
         else:
             text = '<pre>'+str(self.object)+'</pre>'
         return dict(properties, text=escape(text))

--- a/panel/reactive.py
+++ b/panel/reactive.py
@@ -1268,7 +1268,7 @@ class ReactiveHTML(Reactive, metaclass=ReactiveHTMLMetaclass):
     def _cleanup(self, root):
         for child, panes in self._panes.items():
             for pane in panes:
-                child._cleanup(root)
+                pane._cleanup(root)
         super()._cleanup(root)
 
     @property

--- a/panel/template/base.py
+++ b/panel/template/base.py
@@ -335,7 +335,9 @@ class TemplateActions(ReactiveHTML):
 
     close_modal = param.Integer(default=0)
 
-    _template = "<div></div>"
+    margin = param.Integer(default=0)
+
+    _template = ""
 
     _scripts = {
         'open_modal': ["document.getElementById('pn-Modal').style.display = 'block'"],

--- a/panel/tests/test_reactive.py
+++ b/panel/tests/test_reactive.py
@@ -300,6 +300,10 @@ def test_reactive_html_children():
     assert root.children == {'div': [widget_new._models[root.ref['id']][0]]}
     assert test._panes == {'children': [widget_new]}
 
+    test._cleanup(root)
+    assert len(test._models) == 0
+    assert len(widget_new._models) == 0
+    
 
 def test_reactive_html_templated_children():
 

--- a/panel/tests/widgets/test_tables.py
+++ b/panel/tests/widgets/test_tables.py
@@ -223,6 +223,40 @@ def test_tabulator_selected_dataframe():
     pd.testing.assert_frame_equal(table.selected_dataframe, df.iloc[[0, 2]])
 
 
+def test_tabulator_multi_index(document, comm):
+    df = makeMixedDataFrame()
+    table = Tabulator(df.set_index(['A', 'C']))
+
+    model = table.get_root()
+
+    assert model.configuration['columns'] == [
+        {'field': 'A'},
+        {'field': 'C'},
+        {'field': 'B'},
+        {'field': 'D'}
+    ]
+
+    assert np.array_equal(model.source.data['A'], np.array([0., 1., 2., 3., 4.]))
+    assert np.array_equal(model.source.data['C'], np.array(['foo1', 'foo2', 'foo3', 'foo4', 'foo5']))
+
+
+def test_tabulator_multi_index_remote_pagination(document, comm):
+    df = makeMixedDataFrame()
+    table = Tabulator(df.set_index(['A', 'C']), pagination='remote', page_size=3)
+
+    model = table.get_root()
+
+    assert model.configuration['columns'] == [
+        {'field': 'A'},
+        {'field': 'C'},
+        {'field': 'B'},
+        {'field': 'D'}
+    ]
+
+    assert np.array_equal(model.source.data['A'], np.array([0., 1., 2.]))
+    assert np.array_equal(model.source.data['C'], np.array(['foo1', 'foo2', 'foo3']))
+
+
 def test_tabulator_selected_and_filtered_dataframe(document, comm):
     df = makeMixedDataFrame()
     table = Tabulator(df)

--- a/panel/tests/widgets/test_tables.py
+++ b/panel/tests/widgets/test_tables.py
@@ -307,6 +307,23 @@ def test_tabulator_groups(document, comm):
     ]
 
 
+def test_tabulator_numeric_groups(document, comm):
+    df = pd.DataFrame(np.random.rand(10, 3))
+    table = Tabulator(df, groups={'Number': [0, 1]})
+
+    model = table.get_root(document, comm)
+
+    assert model.configuration['columns'] == [
+        {'field': 'index'},
+        {'title': 'Number',
+         'columns': [
+            {'field': '0'},
+            {'field': '1'}
+        ]},
+        {'field': '2'}
+    ]
+
+
 def test_tabulator_frozen_cols(document, comm):
     df = makeMixedDataFrame()
     table = Tabulator(df, frozen_columns=['index'])

--- a/panel/tests/widgets/test_tables.py
+++ b/panel/tests/widgets/test_tables.py
@@ -205,6 +205,19 @@ def test_hierarchical_index(document, comm):
     assert isinstance(agg2, MinAggregator)
 
 
+def test_table_index_column(document, comm):
+    df = pd.DataFrame({
+        'int': [1, 2, 3],
+        'float': [3.14, 6.28, 9.42],
+        'index': ['A', 'B', 'C'],
+    }, index=[1, 2, 3])
+    table = DataFrame(value=df)
+
+    model = table.get_root(document, comm=comm)
+
+    assert np.array_equal(model.source.data['level_0'], np.array([1, 2, 3]))
+    assert model.columns[0].field == 'level_0'
+    assert model.columns[0].title == ''
 
 
 def test_none_table(document, comm):

--- a/panel/widgets/tables.py
+++ b/panel/widgets/tables.py
@@ -174,6 +174,8 @@ class BaseTable(ReactiveData, Widget):
             title = self.titles.get(col, str(col))
             if col in indexes and len(indexes) > 1 and self.hierarchical:
                 title = 'Index: %s' % ' | '.join(indexes)
+            elif col in self.indexes and col.startswith('level_'):
+                title = ''
             column = TableColumn(field=str(col), title=title,
                                  editor=editor, formatter=formatter,
                                  **col_kwargs)
@@ -324,7 +326,16 @@ class BaseTable(ReactiveData, Widget):
         df = self._filter_dataframe(self.value)
         if df is None:
             return [], {}
-        elif len(self.indexes) > 1:
+        import pandas as pd
+        if isinstance(self.value.index, pd.MultiIndex):
+            indexes = [
+                f'level_{i}' if n is None else n
+                for i, n in enumerate(df.index.names)
+            ]
+        else:
+            default_index = ('level_0' if 'index' in df.columns else 'index')
+            indexes = [df.index.name or default_index]
+        if len(indexes) > 1:
             df = df.reset_index()
         data = ColumnDataSource.from_df(df).items()
         return df, {k if isinstance(k, str) else str(k): v for k, v in data}
@@ -342,8 +353,12 @@ class BaseTable(ReactiveData, Widget):
         if self.value is None or not self.show_index:
             return []
         elif isinstance(self.value.index, pd.MultiIndex):
-            return list(self.value.index.names)
-        return [self.value.index.name or 'index']
+            return [
+                f'level_{i}' if n is None else n
+                for i, n in enumerate(self.value.index.names)
+            ]
+        default_index = ('level_0' if 'index' in self.value.columns else 'index')
+        return [self.value.index.name or default_index]
 
     def stream(self, stream_value, rollover=None, reset_index=True):
         """
@@ -851,9 +866,13 @@ class Tabulator(BaseTable):
         start = (self.page-1)*nrows
         page_df = df.iloc[start: start+nrows]
         if isinstance(self.value.index, pd.MultiIndex):
-            indexes = list(df.index.names)
+            indexes = [
+                f'level_{i}' if n is None else n
+                for i, n in enumerate(df.index.names)
+            ]
         else:
-            indexes = [df.index.name or 'index']
+            default_index = ('level_0' if 'index' in df.columns else 'index')
+            indexes = [df.index.name or default_index]
         if len(indexes) > 1:
             page_df = page_df.reset_index()
         data = ColumnDataSource.from_df(page_df).items()

--- a/panel/widgets/tables.py
+++ b/panel/widgets/tables.py
@@ -844,11 +844,18 @@ class Tabulator(BaseTable):
     def _get_data(self):
         if self.pagination != 'remote' or self.value is None:
             return super()._get_data()
+        import pandas as pd
         df = self._filter_dataframe(self.value)
         df = self._sort_df(df)
         nrows = self.page_size
         start = (self.page-1)*nrows
         page_df = df.iloc[start: start+nrows]
+        if isinstance(self.value.index, pd.MultiIndex):
+            indexes = list(df.index.names)
+        else:
+            indexes = [df.index.name or 'index']
+        if len(indexes) > 1:
+            page_df = page_df.reset_index()
         data = ColumnDataSource.from_df(page_df).items()
         return df, {k if isinstance(k, str) else str(k): v for k, v in data}
 

--- a/panel/widgets/tables.py
+++ b/panel/widgets/tables.py
@@ -1090,9 +1090,13 @@ class Tabulator(BaseTable):
                     column_objs.remove(cols[0])
         ordered += column_objs
 
+        grouping = {
+            group: [str(gc) for gc in group_cols]
+            for group, group_cols in self.groups.items()
+        }
         for i, column in enumerate(ordered):
             matching_groups = [
-                group for group, group_cols in self.groups.items()
+                group for group, group_cols in grouping.items()
                 if column.field in group_cols
             ]
             col_dict = {'field': column.field}

--- a/setup.py
+++ b/setup.py
@@ -142,7 +142,7 @@ extras_require = {
         'scikit-learn',
         'datashader',
         'jupyter_bokeh >=3.0.2',
-        'django',
+        'django <4',
         'channels',
         'pyvista',
         'ipywidgets',


### PR DESCRIPTION
The 0.12.6 release fixes a major regression introduced in the last release along with a small number of pre-existing bugs. 

Regressions:

- Always load imported bokeh extensions ([#2957](https://github.com/holoviz/panel/pull/2957))
- Fix regression rendering `HoloViews` plotly backend ([#2961](https://github.com/holoviz/panel/pull/2961))

Bug fixes:

- Do not run `Ace` import on initialization ([#2959](https://github.com/holoviz/panel/pull/2959))
- Improve handling of `ReactiveHTML` cleanup ([#2974](https://github.com/holoviz/panel/pull/2974), [#2993](https://github.com/holoviz/panel/pull/2993))
- Ensure empty `Str` has same height as non-empty ([#2981](https://github.com/holoviz/panel/pull/2981))
- Ensure `Tabulator` supports grouping on numeric columns ([#2987](https://github.com/holoviz/panel/pull/2987))
- Fix `Tabulator` with multi-index and pagination ([#2989](https://github.com/holoviz/panel/pull/2989))
- Allow index as column name in table widgets ([#2990](https://github.com/holoviz/panel/pull/2990))
- Ensure TemplateActions component does not have height ([#2997](https://github.com/holoviz/panel/pull/2997))
