### PR TITLE
Update remaining bokeh property definitions

### DIFF
--- a/panel/models/progress.ts
+++ b/panel/models/progress.ts
@@ -97,12 +97,12 @@ export class Progress extends HTMLBox {
 
   static init_Progress(): void {
     this.prototype.default_view = ProgressView
-    this.define<Progress.Props>({
-      active:    [ p.Boolean, true ],
-      bar_color: [ p.String, 'primary' ],
-      style:     [ p.Any, {} ],
-      max:       [ p.Number, 100 ],
-      value:     [ p.Any, null ],
-    })
+    this.define<Progress.Props>(({Any, Boolean, Number, String}) => ({
+      active:    [ Boolean, true ],
+      bar_color: [ String, 'primary' ],
+      style:     [ Any, {} ],
+      max:       [ Number, 100 ],
+      value:     [ Any, null ],
+    }))
   }
 }

--- a/panel/models/speech_to_text.ts
+++ b/panel/models/speech_to_text.ts
@@ -212,25 +212,25 @@ export class SpeechToText extends HTMLBox {
   static init_SpeechToText(): void {
     this.prototype.default_view = SpeechToTextView
 
-    this.define<SpeechToText.Props>({
-      start: [ p.Boolean, false   ],
-      stop: [ p.Boolean, false   ],
-      abort: [ p.Boolean, false   ],
-      grammars: [p.Array, []],
-      lang: [p.String, ""],
-      continuous: [ p.Boolean,   false ],
-      interim_results: [ p.Boolean,   false ],
-      max_alternatives: [ p.Number,   1 ],
-      service_uri: [p.String, ],
-      started: [ p.Boolean,   false ],
-      audio_started: [ p.Boolean,   false ],
-      sound_started: [ p.Boolean,   false ],
-      speech_started: [ p.Boolean,   false ],
-      button_type: [p.String, 'light'],
-      button_hide: [ p.Boolean,   false ],
-      button_not_started: [ p.String,   '' ],
-      button_started: [ p.String,   '' ],
-      results: [ p.Array, []],
-    })
+    this.define<SpeechToText.Props>(({Array, Boolean, Number, String}) => ({
+      start: [ Boolean, false   ],
+      stop: [ Boolean, false   ],
+      abort: [ Boolean, false   ],
+      grammars: [Array(String), []],
+      lang: [String, ""],
+      continuous: [ Boolean,   false ],
+      interim_results: [ Boolean,   false ],
+      max_alternatives: [ Number,   1 ],
+      service_uri: [String, ],
+      started: [ Boolean,   false ],
+      audio_started: [ Boolean,   false ],
+      sound_started: [ Boolean,   false ],
+      speech_started: [ Boolean,   false ],
+      button_type: [String, 'light'],
+      button_hide: [ Boolean,   false ],
+      button_not_started: [ String,   '' ],
+      button_started: [ String,   '' ],
+      results: [ Array(String), []],
+    }))
   }
 }

--- a/panel/models/vtk/vtkaxes.ts
+++ b/panel/models/vtk/vtkaxes.ts
@@ -38,17 +38,17 @@ export class VTKAxes extends Model {
   static __module__ = "panel.models.vtk"
 
   static init_VTKAxes(): void {
-    this.define<VTKAxes.Props>({
-      origin: [p.Array],
-      xticker: [p.Instance],
-      yticker: [p.Instance],
-      zticker: [p.Instance],
-      digits: [p.Number, 1],
-      show_grid: [p.Boolean, true],
-      grid_opacity: [p.Number, 0.1],
-      axes_opacity: [p.Number, 1],
-      fontsize: [p.Number, 12],
-    })
+    this.define<VTKAxes.Props>(({Any, Array, Boolean, Number}) => ({
+      origin: [Array(Number)],
+      xticker: [Any],
+      yticker: [Any],
+      zticker: [Any],
+      digits: [Number, 1],
+      show_grid: [Boolean, true],
+      grid_opacity: [Number, 0.1],
+      axes_opacity: [Number, 1],
+      fontsize: [Number, 12]
+    }))
   }
 
   get xticks(): number[] {


### PR DESCRIPTION
Starting in bokeh 3.0 the old property definitions will no longer be supported.