### PR TITLE
Remove redundant and confusing JupyterLab install instructions

### DIFF
--- a/doc/getting_started/index.rst
+++ b/doc/getting_started/index.rst
@@ -11,7 +11,7 @@ Installation
 
 |CondaPyViz|_ |CondaDefaults|_ |PyPI|_ |License|_
 
-Panel works with `Python 2.7 and Python 3 <https://travis-ci.org/pyviz/panel>`_ on Linux, Windows, or Mac.  The recommended way to install Panel is using the `conda <http://conda.pydata.org/docs/>`_ command provided by `Anaconda <http://docs.continuum.io/anaconda/install>`_ or `Miniconda <http://conda.pydata.org/miniconda.html>`_::
+Panel works with Python 3 on Linux, Windows, or Mac.  The recommended way to install Panel is using the `conda <http://conda.pydata.org/docs/>`_ command provided by `Anaconda <http://docs.continuum.io/anaconda/install>`_ or `Miniconda <http://conda.pydata.org/miniconda.html>`_::
 
   conda install -c pyviz panel
 

--- a/doc/getting_started/index.rst
+++ b/doc/getting_started/index.rst
@@ -19,11 +19,6 @@ or using PyPI::
 
   pip install panel
 
-Support for classic Jupyter Notebook is included with Panel. If you want to work with JupyterLab, you will also need to install the optional PyViz JupyterLab extension::
-
-  conda install -c conda-forge jupyterlab
-  jupyter labextension install @pyviz/jupyterlab_pyviz
-
 
 .. |CondaPyViz| image:: https://img.shields.io/conda/v/pyviz/panel.svg
 .. _CondaPyViz: https://anaconda.org/pyviz/panel


### PR DESCRIPTION
And also remove a reference to Python 2.7 and a link to Travis.