### PR TITLE
Remove "utf-8" coding cookies from modules

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import param
 
 param.parameterized.docstring_signature = False

--- a/doc/generate_modules.py
+++ b/doc/generate_modules.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 """
 sphinx-autopackage-script
 This script parses a directory tree looking for python modules and packages and

--- a/panel/models/vtk.py
+++ b/panel/models/vtk.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 """
 Defines custom VTKPlot bokeh model to render VTK objects.
 """

--- a/panel/pane/vtk/vtk.py
+++ b/panel/pane/vtk/vtk.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 """
 Defines a VTKPane which renders a vtk plot using VTKPlot bokeh model.
 """

--- a/panel/tests/pane/test_vtk.py
+++ b/panel/tests/pane/test_vtk.py
@@ -1,5 +1,3 @@
-# coding: utf-8
-
 import os
 import base64
 from io import BytesIO

--- a/panel/widgets/file_selector.py
+++ b/panel/widgets/file_selector.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Defines a FileSelector widget which allows selecting files and
 directories on the server.


### PR DESCRIPTION
The default encoding on Python 3 is `"utf-8"` so we can remove the coding cookies from python modules in the package.