### PR TITLE
Serve index under alias for backward compatibility

### DIFF
--- a/panel/command/serve.py
+++ b/panel/command/serve.py
@@ -205,7 +205,7 @@ class Serve(_BkServe):
                 if index.endswith(ext):
                     index = index[:-len(ext)]
             if f'/{index}' in applications:
-                applications['/'] = applications.pop(f'/{index}')
+                applications['/'] = applications[f'/{index}']
         return super().customize_applications(args, applications)
 
     def customize_kwargs(self, args, server_kwargs):


### PR DESCRIPTION
Recent changes meant that an app served using the `--index` option was no longer served under the original endpoint. This is problematic for backward compatibility reason so for now we simply alias the endpoint to both root (`/`) and the original endpoint.