### PR TITLE
Ensure Tabulator theme CSS is loaded from correct place

### DIFF
--- a/panel/models/tabulator.py
+++ b/panel/models/tabulator.py
@@ -38,15 +38,7 @@ class TableEditEvent(ModelEvent):
 
 
 def _get_theme_url(url, theme):
-    if 'bootstrap' in theme:
-        url += 'bootstrap/'
-    elif 'materialize' in theme:
-        url += 'materialize/'
-    elif 'semantic-ui' in theme:
-        url += 'semantic-ui/'
-    elif 'bulma' in theme:
-        url += 'bulma/'
-    elif 'fast' in theme:
+    if 'fast' in theme:
         if url.startswith(THEME_URL):
             url = url.replace(THEME_URL, PANEL_CDN)
         url += 'fast/'


### PR DESCRIPTION
Since Tabulator 5.0 the theme CSS for bootstrap, materialize are no longer nested into sub-directories.