### PR TITLE
add document argument to django.py autoload_js_script call

### DIFF
--- a/panel/io/django.py
+++ b/panel/io/django.py
@@ -34,7 +34,7 @@ async def autoload_handle(self, body):
         server_url = None
 
     resources = self.resources(server_url)
-    js = autoload_js_script(resources, session.token, element_id, app_path, absolute_url)
+    js = autoload_js_script(session.document, resources, session.token, element_id, app_path, absolute_url)
 
     headers = [
         (b"Access-Control-Allow-Headers", b"*"),


### PR DESCRIPTION
adds missing argument in call to `autoload_js_script`

fixes #3099