### PR TITLE
Add home to TOC of the home page

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -96,6 +96,7 @@ The Panel project is grateful for the sponsorship by the organizations and compa
    :hidden:
    :maxdepth: 2
 
+   Home <self>
    Getting Started <getting_started/index>
    User Guide <user_guide/index>
    Gallery <gallery/index>


### PR DESCRIPTION
Attempt to get the table of content in the left side bar on the home page. Trying that because it's the only difference I could spot with `holoviews`.