### PR TITLE
Use https instead of the git:// protocol to clone in GHA

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -73,7 +73,7 @@ jobs:
       - name: windows_opengl
         if: contains(matrix.os, 'windows')
         run: |
-          git clone --depth 1 git://github.com/pyvista/gl-ci-helpers.git
+          git clone --depth 1 https://github.com/pyvista/gl-ci-helpers.git
           powershell gl-ci-helpers/appveyor/install_opengl.ps1
       - name: doit env_capture
         run: |


### PR DESCRIPTION
Github has [improved its Git protocol security](https://github.blog/2021-09-01-improving-git-protocol-security-github/) which means that usage of `git://` has been disabled. This broke the CI on Windows.