### PR TITLE
Support jupyter server root_dir with lab extension

### DIFF
--- a/panel/io/jupyter_server_extension.py
+++ b/panel/io/jupyter_server_extension.py
@@ -1,6 +1,7 @@
 from urllib.parse import urljoin
 
 import tornado
+import os
 
 from bokeh.command.util import build_single_handler_application
 from bokeh.embed.bundle import extension_dirs
@@ -65,6 +66,17 @@ class ServerApplicationProxy:
     def __init__(self, app, **kw):
         self._app = app
 
+    @property
+    def root_dir(self):
+        """
+        Gets the root directory of the jupyter server app
+
+        This is useful as the path sent received by the handler
+        may be different from the root dir.
+        Reference: https://github.com/holoviz/panel/issues/3170
+        """
+        return self._app.settings['server_root_dir']
+
     def __getattr__(self, key):
         return getattr(self._app, key)
 
@@ -81,6 +93,7 @@ class PanelHandler(DocHandler):
         pass
 
     async def get(self, path, *args, **kwargs):
+        path = os.path.join(self.application.root_dir, path)
         if path in _APPS:
             app, context = _APPS[path]
         else:
@@ -122,6 +135,7 @@ class PanelWSHandler(WSHandler):
         pass
 
     async def open(self, path, *args, **kwargs):
+        path = os.path.join(self.application.root_dir, path)
         _, context = _APPS[path]
 
         token = self._token


### PR DESCRIPTION
Jupyter sends path relative to the root_dir which can be different from the cwd. This commit fixes the lab extension for panel preview to account for root_dir.

Reference: #3170