### PR TITLE
Do not set fixed button width on Tabulator

### DIFF
--- a/panel/models/tabulator.ts
+++ b/panel/models/tabulator.ts
@@ -727,7 +727,6 @@ export class DataTabulatorView extends PanelHTMLBoxView {
       };
       const button_column = {
 	formatter: button_formatter,
-	width: 40,
 	hozAlign: "center",
 	cellClick: (_: any, cell: any) => {
 	  const index = cell._cell.row.data._index;


### PR DESCRIPTION
Buttons can be any width so we let Tabulator auto-compute the width.