### PR TITLE
Expose the `orientation` parameter of the button group widgets

### DIFF
--- a/examples/reference/widgets/CheckButtonGroup.ipynb
+++ b/examples/reference/widgets/CheckButtonGroup.ipynb
@@ -32,6 +32,7 @@
     "* **``button_type``** (str): A button theme should be one of ``'default'`` (white), ``'primary'`` (blue), ``'success'`` (green), ``'info'`` (yellow), or ``'danger'`` (red)\n",
     "* **``disabled``** (boolean): Whether the widget is editable\n",
     "* **``name``** (str): The title of the widget\n",
+    "* **``orientation``** (str, default='horizontal'): Button group orientation, either 'horizontal' or 'vertical'\n",
     "\n",
     "___"
    ]

--- a/examples/reference/widgets/RadioButtonGroup.ipynb
+++ b/examples/reference/widgets/RadioButtonGroup.ipynb
@@ -32,6 +32,7 @@
     "* **``button_type``** (str): A button theme should be one of ``'default'`` (white), ``'primary'`` (blue), ``'success'`` (green), ``'info'`` (yellow), or ``'danger'`` (red)\n",
     "* **``disabled``** (boolean): Whether the widget is editable\n",
     "* **``name``** (str): The title of the widget\n",
+    "* **``orientation``** (str, default='horizontal'): Button group orientation, either 'horizontal' or 'vertical'.\n",
     "\n",
     "\n",
     "___"

--- a/panel/widgets/select.py
+++ b/panel/widgets/select.py
@@ -377,6 +377,10 @@ class _RadioGroupBase(SingleSelectBase):
 
 class RadioButtonGroup(_RadioGroupBase, _ButtonBase):
 
+    orientation = param.Selector(default='horizontal',
+        objects=['horizontal', 'vertical'], doc="""
+        Button group orientation, either 'horizontal' (default) or 'vertical'.""")
+
     _widget_type = _BkRadioButtonGroup
 
     _supports_embed = True
@@ -434,6 +438,10 @@ class _CheckGroupBase(SingleSelectBase):
 
 
 class CheckButtonGroup(_CheckGroupBase, _ButtonBase):
+
+    orientation = param.Selector(default='horizontal',
+        objects=['horizontal', 'vertical'], doc="""
+        Button group orientation, either 'horizontal' (default) or 'vertical'.""")
 
     _widget_type = _BkCheckboxButtonGroup
 


### PR DESCRIPTION
This PR simply exposes a Bokeh property not exposed by Panel.

![image](https://user-images.githubusercontent.com/35924738/148699641-a1b2da1d-8fe1-4575-80e3-649f2b9c2c4f.png)

Is the CSS of some templates to adapt for this kind of change or is this good to go?
