### PR TITLE
Allow none value on numeric sliders and LiteralInput

### DIFF
--- a/panel/param.py
+++ b/panel/param.py
@@ -472,7 +472,6 @@ class Param(PaneBase):
         if isinstance(widget_class, Widget):
             widget = widget_class
         else:
-            print(kwargs, widget_class, p_obj.allow_None)
             widget = widget_class(**kwargs)
         widget._param_pane = self
         widget._param_name = p_name

--- a/panel/param.py
+++ b/panel/param.py
@@ -422,7 +422,10 @@ class Param(PaneBase):
             kw['visible'] = not p_obj.constant
 
         value = getattr(self.object, p_name)
-        if value is not None or getattr(p_obj, 'allow_None', False):
+        allow_None = p_obj.allow_None or False
+        if isinstance(widget_class, type) and issubclass(widget_class, Widget):
+            allow_None &= widget_class.param.value.allow_None
+        if value is not None or allow_None:
             kw['value'] = value
 
         if hasattr(p_obj, 'get_range'):
@@ -469,6 +472,7 @@ class Param(PaneBase):
         if isinstance(widget_class, Widget):
             widget = widget_class
         else:
+            print(kwargs, widget_class, p_obj.allow_None)
             widget = widget_class(**kwargs)
         widget._param_pane = self
         widget._param_name = p_name

--- a/panel/param.py
+++ b/panel/param.py
@@ -422,7 +422,7 @@ class Param(PaneBase):
             kw['visible'] = not p_obj.constant
 
         value = getattr(self.object, p_name)
-        if value is not None:
+        if value is not None or getattr(p_obj, 'allow_None', False):
             kw['value'] = value
 
         if hasattr(p_obj, 'get_range'):

--- a/panel/tests/test_param.py
+++ b/panel/tests/test_param.py
@@ -419,6 +419,16 @@ def test_object_selector_param_overrides(document, comm):
     assert select.disabled == False
 
 
+def test_number_input_none_support():
+    class Test(param.Parameterized) :
+        number = param.Number(default=0, allow_None=True)
+        none = param.Number(default=None, allow_None=True)
+
+    test_widget = Param(Test())
+    assert test_widget[1].value == 0
+    assert test_widget[2].value is None
+
+
 def test_explicit_params(document, comm):
     class Test(param.Parameterized):
         a = param.Boolean(default=False)

--- a/panel/widgets/input.py
+++ b/panel/widgets/input.py
@@ -999,11 +999,6 @@ class Checkbox(Widget):
 
     _widget_type: ClassVar[Type[Model]] = _BkCheckboxGroup
 
-    def __init__(self, **params):
-        if params.get('value') is None:
-            params['value'] = False
-        super().__init__(**params)
-
     def _process_property_change(self, msg):
         msg = super()._process_property_change(msg)
         if 'value' in msg:

--- a/panel/widgets/input.py
+++ b/panel/widgets/input.py
@@ -638,6 +638,9 @@ class LiteralInput(Widget):
     >>> LiteralInput(name='Dictionary', value={'key': [1, 2, 3]}, type=dict)
     """
 
+    placeholder = param.String(default='', doc="""
+      Placeholder for empty input field.""")
+
     serializer = param.ObjectSelector(default='ast', objects=['ast', 'json'], doc="""
        The serialization (and deserialization) method to use. 'ast'
        uses ast.literal_eval and 'json' uses json.loads and json.dumps.
@@ -685,7 +688,9 @@ class LiteralInput(Widget):
         if 'value' in msg:
             value = msg.pop('value')
             try:
-                if self.serializer == 'json':
+                if value == '':
+                    value = ''
+                elif self.serializer == 'json':
                     value = json.loads(value)
                 else:
                     value = ast.literal_eval(value)
@@ -703,7 +708,9 @@ class LiteralInput(Widget):
                             pass
                         else:
                             break
-                    if typed_value is None and value is not None:
+                    if typed_value is None and value == '':
+                        value = None
+                    elif typed_value is None and value is not None:
                         new_state = ' (wrong type)'
                         value = self.value
                     else:

--- a/panel/widgets/input.py
+++ b/panel/widgets/input.py
@@ -999,6 +999,11 @@ class Checkbox(Widget):
 
     _widget_type: ClassVar[Type[Model]] = _BkCheckboxGroup
 
+    def __init__(self, **params):
+        if params.get('value') is None:
+            params['value'] = False
+        super().__init__(**params)
+
     def _process_property_change(self, msg):
         msg = super()._process_property_change(msg)
         if 'value' in msg:

--- a/panel/widgets/input.py
+++ b/panel/widgets/input.py
@@ -524,7 +524,7 @@ class _SpinnerBase(_NumericInputBase):
     __abstract = True
 
     def __init__(self, **params):
-        if params.get('value') is None:
+        if 'value' not in params:
             value = params.get('start', self.value)
             if value is not None:
                 params['value'] = value

--- a/panel/widgets/slider.py
+++ b/panel/widgets/slider.py
@@ -105,7 +105,7 @@ class ContinuousSlider(_SliderBase):
     __abstract = True
 
     def __init__(self, **params):
-        if 'value' not in params:
+        if params.get('value') is None:
             params['value'] = params.get('start', self.start)
         super().__init__(**params)
 

--- a/panel/widgets/slider.py
+++ b/panel/widgets/slider.py
@@ -105,7 +105,7 @@ class ContinuousSlider(_SliderBase):
     __abstract = True
 
     def __init__(self, **params):
-        if params.get('value') is None:
+        if 'value' not in params:
             params['value'] = params.get('start', self.start)
         super().__init__(**params)
 
@@ -156,21 +156,19 @@ class FloatSlider(ContinuousSlider):
     >>> FloatSlider(value=0.5, start=0.0, end=1.0, step=0.1, name="Float value")
     """
 
-    value = param.Number(default=0.0, doc="""
-        The selected floating-point value of the slider. Updated when the handle is dragged.
-        """)
+    start = param.Number(default=0.0, doc="The lower bound.")
+
+    end = param.Number(default=1.0, doc="The upper bound.")
+
+    step = param.Number(default=0.1, doc="The step size.")
+
+    value = param.Number(default=0.0, allow_None=True, doc="""
+        The selected floating-point value of the slider. Updated when
+        the handle is dragged."""
+    )
 
     value_throttled = param.Number(default=None, constant=True, doc="""
          The value of the slider. Updated when the handle is released.""")
-
-    start = param.Number(default=0.0, doc="""
-        The lower bound.""")
-
-    end = param.Number(default=1.0, doc="""
-        The upper bound.""")
-
-    step = param.Number(default=0.1, doc="""
-        The step size.""")
 
     _rename: ClassVar[Mapping[str, str | None]] = {'name': 'title'}
 
@@ -187,9 +185,6 @@ class IntSlider(ContinuousSlider):
     >>> IntSlider(value=5, start=0, end=10, step=1, name="Integer Value")
     """
 
-    value = param.Integer(default=0, doc="""
-        The selected integer value of the slider. Updated when the handle is dragged.""")
-
     start = param.Integer(default=0, doc="""
         The lower bound.""")
 
@@ -198,6 +193,9 @@ class IntSlider(ContinuousSlider):
 
     step = param.Integer(default=1, doc="""
         The step size.""")
+
+    value = param.Integer(default=0, allow_None=True, doc="""
+        The selected integer value of the slider. Updated when the handle is dragged.""")
 
     value_throttled = param.Integer(default=None, constant=True, doc="""
         The value of the slider. Updated when the handle is released""")

--- a/panel/widgets/slider.py
+++ b/panel/widgets/slider.py
@@ -498,7 +498,7 @@ class DiscreteSlider(CompositeWidget, _SliderBase):
 
 class _RangeSliderBase(_SliderBase):
 
-    value = param.Tuple(length=2, doc="""
+    value = param.Tuple(length=2, allow_None=False, doc="""
         The selected range of the slider. Updated when a handle is dragged.""")
 
     value_start = param.Parameter(readonly=True, doc="""The lower value of the selected range.""")
@@ -509,9 +509,11 @@ class _RangeSliderBase(_SliderBase):
 
     def __init__(self, **params):
         if 'value' not in params:
-            params['value'] = (params.get('start', self.start),
-                               params.get('end', self.end))
-        params['value_start'], params['value_end'] = params['value']
+            params['value'] = (
+                params.get('start', self.start), params.get('end', self.end)
+            )
+        if params['value'] is not None:
+            params['value_start'], params['value_end'] = params['value']
         with edit_readonly(self):
             super().__init__(**params)
 
@@ -544,7 +546,7 @@ class RangeSlider(_RangeSliderBase):
     ... )
     """
 
-    value = param.Range(default=(0, 1), doc=
+    value = param.Range(default=(0, 1), allow_None=False, doc=
         """The selected range as a tuple of values. Updated when a handle is
         dragged.""")
 
@@ -636,7 +638,7 @@ class DateRangeSlider(_SliderBase):
     ... )
     """
 
-    value = param.DateRange(default=None, doc="""
+    value = param.DateRange(default=None, allow_None=False, doc="""
         The selected range as a tuple of values. Updated when one of the handles is
         dragged. Supports datetime.datetime, datetime.date, and np.datetime64 ranges.""")
 
@@ -932,7 +934,8 @@ class EditableRangeSlider(CompositeWidget, _SliderBase):
     ... )
     """
 
-    value = param.Range(default=(0, 1), doc="Current range value. Updated when a handle is dragged")
+    value = param.Range(default=(0, 1), allow_None=False, doc="""
+        Current range value. Updated when a handle is dragged.""")
 
     value_throttled = param.Range(default=None, constant=True, doc="""
         The value of the slider. Updated when the handle is released.""")


### PR DESCRIPTION
```python
import param
import panel as pn


class Test(param.Parameterized) :
    number = param.Number(default=0, allow_None=True)
    none = param.Number(default=None, allow_None=True)

    def view(self):
        return self.number, self.none


t = Test()
pn.Column(t, t.view).servable()
```

Supersedes https://github.com/holoviz/panel/pull/1837
Fixes #1836
Fixes https://github.com/holoviz/panel/issues/581