### PR TITLE
Respect the default filename set by `download_menu`

### DIFF
--- a/panel/widgets/tables.py
+++ b/panel/widgets/tables.py
@@ -1470,22 +1470,20 @@ class Tabulator(BaseTable):
         button: Button
             The Button that triggers a download.
         """
-        button_kwargs = dict(button_kwargs)
-        if 'name' not in button_kwargs:
-            button_kwargs['name'] = 'Download'
-        button = Button(**button_kwargs)
-        button.js_on_click({'table': self}, code="""
-        table.download = !table.download
-        """)
-
         text_kwargs = dict(text_kwargs)
         if 'name' not in text_kwargs:
             text_kwargs['name'] = 'Filename'
         if 'value' not in text_kwargs:
             text_kwargs['value'] = 'table.csv'
         filename = TextInput(**text_kwargs)
-        filename.jscallback({'table': self}, value="""
-        table.filename = cb_obj.value
+
+        button_kwargs = dict(button_kwargs)
+        if 'name' not in button_kwargs:
+            button_kwargs['name'] = 'Download'
+        button = Button(**button_kwargs)
+        button.js_on_click({'table': self, 'filename': filename}, code="""
+        table.filename = filename.value
+        table.download = !table.download
         """)
         return filename, button
 


### PR DESCRIPTION
Fixes https://github.com/holoviz/panel/issues/3060

The JS callback set on the TextInput widget wasn't being initially triggered so the Tabulator `filename` property still had its original default value (`'table.csv`). I found no way to either trigger the JS callback or set the `filename` Tabulator property (it's not exposed to Panel users, it's just a property of the model). Instead I've removed that JS callback entirely and have set `filename` in the button JS callback.