### PR TITLE
Add ability to require explicit load of ReactiveHTML extension

### DIFF
--- a/examples/user_guide/Custom_Components.ipynb
+++ b/examples/user_guide/Custom_Components.ipynb
@@ -474,7 +474,7 @@
    "source": [
     "## External dependencies\n",
     "\n",
-    "Often you will want to wrap a component with some external Javascript or CSS dependencies. To make this possible `ReactiveHTML` components may declare `__javascript__`, `__javascript_modules__` and `__css__` attributes, specifying the external dependencies to load. Note that in a notebook the component must be declared before `pn.extension` is called, otherwise the libraries won't be loaded (in this case we explicitly loaded them above).\n",
+    "Often the components you build will have dependencies on some external Javascript or CSS files. To make this possible `ReactiveHTML` components may declare `__javascript__`, `__javascript_modules__` and `__css__` attributes, specifying the external dependencies to load. Note that in a notebook as long as the component is imported before the call to `pn.extension` all its dependencies will be loaded automatically. If you want to require users to load the components as an extension explicitly via a `pn.extension` call you can declare an `_extension_name`.\n",
     "\n",
     "Below we will create a Material UI text field and declare the Javascript and CSS components to load:"
    ]
@@ -499,7 +499,10 @@
     "    \"\"\"\n",
     "    \n",
     "    _dom_events = {'text-input': ['change']}\n",
-    "    \n",
+    "\n",
+    "    # By declaring an _extension_name the component should be loaded explicitly with pn.extension('material-components')\n",
+    "    _extension_name = 'material-components'\n",
+    "\n",
     "    _scripts = {\n",
     "        'render': \"mdc.textField.MDCTextField.attachTo(text_field);\"\n",
     "    }\n",
@@ -515,6 +518,13 @@
     "text_field = MaterialTextField()\n",
     "\n",
     "text_field"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In a notebook dependencies for this component will not be loaded unless the user explicitly loads them with a `pn.extension('material-components')`. In a server context you will also have to explicitly load this extension unless the component is rendered on initial page load, i.e. if the component is only added to the page in a callback you will also have to explicitly run `pn.extension('material-components')`."
    ]
   },
   {

--- a/panel/config.py
+++ b/panel/config.py
@@ -468,8 +468,7 @@ class panel_extension(_pyviz_extension):
         }
         for arg in args:
             if arg in self._imports:
-                 __import__(self._imports[arg])
-
+                __import__(self._imports[arg])
             elif arg in reactive_exts:
                 ReactiveHTMLMetaclass._loaded_extensions.add(arg)
             else:

--- a/panel/io/resources.py
+++ b/panel/io/resources.py
@@ -206,7 +206,7 @@ class Resources(BkResources):
         files = super(Resources, self).js_files
 
         for model in param.concrete_descendents(ReactiveHTML).values():
-            if hasattr(model, '__javascript__'):
+            if getattr(model, '__javascript__', None) and model._loaded():
                 for jsfile in model.__javascript__:
                     if jsfile not in files:
                         files.append(jsfile)
@@ -245,7 +245,7 @@ class Resources(BkResources):
         from ..reactive import ReactiveHTML
         modules = list(config.js_modules.values())
         for model in param.concrete_descendents(ReactiveHTML).values():
-            if hasattr(model, '__javascript_modules__'):
+            if hasattr(model, '__javascript_modules__') and model._loaded():
                 for jsmodule in model.__javascript_modules__:
                     if jsmodule not in modules:
                         modules.append(jsmodule)
@@ -259,7 +259,7 @@ class Resources(BkResources):
         files = super(Resources, self).css_files
 
         for model in param.concrete_descendents(ReactiveHTML).values():
-            if hasattr(model, '__css__'):
+            if getattr(model, '__css__', None) and model._loaded():
                 for css_file in model.__css__:
                     if css_file not in files:
                         files.append(css_file)
@@ -296,7 +296,7 @@ class Bundle(BkBundle):
         from ..reactive import ReactiveHTML
         js_modules = list(config.js_modules.values())
         for model in param.concrete_descendents(ReactiveHTML).values():
-            if hasattr(model, '__javascript_modules__'):
+            if getattr(model, '__javascript_modules__', None) and model._loaded():
                 for js_module in model.__javascript_modules__:
                     if js_module not in js_modules:
                         js_modules.append(js_module)

--- a/panel/layout/__init__.py
+++ b/panel/layout/__init__.py
@@ -3,5 +3,6 @@ from .base import Column, ListLike, ListPanel, Panel, Row, WidgetBox # noqa
 from .card import Card # noqa
 from .flex import FlexBox # noqa
 from .grid import GridBox, GridSpec # noqa
+from .gridstack import GridStack # noqa
 from .spacer import Divider, HSpacer, Spacer, VSpacer # noqa
 from .tabs import Tabs # noqa

--- a/panel/layout/gridstack.py
+++ b/panel/layout/gridstack.py
@@ -28,6 +28,8 @@ class GridStack(ReactiveHTML, GridSpec):
 
     height = param.Integer(default=None)
 
+    _extension_name = 'gridstack'
+
     _template = """
     <div id="grid" class="grid-stack">
     {% for key, obj in objects.items() %}


### PR DESCRIPTION
Currently any ReactiveHTML component that is imported when the panel extension is run or a server app is served for the first time will be loaded and all its JS/CSS dependencies will be embedded in the page. This isn't really a nice way to handle this problem because it creates a tension between offering helpful namespaces that include all components and reducing the number of external JS/CSS that are included in the page. To get around this we introduce the concept of a `ReactiveHTML._extension_name`. This, if declared, tells Panel not to load the dependencies for this component unless it has been explicitly loaded with `pn.extension(<extension_name>)`. This replicates the behavior we have long implemented for regular Bokeh models with dependencies we do not want to include by default and which have to be loaded using the panel extension.