### PR TITLE
Do no override param.Date and param.CalendarDate mapping

### DIFF
--- a/panel/param.py
+++ b/panel/param.py
@@ -429,11 +429,11 @@ class Param(PaneBase):
                 kw['start'] = bounds[0]
             if bounds[1] is not None:
                 kw['end'] = bounds[1]
-            if ('start' not in kw or 'end' not in kw):
+            if (('start' not in kw or 'end' not in kw) and
+                not isinstance(p_obj, (param.Date, param.CalendarDate))):
                 # Do not change widget class if mapping was overridden
                 if not widget_class_overridden:
-                    if (isinstance(p_obj, param.Number) and
-                        not isinstance(p_obj, (param.Date, param.CalendarDate))):
+                    if isinstance(p_obj, param.Number):
                         widget_class = FloatInput
                         if isinstance(p_obj, param.Integer):
                             widget_class = IntInput

--- a/panel/tests/test_param.py
+++ b/panel/tests/test_param.py
@@ -11,7 +11,10 @@ from bokeh.models import (
 from panel.pane import Pane, PaneBase, Matplotlib, Bokeh, HTML
 from panel.layout import Tabs, Row
 from panel.param import Param, ParamMethod, ParamFunction, JSONInit
-from panel.widgets import AutocompleteInput, LiteralInput, NumberInput, RangeSlider
+from panel.widgets import (
+    AutocompleteInput, DatePicker, DatetimeInput, LiteralInput,
+    NumberInput, RangeSlider
+)
 from panel.tests.util import mpl_available, mpl_figure
 
 
@@ -793,7 +796,6 @@ def test_switch_param_subobject(document, comm):
     assert subpanel._models == {}
 
 
-
 def test_expand_param_subobject_into_row(document, comm):
     class Test(param.Parameterized):
         a = param.Parameter()
@@ -921,6 +923,24 @@ def test_param_js_callbacks(document, comm):
     assert 'button_click' in callbacks
     assert len(callbacks['button_click']) == 1
     assert code in callbacks['button_click'][0].code
+
+
+def test_param_calendar_date_mapping():
+
+    class Test(param.Parameterized):
+
+        a = param.CalendarDate()
+
+    assert isinstance(Param(Test().param).layout[1], DatePicker)
+
+
+def test_param_date_mapping():
+
+    class Test(param.Parameterized):
+
+        a = param.Date()
+
+    assert isinstance(Param(Test().param).layout[1], DatetimeInput)
 
 
 class View(param.Parameterized):


### PR DESCRIPTION
Ensures param.Date and param.CalendarDate are correctly mapped to date widgets rather than `LiteralInput`.