### PR TITLE
Expose save_png in save

### DIFF
--- a/panel/io/save.py
+++ b/panel/io/save.py
@@ -98,7 +98,7 @@ def save_png(model, filename, resources=CDN, template=None, template_variables=N
         if img.width == 0 or img.height == 0:
             raise ValueError("unable to save an empty image")
 
-        img.save(filename)
+        img.save(filename, format="png")
     except Exception:
         raise
     finally:
@@ -148,7 +148,8 @@ def file_html(models, resources, title=None, template=BASE_TEMPLATE,
 def save(panel, filename, title=None, resources=None, template=None,
          template_variables=None, embed=False, max_states=1000,
          max_opts=3, embed_json=False, json_prefix='', save_path='./',
-         load_path=None, progress=True, embed_states={}, **kwargs):
+         load_path=None, progress=True, embed_states={}, as_png=None,
+         **kwargs):
     """
     Saves Panel objects to file.
 
@@ -184,6 +185,9 @@ def save(panel, filename, title=None, resources=None, template=None,
       Whether to report progress
     embed_states: dict (default={})
       A dictionary specifying the widget values to embed for each widget
+    save_png: boolean (default=None)
+        To save as a .png. If None save_png will be true if filename is
+        string and ends with png.
     """
     from ..pane import PaneBase
     from ..template import BaseTemplate
@@ -191,7 +195,8 @@ def save(panel, filename, title=None, resources=None, template=None,
     if isinstance(panel, PaneBase) and len(panel.layout) > 1:
         panel = panel.layout
 
-    as_png = isinstance(filename, str) and filename.endswith('png')
+    if as_png is None:
+        as_png = isinstance(filename, str) and filename.endswith('png')
 
     if isinstance(panel, Document):
         doc = panel

--- a/panel/viewable.py
+++ b/panel/viewable.py
@@ -733,7 +733,8 @@ class Viewable(Renderable, Layoutable, ServableMixin):
     def save(self, filename, title=None, resources=None, template=None,
              template_variables=None, embed=False, max_states=1000,
              max_opts=3, embed_json=False, json_prefix='', save_path='./',
-             load_path=None, progress=True, embed_states={}, **kwargs):
+             load_path=None, progress=True, embed_states={}, as_png=None,
+             **kwargs):
         """
         Saves Panel objects to file.
 
@@ -767,11 +768,14 @@ class Viewable(Renderable, Layoutable, ServableMixin):
           Whether to report progress
         embed_states: dict (default={})
           A dictionary specifying the widget values to embed for each widget
+        save_png: boolean (default=None)
+          To save as a .png. If None save_png will be true if filename is
+          string and ends with png.
         """
         return save(self, filename, title, resources, template,
                     template_variables, embed, max_states, max_opts,
                     embed_json, json_prefix, save_path, load_path,
-                    progress, embed_states, **kwargs)
+                    progress, embed_states, as_png, **kwargs)
 
     def server_doc(self, doc=None, title=None, location=True):
         """


### PR DESCRIPTION
Fixes #3005 

https://user-images.githubusercontent.com/19758978/151700567-3a338759-4d8a-4064-a5a3-a1bcf5e7e448.mp4
<details>
  <summary> Code </summary>

``` python
from io import BytesIO

import hvplot.pandas
import panel as pn
import pandas as pd
import param

pn.extension(sizing_mode="stretch_width")
ACCENT_COLOR = "#0072B5"


class Explorer(param.Parameterized):
    df = pd.DataFrame({"y": range(10)})

    def __init__(self, **params):
        super().__init__(**params)
        self.plot = pn.Column(
            self.df.hvplot().opts(color=ACCENT_COLOR, line_width=6, responsive=True),
            self.df.hvplot().opts(color=ACCENT_COLOR, line_width=6, responsive=True),
        )
        self.save_to_png = pn.widgets.FileDownload(
            filename="timeseries.png",
            label="Download .png",
            button_type="primary",
            callback=self.download_column,
        )

    def download_column(self):
        self.save_to_png.loading = True

        b = BytesIO()
        self.plot.save(b, as_png=True)
        b.seek(0)

        self.save_to_png.loading = False
        return b


explorer = Explorer()

pn.template.FastListTemplate(
    site="Awesome Panel",
    title="Application with .png download",
    sidebar=[explorer.save_to_png],
    main=[explorer.plot],
    accent_base_color=ACCENT_COLOR,
    header_background=ACCENT_COLOR,
).servable()
```

</details>

I don't know if this should also be made available for saving the template, right here: 
https://github.com/holoviz/panel/blob/5bd9fc8187bb3a663d29ce6ff200d88b72991123/panel/template/base.py#L247-L249

I have observed that sometimes the saved plot is cropped, but I don't think this is related to the changes in the PR.
**Cropped**
![cropped](https://user-images.githubusercontent.com/19758978/151701049-8eb6abf0-64a7-4df8-a5d0-37b536a43aea.png)

**Not cropped**
![not cropped](https://user-images.githubusercontent.com/19758978/151701062-484b1a61-c0e1-4672-9ee8-cf300d08d8b2.png)



