### PR TITLE
Added reactive and viewable to init

### DIFF
--- a/panel/__init__.py
+++ b/panel/__init__.py
@@ -3,6 +3,8 @@ from . import links # noqa
 from . import pane # noqa
 from . import param # noqa
 from . import pipeline # noqa
+from . import reactive # noqa
+from . import viewable # noqa
 from . import widgets # noqa
 
 from .config import config, panel_extension as extension, __version__ # noqa


### PR DESCRIPTION
Fixes #3135

I wanted to add all missing files to `__init__` but got `ImportError: cannot import name 'panel_extension' from partially initialized module 'panel.config' (most likely due to a circular import) (/home/shh/Development/holoviz/panel/panel/config.py)`or similar. So settled with adding the files for the two import I miss the most `pn.viewable.Viewer` and `pn.reactive.ReactiveHTML`. 

I used this code to be able to find missing imports:
``` python
import re
from pathlib import Path

def find_missing_import(file):
    file = Path(file)
    matches = re.findall(r"\w+", file.read_text())

    missing = []
    for f in sorted(file.parent.glob("*.py")):
        f = f.name[:-3]
        if f[0] != "_" and f not in matches:
            missing.append(f)

    return missing


files = Path("panel").rglob("__init__.py")
for file in files:
    if "tests" in str(file):
        continue
    
    missing = find_missing_import(file)
    if missing: 
        print(file, "->", ", ".join(missing))
```
Which outputs:
``` 
panel/__init__.py -> auth, compiler, util
panel/template/fast/__init__.py -> base, theme
panel/layout/__init__.py -> gridstack
panel/pane/vtk/__init__.py -> enums, synchronizable_deserializer, synchronizable_serializer
panel/io/__init__.py -> admin, datamodel, jupyter_server_extension, location, notifications, reload, rest, save
panel/models/__init__.py -> ace, comm_manager, deckgl, echarts, enums, katex, mathjax, perspective, plotly, quill, speech_to_text, tabulator, terminal, text_to_speech, vega, vtk
```