### PR TITLE
Adds template_kwargs to config

### DIFF
--- a/panel/config.py
+++ b/panel/config.py
@@ -126,6 +126,9 @@ class _config(_base_config):
     template = param.ObjectSelector(default=None, doc="""
         The default template to render served applications into.""")
 
+    template_kwargs = param.Dict(default={}, instantiate=True, doc="""
+        A dictionary of arguments to apply to the template specified.""")
+
     theme = param.ObjectSelector(default='default', objects=['default', 'dark'], doc="""
         The theme to apply to the selected global template.""")
 

--- a/panel/io/state.py
+++ b/panel/io/state.py
@@ -500,7 +500,7 @@ class _state(param.Parameterized):
             return self._templates[self.curdoc]
         elif self.curdoc is None and self._template:
             return self._template
-        template = config.template(theme=config.theme)
+        template = config.template(theme=config.theme, **config.template_kwargs)
         if self.curdoc is None:
             self._template = template
         else:

--- a/panel/tests/io/test_state.py
+++ b/panel/tests/io/test_state.py
@@ -1,4 +1,5 @@
 from panel.io.state import state
+import panel as pn
 
 
 def test_as_cached_key_only():
@@ -31,3 +32,15 @@ def test_as_cached_key_and_kwarg():
     assert state.as_cached('test', test_fn, a=1) == 1
     assert state.as_cached('test', test_fn, a=2) == 2
     state.cache.clear()
+
+def test_config_template_kwargs_are_applied():
+    template_kwargs=dict(header_background="blue")
+    pn.config.template="fast"
+    pn.config.template_kwargs=template_kwargs
+    assert pn.state.template.header_background=="blue"
+
+def test_extension_template_kwargs_are_applied():
+    template_kwargs=dict(header_background="blue")
+    pn.extension(template="fast", template_kwargs=template_kwargs)
+    assert pn.config.template_kwargs==template_kwargs
+    assert pn.state.template.header_background=="blue"


### PR DESCRIPTION
Addresses https://github.com/holoviz/panel/issues/3086

Makes it easy to configure the template.

```python
import panel as pn

pn.extension(sizing_mode="stretch_width", template="fast", template_kwargs=dict(header_background="red"))

pn.panel("hello").servable()
```

![image](https://user-images.githubusercontent.com/42288570/150286106-4d695eed-15fc-44c4-bab2-a1c6ddc4ea40.png)

Without this you would have to do something like 

```python
import panel as pn

pn.extension(sizing_mode="stretch_width", template="fast")
pn.state.template.header_background = "red"
# ...

pn.panel("hello").servable()
```

which is not very concise if you want to set many attributes.

I could not find a natural place to document this @philippjfr . I would be happy to update some docs if you could point out where. You are welcome to consider whether you want this PR. I can live with setting attributes of `pn.state.template`. But this api would be "nice to have". Thanks.