### PR TITLE
Fix Tabulator.on_edit events on server

### DIFF
--- a/panel/widgets/tables.py
+++ b/panel/widgets/tables.py
@@ -912,6 +912,8 @@ class Tabulator(BaseTable):
 
     _manual_params = BaseTable._manual_params + _config_params
 
+    _priority_changes = ['data']
+
     _rename = {
         'disabled': 'editable', 'selection': None, 'selectable': 'select_mode',
         'row_content': None
@@ -955,7 +957,7 @@ class Tabulator(BaseTable):
 
     def _process_event(self, event):
         if event.event_name == 'table-edit':
-            event.value = self.value[event.column].iloc[event.row]
+            event.value = self._processed[event.column].iloc[event.row]
             for cb in self._on_edit_callbacks:
                 cb(event)
         else:


### PR DESCRIPTION
This adds so called `_priority_changes` to `Syncable` objects which are change events which should not be debounced. This is important in some cases such as Tabulator where the change in the data has to be processed before the `TableEditEvent` arrives. 

Fixes https://github.com/holoviz/panel/issues/3196