### PR TITLE
Redesign Tabulator styles handling

### DIFF
--- a/panel/models/tabulator.py
+++ b/panel/models/tabulator.py
@@ -113,7 +113,7 @@ class DataTabulator(HTMLBox):
 
     source = Instance(ColumnDataSource)
 
-    styles = Dict(Int, Dict(Int, List(Either(String, Tuple(String, String)))))
+    styles = Dict(String, Either(String, Dict(Int, Dict(Int, List(Either(String, Tuple(String, String)))))))
 
     pagination = Nullable(String)
 

--- a/panel/models/tabulator.ts
+++ b/panel/models/tabulator.ts
@@ -233,8 +233,6 @@ export class DataTabulatorView extends PanelHTMLBoxView {
   _updating_page: boolean = true
   _relayouting: boolean = false
   _selection_updating: boolean =false
-  _styled_cells: any[] = []
-  _styles: any = null
   _initializing: boolean
 
   connect_signals(): void {
@@ -259,11 +257,7 @@ export class DataTabulatorView extends PanelHTMLBoxView {
       }
     })
 
-    this.connect(this.model.properties.styles.change, () => {
-      this._styles = this.model.styles
-      this.setStyles()
-    })
-
+    this.connect(this.model.properties.styles.change, () => this.setStyles())
     this.connect(this.model.properties.hidden_columns.change, () => this.setHidden())
     this.connect(this.model.properties.page_size.change, () => this.setPageSize())
     this.connect(this.model.properties.page.change, () => {
@@ -297,9 +291,8 @@ export class DataTabulatorView extends PanelHTMLBoxView {
 
   after_layout(): void {
     super.after_layout()
-    if (this.tabulator != null && (!this._relayouting || this._initializing)) {
+    if (this.tabulator != null && (!this._relayouting || this._initializing))
       this.redraw()
-    }
   }
 
   render(): void {
@@ -308,8 +301,6 @@ export class DataTabulatorView extends PanelHTMLBoxView {
     if (wait)
       return
     this._initializing = true
-    if (this._styles == null)
-      this._styles = this.model.styles
     const container = div({class: "pnx-tabulator"})
     set_size(container, this.model)
     let configuration = this.getConfiguration()
@@ -335,7 +326,7 @@ export class DataTabulatorView extends PanelHTMLBoxView {
     } else
       this.setFrozen()
 
-    this.el.appendChild(container);
+    this.el.appendChild(container)
   }
 
   /*
@@ -807,6 +798,7 @@ export class DataTabulatorView extends PanelHTMLBoxView {
 
     let data = transform_cds_to_records(this.model.source, true)
     this.tabulator.setData(data)
+    console.log('update')
     this.postUpdate()
   }
 
@@ -876,13 +868,10 @@ export class DataTabulatorView extends PanelHTMLBoxView {
   }
 
   setStyles(): void {
-    for (const cell_el of this._styled_cells)
-      cell_el.cssText = ""
-    this._styled_cells = []
-    if (this._styles == null || this.tabulator == null || this.tabulator.getDataCount() == 0)
+    if (this.tabulator == null || this.tabulator.getDataCount() == 0)
       return
-    for (const r in this._styles) {
-      const row_style = this._styles[r]
+    for (const r in this.model.styles.data) {
+      const row_style = this.model.styles.data[r]
       const row = this.tabulator.getRow(r)
       if (!row)
         continue
@@ -893,8 +882,6 @@ export class DataTabulatorView extends PanelHTMLBoxView {
         if (cell == null || !style.length)
           continue
         const element = cell.element
-        this._styled_cells.push(element)
-        element.cssText = ""
         for (const s of style) {
           let prop, value
           if (isArray(s))
@@ -907,9 +894,6 @@ export class DataTabulatorView extends PanelHTMLBoxView {
         }
       }
     }
-    const styles = this._styles
-    this.model.styles = {}
-    this._styles = styles
   }
 
   setHidden(): void {

--- a/panel/tests/widgets/test_tables.py
+++ b/panel/tests/widgets/test_tables.py
@@ -644,7 +644,7 @@ def test_tabulator_styling(document, comm):
 
     model = table.get_root(document, comm)
 
-    assert model.styles == {
+    assert model.styles['data'] == {
         0: {1: [('color', 'black')]},
         1: {1: [('color', 'black')]},
         2: {1: [('color', 'black')]},

--- a/panel/widgets/tables.py
+++ b/panel/widgets/tables.py
@@ -1,4 +1,5 @@
 import datetime as dt
+import uuid
 
 from functools import partial
 from types import FunctionType, MethodType
@@ -783,7 +784,7 @@ class DataFrame(BaseTable):
         props['fit_columns'] = self.fit_columns
         if 'autosize_mode' in DataTable.properties():
             props['frozen_columns'] = self.frozen_columns
-            props['frozen_rows'] = self.frozen_rows
+            props['frozen_rows'] = self.frozen_bows
             props['autosize_mode'] = self.autosize_mode
             props['auto_edit'] = self.auto_edit
         props['row_height'] = self.row_height
@@ -1067,7 +1068,7 @@ class Tabulator(BaseTable):
             if r not in styles:
                 styles[int(r)] = {}
             styles[int(r)][offset+int(c)] = s
-        return styles
+        return {'id': uuid.uuid4().hex, 'data': styles}
 
     def _get_selectable(self):
         if self.value is None or self.selectable_rows is None:

--- a/panel/widgets/tables.py
+++ b/panel/widgets/tables.py
@@ -784,7 +784,7 @@ class DataFrame(BaseTable):
         props['fit_columns'] = self.fit_columns
         if 'autosize_mode' in DataTable.properties():
             props['frozen_columns'] = self.frozen_columns
-            props['frozen_rows'] = self.frozen_bows
+            props['frozen_rows'] = self.frozen_rows
             props['autosize_mode'] = self.autosize_mode
             props['auto_edit'] = self.auto_edit
         props['row_height'] = self.row_height


### PR DESCRIPTION
Previously we were resetting the `styles` property on the model and keeping a local copy on the view. The problem with this is that the same model can be rendered again at a later stage and if when it was deleted the `styles` had been reset then it would render without the styles the second time. Therefore we take the simpler approach of including a random id in the styles so that even when the style hasn't changed it will still trigger updates.