### PR TITLE
Guard pn.state.curdoc access

### DIFF
--- a/panel/io/state.py
+++ b/panel/io/state.py
@@ -469,8 +469,11 @@ class _state(param.Parameterized):
             doc = _curdoc()
         except Exception:
             return None
-        if doc.session_context:
-            return doc
+        try:
+            if doc.session_context:
+                return doc
+        except Exception:
+            return None
 
     @curdoc.setter
     def curdoc(self, doc):


### PR DESCRIPTION
When a document has been destroyed the session_context is not longer accessible but it may still be accessed.

@MarcSkovMadsen Could you test?

Fixes https://github.com/holoviz/panel/issues/3225