### PR TITLE
fix: wrong offset when memoryview format is non-byte

### DIFF
--- a/panel/io/ipywidget.py
+++ b/panel/io/ipywidget.py
@@ -28,7 +28,7 @@ class PanelSessionWebsocket(SessionWebsocket):
             offsets = [start]
 
             for buffer in buffers[:-1]:
-                start += len(buffer)
+                start += memoryview(buffer).nbytes
                 offsets.append(start)
 
             u32 = lambda n: n.to_bytes(4, "big")


### PR DESCRIPTION
the offset should be in bytes, not elements. See also https://github.com/bokeh/ipywidgets_bokeh/issues/46#issuecomment-1046292704