### PR TITLE
Add thread safety and TTL to pn.state.as_cached

### DIFF
--- a/panel/io/state.py
+++ b/panel/io/state.py
@@ -263,7 +263,7 @@ class _state(param.Parameterized):
                 if key in self.cache:
                     ret, expiry = self.cache.get(key)
                 else:
-                    ret = _Undefined
+                    ret, expiry = _Undefined, None
                 if ret is _Undefined or (expiry is not None and expiry < time.monotonic()):
                     ret, _ = self.cache[key] = (fn(**kwargs), new_expiry)
         finally:

--- a/panel/tests/conftest.py
+++ b/panel/tests/conftest.py
@@ -168,7 +168,6 @@ def set_env_var(env_var, value):
     else:
         os.environ[env_var] = old_value
 
-
 @pytest.fixture(autouse=True)
 def server_cleanup():
     """
@@ -181,6 +180,7 @@ def server_cleanup():
         state._indicators.clear()
         state._locations.clear()
         state._curdoc = None
+        state.cache.clear()
         if state._thread_pool is not None:
             state._thread_pool.shutdown(wait=False)
             state._thread_pool = None

--- a/panel/tests/io/test_state.py
+++ b/panel/tests/io/test_state.py
@@ -6,25 +6,17 @@ from panel.io.state import state
 
 
 def test_as_cached_key_only():
-    global i
-    i = 0
-
-    def test_fn():
-        global i
-        i += 1
-        return i
+    def test_fn(i=[0]):
+        i[0] += 1
+        return i[0]
 
     assert state.as_cached('test', test_fn) == 1
     assert state.as_cached('test', test_fn) == 1
 
 def test_as_cached_key_and_kwarg():
-    global i
-    i = 0
-
-    def test_fn(a):
-        global i
-        i += 1
-        return i
+    def test_fn(a, i=[0]):
+        i[0] += 1
+        return i[0]
 
     assert state.as_cached('test', test_fn, a=1) == 1
     assert state.as_cached('test', test_fn, a=1) == 1
@@ -33,14 +25,10 @@ def test_as_cached_key_and_kwarg():
     assert state.as_cached('test', test_fn, a=2) == 2
 
 def test_as_cached_thread_locks():
-    global j
-    j = 0
-
-    def test_fn():
-        global j
-        j += 1
+    def test_fn(i=[0]):
+        i[0] += 1
         time.sleep(0.1)
-        return j
+        return i[0]
 
     results = []
     with ThreadPoolExecutor(max_workers=4) as executor:
@@ -51,14 +39,10 @@ def test_as_cached_thread_locks():
     assert len(state._cache_locks) == 1
 
 def test_as_cached_ttl():
-    global i
-    i = 0
-
-    def test_fn():
-        global i
-        i += 1
-        return i
+    def test_fn(i=[0]):
+        i[0] += 1
+        return i[0]
 
     assert state.as_cached('test', test_fn, ttl=0.1) == 1
-    time.sleep(0.1)
+    time.sleep(0.11)
     assert state.as_cached('test', test_fn, ttl=0.1) == 2

--- a/panel/tests/io/test_state.py
+++ b/panel/tests/io/test_state.py
@@ -16,7 +16,6 @@ def test_as_cached_key_only():
 
     assert state.as_cached('test', test_fn) == 1
     assert state.as_cached('test', test_fn) == 1
-    state.cache.clear()
 
 def test_as_cached_key_and_kwarg():
     global i
@@ -32,7 +31,6 @@ def test_as_cached_key_and_kwarg():
     assert state.as_cached('test', test_fn, a=2) == 2
     assert state.as_cached('test', test_fn, a=1) == 1
     assert state.as_cached('test', test_fn, a=2) == 2
-    state.cache.clear()
 
 def test_as_cached_thread_locks():
     global j
@@ -63,4 +61,4 @@ def test_as_cached_ttl():
 
     assert state.as_cached('test', test_fn, ttl=0.1) == 1
     time.sleep(0.1)
-    assert state.as_cached('test', test_fn) == 2
+    assert state.as_cached('test', test_fn, ttl=0.1) == 2

--- a/panel/tests/io/test_state.py
+++ b/panel/tests/io/test_state.py
@@ -1,3 +1,7 @@
+import time
+
+from concurrent.futures import ThreadPoolExecutor
+
 from panel.io.state import state
 
 
@@ -14,8 +18,6 @@ def test_as_cached_key_only():
     assert state.as_cached('test', test_fn) == 1
     state.cache.clear()
 
-
-
 def test_as_cached_key_and_kwarg():
     global i
     i = 0
@@ -31,3 +33,34 @@ def test_as_cached_key_and_kwarg():
     assert state.as_cached('test', test_fn, a=1) == 1
     assert state.as_cached('test', test_fn, a=2) == 2
     state.cache.clear()
+
+def test_as_cached_thread_locks():
+    global j
+    j = 0
+
+    def test_fn():
+        global j
+        j += 1
+        time.sleep(0.1)
+        return j
+
+    results = []
+    with ThreadPoolExecutor(max_workers=4) as executor:
+        for i in range(4):
+            future = executor.submit(state.as_cached, 'test', test_fn)
+            results.append(future)
+    assert [r.result() for r in results] == [1, 1, 1, 1]
+    assert len(state._cache_locks) == 1
+
+def test_as_cached_ttl():
+    global i
+    i = 0
+
+    def test_fn():
+        global i
+        i += 1
+        return i
+
+    assert state.as_cached('test', test_fn, ttl=0.1) == 1
+    time.sleep(0.1)
+    assert state.as_cached('test', test_fn) == 2


### PR DESCRIPTION
Now that we have the ability to set `--num-threads` I expect many more users will leverage threads to speed up their application. However not all functionality in Panel was written with thread-safety in mind. This PR ensures that `pn.state.as_cached` maintains thread locks for each cache key ensuring that if multiple threads are trying to access the same cache key at the same time only one of the executes the function that is being cached on.

Additionally this PR also adds a TTL (time-to-live) for cache items allowing users to declare when a cached value expires and has to be refreshed.