### PR TITLE
Fix Fast Vertical Slider CSS

### DIFF
--- a/panel/template/fast/css/fast_bokeh.css
+++ b/panel/template/fast/css/fast_bokeh.css
@@ -1521,6 +1521,23 @@ input[type=range]::-moz-range-track {
   cursor: not-allowed;
   opacity: 0.5;
 }
+.bk-root .noUi-vertical {
+  margin-top: 15px;
+  width: calc(var(--track-width) * 1px);
+  background-color: var(--neutral-outline-rest);
+  border-radius: calc(var(--corner-radius) * 1px);
+}
+.bk-root .noUi-target.noUi-vertical {
+    margin-top: 10px;
+}
+.bk-root .noUi-vertical .noUi-handle {
+    border: none;
+    width: 12px;
+    height: 12px;
+    background: var(--neutral-foreground-rest);
+    border-radius: calc(var(--corner-radius) * 1px);
+    box-shadow: none;
+}
 .bk-root .bk-tabs-header {
   display: flex;
   display: -webkit-flex;

--- a/panel/template/fast/css/fast_bokeh.css
+++ b/panel/template/fast/css/fast_bokeh.css
@@ -1491,10 +1491,13 @@ input[type=range]::-moz-range-track {
   background-position: center;
   border-radius: calc(var(--corner-radius) * 1px);
 }
+.noUi-connect, .noUi-connects {
+  background-color: var(--neutral-outline-rest) !important;
+}
 .bk-root .noUi-horizontal {
   /* height: 2px; */
   margin-top: 15px;
-  height: calc(var(--track-width) * 1px);
+  height: calc(var(--track-width) * 2px);
   background-color: var(--neutral-outline-rest);
   border-radius: calc(var(--corner-radius) * 1px);
 }
@@ -1510,8 +1513,8 @@ input[type=range]::-moz-range-track {
 
 .bk-root .noUi-horizontal .noUi-handle {
     border: none;
-    width: 12px;
-    height: 12px;
+    width: 13px;
+    height: 13px;
     background: var(--neutral-foreground-rest);
     border-radius: calc(var(--corner-radius) * 1px);
     box-shadow: none;
@@ -1523,7 +1526,7 @@ input[type=range]::-moz-range-track {
 }
 .bk-root .noUi-vertical {
   margin-top: 15px;
-  width: calc(var(--track-width) * 1px);
+  width: calc(var(--track-width) * 2px);
   background-color: var(--neutral-outline-rest);
   border-radius: calc(var(--corner-radius) * 1px);
 }
@@ -1532,8 +1535,8 @@ input[type=range]::-moz-range-track {
 }
 .bk-root .noUi-vertical .noUi-handle {
     border: none;
-    width: 12px;
-    height: 12px;
+    width: 13px;
+    height: 13px;
     background: var(--neutral-foreground-rest);
     border-radius: calc(var(--corner-radius) * 1px);
     box-shadow: none;


### PR DESCRIPTION
Fixes #3003

You can verify via

```python
import panel as pn
import panel.widgets as pnw

horizontal = pnw.FloatSlider(name='Horizontal', value=0, step=0.05, start=0, end=1)
vertical = pnw.FloatSlider(name='Vertical', value=0, step=0.05, start=0, end=1, orientation='vertical')

template = pn.template.FastListTemplate(
    title="FastListTemplate",
    main=[horizontal, vertical]).servable()
```

![image](https://user-images.githubusercontent.com/42288570/147448623-0db8f9fb-17af-43b5-a807-36a5dea9cb60.png)
