### PR TITLE
Add LinearGauge indicator

### DIFF
--- a/examples/reference/indicators/LinearGauge.ipynb
+++ b/examples/reference/indicators/LinearGauge.ipynb
@@ -15,24 +15,22 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The ``LinearGauge`` is a value indicator providing a visual representation of a value in a certain range as a simple linear gauge.\n",
+    "The ``LinearGauge`` is a value indicator providing a visual representation of a value in a certain range as a simple linear gauge. It is similar to `Dial` and `Gauge` elements but visually more compact.\n",
     "\n",
     "#### Parameters:\n",
     "\n",
     "For layout and styling related parameters see the [customization user guide](../../user_guide/Customization.ipynb).\n",
     "\n",
     "* **``bounds``** (tuple, default=(0, 100)): The upper and lower bound of the dial.\n",
-    "* **``colors``** (list): Color thresholds for the Gauge, specified as a list of tuples of the fractional threshold and the color to switch to.\n",
+    "* **``colors``** (list): Color thresholds for the gauge, specified as a list of evenly spaced colors or  tuples of the fractional threshold and the color to switch to.\n",
     "* **``default_color``** (str, default='lightblue'): Color to use if no color threshold are supplied to the `color` parameter\n",
-    "* **``end_angle``** (float or int, default=-45) Angle at which the gauge ends.\n",
     "* **``format``** str(str, default='{value}%'): Formatting string for the value indicator.\n",
     "* **``nan_format``** str(str, default='-'): How to format nan values.\n",
     "* **``needle_color``** (str, default='black): Color of the needle.\n",
-    "* **``needle_width``** (float, default=0.1): Radial width of needle in radians.\n",
-    "* **``start_angle``** (float or int, default=225): Angle at which the gauge starts.\n",
+    "* **``show_boundaries``** (boolean, default=False): Whether to show transitions between colors.\n",
     "* **``tick_size``** (int): Font size of the tick labels.\n",
     "* **``title_size``** (int): Font size of the title.\n",
-    "* **``unfilled_color``** (str, default='whitesmoke'): Color of the unfilled region of the Dial\n",
+    "* **``unfilled_color``** (str, default='whitesmoke'): Color of the unfilled region of the LinearGauge\n",
     "* **``value``** (float or int, default=25): Value to indicate on the dial a value within the declared bounds.\n",
     "* **``value_size``** (str): Font size of value label.\n",
     "\n",
@@ -52,7 +50,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "pn.indicators.LinearGauge(name='Failure Rate', value=10, bounds=(0, 100), colors=['red', 'gold', 'green'])"
+    "pn.indicators.LinearGauge(name='Failure Rate', value=30, bounds=(0, 100))"
    ]
   },
   {
@@ -69,8 +67,27 @@
    "outputs": [],
    "source": [
     "pn.indicators.LinearGauge(\n",
-    "    name='Engine', value=2500, bounds=(0, 3000), format='{value} rpm',\n",
-    "    colors=['green', 'gold', 'red']\n",
+    "    name='Engine', value=2500, bounds=(0, 3000), format='{value:.0f} rpm',\n",
+    "    colors=['green', 'gold', 'red'], horizontal=True, width=125\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If we want to show the transition points between the different colors we can also enable `show_boundaries`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pn.indicators.LinearGauge(\n",
+    "    name='Engine', value=2800, bounds=(0, 3000), format='{value:.0f} rpm',\n",
+    "    colors=[(0.2, 'green'), (0.8, 'gold'), (1, 'red')], show_boundaries=True\n",
     ")"
    ]
   }

--- a/examples/reference/indicators/LinearGauge.ipynb
+++ b/examples/reference/indicators/LinearGauge.ipynb
@@ -1,0 +1,106 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import panel as pn\n",
+    "\n",
+    "pn.extension()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The ``LinearGauge`` is a value indicator providing a visual representation of a value in a certain range as a simple linear gauge.\n",
+    "\n",
+    "#### Parameters:\n",
+    "\n",
+    "For layout and styling related parameters see the [customization user guide](../../user_guide/Customization.ipynb).\n",
+    "\n",
+    "* **``bounds``** (tuple, default=(0, 100)): The upper and lower bound of the dial.\n",
+    "* **``colors``** (list): Color thresholds for the Gauge, specified as a list of tuples of the fractional threshold and the color to switch to.\n",
+    "* **``default_color``** (str, default='lightblue'): Color to use if no color threshold are supplied to the `color` parameter\n",
+    "* **``end_angle``** (float or int, default=-45) Angle at which the gauge ends.\n",
+    "* **``format``** str(str, default='{value}%'): Formatting string for the value indicator.\n",
+    "* **``nan_format``** str(str, default='-'): How to format nan values.\n",
+    "* **``needle_color``** (str, default='black): Color of the needle.\n",
+    "* **``needle_width``** (float, default=0.1): Radial width of needle in radians.\n",
+    "* **``start_angle``** (float or int, default=225): Angle at which the gauge starts.\n",
+    "* **``tick_size``** (int): Font size of the tick labels.\n",
+    "* **``title_size``** (int): Font size of the title.\n",
+    "* **``unfilled_color``** (str, default='whitesmoke'): Color of the unfilled region of the Dial\n",
+    "* **``value``** (float or int, default=25): Value to indicate on the dial a value within the declared bounds.\n",
+    "* **``value_size``** (str): Font size of value label.\n",
+    "\n",
+    "___"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The simplest form of a `LinearGauge` just requires setting a `value` which must be within the `bounds`. The default formatter and bounds assume you are providing a percentage:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pn.indicators.LinearGauge(name='Failure Rate', value=10, bounds=(0, 100), colors=['red', 'gold', 'green'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If we want to display some other value such as the revolutions per minute of an engine we can set a different `bounds` value and override the `format`. Additionally we may also provide a different set of colors defining the threshold points at which the color should change as a fraction of the provided bounds. The `colors` accepts a list of tuples defining the fractions and the color:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pn.indicators.LinearGauge(\n",
+    "    name='Engine', value=2500, bounds=(0, 3000), format='{value} rpm',\n",
+    "    colors=['green', 'gold', 'red']\n",
+    ")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.8"
+  },
+  "widgets": {
+   "application/vnd.jupyter.widget-state+json": {
+    "state": {},
+    "version_major": 2,
+    "version_minor": 0
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/panel/tests/widgets/test_base.py
+++ b/panel/tests/widgets/test_base.py
@@ -5,15 +5,15 @@ from panel.io import block_comm
 from panel.layout import Row
 from panel.links import CallbackGenerator
 from panel.widgets import (
-    CompositeWidget, Dial, FileDownload, FloatSlider, TextInput,
-    Terminal, ToggleGroup, Tqdm, Widget
+    CompositeWidget, Dial, FileDownload, FloatSlider, LinearGauge,
+    TextInput, Terminal, ToggleGroup, Tqdm, Widget
 )
 from panel.widgets.tables import BaseTable
 from panel.tests.util import check_layoutable_properties
 
 excluded = (
-    BaseTable, CompositeWidget, Dial, FileDownload, ToggleGroup, Terminal,
-    Tqdm
+    BaseTable, CompositeWidget, Dial, FileDownload, LinearGauge,
+    ToggleGroup, Terminal, Tqdm 
 )
 
 all_widgets = [

--- a/panel/widgets/__init__.py
+++ b/panel/widgets/__init__.py
@@ -40,6 +40,7 @@ from .indicators import ( # noqa
     BooleanStatus,
     Dial,
     Gauge,
+    LinearGauge,
     LoadingSpinner,
     Number,
     Progress,

--- a/panel/widgets/indicators.py
+++ b/panel/widgets/indicators.py
@@ -179,7 +179,7 @@ class Progress(ValueIndicator):
 
     max = param.Integer(default=100, doc="The maximum value of the progress bar.")
 
-    value = param.Integer(default=-1, bounds=(-1, None), allow_None=True, doc="""
+    value = param.Integer(default=-1, bounds=(-1, None), doc="""
         The current value of the progress bar. If set to -1 the progress
         bar will be indeterminate and animate depending on the active
         parameter.""")
@@ -191,13 +191,6 @@ class Progress(ValueIndicator):
     @param.depends('max', watch=True)
     def _update_value_bounds(self):
         self.param.value.bounds = (-1, self.max)
-
-    @param.depends('value', watch=True)
-    def _warn_deprecation(self):
-        if self.value is None:
-            self.value = -1
-            warnings.warn('Setting the progress value to None is deprecated, use -1 instead.',
-                          FutureWarning,  stacklevel=2)
 
     def __init__(self,**params):
         super().__init__(**params)


### PR DESCRIPTION
A `LinearGauge` provides a much more compact value indicator than `Dial` or `Gauge`. 

<img width="464" alt="Screen Shot 2022-04-13 at 15 53 15" src="https://user-images.githubusercontent.com/1550771/163196107-93523653-5f20-4b9a-8b6d-921ec5e867ca.png">
<img width="190" alt="Screen Shot 2022-04-13 at 15 53 00" src="https://user-images.githubusercontent.com/1550771/163196099-4996805a-d550-46fa-80aa-d70c5d3afe38.png">


- [ ] Add tests
- [x] Make `colors` handling consistent with `Gauge` and `Dial`
- [x] Improve `horizontal` support