### PR TITLE
Downgrade Tabulator to 4.9.3

### DIFF
--- a/examples/reference/widgets/Tabulator.ipynb
+++ b/examples/reference/widgets/Tabulator.ipynb
@@ -1050,7 +1050,7 @@
    "source": [
     "stream_df = pd.DataFrame(np.random.randn(10, 5), columns=list('ABCDE'))\n",
     "\n",
-    "stream_table = pn.widgets.Tabulator(stream_df, layout='fit_columns', width=450)\n",
+    "stream_table = pn.widgets.Tabulator(stream_df, layout='fit_columns', width=450, height=400)\n",
     "stream_table"
    ]
   },

--- a/panel/models/tabulator.py
+++ b/panel/models/tabulator.py
@@ -15,10 +15,10 @@ from bokeh.models.widgets.tables import TableColumn
 from ..io.resources import bundled_files
 from ..util import classproperty
 
-JS_SRC = "https://unpkg.com/tabulator-tables@5.0.10/dist/js/tabulator.js"
+JS_SRC = "https://unpkg.com/tabulator-tables@4.9.3/dist/js/tabulator.js"
 MOMENT_SRC = "https://cdn.jsdelivr.net/npm/luxon/build/global/luxon.min.js"
 
-THEME_PATH = "tabulator-tables@5.0.10/dist/css/"
+THEME_PATH = "tabulator-tables@4.9.3/dist/css/"
 THEME_URL = f"https://unpkg.com/{THEME_PATH}"
 PANEL_CDN = f'https://cdn.jsdelivr.net/npm/@holoviz/panel/dist/bundled/{THEME_PATH}'
 TABULATOR_THEMES = [
@@ -36,9 +36,16 @@ class TableEditEvent(ModelEvent):
         self.value = value
         super().__init__(model=model)
 
-
 def _get_theme_url(url, theme):
-    if 'fast' in theme:
+    if 'bootstrap' in theme:
+        url += 'bootstrap/'
+    elif 'materialize' in theme:
+        url += 'materialize/'
+    elif 'semantic-ui' in theme:
+        url += 'semantic-ui/'
+    elif 'bulma' in theme:
+        url += 'bulma/'
+    elif 'fast' in theme:
         if url.startswith(THEME_URL):
             url = url.replace(THEME_URL, PANEL_CDN)
         url += 'fast/'


### PR DESCRIPTION
The upgrade to 5.0.x was premature since at least as of right now the performance is **significantly** worse.

Hopefully these issues will eventually be addressed and we'll be able to upgrade again.