### PR TITLE
Improve support for jinja2 loops in ReactiveHTML

### DIFF
--- a/panel/models/reactive_html.ts
+++ b/panel/models/reactive_html.ts
@@ -389,7 +389,7 @@ export class ReactiveHTMLView extends PanelHTMLBoxView {
       for (const callback of this.model.callbacks[elname]) {
         const [cb, method] = callback;
         let definition: string
-        htm = htm.replace('${'+method, '$--{'+method)
+        htm = htm.replaceAll('${'+method, '$--{'+method)
         if (method.startsWith('script(')) {
           const meth = (
             method
@@ -397,8 +397,8 @@ export class ReactiveHTMLView extends PanelHTMLBoxView {
               .replace('("', "_").replace('")', "")
               .replace('-', '_')
           )
-          const script_name = meth.replace("script_", "")
-          htm = htm.replace(method, meth)
+          const script_name = meth.replaceAll("script_", "")
+          htm = htm.replaceAll(method, meth)
           definition = `
           const ${meth} = (event) => {
             view._state.event = event

--- a/panel/reactive.py
+++ b/panel/reactive.py
@@ -1364,9 +1364,9 @@ class ReactiveHTML(Reactive, metaclass=ReactiveHTMLMetaclass):
             if isinstance(v, str):
                 v = bleach.clean(v)
             data_params[k] = v
-        html, nodes, attrs = self._get_template()
+        html, nodes, self._attrs = self._get_template()
         params.update({
-            'attrs': attrs,
+            'attrs': self._attrs,
             'callbacks': self._node_callbacks,
             'data': self._data_model(**self._process_param_change(data_params)),
             'events': self._get_events(),
@@ -1620,8 +1620,8 @@ class ReactiveHTML(Reactive, metaclass=ReactiveHTMLMetaclass):
                 data_msg[prop] = v
         if new_children:
             if self._parser.looped:
-                html, nodes, attrs = self._get_template()
-                model_msg['attrs'] = attrs
+                html, nodes, self._attrs = self._get_template()
+                model_msg['attrs'] = self._attrs
                 model_msg['nodes'] = nodes
                 model_msg['html'] = escape(textwrap.dedent(html))
             children = self._get_children(doc, root, model, comm)

--- a/panel/reactive.py
+++ b/panel/reactive.py
@@ -1112,7 +1112,6 @@ class ReactiveHTMLMetaclass(ParameterizedMetaclass):
         mcs._inline_callbacks = []
         for node, attrs in mcs._parser.attrs.items():
             for (attr, parameters, template) in attrs:
-                param_attrs = []
                 for p in parameters:
                     if p in mcs.param or '.' in p:
                         continue

--- a/panel/reactive.py
+++ b/panel/reactive.py
@@ -1108,15 +1108,15 @@ class ReactiveHTMLMetaclass(ParameterizedMetaclass):
                 "ensure there is a matching </div> tag."
             )
 
-        mcs._attrs, mcs._node_callbacks = {}, {}
+        mcs._node_callbacks = {}
         mcs._inline_callbacks = []
         for node, attrs in mcs._parser.attrs.items():
             for (attr, parameters, template) in attrs:
                 param_attrs = []
                 for p in parameters:
                     if p in mcs.param or '.' in p:
-                        param_attrs.append(p)
-                    elif re.match(mcs._script_regex, p):
+                        continue
+                    if re.match(mcs._script_regex, p):
                         name = re.findall(mcs._script_regex, p)[0]
                         if name not in mcs._scripts:
                             raise ValueError(
@@ -1140,9 +1140,7 @@ class ReactiveHTMLMetaclass(ParameterizedMetaclass):
                             f"parameter or method '{p}', similar parameters "
                             f"and methods include {matches}."
                         )
-                if node not in mcs._attrs:
-                    mcs._attrs[node] = []
-                mcs._attrs[node].append((attr, param_attrs, template))
+
         ignored = list(Reactive.param)
         types = {}
         for child in mcs._parser.children.values():
@@ -1247,7 +1245,7 @@ class ReactiveHTML(Reactive, metaclass=ReactiveHTMLMetaclass):
 
     Additionally we can invoke pure JS scripts defined on the class, e.g.:
 
-        <input id="input" onchange="${run_script('some_script')}"></input>
+        <input id="input" onchange="${script('some_script')}"></input>
 
     This will invoke the following script if it is defined on the class:
 
@@ -1326,6 +1324,7 @@ class ReactiveHTML(Reactive, metaclass=ReactiveHTMLMetaclass):
             else:
                 params[children_param] = panel(child_value)
         super().__init__(**params)
+        self._attrs = {}
         self._panes = {}
         self._event_callbacks = defaultdict(lambda: defaultdict(list))
 
@@ -1366,13 +1365,14 @@ class ReactiveHTML(Reactive, metaclass=ReactiveHTMLMetaclass):
             if isinstance(v, str):
                 v = bleach.clean(v)
             data_params[k] = v
+        html, nodes, attrs = self._get_template()
         params.update({
-            'attrs': self._attrs,
+            'attrs': attrs,
             'callbacks': self._node_callbacks,
             'data': self._data_model(**self._process_param_change(data_params)),
             'events': self._get_events(),
-            'html': escape(textwrap.dedent(self._get_template())),
-            'nodes': self._parser.nodes,
+            'html': escape(textwrap.dedent(html)),
+            'nodes': nodes,
             'looped': [node for node, _ in self._parser.looped],
             'scripts': {}
         })
@@ -1509,6 +1509,18 @@ class ReactiveHTML(Reactive, metaclass=ReactiveHTMLMetaclass):
                 .replace(f'id="{name}"', f'id="{name}-${{id}}"')
             )
 
+        # Parse attrs
+        p_attrs = {}
+        for node, attrs in parser.attrs.items():
+            for (attr, parameters, template) in attrs:
+                param_attrs = []
+                for p in parameters:
+                    if p in self.param or '.' in p:
+                        param_attrs.append(p)
+                if node not in p_attrs:
+                    p_attrs[node] = []
+                p_attrs[node].append((attr, param_attrs, template))
+
         # Remove child node template syntax
         for parent, child_name in self._parser.children.items():
             if (parent, child_name) in self._parser.looped:
@@ -1516,7 +1528,7 @@ class ReactiveHTML(Reactive, metaclass=ReactiveHTMLMetaclass):
                     html = html.replace('${%s[%d]}' % (child_name, i), '')
             else:
                 html = html.replace('${%s}' % child_name, '')
-        return html
+        return html, parser.nodes, p_attrs
 
     def _linked_properties(self):
         linked_properties = [p for pss in self._attrs.values() for _, ps, _ in pss for p in ps]
@@ -1609,7 +1621,10 @@ class ReactiveHTML(Reactive, metaclass=ReactiveHTMLMetaclass):
                 data_msg[prop] = v
         if new_children:
             if self._parser.looped:
-                model_msg['html'] = escape(self._get_template())
+                html, nodes, attrs = self._get_template()
+                model_msg['attrs'] = attrs
+                model_msg['nodes'] = nodes
+                model_msg['html'] = escape(textwrap.dedent(html))
             children = self._get_children(doc, root, model, comm)
         else:
             children = None

--- a/panel/tests/test_reactive.py
+++ b/panel/tests/test_reactive.py
@@ -169,12 +169,11 @@ def test_reactive_html_basic():
     assert isinstance(float_prop.property, bp.Float)
     assert float_prop.class_default(data_model) == 3.14
 
-    assert Test._attrs == {'div': [('width', ['int'], '{int}')]}
     assert Test._node_callbacks == {}
-
 
     test = Test()
     root = test.get_root()
+    assert test._attrs == {'div': [('width', ['int'], '{int}')]}
     assert root.callbacks == {}
     assert root.events == {}
 
@@ -226,11 +225,11 @@ def test_reactive_html_dom_events():
     assert isinstance(float_prop.property, bp.Float)
     assert float_prop.class_default(data_model) == 3.14
 
-    assert TestDOMEvents._attrs == {'div': [('width', ['int'], '{int}')]}
     assert TestDOMEvents._node_callbacks == {}
 
     test = TestDOMEvents()
     root = test.get_root()
+    assert test._attrs == {'div': [('width', ['int'], '{int}')]}
     assert root.callbacks == {}
     assert root.events == {'div': {'change': True}}
 
@@ -255,17 +254,17 @@ def test_reactive_html_inline():
     assert isinstance(int_prop.property, bp.Int)
     assert int_prop.class_default(data_model) == 3
 
-    assert TestInline._attrs == {
-        'div': [
-            ('onchange', [], '{_div_change}'),
-            ('width', ['int'], '{int}')
-        ]
-    }
     assert TestInline._node_callbacks == {'div': [('onchange', '_div_change')]}
     assert TestInline._inline_callbacks == [('div', 'onchange', '_div_change')]
 
     test = TestInline()
     root = test.get_root()
+    assert test._attrs == {
+        'div': [
+            ('onchange', [], '{_div_change}'),
+            ('width', ['int'], '{int}')
+        ]
+    }
     assert root.callbacks == {'div': [('onchange', '_div_change')]}
     assert root.events == {}
 
@@ -281,7 +280,6 @@ def test_reactive_html_children():
 
         _template = '<div id="div">${children}</div>'
 
-    assert TestChildren._attrs == {}
     assert TestChildren._node_callbacks == {}
     assert TestChildren._inline_callbacks == []
     assert TestChildren._parser.children == {'div': 'children'}
@@ -289,6 +287,7 @@ def test_reactive_html_children():
     widget = TextInput()
     test = TestChildren(children=[widget])
     root = test.get_root()
+    assert test._attrs == {}
     assert root.children == {'div': [widget._models[root.ref['id']][0]]}
     assert len(widget._models) == 1
     assert test._panes == {'children': [widget]}
@@ -318,7 +317,6 @@ def test_reactive_html_templated_children():
         </div>
         """
 
-    assert TestTemplatedChildren._attrs == {}
     assert TestTemplatedChildren._node_callbacks == {}
     assert TestTemplatedChildren._inline_callbacks == []
     assert TestTemplatedChildren._parser.children == {'option': 'children'}
@@ -326,6 +324,7 @@ def test_reactive_html_templated_children():
     widget = TextInput()
     test = TestTemplatedChildren(children=[widget])
     root = test.get_root()
+    assert test._attrs == {}
     assert root.looped == ['option']
     assert root.children == {'option': [widget._models[root.ref['id']][0]]}
     assert test._panes == {'children': [widget]}
@@ -351,7 +350,6 @@ def test_reactive_html_templated_dict_children():
         </div>
         """
 
-    assert TestTemplatedChildren._attrs == {}
     assert TestTemplatedChildren._node_callbacks == {}
     assert TestTemplatedChildren._inline_callbacks == []
     assert TestTemplatedChildren._parser.children == {'option': 'children'}
@@ -359,6 +357,7 @@ def test_reactive_html_templated_dict_children():
     widget = TextInput()
     test = TestTemplatedChildren(children={'test': widget})
     root = test.get_root()
+    assert test._attrs == {}
     assert root.looped == ['option']
     assert root.children == {'option': [widget._models[root.ref['id']][0]]}
     assert test._panes == {'children': [widget]}
@@ -390,14 +389,13 @@ def test_reactive_html_templated_children_add_loop_id():
         </select>
         """
 
-    assert TestTemplatedChildren._attrs == {}
     assert TestTemplatedChildren._node_callbacks == {}
     assert TestTemplatedChildren._inline_callbacks == []
     assert TestTemplatedChildren._parser.children == {'option': 'children'}
 
     test = TestTemplatedChildren(children=['A', 'B', 'C'])
 
-    assert test._get_template() == """
+    assert test._get_template()[0] == """
         <select id="select-${id}">
         
           <option id="option-0-${id}"></option>
@@ -410,6 +408,7 @@ def test_reactive_html_templated_children_add_loop_id():
         """
 
     model = test.get_root()
+    assert test._attrs == {}
     assert model.looped == ['option']
 
 
@@ -427,14 +426,13 @@ def test_reactive_html_templated_children_add_loop_id_and_for_loop_var():
         </select>
         """
 
-    assert TestTemplatedChildren._attrs == {}
     assert TestTemplatedChildren._node_callbacks == {}
     assert TestTemplatedChildren._inline_callbacks == []
     assert TestTemplatedChildren._parser.children == {'option': 'children'}
 
     test = TestTemplatedChildren(children=['A', 'B', 'C'])
 
-    assert test._get_template() == """
+    assert test._get_template()[0] == """
         <select id="select-${id}">
         
           <option id="option-0-${id}"></option>
@@ -446,6 +444,7 @@ def test_reactive_html_templated_children_add_loop_id_and_for_loop_var():
         </select>
         """
     model = test.get_root()
+    assert test._attrs == {}
     assert model.looped == ['option']
 
 


### PR DESCRIPTION
- Handle inline script callbacks for DOM nodes created in jinja loops
- Update nodes and attributes to watch when re-evaluating template on looped parameter changes