### PR TITLE
Updates for Python 3.10 deprecations

### DIFF
--- a/panel/pane/holoviews.py
+++ b/panel/pane/holoviews.py
@@ -5,7 +5,7 @@ objects and their widgets and support for Links
 import sys
 
 from collections import OrderedDict, defaultdict
-from distutils.version import LooseVersion
+from packaging.version import Version
 from functools import partial
 
 import param
@@ -303,7 +303,7 @@ class HoloViews(PaneBase):
                 renderer = renderer.instance(**params)
 
         kwargs = {'margin': self.margin}
-        if backend == 'bokeh' or LooseVersion(str(hv.__version__)) >= str('1.13.0'):
+        if backend == 'bokeh' or Version(str(hv.__version__)) >= Version('1.13.0'):
             kwargs['doc'] = doc
             kwargs['root'] = root
             if comm:

--- a/panel/param.py
+++ b/panel/param.py
@@ -8,7 +8,8 @@ import json
 import os
 import types
 
-from collections import OrderedDict, defaultdict, namedtuple, Callable
+from collections.abc import Callable
+from collections import OrderedDict, defaultdict, namedtuple
 from contextlib import contextmanager
 from functools import partial
 

--- a/panel/tests/pane/test_vega.py
+++ b/panel/tests/pane/test_vega.py
@@ -1,10 +1,10 @@
-from distutils.version import LooseVersion
+from packaging.version import Version
 
 import pytest
 
 try:
     import altair as alt
-    altair_version = LooseVersion(alt.__version__)
+    altair_version = Version(alt.__version__)
 except Exception:
     alt = None
 
@@ -216,7 +216,7 @@ def test_altair_pane(document, comm):
     assert isinstance(model, VegaPlot)
 
     expected = dict(vega_example, data={})
-    if altair_version >= '4.0.0':
+    if altair_version >= Version('4.0.0'):
         expected['config'] = vega4_config
     assert dict(model.data, **blank_schema) == dict(expected, **blank_schema)
 
@@ -229,7 +229,7 @@ def test_altair_pane(document, comm):
     chart.data.values[0]['x'] = 'C'
     pane.object = chart
     point_example = dict(vega_example, mark='point')
-    if altair_version >= '4.0.0':
+    if altair_version >= Version('4.0.0'):
         point_example['config'] = vega4_config
     assert dict(model.data, **blank_schema) == dict(point_example, **blank_schema)
     cds_data = model.data_sources['data'].data

--- a/panel/tests/test_pipeline.py
+++ b/panel/tests/test_pipeline.py
@@ -1,4 +1,4 @@
-from distutils.version import LooseVersion
+from packaging.version import Version
 
 import pytest
 import param
@@ -9,7 +9,7 @@ from panel.param import ParamMethod
 from panel.pipeline import Pipeline, find_route
 from panel.widgets import Button, Select
 
-if LooseVersion(param.__version__) < '1.8.2':
+if Version(param.__version__) < Version('1.8.2'):
     pytestmark = pytest.mark.skip("skipping if param version < 1.8.2", allow_module_level=True)
 
 try:

--- a/panel/tests/test_template.py
+++ b/panel/tests/test_template.py
@@ -1,8 +1,7 @@
 """
 These that verify Templates are working correctly.
 """
-from distutils.version import LooseVersion
-from panel.layout.grid import GridSpec
+from packaging.version import Version
 
 try:
     import holoviews as hv
@@ -12,10 +11,11 @@ except Exception:
 import param
 import pytest
 
-latest_param = pytest.mark.skipif(LooseVersion(param.__version__) < '1.10.0a4',
+latest_param = pytest.mark.skipif(Version(param.__version__) < Version('1.10.0a4'),
                                   reason="requires param>=1.10.0a4")
 
-from panel.layout import Row
+
+from panel.layout import GridSpec, Row
 from panel.pane import HoloViews, Markdown
 from panel.template import (
     BootstrapTemplate, GoldenTemplate, MaterialTemplate, ReactTemplate,

--- a/panel/tests/util.py
+++ b/panel/tests/util.py
@@ -1,14 +1,15 @@
-from distutils.version import LooseVersion
+from packaging.version import Version
 
 import numpy as np
 import pytest
 
 try:
     import holoviews as hv
-    hv_version = LooseVersion(hv.__version__)
+    hv_version = Version(hv.__version__)
 except Exception:
     hv, hv_version = None, None
-hv_available = pytest.mark.skipif(hv is None or hv_version < '1.13.0a23', reason="requires holoviews")
+hv_available = pytest.mark.skipif(hv is None or hv_version < Version('1.13.0a23'),
+                                  reason="requires holoviews")
 
 try:
     import matplotlib as mpl

--- a/panel/tests/widgets/test_tables.py
+++ b/panel/tests/widgets/test_tables.py
@@ -1,7 +1,7 @@
 import datetime as dt
 import pytest
 
-from distutils.version import LooseVersion
+from packaging.version import Version
 
 import numpy as np
 
@@ -24,8 +24,8 @@ from panel.models.tabulator import TableEditEvent
 from panel.widgets import Button, TextInput
 from panel.widgets.tables import DataFrame, Tabulator
 
-pd_old = pytest.mark.skipif(LooseVersion(pd.__version__) < '1.3',
-                          reason="Requires latest pandas")
+pd_old = pytest.mark.skipif(Version(pd.__version__) < Version('1.3'),
+                            reason="Requires latest pandas")
 
 
 def test_dataframe_widget(dataframe, document, comm):

--- a/panel/util.py
+++ b/panel/util.py
@@ -16,10 +16,10 @@ from collections.abc import MutableSequence, MutableMapping
 from collections import defaultdict, OrderedDict
 from contextlib import contextmanager
 from datetime import datetime
-from distutils.version import LooseVersion
 from functools import partial
 from html import escape # noqa
 from importlib import import_module
+from packaging.version import Version
 
 import bokeh
 import param
@@ -27,7 +27,7 @@ import numpy as np
 
 datetime_types = (np.datetime64, dt.datetime, dt.date)
 
-bokeh_version = LooseVersion(bokeh.__version__)
+bokeh_version = Version(bokeh.__version__)
 
 
 def isfile(path):


### PR DESCRIPTION
- `from collections import Callable` -> `from collections.abc import Callable`
- `from distutils.version import LooseVersion` -> `from packaging.version import Version`