### PR TITLE
Resize layout after expanding Tabulator row

### DIFF
--- a/panel/models/tabulator.ts
+++ b/panel/models/tabulator.ts
@@ -452,8 +452,9 @@ export class DataTabulatorView extends PanelHTMLBoxView {
     const bg = style.backgroundColor
     const neg_margin = "-" + rowEl.style.paddingLeft
     const row_view = div({style: "background-color: " + bg +"; margin-left:" + neg_margin})
+    row.getElement().appendChild(row_view);
+    (view as any)._parent = this
     view.renderTo(row_view)
-    row.getElement().appendChild(row_view)
   }
 
   _expand_render(cell: any): string {


### PR DESCRIPTION
Without this the Tabulator can end up overlapping with another component. This ensures that renderComplete events are triggered and inform the parent table of any layout invalidations.