### PR TITLE
Implement Notifications API for templates

### DIFF
--- a/panel/template/base.py
+++ b/panel/template/base.py
@@ -21,6 +21,7 @@ from pyviz_comms import JupyterCommManager as _JupyterCommManager
 from ..config import _base_config, config, panel_extension
 from ..io.model import add_to_doc
 from ..io.notebook import render_template
+from ..io.notifications import NotificationArea
 from ..io.resources import CDN_DIST, LOCAL_DIST, BUNDLE_DIR
 from ..io.save import save
 from ..io.state import state
@@ -372,6 +373,10 @@ class BasicTemplate(BaseTemplate):
         The maximum width of the main area. For example '800px' or '80%'.
         If the string is '' (default) no max width is set.""")
 
+    notifications = param.ClassSelector(default=NotificationArea(),
+        class_=NotificationArea, constant=True, doc="""
+        A Notifications instance which allows displaying toasts inside the template.""")
+
     sidebar = param.ClassSelector(class_=ListLike, constant=True, doc="""
         A list-like container which populates the sidebar.""")
 
@@ -489,10 +494,12 @@ class BasicTemplate(BaseTemplate):
             params['favicon'] = str(params['favicon'])
         super().__init__(template=template, **params)
         self._js_area = HTML(margin=0, width=0, height=0)
-        if '{{ embed(roots.js_area) }}' in template:
+        if 'embed(roots.js_area)' in template:
             self._render_items['js_area'] = (self._js_area, [])
-        if '{{ embed(roots.actions) }}' in template:
+        if 'embed(roots.actions)' in template:
             self._render_items['actions'] = (self._actions, [])
+        if 'embed(roots.notifications)' in template:
+            self._render_items['notifications'] = (self.notifications, [])
         self._update_busy()
         self.main.param.watch(self._update_render_items, ['objects'])
         self.modal.param.watch(self._update_render_items, ['objects'])

--- a/panel/template/bootstrap/__init__.py
+++ b/panel/template/bootstrap/__init__.py
@@ -5,15 +5,55 @@ import pathlib
 
 import param
 
+from ...io.notifications import Notification, NotificationArea
 from ...layout import Card
+from ...reactive import ReactiveHTML
 from ..base import BasicTemplate
 from ..theme import DarkTheme, DefaultTheme
+
+
+class BootstrapNotification(Notification, ReactiveHTML):
+
+    _template = """
+    <div id="toast" class="toast">
+      <div class="toast-header">
+      ${header}
+      <button type="button" class="ml-2 mb-1 close" data-dismiss="toast" aria-label="Close">
+        <span aria-hidden="true">×</span>
+      </button>
+      </div>
+      <div class="toast-body">
+      ${body}
+      </div>
+    </div>
+    """
+
+    _scripts = {
+        'render': """
+      $(toast).toast({autohide: data.autohide, delay: data.duration})
+      $(toast).toast("show")
+      $(toast).on("hidden.bs.toast", function () {
+        data._destroyed = true;
+      })
+    """,
+        '_destroyed': """
+      $(toast).toast("dispose")
+    """}
+
+
+class BootstrapNotificationArea(NotificationArea):
+
+    _notification_type = BootstrapNotification
 
 
 class BootstrapTemplate(BasicTemplate):
     """
     BootstrapTemplate
     """
+
+    notifications = param.ClassSelector(default=BootstrapNotificationArea(),
+                                        class_=NotificationArea)
+
     sidebar_width = param.Integer(350, doc="""
         The width of the sidebar in pixels. Default is 350.""")
 
@@ -35,7 +75,7 @@ class BootstrapTemplate(BasicTemplate):
         },
         'js': {
             'jquery': "https://code.jquery.com/jquery-3.5.1.slim.min.js",
-            'bootstrap': "https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/js/bootstrap.min.js",
+            'bootstrap': "https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/js/bootstrap.min.js"
         }
     }
 

--- a/panel/template/bootstrap/bootstrap.html
+++ b/panel/template/bootstrap/bootstrap.html
@@ -120,6 +120,9 @@
       </div>
     </div>
   </div>
+  <div id="pn-notifications-area">
+  {{ embed(roots.notifications) }}
+  </div>
 </div>
 
 <script>

--- a/panel/template/fast/base.py
+++ b/panel/template/fast/base.py
@@ -2,6 +2,7 @@ import pathlib
 
 import param
 
+from ...io.notifications import ToastedNotificationArea, NotificationArea
 from ...io.state import state
 from ..base import BasicTemplate
 from ..react import ReactTemplate
@@ -49,6 +50,10 @@ class FastBaseTemplate(BasicTemplate):
     main_layout = param.Selector(default="card", label="Layout", objects=["", "card"], doc="""
         What to wrap the main components into. Options are '' (i.e. none) and 'card' (Default).
         Could be extended to Accordion, Tab etc. in the future.""")
+
+
+    notifications = param.ClassSelector(default=ToastedNotificationArea(),
+                                        class_=NotificationArea)
 
     _css = [
         _ROOT / "css/fast_root.css",

--- a/panel/template/fast/list/fast_list_template.html
+++ b/panel/template/fast/list/fast_list_template.html
@@ -347,5 +347,6 @@
 {{ embed(roots.js_area) }}
 {{ embed(roots.actions) }}
 {{ embed(roots.location) }}
+{{ embed(roots.notifications) }}
 
 {% endblock %}

--- a/panel/template/material/__init__.py
+++ b/panel/template/material/__init__.py
@@ -7,10 +7,49 @@ import param
 
 from bokeh.themes import Theme as _BkTheme
 
+from ...io.notifications import NotificationArea, Notification
 from ...layout import Card
+from ...reactive import ReactiveHTML
 from ..base import BasicTemplate, TemplateActions
 from ..theme import DefaultTheme, DarkTheme
 
+
+class MaterialNotification(Notification, ReactiveHTML):
+
+    _template = """
+    <aside id="toast" class="mdc-snackbar {% if position: left %}mdc-snackbar--leading{% endif %}">
+      <div class="mdc-snackbar__surface" role="status" aria-relevant="additions">
+        <div class="mdc-snackbar__label" aria-atomic="false">
+        ${body}
+        </div>
+        <div class="mdc-snackbar__actions" aria-atomic="true">
+          <button type="button" class="mdc-button mdc-snackbar__dismiss">
+            <div class="mdc-button__ripple"></div>
+            <span class="mdc-button__label">×</span>
+          </button>
+        </div>
+      </div>
+    </aside>
+    """
+
+    _scripts = {
+        'render': """
+          state.toast = new mdc.snackbar.MDCSnackbar(toast);
+          state.toast.timeoutMs = data.autohide ? data.duration : -1;
+          state.toast.listen('MDCSnackbar:closed', function () {
+            data._destroyed = true;
+          });
+          state.toast.open();
+        """,
+        'destroyed': """
+          state.toast.destroy()
+        """
+    }
+
+
+class MaterialNotificationArea(NotificationArea):
+
+    _notification_type = MaterialNotification
 
 
 class MaterialTemplateActions(TemplateActions):
@@ -24,11 +63,14 @@ class MaterialTemplateActions(TemplateActions):
     }
 
 
-
 class MaterialTemplate(BasicTemplate):
     """
     MaterialTemplate is built on top of Material web components.
     """
+
+    notifications = param.ClassSelector(default=MaterialNotificationArea(),
+                                        class_=NotificationArea)
+
     sidebar_width = param.Integer(370, doc="""
         The width of the sidebar in pixels. Default is 370.""")
 

--- a/panel/template/material/material.html
+++ b/panel/template/material/material.html
@@ -131,6 +131,10 @@
   </div>
 </div>
 
+<div id="pn-notifications-area">
+{{ embed(roots.notifications) }}
+</div>
+
 <script>
   {% if nav %}
   var drawer = mdc.drawer.MDCDrawer.attachTo(document.querySelector('.mdc-drawer'));


### PR DESCRIPTION
Adds `Template.notifications` which provides an API to display notifications/toasts on the frontend. Each template can provide its own `NotificationArea` implementation based on whatever CSS/JS framework you want. Currently we ship three `NotificationArea` implementations:

1. `BootstrapNotificationArea` builds on Bootstrap's [built-in support for toasts](https://getbootstrap.com/docs/4.3/components/toasts/)
2. `MaterialNotificationArea` builds on the Material component [built-in "snackbar" support](https://material.io/components/snackbars/web)
3. `ToastedNotificationArea` builds on [toasted.js](https://github.com/shakee93/toastedjs) a very light-weight toast implementation

## Implementation

The Bootstrap and Material implementations both rely on adding `Notification` instances as children of the `NotificationArea` while the `Toasted` implementation simply creates a bokeh `DataModel` which is linked to the notification via callbacks in JS.

## API

Currently I envision the following API:

- `NotificationArea.send(body: str, header=None: str, duration=3000: int, autohide=True: boolean): Notification`: Displays a notification and returns a Notification instance
- `NotificationArea.position = 'left' | 'right'`: Controls whether to display notification on bottom-left or bottom-right
- `NotificationArea.clear()`: Clears all notifications
- `Notification.destroy()`: Destroys the notification

## Styling

Of course styling depends a little bit on the specific implementation however most support some variation of `type`: 'info' | 'warning' | 'error' borrowing on the bootstrap API. So at minimum this is what I would expose.

## Demo

![notifications](https://user-images.githubusercontent.com/1550771/149000959-29012f27-8a53-4aff-923e-525343ced130.gif)

## ToDo

- [ ] Finalize API after feedback
- [ ] Decide on styling API
- [ ] Add docs
- [ ] Add tests
