### PR TITLE
Allow onload callbacks to be threaded

### DIFF
--- a/panel/command/serve.py
+++ b/panel/command/serve.py
@@ -292,6 +292,11 @@ class Serve(_BkServe):
             state.publish('session_info', state, ['session_info'])
 
         if args.num_threads is not None:
+            if config.nthreads is not None:
+                raise ValueError(
+                    "Supply num_threads either using the environment variable "
+                    "PANEL_NUM_THREADS or as an explicit argument, not both."
+                )
             config.nthreads = args.num_threads
 
         if args.oauth_provider:

--- a/panel/config.py
+++ b/panel/config.py
@@ -322,7 +322,7 @@ class _config(_base_config):
 
     @property
     def comms(self):
-        return os.environ.get('PANEL_COMMS', _config._comms)
+        return os.environ.get('PANEL_COMMS', self._comms)
 
     @property
     def embed_json(self):
@@ -356,47 +356,47 @@ class _config(_base_config):
 
     @property
     def oauth_provider(self):
-        provider = os.environ.get('PANEL_OAUTH_PROVIDER', _config._oauth_provider)
+        provider = os.environ.get('PANEL_OAUTH_PROVIDER', self._oauth_provider)
         return provider.lower() if provider else None
 
     @property
     def oauth_expiry(self):
-        provider = os.environ.get('PANEL_OAUTH_EXPIRY', _config._oauth_expiry)
+        provider = os.environ.get('PANEL_OAUTH_EXPIRY', self._oauth_expiry)
         return float(provider)
 
     @property
     def oauth_key(self):
-        return os.environ.get('PANEL_OAUTH_KEY', _config._oauth_key)
+        return os.environ.get('PANEL_OAUTH_KEY', self._oauth_key)
 
     @property
     def cookie_secret(self):
         return os.environ.get(
             'PANEL_COOKIE_SECRET',
-            os.environ.get('BOKEH_COOKIE_SECRET', _config._cookie_secret)
+            os.environ.get('BOKEH_COOKIE_SECRET', self._cookie_secret)
         )
 
     @property
     def oauth_secret(self):
-        return os.environ.get('PANEL_OAUTH_SECRET', _config._oauth_secret)
+        return os.environ.get('PANEL_OAUTH_SECRET', self._oauth_secret)
 
     @property
     def oauth_redirect_uri(self):
-        return os.environ.get('PANEL_OAUTH_REDIRECT_URI', _config._oauth_redirect_uri)
+        return os.environ.get('PANEL_OAUTH_REDIRECT_URI', self._oauth_redirect_uri)
 
     @property
     def oauth_jwt_user(self):
-        return os.environ.get('PANEL_OAUTH_JWT_USER', _config._oauth_jwt_user)
+        return os.environ.get('PANEL_OAUTH_JWT_USER', self._oauth_jwt_user)
 
     @property
     def oauth_encryption_key(self):
-        return os.environ.get('PANEL_OAUTH_ENCRYPTION', _config._oauth_encryption_key)
+        return os.environ.get('PANEL_OAUTH_ENCRYPTION', self._oauth_encryption_key)
 
     @property
     def oauth_extra_params(self):
         if 'PANEL_OAUTH_EXTRA_PARAMS' in os.environ:
             return ast.literal_eval(os.environ['PANEL_OAUTH_EXTRA_PARAMS'])
         else:
-            return _config._oauth_extra_params
+            return self._oauth_extra_params
 
 
 if hasattr(_config.param, 'objects'):

--- a/panel/config.py
+++ b/panel/config.py
@@ -351,7 +351,8 @@ class _config(_base_config):
 
     @property
     def nthreads(self):
-        return int(os.environ.get('PANEL_NUM_THREADS', self._nthreads))
+        nthreads = os.environ.get('PANEL_NUM_THREADS', self._nthreads)
+        return None if nthreads is None else int(nthreads) 
 
     @property
     def oauth_provider(self):

--- a/panel/config.py
+++ b/panel/config.py
@@ -126,13 +126,10 @@ class _config(_base_config):
     theme = param.ObjectSelector(default='default', objects=['default', 'dark'], doc="""
         The theme to apply to the selected global template.""")
 
-    nthreads = param.Integer(default=None, doc="""
-        When set to a non-None value a thread pool will be started.
-        Whenever an event arrives from the frontend it will be
-        dispatched to the thread pool to be processed.""")
-
     throttled = param.Boolean(default=False, doc="""
         If sliders and inputs should be throttled until release of mouse.""")
+
+    _admin = param.Boolean(default=False, doc="Whether the admin panel was enabled.")
 
     _comms = param.ObjectSelector(
         default='default', objects=['default', 'ipywidgets', 'vscode', 'colab'], doc="""
@@ -167,6 +164,11 @@ class _config(_base_config):
         default='WARNING', objects=['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'],
         doc="Log level of Panel loggers")
 
+    _nthreads = param.Integer(default=None, doc="""
+        When set to a non-None value a thread pool will be started.
+        Whenever an event arrives from the frontend it will be
+        dispatched to the thread pool to be processed.""")
+
     _oauth_provider = param.ObjectSelector(
         default=None, allow_None=True, objects=[], doc="""
         Select between a list of authentification providers.""")
@@ -196,7 +198,12 @@ class _config(_base_config):
         Whether to inline JS and CSS resources. If disabled, resources
         are loaded from CDN if one is available.""")
 
-    _admin = param.Boolean(default=False, doc="Whether the admin panel was enabled.")
+    _globals = [
+        'autoreload', 'comms', 'cookie_secret', 'nthreads',
+        'oauth_provider', 'oauth_expiry', 'oauth_key', 'oauth_secret',
+        'oauth_jwt_user', 'oauth_redirect_uri','oauth_encryption_key',
+        'oauth_extra_params'
+    ]
 
     _truthy = ['True', 'true', '1', True, 1]
 
@@ -206,12 +213,12 @@ class _config(_base_config):
         super().__init__(**params)
         self._validating = False
         for p in self.param:
-            if p.startswith('_'):
+            if p.startswith('_') and p[1:] not in self._globals:
                 setattr(self, p+'_', None)
         if self.log_level:
             panel_log_handler.setLevel(self.log_level)
 
-    @param.depends('nthreads', watch=True)
+    @param.depends('_nthreads', watch=True, on_init=True)
     def _set_thread_pool(self):
         from .io.state import state
         if self.nthreads is None:
@@ -227,7 +234,10 @@ class _config(_base_config):
     @contextmanager
     def set(self, **kwargs):
         values = [(k, v) for k, v in self.param.values().items() if k != 'name']
-        overrides = [(k, getattr(self, k+'_')) for k in self.param if k.startswith('_')]
+        overrides = [
+            (k, getattr(self, k+'_')) for k in self.param
+            if k.startswith('_') and k[1:] not in self._globals
+        ]
         for k, v in kwargs.items():
             setattr(self, k, v)
         try:
@@ -242,7 +252,9 @@ class _config(_base_config):
         if not getattr(self, 'initialized', False) or (attr.startswith('_') and attr.endswith('_')) or attr == '_validating':
             return super().__setattr__(attr, value)
         value = getattr(self, f'_{attr}_hook', lambda x: x)(value)
-        if state.curdoc is not None:
+        if attr in self._globals:
+            super().__setattr__(attr if attr in self.param else f'_{attr}', value)
+        elif state.curdoc is not None:
             if attr in self.param:
                 validate_config(self, attr, value)
             elif f'_{attr}' in self.param:
@@ -265,6 +277,7 @@ class _config(_base_config):
     def __getattribute__(self, attr):
         from .io.state import state
         init = super().__getattribute__('initialized')
+        global_params = super().__getattribute__('_globals')
         if init and not attr.startswith('__'):
             params = super().__getattribute__('param')
         else:
@@ -276,7 +289,9 @@ class _config(_base_config):
             state.curdoc and attr not in session_config[state.curdoc]):
             new_obj = copy.copy(super().__getattribute__(attr))
             setattr(self, attr, new_obj)
-        if state.curdoc and state.curdoc in session_config and attr in session_config[state.curdoc]:
+        if attr in global_params:
+            return super().__getattribute__(attr)
+        elif state.curdoc and state.curdoc in session_config and attr in session_config[state.curdoc]:
             return session_config[state.curdoc][attr]
         elif f'_{attr}' in params and getattr(self, f'_{attr}_') is not None:
             return super().__getattribute__(f'_{attr}_')
@@ -333,6 +348,10 @@ class _config(_base_config):
     def log_level(self):
         log_level = os.environ.get('PANEL_LOG_LEVEL', self._log_level)
         return log_level.upper() if log_level else None
+
+    @property
+    def nthreads(self):
+        return int(os.environ.get('PANEL_NUM_THREADS', self._nthreads))
 
     @property
     def oauth_provider(self):

--- a/panel/io/server.py
+++ b/panel/io/server.py
@@ -53,7 +53,7 @@ from .logging import LOG_SESSION_CREATED, LOG_SESSION_DESTROYED, LOG_SESSION_LAU
 from .profile import profile_ctx
 from .reload import autoreload_watcher
 from .resources import BASE_TEMPLATE, Resources, bundle_resources
-from .state import state
+from .state import set_curdoc, state
 
 logger = logging.getLogger(__name__)
 
@@ -417,12 +417,6 @@ def init_doc(doc):
     doc.on_event('document_ready', state._init_session)
     return doc
 
-@contextmanager
-def set_curdoc(doc):
-    orig_doc = state._curdoc
-    state.curdoc = doc
-    yield
-    state.curdoc = orig_doc
 
 def with_lock(func):
     """

--- a/panel/io/state.py
+++ b/panel/io/state.py
@@ -192,8 +192,8 @@ class _state(param.Parameterized):
         return link
 
     def _schedule_on_load(self, event):
-        if state._thread_pool:
-            state._thread_pool.submit(self._on_load, self.curdoc)
+        if self._thread_pool:
+            self._thread_pool.submit(self._on_load, self.curdoc)
         else:
             self._on_load()
 
@@ -342,7 +342,10 @@ class _state(param.Parameterized):
         Callback that is triggered when a session has been served.
         """
         if self.curdoc is None:
-            callback()
+            if self._thread_pool:
+                self._thread_pool.submit(callback)
+            else:
+                callback()
             return
         if self.curdoc not in self._onload:
             self._onload[self.curdoc] = []


### PR DESCRIPTION
This allows `pn.state.onload` callbacks to take advantage of the threading support that was recently added.