### PR TITLE
Revert "Ensure CachedVariadicBox only caches layout for finite height and width"

### DIFF
--- a/panel/models/layout.ts
+++ b/panel/models/layout.ts
@@ -73,7 +73,7 @@ export class CachedVariadicBox extends VariadicBox {
     const min_count = (!this.changed || (this.sizing_mode == 'fixed') || (this.sizing_mode == null)) ? 0 : 1;
     const cached = this._cache.get(key_str);
     const cache_count = this._cache_count.get(key_str)
-    if (cached != null && cache_count != null && (cache_count >= min_count) && (isFinite(viewport.width)) && (isFinite(viewport.height))) {
+    if (cached != null && cache_count != null && (cache_count >= min_count)) {
       this._cache_count.set(key_str, cache_count + 1);
       return cached
     }


### PR DESCRIPTION
Reverts holoviz/panel#3024

Sadly have to revert, while this fix is correct it is having severe consequences for some production applications which we cannot easily work around.