### PR TITLE
FIX #3121: align-items missing from flexbox render template

### DIFF
--- a/panel/layout/flexbox.html
+++ b/panel/layout/flexbox.html
@@ -1,4 +1,4 @@
-<div id="flexbox" style="display: flex; flex-wrap: ${flex_wrap}; justify-content: ${justify_content}; flex-direction: ${flex_direction}; align-content: ${align_content}; height: 100%;">
+<div id="flexbox" style="display: flex; flex-wrap: ${flex_wrap}; justify-content: ${justify_content}; flex-direction: ${flex_direction}; align-content: ${align_content}; align-items: ${align_items}; height: 100%;">
   {% for obj in objects %}
   <div id="flex-item-{{ loop.index0 }}">
     ${objects[{{ loop.index0 }}]}


### PR DESCRIPTION
See Issue #3121