### PR TITLE
Fix handling of loading_max_height

### DIFF
--- a/panel/io/resources.py
+++ b/panel/io/resources.py
@@ -90,7 +90,7 @@ def loading_css():
     return f"""
     .bk.pn-loading.{config.loading_spinner}:before {{
       background-image: url("data:image/svg+xml;base64,{b64}");
-      max-height: {config.loading_max_height}px;
+      background-size: auto calc(min(50%, {config.loading_max_height}px));
     }}
     """
 


### PR DESCRIPTION
Setting an max-height meant that the entire loading overlay had a max-height of 400px when the desired effect was to set a max-height only for the loading animation.

Fixes https://github.com/holoviz/panel/issues/3204