### PR TITLE
Bidirectionally sync Tabulator.sorters

### DIFF
--- a/examples/reference/widgets/Tabulator.ipynb
+++ b/examples/reference/widgets/Tabulator.ipynb
@@ -65,6 +65,7 @@
     "      The maximum number of selectable rows.\n",
     "* **``selectable_rows``** (`callable`): A function that should return a list of integer indexes given a DataFrame indicating which rows may be selected.\n",
     "* **``show_index``** (``boolean``, `default=True`): Whether to show the index column.\n",
+    "* **``sorters``** (list): A lisst of sorter definitions mapping where each item should declare the column to sort on and the direction to sort, e.g. `[{'field': 'column_name', 'dir': 'asc'}, {'field': 'another_column', 'dir': 'desc'}]`.\n",
     "* **``text_align``** (``dict`` or ``str``): A mapping from column name to alignment or a fixed column alignment, which should be one of `'left'`, `'center'`, `'right'`.\n",
     "* **`theme`** (``str``, `default='simple'`): The CSS theme to apply (note that changing the theme will restyle all tables on the page), which should be one of `'default'`, `'site'`, `'simple'`, `'midnight'`, `'modern'`, `'bootstrap'`, `'bootstrap4'`, `'materialize'`, `'bulma'`, `'semantic-ui'`, or `'fast'`.\n",
     "* **``titles``** (``dict``): A mapping from column name to a title to override the name with.\n",


### PR DESCRIPTION
Previously we exposed sorters only so that remote pagination could correctly send the appropriate data but for consistency and ensuring that sorting persists when updating data we now always sync it bi-directionally.