### PR TITLE
Ensure gc.collect is not excessively called

### DIFF
--- a/panel/io/state.py
+++ b/panel/io/state.py
@@ -530,7 +530,7 @@ class _state(param.Parameterized):
                     "A separate task was already scheduled under the "
                     f"name {name!r}. The new task will be ignored. If "
                     "you want to replace the existing task cancel it "
-                    "with `state.cancel_task({name!r})` before adding "
+                    f"with `state.cancel_task({name!r})` before adding "
                     "adding a new task under the same name."
                 )
             return


### PR DESCRIPTION
Currently bokeh will call gc.collect() on every `Document.destroy()`. If you are cleaning up multiple sessions simultaneously this is excessive and can in fact lock up the server for multiple seconds. Here we override `Document.destroy` and schedule a separate task that effectively throttles gc.collect calls.