### PR TITLE
Remove usage of "sys.version_info" to handle Python 2 code

### DIFF
--- a/panel/config.py
+++ b/panel/config.py
@@ -433,7 +433,7 @@ class panel_extension(_pyviz_extension):
             else:
                 setattr(config, k, v)
 
-        if config.apply_signatures and sys.version_info.major >= 3:
+        if config.apply_signatures:
             self._apply_signatures()
 
         loaded = self._loaded

--- a/panel/interact.py
+++ b/panel/interact.py
@@ -37,7 +37,6 @@ import param
 from .layout import Panel, Column, Row
 from .pane import PaneBase, HTML, panel
 from .pane.base import ReplacementPane
-from .util import as_unicode
 from .viewable import Viewable
 from .widgets import (Checkbox, TextInput, Widget, IntSlider, FloatSlider,
                       Select, DiscreteSlider, Button)
@@ -302,7 +301,7 @@ class interactive(PaneBase):
     def widget_from_single_value(o, name):
         """Make widgets from single values, which can be used as parameter defaults."""
         if isinstance(o, string_types):
-            return TextInput(value=as_unicode(o), name=name)
+            return TextInput(value=str(o), name=name)
         elif isinstance(o, bool):
             return Checkbox(value=o, name=name)
         elif isinstance(o, Integral):

--- a/panel/pane/holoviews.py
+++ b/panel/pane/holoviews.py
@@ -339,7 +339,7 @@ class HoloViews(PaneBase):
     def widgets_from_dimensions(cls, object, widget_types=None, widgets_type='individual'):
         from holoviews.core import Dimension, DynamicMap
         from holoviews.core.options import SkipRendering
-        from holoviews.core.util import isnumeric, unicode, datetime_types, unique_iterator
+        from holoviews.core.util import isnumeric, datetime_types, unique_iterator
         from holoviews.core.traversal import unique_dimkeys
         from holoviews.plotting.plot import Plot, GenericCompositePlot
         from holoviews.plotting.util import get_dynamic_mode
@@ -421,7 +421,7 @@ class HoloViews(PaneBase):
             if vals:
                 if all(isnumeric(v) or isinstance(v, datetime_types) for v in vals) and len(vals) > 1:
                     vals = sorted(vals)
-                    labels = [unicode(dim.pprint_value(v)) for v in vals]
+                    labels = [str(dim.pprint_value(v)) for v in vals]
                     options = OrderedDict(zip(labels, vals))
                     widget_type = widget_type or DiscreteSlider
                 else:

--- a/panel/pane/vtk/synchronizable_serializer.py
+++ b/panel/pane/vtk/synchronizable_serializer.py
@@ -2,7 +2,6 @@ import base64
 import hashlib
 import io
 import struct
-import sys
 import time
 import zipfile
 
@@ -13,25 +12,12 @@ from vtk.vtkCommonDataModel import vtkDataObject
 
 from .enums import TextPosition
 
-# -----------------------------------------------------------------------------
-# Python compatibility handling 2.6, 2.7, 3+
-# -----------------------------------------------------------------------------
 
-py3 = sys.version_info >= (3, 0)
+def iteritems(d, **kwargs):
+    return iter(d.items(**kwargs))
 
-if py3:
-    def iteritems(d, **kwargs):
-        return iter(d.items(**kwargs))
-else:
-    def iteritems(d, **kwargs):
-        return d.iteritems(**kwargs)
-
-if sys.version_info >= (2, 7):
-    buffer = memoryview
-    base64Encode = lambda x: base64.b64encode(x).decode('utf-8')
-else:
-    buffer = buffer
-    base64Encode = lambda x: x.encode('base64')
+buffer = memoryview
+base64Encode = lambda x: base64.b64encode(x).decode('utf-8')
 
 # -----------------------------------------------------------------------------
 # Array helpers

--- a/panel/param.py
+++ b/panel/param.py
@@ -6,7 +6,6 @@ import inspect
 import itertools
 import json
 import os
-import sys
 import types
 
 from collections import OrderedDict, defaultdict, namedtuple
@@ -578,9 +577,7 @@ class Param(PaneBase):
         filtered = [(k, p) for k, p in sorted_precedence]
         groups = itertools.groupby(filtered, key=key_fn)
         # Params preserve definition order in Python 3.6+
-        dict_ordered_py3 = (sys.version_info.major == 3 and sys.version_info.minor >= 6)
-        dict_ordered = dict_ordered_py3 or (sys.version_info.major > 3)
-        ordered_groups = [list(grp) if dict_ordered else sorted(grp) for (_, grp) in groups]
+        ordered_groups = [list(grp) for (_, grp) in groups]
         ordered_params = [el[0] for group in ordered_groups for el in group
                           if (el[0] != 'name' or el[0] in self.parameters)]
         return ordered_params

--- a/panel/tests/layout/test_base.py
+++ b/panel/tests/layout/test_base.py
@@ -10,13 +10,12 @@ from panel.layout import (
 from panel.layout.base import ListPanel, NamedListPanel
 from panel.param import Param
 from panel.pane import Bokeh
-from panel.tests.util import check_layoutable_properties, py3_only
+from panel.tests.util import check_layoutable_properties
 
 
 all_panels = [w for w in param.concrete_descendents(ListPanel).values()
                if not w.__name__.startswith('_') and w is not NamedListPanel]
 
-@py3_only
 @pytest.mark.parametrize('panel', all_panels)
 def test_layout_signature(panel):
     from inspect import signature

--- a/panel/tests/pane/test_base.py
+++ b/panel/tests/pane/test_base.py
@@ -9,7 +9,7 @@ from panel.pane import (
     Bokeh, HoloViews, IPyWidget, Interactive, IDOM, Pane, PaneBase, Vega
 )
 from panel.param import ParamMethod
-from panel.tests.util import check_layoutable_properties, py3_only
+from panel.tests.util import check_layoutable_properties
 
 
 SKIP_PANES = (Bokeh, HoloViews, ParamMethod, interactive, IPyWidget, Interactive, IDOM, Vega)
@@ -65,7 +65,6 @@ def test_pane_clone(pane):
             [(k, v) for k, v in sorted(clone.param.values().items()) if k != 'name'])
 
 
-@py3_only
 @pytest.mark.parametrize('pane', all_panes)
 def test_pane_signature(pane):
     from inspect import Parameter, signature

--- a/panel/tests/pane/test_image.py
+++ b/panel/tests/pane/test_image.py
@@ -1,5 +1,4 @@
 import os
-import pytest
 
 from base64 import b64decode, b64encode
 from pathlib import Path

--- a/panel/tests/pane/test_image.py
+++ b/panel/tests/pane/test_image.py
@@ -1,5 +1,4 @@
 import os
-import sys
 import pytest
 
 from base64 import b64decode, b64encode
@@ -77,7 +76,6 @@ def test_load_from_byteio():
     image_data = image_pane._data()
     assert b'PNG' in image_data
 
-@pytest.mark.skipif(sys.version_info.major <= 2, reason="Doesn't work with python 2")
 def test_load_from_stringio():
     """Testing a loading a image from a StringIO"""
     memory = StringIO()

--- a/panel/tests/test_viewable.py
+++ b/panel/tests/test_viewable.py
@@ -6,7 +6,7 @@ from panel.interact import interactive
 from panel.pane import Str, panel
 from panel.viewable import Viewable, Viewer
 
-from .util import jb_available, py3_only
+from .util import jb_available
 
 all_viewables = [w for w in param.concrete_descendents(Viewable).values()
                if not w.__name__.startswith('_') and
@@ -20,7 +20,6 @@ def test_viewable_ipywidget():
     assert 'application/vnd.jupyter.widget-view+json' in data
 
 
-@py3_only
 @pytest.mark.parametrize('viewable', all_viewables)
 def test_viewable_signature(viewable):
     from inspect import Parameter, signature

--- a/panel/tests/util.py
+++ b/panel/tests/util.py
@@ -1,5 +1,3 @@
-import sys
-
 from distutils.version import LooseVersion
 
 import numpy as np
@@ -36,8 +34,6 @@ try:
 except Exception:
     jupyter_bokeh = None
 jb_available = pytest.mark.skipif(jupyter_bokeh is None, reason="requires jupyter_bokeh")
-
-py3_only = pytest.mark.skipif(sys.version_info.major < 3, reason="requires Python 3")
 
 from panel.pane.markup import Markdown
 

--- a/panel/tests/widgets/test_select.py
+++ b/panel/tests/widgets/test_select.py
@@ -6,7 +6,6 @@ import pytest
 from panel.widgets import (
     CrossSelector, MultiChoice, MultiSelect, Select, ToggleGroup
 )
-from panel.util import as_unicode
 
 
 def test_select_list_constructor():
@@ -46,18 +45,18 @@ def test_select(document, comm):
 
     assert isinstance(widget, select._widget_type)
     assert widget.title == 'Select'
-    assert widget.value == as_unicode(opts['1'])
-    assert widget.options == [(as_unicode(v),k) for k,v in opts.items()]
+    assert widget.value == str(opts['1'])
+    assert widget.options == [(str(v),k) for k,v in opts.items()]
 
-    select._process_events({'value': as_unicode(opts['A'])})
+    select._process_events({'value': str(opts['A'])})
     assert select.value == opts['A']
 
-    widget.value = as_unicode(opts['1'])
+    widget.value = str(opts['1'])
     select.value = opts['1']
     assert select.value == opts['1']
 
     select.value = opts['A']
-    assert widget.value == as_unicode(opts['A'])
+    assert widget.value == str(opts['A'])
 
 
 def test_select_groups_list_options(document, comm):
@@ -68,17 +67,17 @@ def test_select_groups_list_options(document, comm):
 
     assert isinstance(widget, select._widget_type)
     assert widget.title == 'Select'
-    assert widget.value == as_unicode(groups['a'][0])
-    assert widget.options == {gr: [(as_unicode(v), as_unicode(v)) for v in values] for gr, values in groups.items()}
+    assert widget.value == str(groups['a'][0])
+    assert widget.options == {gr: [(str(v), str(v)) for v in values] for gr, values in groups.items()}
 
-    select._process_events({'value': as_unicode(groups['a'][1])})
+    select._process_events({'value': str(groups['a'][1])})
     assert select.value == groups['a'][1]
 
-    widget.value = as_unicode(groups['a'][0])
+    widget.value = str(groups['a'][0])
     assert select.value == groups['a'][0]
 
     select.value = groups['a'][1]
-    assert widget.value == as_unicode(groups['a'][1])
+    assert widget.value == str(groups['a'][1])
 
 
 def test_select_groups_dict_options(document, comm):
@@ -89,17 +88,17 @@ def test_select_groups_dict_options(document, comm):
 
     assert isinstance(widget, select._widget_type)
     assert widget.title == 'Select'
-    assert widget.value == as_unicode(groups['A']['a'])
+    assert widget.value == str(groups['A']['a'])
     assert widget.options == {'A': [('1', 'a'), ('2', 'b')], 'B': [('3', 'c')]}
 
-    select._process_events({'value': as_unicode(groups['B']['c'])})
+    select._process_events({'value': str(groups['B']['c'])})
     assert select.value == groups['B']['c']
 
-    widget.value = as_unicode(groups['A']['b'])
+    widget.value = str(groups['A']['b'])
     assert select.value == groups['A']['b']
 
     select.value = groups['A']['a']
-    assert widget.value == as_unicode(groups['A']['a'])
+    assert widget.value == str(groups['A']['a'])
 
 
 def test_select_change_groups(document, comm):
@@ -111,7 +110,7 @@ def test_select_change_groups(document, comm):
     new_groups = dict(C=dict(d=4), D=dict(e=5, f=6))
     select.groups = new_groups
     assert select.value == new_groups['C']['d']
-    assert widget.value == as_unicode(new_groups['C']['d'])
+    assert widget.value == str(new_groups['C']['d'])
     assert widget.options == {'C': [('4', 'd')], 'D': [('5', 'e'), ('6', 'f')]}
 
     select.groups = {}
@@ -146,7 +145,7 @@ def test_select_change_options(document, comm):
 
     select.options = {'A': 'a'}
     assert select.value == opts['A']
-    assert widget.value == as_unicode(opts['A'])
+    assert widget.value == str(opts['A'])
 
     select.options = {}
     assert select.value == None
@@ -161,12 +160,12 @@ def test_select_non_hashable_options(document, comm):
 
     select.value = opts['A']
     assert select.value is opts['A']
-    assert widget.value == as_unicode(opts['A'])
+    assert widget.value == str(opts['A'])
 
     opts.pop('A')
     select.options = opts
     assert select.value is opts['1']
-    assert widget.value == as_unicode(opts['1'])
+    assert widget.value == str(opts['1'])
 
 
 def test_select_mutables(document, comm):
@@ -177,19 +176,19 @@ def test_select_mutables(document, comm):
 
     assert isinstance(widget, select._widget_type)
     assert widget.title == 'Select'
-    assert widget.value == as_unicode(opts['B'])
-    assert widget.options == [(as_unicode(v),k) for k,v in opts.items()]
+    assert widget.value == str(opts['B'])
+    assert widget.options == [(str(v),k) for k,v in opts.items()]
 
-    widget.value = as_unicode(opts['B'])
-    select._process_events({'value': as_unicode(opts['A'])})
+    widget.value = str(opts['B'])
+    select._process_events({'value': str(opts['A'])})
     assert select.value == opts['A']
 
-    widget.value = as_unicode(opts['B'])
-    select._process_events({'value': as_unicode(opts['B'])})
+    widget.value = str(opts['B'])
+    select._process_events({'value': str(opts['B'])})
     assert select.value == opts['B']
 
     select.value = opts['A']
-    assert widget.value == as_unicode(opts['A'])
+    assert widget.value == str(opts['A'])
 
 
 def test_select_change_options_on_watch(document, comm):
@@ -204,8 +203,8 @@ def test_select_change_options_on_watch(document, comm):
     model = select.get_root(document, comm=comm)
 
     select.value = 1
-    assert model.value == as_unicode(list(select.options.values())[0])
-    assert model.options == [(as_unicode(v),k) for k,v in select.options.items()]
+    assert model.value == str(list(select.options.values())[0])
+    assert model.options == [(str(v),k) for k,v in select.options.items()]
 
 
 def test_multi_select(document, comm):

--- a/panel/util.py
+++ b/panel/util.py
@@ -28,9 +28,6 @@ import numpy as np
 
 datetime_types = (np.datetime64, dt.datetime, dt.date)
 
-if sys.version_info.major > 2:
-    unicode = str
-
 bokeh_version = LooseVersion(bokeh.__version__)
 
 
@@ -107,31 +104,12 @@ def indexOf(obj, objs):
     raise ValueError('%s not in list' % obj)
 
 
-def as_unicode(obj):
-    """
-    Safely casts any object to unicode including regular string
-    (i.e. bytes) types in python 2.
-    """
-    if sys.version_info.major < 3 and isinstance(obj, str):
-        obj = obj.decode('utf-8')
-    return unicode(obj)
-
-
 def param_name(name):
     """
     Removes the integer id from a Parameterized class name.
     """
     match = re.findall(r'\D+(\d{5,})', name)
     return name[:name.index(match[0])] if match else name
-
-
-def unicode_repr(obj):
-    """
-    Returns a repr without the unicode prefix.
-    """
-    if sys.version_info.major == 2 and isinstance(obj, unicode):
-        return repr(obj)[1:]
-    return repr(obj)
 
 
 def recursive_parameterized(parameterized, objects=None):
@@ -229,10 +207,7 @@ def get_method_owner(meth):
     the class owning the supplied classmethod.
     """
     if inspect.ismethod(meth):
-        if sys.version_info < (3,0):
-            return meth.im_class if meth.im_self is None else meth.im_self
-        else:
-            return meth.__self__
+        return meth.__self__
 
 
 def is_parameterized(obj):

--- a/panel/widgets/input.py
+++ b/panel/widgets/input.py
@@ -21,7 +21,7 @@ from bokeh.models.widgets import (
 
 from ..config import config
 from ..layout import Column
-from ..util import param_reprs, as_unicode
+from ..util import param_reprs
 from .base import Widget, CompositeWidget
 from ..models import DatetimePicker as _bkDatetimePicker
 
@@ -129,7 +129,7 @@ class StaticText(Widget):
     def _process_param_change(self, msg):
         msg = super()._process_property_change(msg)
         if 'value' in msg:
-            text = as_unicode(msg.pop('value'))
+            text = str(msg.pop('value'))
             partial = self._format.replace('{value}', '').format(title=self.name)
             if self.name:
                 text = self._format.format(title=self.name, value=text.replace(partial, ''))
@@ -498,7 +498,7 @@ class LiteralInput(Widget):
             elif self.serializer == 'json':
                 value = json.dumps(value)
             else:
-                value = '' if value is None else as_unicode(value)
+                value = '' if value is None else str(value)
             msg['value'] = value
         msg['title'] = self.name
         return msg

--- a/panel/widgets/select.py
+++ b/panel/widgets/select.py
@@ -18,7 +18,7 @@ from bokeh.models.widgets import (
 
 from ..layout import Column, VSpacer
 from ..models import SingleSelect as _BkSingleSelect
-from ..util import as_unicode, isIn, indexOf
+from ..util import isIn, indexOf
 from .base import Widget, CompositeWidget
 from .button import _ButtonBase, Button
 from .input import TextInput, TextAreaInput
@@ -32,7 +32,7 @@ class SelectBase(Widget):
 
     @property
     def labels(self):
-        return [as_unicode(o) for o in self.options]
+        return [str(o) for o in self.options]
 
     @property
     def values(self):
@@ -95,7 +95,7 @@ class SingleSelectBase(SelectBase):
 
     @property
     def unicode_values(self):
-        return [as_unicode(v) for v in self.values]
+        return [str(v) for v in self.values]
 
     def _process_property_change(self, msg):
         msg = super()._process_property_change(msg)
@@ -175,18 +175,18 @@ class Select(SingleSelectBase):
                 if isinstance(next(iter(self.groups.values())), dict):
                     if unique:
                         options = {
-                            group: [(as_unicode(value), label) for label, value in subd.items()]
+                            group: [(str(value), label) for label, value in subd.items()]
                             for group, subd in groups.items()
                         }
                     else:
                         options = {
-                            group: [as_unicode(v) for v in self.groups[group]]
+                            group: [str(v) for v in self.groups[group]]
                             for group in groups.keys()
                         }
                     msg['options'] = options
                 else:
                     msg['options'] = {
-                        group: [(as_unicode(value), as_unicode(value)) for value in values]
+                        group: [(str(value), str(value)) for value in values]
                         for group, values in groups.items()
                     }
             val = self.value
@@ -205,7 +205,7 @@ class Select(SingleSelectBase):
             if not self.groups:
                 return {}
             else:
-                return list(map(as_unicode, itertools.chain(*self.groups.values())))
+                return list(map(str, itertools.chain(*self.groups.values())))
 
     @property
     def values(self):

--- a/panel/widgets/slider.py
+++ b/panel/widgets/slider.py
@@ -17,7 +17,7 @@ from bokeh.models.widgets import (
 from ..config import config
 from ..io import state
 from ..util import (
-    edit_readonly, param_reprs, unicode_repr, value_as_datetime, value_as_date
+    edit_readonly, param_reprs, value_as_datetime, value_as_date
 )
 from ..viewable import Layoutable
 from ..layout import Column, Row
@@ -253,7 +253,7 @@ class DiscreteSlider(CompositeWidget, _SliderBase):
         )
         self._update_style()
         js_code = self._text_link.format(
-            labels='['+', '.join([unicode_repr(l) for l in labels])+']'
+            labels='['+', '.join([repr(l) for l in labels])+']'
         )
         self._jslink = self._slider.jslink(self._text, code={'value': js_code})
         self._slider.param.watch(self._sync_value, 'value')


### PR DESCRIPTION
This PR removes the usage of `sys.version_info` and derivatives in the codebase to handle Python < 3 code. The derivatives are - 

- `@py3_only` decorator used to mark tests that are meant to be run on Python > 2.
- `as_unicode` and `unicode_repr` utility functions
- `unicode` alias to `str` on Python 3

These changes can be done now that the package supports only Python >= 3.6