### PR TITLE
Add pyodide support to ReactiveHTML

### DIFF
--- a/panel/config.py
+++ b/panel/config.py
@@ -441,7 +441,8 @@ class panel_extension(_pyviz_extension):
         'tabulator': 'panel.models.tabulator',
         'gridstack': 'panel.layout.gridstack',
         'texteditor': 'panel.models.quill',
-        'jsoneditor': 'panel.models.json_editor'
+        'jsoneditor': 'panel.models.json_editor',
+        'pyiodide': 'panel.models.pyiodide'
     }
 
     # Check whether these are loaded before rendering (if any item

--- a/panel/models/pyiodide.py
+++ b/panel/models/pyiodide.py
@@ -1,0 +1,31 @@
+"""
+Defines a custom MathJax bokeh model to render text using MathJax.
+"""
+
+from bokeh.core.properties import String
+from bokeh.models import LayoutDOM
+
+from ..io.resources import bundled_files
+from ..util import classproperty
+
+
+class PyIodide(LayoutDOM):
+    """
+    A bokeh model that runs pyiodide scripts.
+    """
+
+    code = String()
+
+    __javascript__ = ["https://cdn.jsdelivr.net/pyodide/v0.19.0/full/pyodide.js"]
+
+    __js_skip__ = {'loadPyodide': __javascript__}
+
+    __js_require__ = {
+        'paths': {
+            'mathjax': "//cdn.jsdelivr.net/pyodide/v0.19.0/full/pyodide"
+        },
+        'shim': {'loadPyiodide': {'exports': "loadPyodide"}}
+    }
+
+
+

--- a/panel/models/pyiodide.ts
+++ b/panel/models/pyiodide.ts
@@ -1,0 +1,46 @@
+import * as p from "@bokehjs/core/properties"
+import {HTMLBox, HTMLBoxView} from "@bokehjs/models/layouts/html_box"
+
+export class PyIodideView extends HTMLBoxView {
+  model: PyIodide
+
+  override async lazy_initialize(): Promise<void> {
+    super.lazy_initialize()
+    if (!(window as any).pyiodide) {
+      (window as any).pyiodide = await (window as any).loadPyodide({
+	indexURL : "https://cdn.jsdelivr.net/pyodide/v0.19.0/full/"
+      });
+    }
+  }
+
+  render(): void {
+    if (!(window as any).pyiodide) { return }
+    (window as any).pyiodide.runPython(this.model.code)
+  }
+}
+
+export namespace PyIodide {
+  export type Attrs = p.AttrsOf<Props>
+  export type Props = HTMLBox.Props & {
+    code: p.Property<string>
+  }
+}
+
+export interface PyIodide extends PyIodide.Attrs {}
+
+export class PyIodide extends HTMLBox {
+  properties: PyIodide.Props
+
+  constructor(attrs?: Partial<PyIodide.Attrs>) {
+    super(attrs)
+  }
+
+  static __module__ = "panel.models.pyiodide"
+
+  static init_PyIodide(): void {
+    this.prototype.default_view = PyIodideView
+    this.define<PyIodide.Props>(({String}) => ({
+      code: [ String, '']
+    }))
+  }
+}

--- a/panel/models/reactive_html.py
+++ b/panel/models/reactive_html.py
@@ -189,6 +189,8 @@ class ReactiveHTML(HTMLBox):
 
     children = bp.Dict(bp.String, bp.Either(bp.List(bp.Either(bp.Instance(LayoutDOM), bp.String)), bp.String))
 
+    code = bp.Dict(bp.String, bp.String)
+
     data = bp.Instance(DataModel)
 
     events = bp.Dict(bp.String, bp.Dict(bp.String, bp.Bool))


### PR DESCRIPTION
Mostly an experiment for now but this PR explores what it would be like if we allowed users to write `ReactiveHTML` callbacks in Python and execute them using pyiodide.

```python
class ClickCounter(pn.reactive.ReactiveHTML):
    
    clicks = param.Integer()
    
    _template = """
    <div id='counter' onclick="${click}"><h1>Clicked 0 times</h1></div>
    """

    @pyscript
    def click(self):
        self.clicks += 1
        counter.innerHTML = f"<h1>Clicked {self.clicks} times</h1>"
```

![pyiodide](https://user-images.githubusercontent.com/1550771/155136830-4c92e88c-3848-478e-aeb8-eb6b1252f10a.gif)


