### PR TITLE
Ensure TemplateActions component does not have height

### DIFF
--- a/panel/template/base.py
+++ b/panel/template/base.py
@@ -335,7 +335,9 @@ class TemplateActions(ReactiveHTML):
 
     close_modal = param.Integer(default=0)
 
-    _template = "<div></div>"
+    margin = param.Integer(default=0)
+
+    _template = ""
 
     _scripts = {
         'open_modal': ["document.getElementById('pn-Modal').style.display = 'block'"],


### PR DESCRIPTION
The `TemplateActions` component added to all templates had a margin and therefore took up unnecessary height.