### PR TITLE
Implement Tabulator buttons

### DIFF
--- a/examples/reference/widgets/Tabulator.ipynb
+++ b/examples/reference/widgets/Tabulator.ipynb
@@ -11,7 +11,7 @@
     "import pandas as pd\n",
     "import panel as pn\n",
     "\n",
-    "pn.extension('tabulator')"
+    "pn.extension('tabulator', css_files=[pn.io.resources.CSS_URLS['font-awesome']])"
    ]
   },
   {
@@ -29,6 +29,7 @@
     "##### Core\n",
     "\n",
     "* **``aggregators``** (``dict``): A dictionary mapping from index name to an aggregator to be used for `hierarchical` multi-indexes (valid aggregators include 'min', 'max', 'mean' and 'sum'). If separate aggregators for different columns are required the dictionary may be nested as `{index_name: {column_name: aggregator}}`\n",
+    "* **``buttons``** (``dict``): A dictionary of buttons to add to the table mapping from column name to the HTML contents of the button cell, e.g. `{'print': '<i class=\"fa fa-print\"></i>'}`. Buttons are added after all data columns.\n",
     "* **``configuration``** (``dict``): A dictionary mapping used to specify tabulator options not explicitly exposed by panel.\n",
     "* **``editors``** (``dict``):  A dictionary mapping from column name to a bokeh `CellEditor` instance or tabulator editor specification.\n",
     "* **``embed_content``** (``boolean``): Whether to embed the `row_content` or to dynamically fetch it when a row is expanded.\n",
@@ -105,7 +106,7 @@
     "    'datetime': [dt.datetime(2019, 1, 1, 10), dt.datetime(2020, 1, 1, 12), dt.datetime(2020, 1, 10, 13)]\n",
     "}, index=[1, 2, 3])\n",
     "\n",
-    "df_widget = pn.widgets.Tabulator(df)\n",
+    "df_widget = pn.widgets.Tabulator(df, buttons={'Print': \"<i class='fa fa-print'></i>\"})\n",
     "df_widget"
    ]
   },
@@ -1031,6 +1032,32 @@
     "    pn.Column(filename, button),\n",
     "    download_table\n",
     ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Buttons\n",
+    "\n",
+    "If you want to trigger custom actions by clicking on a table cell you may declare a set of `buttons` that are rendered in columns after all the data columns. To respond to button clicks you can register a callback using the `on_button_click` method:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "button_table = pn.widgets.Tabulator(df, buttons={'print': '<i class=\"fa fa-print\"></i>'})\n",
+    "\n",
+    "string = pn.widgets.StaticText()\n",
+    "\n",
+    "button_table.on_button_click(\n",
+    "    'print', lambda e: string.param.update(value=f'Clicked {e.column!r} on row {e.row}')\n",
+    ")\n",
+    "\n",
+    "pn.Row(button_table, string)"
    ]
   },
   {

--- a/examples/reference/widgets/Tabulator.ipynb
+++ b/examples/reference/widgets/Tabulator.ipynb
@@ -1049,12 +1049,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "button_table = pn.widgets.Tabulator(df, buttons={'print': '<i class=\"fa fa-print\"></i>'})\n",
+    "button_table = pn.widgets.Tabulator(df, buttons={\n",
+    "    'print': '<i class=\"fa fa-print\"></i>',\n",
+    "    'check': '<i class=\"fa fa-check\"></i>'\n",
+    "})\n",
     "\n",
     "string = pn.widgets.StaticText()\n",
     "\n",
     "button_table.on_button_click(\n",
-    "    'print', lambda e: string.param.update(value=f'Clicked {e.column!r} on row {e.row}')\n",
+    "    lambda e: string.param.update(value=f'Clicked {e.column!r} on row {e.row}')\n",
     ")\n",
     "\n",
     "pn.Row(button_table, string)"

--- a/panel/models/tabulator.py
+++ b/panel/models/tabulator.py
@@ -36,6 +36,17 @@ class TableEditEvent(ModelEvent):
         self.value = value
         super().__init__(model=model)
 
+
+class CellClickEvent(ModelEvent):
+
+    event_name = 'cell-click'
+
+    def __init__(self, model, column, row):
+        self.column = column
+        self.row = row
+        super().__init__(model=model)
+
+
 def _get_theme_url(url, theme):
     if 'bootstrap' in theme:
         url += 'bootstrap/'
@@ -67,6 +78,8 @@ class DataTabulator(HTMLBox):
     """
 
     aggregators = Dict(String, String)
+
+    buttons = Dict(String, String)
 
     configuration = Dict(String, Any)
 

--- a/panel/models/tabulator.ts
+++ b/panel/models/tabulator.ts
@@ -26,6 +26,18 @@ export class TableEditEvent extends ModelEvent {
   }
 }
 
+export class CellClickEvent extends ModelEvent {
+  event_name: string = "cell-click"
+
+  constructor(readonly column: string, readonly row: number) {
+    super()
+  }
+
+  protected _to_json(): JSON {
+    return {model: this.origin, column: this.column, row: this.row}
+  }
+}
+
 declare const Tabulator: any;
 
 function find_group(key: any, value: string, records: any[]): any {
@@ -702,6 +714,21 @@ export class DataTabulatorView extends PanelHTMLBoxView {
       if (config_columns == null)
         columns.push(tab_column)
     }
+    for (const col in this.model.buttons) {
+      const button_formatter = () => {
+	return this.model.buttons[col];
+      };
+      const button_column = {
+	formatter: button_formatter,
+	width: 40,
+	hozAlign: "center",
+	cellClick: (_: any, cell: any) => {
+	  const index = cell._cell.row.data._index;
+	  this.model.trigger_event(new CellClickEvent(col, index))
+	}
+      }
+      columns.push(button_column)
+    }
     return columns
   }
 
@@ -991,6 +1018,7 @@ export namespace DataTabulator {
   export type Attrs = p.AttrsOf<Props>
   export type Props = HTMLBox.Props & {
     aggregators: p.Property<any>
+    buttons: p.Property<any>
     children: p.Property<any>
     columns: p.Property<TableColumn[]>
     configuration: p.Property<any>
@@ -1036,6 +1064,7 @@ export class DataTabulator extends HTMLBox {
 
     this.define<DataTabulator.Props>(({Any, Array, Boolean, Nullable, Number, Ref, String}) => ({
       aggregators:    [ Any,                     {} ],
+      buttons:        [ Any,                     {} ],
       children:       [ Any,                     {} ],
       configuration:  [ Any,                     {} ],
       columns:        [ Array(Ref(TableColumn)), [] ],

--- a/panel/widgets/tables.py
+++ b/panel/widgets/tables.py
@@ -948,7 +948,9 @@ class Tabulator(BaseTable):
             for cb in self._on_edit_callbacks:
                 cb(event)
         else:
-            for cb in self._on_click_callbacks[event.column]:
+            for cb in self._on_click_callbacks.get(None, []):
+                cb(event)
+            for cb in self._on_click_callbacks.get(event.column, []):
                 cb(event)
 
     def _get_theme(self, theme, resources=None):
@@ -1513,7 +1515,7 @@ class Tabulator(BaseTable):
         """
         self._on_edit_callbacks.append(callback)
 
-    def on_button_click(self, column, callback):
+    def on_button_click(self, callback, column=None):
         """
         Register a callback to be executed when a cell corresponding
         to a column declared in the `buttons` parameter is clicked.
@@ -1522,11 +1524,11 @@ class Tabulator(BaseTable):
 
         Arguments
         ---------
-        column: (str)
-            The column to respond to clicks on (must be declared in
-             `buttons` parameter).
         callback: (callable)
             The callback to run on edit events.
+        column: (str)
+            Optional argument restricting the callback to a specific
+            column.
         """
         if column not in self._on_click_callbacks:
             self._on_click_callbacks[column] = []


### PR DESCRIPTION
If you want to trigger custom actions by clicking on a table cell you may declare a set of `buttons` that are rendered in columns after all the data columns. To respond to button clicks you can register a callback using the `on_button_click` method:

![button_click](https://user-images.githubusercontent.com/1550771/149945046-642b95a6-be3e-48e6-aeaa-f9b9f7995ee0.gif)

