### PR TITLE
Remove all tornado imports

### DIFF
--- a/panel/__init__.py
+++ b/panel/__init__.py
@@ -24,7 +24,7 @@ from . import widgets # noqa
 from .config import config, panel_extension as extension, __version__ # noqa
 from .depends import bind, depends # noqa
 from .interact import interact # noqa
-from .io import _jupyter_server_extension_paths, ipywidget, state # noqa
+from .io import _jupyter_server_extension_paths, ipywidget, serve, state # noqa
 from .layout import ( # noqa
     Accordion, Card, Column, GridSpec, GridBox, FlexBox, Tabs, Row,
     Spacer, WidgetBox

--- a/panel/__init__.py
+++ b/panel/__init__.py
@@ -24,7 +24,7 @@ from . import widgets # noqa
 from .config import config, panel_extension as extension, __version__ # noqa
 from .depends import bind, depends # noqa
 from .interact import interact # noqa
-from .io import _jupyter_server_extension_paths, ipywidget, serve, state # noqa
+from .io import _jupyter_server_extension_paths, ipywidget, state # noqa
 from .layout import ( # noqa
     Accordion, Card, Column, GridSpec, GridBox, FlexBox, Tabs, Row,
     Spacer, WidgetBox

--- a/panel/config.py
+++ b/panel/config.py
@@ -565,6 +565,9 @@ class panel_extension(_pyviz_extension):
         if "VSCODE_PID" in os.environ:
             config.comms = "vscode"
 
+        if "pyodide" in sys.modules:
+            config.comms = "ipywidgets"
+
         if config.notifications:
             display(state.notifications) # noqa
 

--- a/panel/io/__init__.py
+++ b/panel/io/__init__.py
@@ -16,5 +16,9 @@ from .notebook import ( # noqa
     load_notebook, push, push_notebook
 )
 
-if 'django' in sys.modules:
-    from . import django # noqa
+if 'pyodide' in sys.modules:
+    from .pyodide import serve
+else:
+    from .server import serve # noqa
+    if 'django' in sys.modules:
+        from . import django # noqa

--- a/panel/io/__init__.py
+++ b/panel/io/__init__.py
@@ -5,17 +5,16 @@ model state, and rendering panel objects.
 import sys
 
 from .callbacks import PeriodicCallback # noqa
+from .document import init_doc, unlocked, with_lock
 from .embed import embed_state # noqa
 from .logging import panel_logger # noqa
 from .model import add_to_doc, remove_root, diff # noqa
-from .profile import profile # noqa
 from .resources import Resources # noqa
-from .server import get_server, init_doc, serve, unlocked, with_lock # noqa
 from .state import state # noqa
 from .notebook import ( # noqa
     block_comm, ipywidget, _jupyter_server_extension_paths,
     load_notebook, push, push_notebook
 )
 
-if 'django' in sys.modules:
-    from . import django # noqa
+#if 'django' in sys.modules:
+#    from . import django # noqa

--- a/panel/io/__init__.py
+++ b/panel/io/__init__.py
@@ -5,7 +5,7 @@ model state, and rendering panel objects.
 import sys
 
 from .callbacks import PeriodicCallback # noqa
-from .document import init_doc, unlocked, with_lock
+from .document import init_doc, unlocked, with_lock # noqa
 from .embed import embed_state # noqa
 from .logging import panel_logger # noqa
 from .model import add_to_doc, remove_root, diff # noqa
@@ -16,5 +16,5 @@ from .notebook import ( # noqa
     load_notebook, push, push_notebook
 )
 
-#if 'django' in sys.modules:
-#    from . import django # noqa
+if 'django' in sys.modules:
+    from . import django # noqa

--- a/panel/io/document.py
+++ b/panel/io/document.py
@@ -32,7 +32,6 @@ def init_doc(doc):
     doc.on_event('document_ready', state._init_session)
     return doc
 
-
 def with_lock(func):
     """
     Wrap a callback function to execute with a lock allowing the
@@ -58,7 +57,6 @@ def with_lock(func):
             return func(*args, **kw)
     wrapper.lock = True
     return wrapper
-
 
 def _dispatch_events(doc, events):
     """

--- a/panel/io/document.py
+++ b/panel/io/document.py
@@ -1,11 +1,14 @@
+import datetime as dt
 import inspect
 import threading
 
 from contextlib import contextmanager
+from functools import partial, wraps
 
+from bokeh.document.events import ModelChangedEvent
 from bokeh.io import curdoc
 
-from .state import state
+from .state import set_curdoc, state
 
 
 def init_doc(doc):

--- a/panel/io/document.py
+++ b/panel/io/document.py
@@ -1,0 +1,123 @@
+import inspect
+import threading
+
+from contextlib import contextmanager
+
+from bokeh.io import curdoc
+
+from .state import state
+
+
+def init_doc(doc):
+    doc = doc or curdoc()
+    if not doc.session_context:
+        return doc
+
+    thread = threading.current_thread()
+    if thread:
+        with set_curdoc(doc):
+            state._thread_id = thread.ident
+
+    session_id = doc.session_context.id
+    sessions = state.session_info['sessions']
+    if session_id not in sessions:
+        return doc
+
+    sessions[session_id].update({
+        'started': dt.datetime.now().timestamp()
+    })
+    doc.on_event('document_ready', state._init_session)
+    return doc
+
+
+def with_lock(func):
+    """
+    Wrap a callback function to execute with a lock allowing the
+    function to modify bokeh models directly.
+
+    Arguments
+    ---------
+    func: callable
+      The callable to wrap
+
+    Returns
+    -------
+    wrapper: callable
+      Function wrapped to execute without a Document lock.
+    """
+    if inspect.iscoroutinefunction(func):
+        @wraps(func)
+        async def wrapper(*args, **kw):
+            return await func(*args, **kw)
+    else:
+        @wraps(func)
+        def wrapper(*args, **kw):
+            return func(*args, **kw)
+    wrapper.lock = True
+    return wrapper
+
+
+def _dispatch_events(doc, events):
+    """
+    Handles dispatch of events which could not be processed in
+    unlocked decorator.
+    """
+    for event in events:
+        doc.callbacks.trigger_on_change(event)
+
+@contextmanager
+def unlocked():
+    """
+    Context manager which unlocks a Document and dispatches
+    ModelChangedEvents triggered in the context body to all sockets
+    on current sessions.
+    """
+    from tornado.websocket import WebSocketHandler
+    curdoc = state.curdoc
+    if curdoc is None or curdoc.session_context is None or curdoc.session_context.session is None:
+        yield
+        return
+    connections = curdoc.session_context.session._subscribed_connections
+
+    hold = curdoc.callbacks.hold_value
+    if hold:
+        old_events = list(curdoc.callbacks._held_events)
+    else:
+        old_events = []
+        curdoc.hold()
+    try:
+        yield
+
+        locked = False
+        for conn in connections:
+            socket = conn._socket
+            if hasattr(socket, 'write_lock') and socket.write_lock._block._value == 0:
+                locked = True
+                break
+
+        events = []
+        for event in curdoc.callbacks._held_events:
+            if not isinstance(event, ModelChangedEvent) or event in old_events or locked:
+                events.append(event)
+                continue
+            for conn in connections:
+                socket = conn._socket
+                ws_conn = getattr(socket, 'ws_connection', False)
+                if (not hasattr(socket, 'write_message') or
+                    ws_conn is None or (ws_conn and ws_conn.is_closing())):
+                    continue
+                msg = conn.protocol.create('PATCH-DOC', [event])
+                WebSocketHandler.write_message(socket, msg.header_json)
+                WebSocketHandler.write_message(socket, msg.metadata_json)
+                WebSocketHandler.write_message(socket, msg.content_json)
+                for header, payload in msg._buffers:
+                    WebSocketHandler.write_message(socket, header)
+                    WebSocketHandler.write_message(socket, payload, binary=True)
+        curdoc.callbacks._held_events = events
+    finally:
+        if hold:
+            return
+        try:
+            curdoc.unhold()
+        except RuntimeError:
+            curdoc.add_next_tick_callback(partial(_dispatch_events, curdoc, events))

--- a/panel/io/notebook.py
+++ b/panel/io/notebook.py
@@ -36,7 +36,6 @@ from ..compiler import require_components
 from .embed import embed_state
 from .model import add_to_doc, diff
 from .resources import PANEL_DIR, Bundle, Resources, _env, bundle_resources
-from .server import _server_url, _origin_url, get_server
 from .state import state
 
 
@@ -285,6 +284,7 @@ def show_server(panel, notebook_url, port):
     server: bokeh.server.Server
     """
     from IPython.display import publish_display_data
+    from .server import _server_url, _origin_url, get_server
 
     if callable(notebook_url):
         origin = notebook_url(None)

--- a/panel/io/pyodide.py
+++ b/panel/io/pyodide.py
@@ -1,0 +1,21 @@
+import asyncio
+
+import param
+
+
+def async_execute(func):
+    event_loop = asyncio.get_running_loop()
+    if event_loop.is_running():
+        event_loop.call_soon(func)
+    else:
+        event_loop.run_until_complete(func())
+    return
+
+param.parameterized.async_executor = async_execute
+
+
+def serve(*args, **kwargs):
+    """
+    Stub to replace Tornado based serve function.
+    """
+    raise RuntimeError('Cannot serve application in pyodide context.')

--- a/panel/io/server.py
+++ b/panel/io/server.py
@@ -42,7 +42,6 @@ from bokeh.server.views.static_handler import StaticHandler
 
 # Tornado imports
 from tornado.ioloop import IOLoop
-from tornado.websocket import WebSocketHandler
 from tornado.web import RequestHandler, StaticFileHandler, authenticated
 from tornado.wsgi import WSGIContainer
 
@@ -382,120 +381,6 @@ bokeh.server.tornado.create_static_handler = create_static_handler
 # Public API
 #---------------------------------------------------------------------
 
-def init_doc(doc):
-    doc = doc or curdoc()
-    if not doc.session_context:
-        return doc
-
-    thread = threading.current_thread()
-    if thread:
-        with set_curdoc(doc):
-            state._thread_id = thread.ident
-
-    session_id = doc.session_context.id
-    sessions = state.session_info['sessions']
-    if session_id not in sessions:
-        return doc
-
-    sessions[session_id].update({
-        'started': dt.datetime.now().timestamp()
-    })
-    doc.on_event('document_ready', state._init_session)
-    return doc
-
-
-def with_lock(func):
-    """
-    Wrap a callback function to execute with a lock allowing the
-    function to modify bokeh models directly.
-
-    Arguments
-    ---------
-    func: callable
-      The callable to wrap
-
-    Returns
-    -------
-    wrapper: callable
-      Function wrapped to execute without a Document lock.
-    """
-    if inspect.iscoroutinefunction(func):
-        @wraps(func)
-        async def wrapper(*args, **kw):
-            return await func(*args, **kw)
-    else:
-        @wraps(func)
-        def wrapper(*args, **kw):
-            return func(*args, **kw)
-    wrapper.lock = True
-    return wrapper
-
-
-def _dispatch_events(doc, events):
-    """
-    Handles dispatch of events which could not be processed in
-    unlocked decorator.
-    """
-    for event in events:
-        doc.callbacks.trigger_on_change(event)
-
-
-@contextmanager
-def unlocked():
-    """
-    Context manager which unlocks a Document and dispatches
-    ModelChangedEvents triggered in the context body to all sockets
-    on current sessions.
-    """
-    curdoc = state.curdoc
-    if curdoc is None or curdoc.session_context is None or curdoc.session_context.session is None:
-        yield
-        return
-    connections = curdoc.session_context.session._subscribed_connections
-
-    hold = curdoc.callbacks.hold_value
-    if hold:
-        old_events = list(curdoc.callbacks._held_events)
-    else:
-        old_events = []
-        curdoc.hold()
-    try:
-        yield
-        locked = False
-        for conn in connections:
-            socket = conn._socket
-            if hasattr(socket, 'write_lock') and socket.write_lock._block._value == 0:
-                locked = True
-                break
-
-        events = []
-        for event in curdoc.callbacks._held_events:
-            if not isinstance(event, ModelChangedEvent) or event in old_events or locked:
-                events.append(event)
-                continue
-            for conn in connections:
-                socket = conn._socket
-                ws_conn = getattr(socket, 'ws_connection', False)
-                if (not hasattr(socket, 'write_message') or
-                    ws_conn is None or (ws_conn and ws_conn.is_closing())):
-                    continue
-                msg = conn.protocol.create('PATCH-DOC', [event])
-                WebSocketHandler.write_message(socket, msg.header_json)
-                WebSocketHandler.write_message(socket, msg.metadata_json)
-                WebSocketHandler.write_message(socket, msg.content_json)
-                for header, payload in msg._buffers:
-                    WebSocketHandler.write_message(socket, header)
-                    WebSocketHandler.write_message(socket, payload, binary=True)
-        curdoc.callbacks._held_events = events
-    finally:
-        if hold:
-            return
-        try:
-            curdoc.unhold()
-        except RuntimeError:
-            curdoc.add_next_tick_callback(partial(_dispatch_events, curdoc, events))
-
-
 def serve(panels, port=0, address=None, websocket_origin=None, loop=None,
           show=True, start=True, title=None, verbose=True, location=True,
           threaded=False, **kwargs):
@@ -703,6 +588,8 @@ def get_server(panel, port=0, address=None, websocket_origin=None,
             if (isinstance(app, str) and (app.endswith(".py") or app.endswith(".ipynb"))
                 and os.path.isfile(app)):
                 apps[slug] = build_single_handler_application(app)
+            elif isinstance(app, Application):
+                apps[slug] = app
             else:
                 handler = FunctionHandler(partial(_eval_panel, app, server_id, title_, location))
                 apps[slug] = Application(handler)

--- a/panel/io/server.py
+++ b/panel/io/server.py
@@ -45,6 +45,7 @@ from tornado.wsgi import WSGIContainer
 
 # Internal imports
 from ..util import edit_readonly
+from .document import init_doc, with_lock, unlocked # noqa
 from .logging import LOG_SESSION_CREATED, LOG_SESSION_DESTROYED, LOG_SESSION_LAUNCHING
 from .profile import profile_ctx
 from .reload import autoreload_watcher

--- a/panel/io/server.py
+++ b/panel/io/server.py
@@ -3,7 +3,6 @@ Utilities for creating bokeh Server instances.
 """
 import datetime as dt
 import html
-import inspect
 import logging
 import os
 import pathlib
@@ -29,7 +28,6 @@ from bokeh.application.handlers.code import CodeHandler, _monkeypatch_io, patch_
 from bokeh.application.handlers.function import FunctionHandler
 from bokeh.command.util import build_single_handler_application
 from bokeh.core.templates import AUTOLOAD_JS
-from bokeh.document.events import ModelChangedEvent
 from bokeh.embed.bundle import Script
 from bokeh.embed.elements import html_page_for_render_items, script_for_render_items
 from bokeh.embed.util import RenderItem

--- a/panel/io/state.py
+++ b/panel/io/state.py
@@ -20,8 +20,6 @@ import param
 from bokeh.document import Document
 from bokeh.io import curdoc as _curdoc
 from pyviz_comms import CommManager as _CommManager
-from tornado.ioloop import IOLoop
-from tornado.web import decode_signed_value
 
 from ..util import base64url_decode, parse_timedelta
 from .logging import LOG_SESSION_RENDERED, LOG_USER_MSG
@@ -242,6 +240,7 @@ class _state(param.Parameterized):
             at = None
             del self._scheduled[name]
         if at is not None:
+            from tornado.ioloop import IOLoop
             ioloop = IOLoop.current()
             now = dt.datetime.now().timestamp()
             call_time_seconds = (at - now)
@@ -517,6 +516,7 @@ class _state(param.Parameterized):
         cron: str
           A cron expression (requires croniter to parse)
         """
+        from tornado.ioloop import IOLoop
         if name in self._scheduled:
             if callback is not self._scheduled[name][1]:
                 self.param.warning(
@@ -593,6 +593,7 @@ class _state(param.Parameterized):
 
     @property
     def access_token(self):
+        from tornado.web import decode_signed_value
         from ..config import config
         access_token = self.cookies.get('access_token')
         if access_token is None:
@@ -698,6 +699,7 @@ class _state(param.Parameterized):
 
     @property
     def user(self):
+        from tornado.web import decode_signed_value
         from ..config import config
         user = self.cookies.get('user')
         if user is None or config.cookie_secret is None:
@@ -706,6 +708,7 @@ class _state(param.Parameterized):
 
     @property
     def user_info(self):
+        from tornado.web import decode_signed_value
         from ..config import config
         id_token = self.cookies.get('id_token')
         if id_token is None or config.cookie_secret is None:

--- a/panel/io/state.py
+++ b/panel/io/state.py
@@ -4,8 +4,9 @@ Various utilities for recording and embedding state in a rendered app.
 import asyncio
 import datetime as dt
 import inspect
-import logging
 import json
+import logging
+import sys
 import threading
 import time
 

--- a/panel/param.py
+++ b/panel/param.py
@@ -18,7 +18,6 @@ import param
 from param.parameterized import classlist, discard_events
 
 from .io import init_doc, state
-from .io.server import async_execute
 from .layout import Column, Panel, Row, Spacer, Tabs
 from .pane.base import PaneBase, ReplacementPane
 from .util import (
@@ -790,7 +789,7 @@ class ParamMethod(ReplacementPane):
                 else:
                     new_object = self.eval(self.object)
                 if inspect.isawaitable(new_object):
-                    async_execute(partial(self._eval_async, new_object))
+                    param.parameterized.async_executor(partial(self._eval_async, new_object))
                     return
                 self._update_inner(new_object)
             finally:

--- a/panel/reactive.py
+++ b/panel/reactive.py
@@ -21,9 +21,9 @@ from bokeh.models import LayoutDOM
 from bokeh.model import DataModel
 from param.parameterized import ParameterizedMetaclass, Watcher
 
+from .io.document import unlocked
 from .io.model import hold
 from .io.notebook import push
-from .io.server import unlocked
 from .io.state import set_curdoc, state
 from .models.reactive_html import (
     ReactiveHTML as _BkReactiveHTML, ReactiveHTMLParser

--- a/panel/viewable.py
+++ b/panel/viewable.py
@@ -23,6 +23,7 @@ from bokeh.io import curdoc as _curdoc
 from pyviz_comms import JupyterCommManager
 
 from .config import config, panel_extension
+from .io.document import init_doc
 from .io.embed import embed_state
 from .io.loading import start_loading_spinner, stop_loading_spinner
 from .io.model import add_to_doc, patch_cds_msg
@@ -31,7 +32,6 @@ from .io.notebook import (
 )
 from .io.save import save
 from .io.state import state
-from .io.server import init_doc, serve
 from .util import escape, param_reprs
 
 
@@ -378,6 +378,7 @@ class ServableMixin(object):
           Returns the Bokeh server instance or the thread the server
           was launched on (if threaded=True)
         """
+        from .io.server import serve
         return serve(
             self, port=port, address=address, websocket_origin=websocket_origin,
             show=open, start=True, title=title, verbose=verbose,

--- a/panel/viewable.py
+++ b/panel/viewable.py
@@ -23,6 +23,7 @@ from bokeh.io import curdoc as _curdoc
 from pyviz_comms import JupyterCommManager
 
 from .config import config, panel_extension
+from .io import serve
 from .io.document import init_doc
 from .io.embed import embed_state
 from .io.loading import start_loading_spinner, stop_loading_spinner
@@ -378,7 +379,6 @@ class ServableMixin(object):
           Returns the Bokeh server instance or the thread the server
           was launched on (if threaded=True)
         """
-        from .io.server import serve
         return serve(
             self, port=port, address=address, websocket_origin=websocket_origin,
             show=open, start=True, title=title, verbose=verbose,


### PR DESCRIPTION
This PR makes it so that in a pyiodide context the `panel.io.server` module and all tornado based imports are not run. Additionally this sets the default comm to be `'ipywidgets'` so that all Panel objects are rendered using the `jupyter_bokeh.BokehModel` ipywidget wrapper that also works in jupyterlite.