### PR TITLE
Make only one call to publish_display_data

### DIFF
--- a/panel/io/notebook.py
+++ b/panel/io/notebook.py
@@ -252,17 +252,19 @@ def load_notebook(inline=True, load_timeout=5000):
         else:
             settings.resources.unset_value()
 
-    publish_display_data({
-        'application/javascript': bokeh_js,
-        LOAD_MIME: bokeh_js,
-    })
-    bokeh.io.notebook.curstate().output_notebook()
-
-    # Publish comm manager
+    # CSS and JS for the comm manager
     CSS = (PANEL_DIR / '_templates' / 'jupyter.css').read_text()
     JS = '\n'.join([PYVIZ_PROXY, _JupyterCommManager.js_manager, nb_mime_js])
-    publish_display_data(data={LOAD_MIME: JS, 'application/javascript': JS})
-    publish_display_data(data={'text/html': f'<style>{CSS}</style>'})
+
+    # Call publish_display_data once to avoid displaying more than one empty
+    # line in JupyterLab.
+    merged_js = '\n'.join([bokeh_js, JS])
+    publish_display_data(data={
+        LOAD_MIME: merged_js,
+        'application/javascript': merged_js,
+        'text/html': f'<style>{CSS}</style>',
+    })
+    bokeh.io.notebook.curstate().output_notebook()
 
 
 def show_server(panel, notebook_url, port):

--- a/panel/io/notebook.py
+++ b/panel/io/notebook.py
@@ -252,19 +252,21 @@ def load_notebook(inline=True, load_timeout=5000):
         else:
             settings.resources.unset_value()
 
+    publish_display_data({
+        'application/javascript': bokeh_js,
+        LOAD_MIME: bokeh_js,
+    })
+    bokeh.io.notebook.curstate().output_notebook()
+
     # CSS and JS for the comm manager
     CSS = (PANEL_DIR / '_templates' / 'jupyter.css').read_text()
     JS = '\n'.join([PYVIZ_PROXY, _JupyterCommManager.js_manager, nb_mime_js])
 
-    # Call publish_display_data once to avoid displaying more than one empty
-    # line in JupyterLab.
-    merged_js = '\n'.join([bokeh_js, JS])
     publish_display_data(data={
-        LOAD_MIME: merged_js,
-        'application/javascript': merged_js,
+        LOAD_MIME: JS,
+        'application/javascript': JS,
         'text/html': f'<style>{CSS}</style>',
     })
-    bokeh.io.notebook.curstate().output_notebook()
 
 
 def show_server(panel, notebook_url, port):


### PR DESCRIPTION
`publish_display_data` is used to load come HTML/CSS/JS in a notebook when `pn.extension()` is called. The function it's part of is used by holoviews too (and then geoviews and hvplot). Unfortunately in JupyterLab each call to `publish_display_data` adds an empty line. This PR attempts to reduce the number of calls to `publish_display_data` from 3 to 1. @philippjfr I've merged all the JS into one string (without being quite sure if this is valid). If it's fine, before merging, I'd like to test it by running some notebooks with Jupyter Classic and Lab.