### PR TITLE
ReactiveHTML should not invalidate layout of non-initialized roots

### DIFF
--- a/panel/models/reactive_html.ts
+++ b/panel/models/reactive_html.ts
@@ -309,7 +309,7 @@ export class ReactiveHTMLView extends PanelHTMLBoxView {
   invalidate_layout(): void {
     if (this._parent != null)
       this._parent.invalidate_layout()
-    if (this.root != this)
+    if (this.root != this && this.root.has_finished())
       super.invalidate_layout()
   }
 


### PR DESCRIPTION
Previously ReactiveHTML would in some cases invalidate the layout of a root that was not yet done initializing which would cause errors because you cannot compute sizes of child views that have not yet been rendered. This is a particular issue for `pn.Tabs` which compute their sizes for each tab separately. We therefore do not invalidate the layout unless the root is finished rendering.