### PR TITLE
Added fullpath to jupyter_server_extension

### DIFF
--- a/doc/generate_modules.py
+++ b/doc/generate_modules.py
@@ -160,7 +160,7 @@ def recurse_tree(path, excludes, opts):
     """
     # use absolute path for root, as relative paths like '../../foo' cause
     # 'if "/." in root ...' to filter out *all* modules otherwise
-    path = os.path.abspath(path)
+    path = os.path.abspath(os.path.expanduser(path))
     # check if the base directory is a package and get is name
     if INIT in os.listdir(path):
         package_name = path.split(os.path.sep)[-1]

--- a/panel/command/serve.py
+++ b/panel/command/serve.py
@@ -23,6 +23,7 @@ from tornado.web import StaticFileHandler
 
 from ..auth import OAuthProvider
 from ..config import config
+from ..util import fullpath
 from ..io.rest import REST_PROVIDERS
 from ..io.reload import record_modules, watch
 from ..io.server import INDEX_HTML, get_static_routes, set_curdoc
@@ -267,7 +268,7 @@ class Serve(_BkServe):
             code = compile(nodes, filename=setup_path, mode='exec', dont_inherit=True)
             module_name = 'panel_setup_module'
             module = ModuleType(module_name)
-            module.__dict__['__file__'] = os.path.abspath(os.path.expanduser(setup_path))
+            module.__dict__['__file__'] = fullpath(setup_path)
             exec(code, module.__dict__)
             state._setup_module = module
 

--- a/panel/command/serve.py
+++ b/panel/command/serve.py
@@ -267,7 +267,7 @@ class Serve(_BkServe):
             code = compile(nodes, filename=setup_path, mode='exec', dont_inherit=True)
             module_name = 'panel_setup_module'
             module = ModuleType(module_name)
-            module.__dict__['__file__'] = os.path.abspath(setup_path)
+            module.__dict__['__file__'] = os.path.abspath(os.path.expanduser(setup_path))
             exec(code, module.__dict__)
             state._setup_module = module
 

--- a/panel/io/jupyter_server_extension.py
+++ b/panel/io/jupyter_server_extension.py
@@ -45,6 +45,13 @@ def url_path_join(*pieces):
     return result
 
 
+def fullpath(path):
+    """Expanduser and then abspath for given path
+    """
+    return os.path.abspath(os.path.expanduser(path))
+
+
+
 class ServerApplicationProxy:
     """
     A wrapper around the jupyter_server.serverapp.ServerWebApplication
@@ -75,10 +82,11 @@ class ServerApplicationProxy:
         may be different from the root dir.
         Reference: https://github.com/holoviz/panel/issues/3170
         """
-        return self._app.settings['server_root_dir']
+        return fullpath(self._app.settings['server_root_dir'])
 
     def __getattr__(self, key):
         return getattr(self._app, key)
+
 
 
 class PanelHandler(DocHandler):
@@ -93,7 +101,7 @@ class PanelHandler(DocHandler):
         pass
 
     async def get(self, path, *args, **kwargs):
-        path = os.path.join(self.application.root_dir, path)
+        path = os.path.join(self.application.root_dir, fullpath(path))
         if path in _APPS:
             app, context = _APPS[path]
         else:
@@ -135,7 +143,7 @@ class PanelWSHandler(WSHandler):
         pass
 
     async def open(self, path, *args, **kwargs):
-        path = os.path.join(self.application.root_dir, path)
+        path = os.path.join(self.application.root_dir, fullpath(path))
         _, context = _APPS[path]
 
         token = self._token

--- a/panel/io/jupyter_server_extension.py
+++ b/panel/io/jupyter_server_extension.py
@@ -21,7 +21,7 @@ from bokeh.util.token import get_session_id
 from tornado.web import StaticFileHandler
 
 from ..config import config
-from ..util import edit_readonly
+from ..util import edit_readonly, fullpath
 from .state import state
 from .resources import DIST_DIR, Resources
 
@@ -43,13 +43,6 @@ def url_path_join(*pieces):
     if final: result = result + '/'
     if result == '//': result = '/'
     return result
-
-
-def fullpath(path):
-    """Expanduser and then abspath for given path
-    """
-    return os.path.abspath(os.path.expanduser(path))
-
 
 
 class ServerApplicationProxy:

--- a/panel/io/reload.py
+++ b/panel/io/reload.py
@@ -103,7 +103,7 @@ def record_modules():
             else:
                 filepath = spec.origin
 
-            filepath = os.path.abspath(filepath)
+            filepath = os.path.abspath(os.path.expanduser(filepath))
 
             if filepath is None or in_blacklist(filepath):
                 continue

--- a/panel/io/reload.py
+++ b/panel/io/reload.py
@@ -8,6 +8,7 @@ from functools import partial
 
 from .callbacks import PeriodicCallback
 from .state import state
+from ..util import fullpath
 
 _watched_files = set()
 _modules = set()
@@ -103,7 +104,7 @@ def record_modules():
             else:
                 filepath = spec.origin
 
-            filepath = os.path.abspath(os.path.expanduser(filepath))
+            filepath = fullpath(filepath)
 
             if filepath is None or in_blacklist(filepath):
                 continue

--- a/panel/io/server.py
+++ b/panel/io/server.py
@@ -45,7 +45,7 @@ from tornado.web import RequestHandler, StaticFileHandler, authenticated
 from tornado.wsgi import WSGIContainer
 
 # Internal imports
-from ..util import edit_readonly
+from ..util import edit_readonly, fullpath
 from .document import init_doc, with_lock, unlocked # noqa
 from .logging import LOG_SESSION_CREATED, LOG_SESSION_DESTROYED, LOG_SESSION_LAUNCHING
 from .profile import profile_ctx
@@ -499,7 +499,7 @@ def get_static_routes(static_dirs):
         if slug == '/static':
             raise ValueError("Static file route may not use /static "
                              "this is reserved for internal use.")
-        path = os.path.abspath(os.path.expanduser(path))
+        path = fullpath(path)
         if not os.path.isdir(path):
             raise ValueError("Cannot serve non-existent path %s" % path)
         patterns.append(

--- a/panel/io/server.py
+++ b/panel/io/server.py
@@ -499,7 +499,7 @@ def get_static_routes(static_dirs):
         if slug == '/static':
             raise ValueError("Static file route may not use /static "
                              "this is reserved for internal use.")
-        path = os.path.abspath(path)
+        path = os.path.abspath(os.path.expanduser(path))
         if not os.path.isdir(path):
             raise ValueError("Cannot serve non-existent path %s" % path)
         patterns.append(

--- a/panel/param.py
+++ b/panel/param.py
@@ -21,7 +21,7 @@ from .io import init_doc, state
 from .layout import Column, Panel, Row, Spacer, Tabs
 from .pane.base import PaneBase, ReplacementPane
 from .util import (
-    abbreviated_repr, classproperty, full_groupby, get_method_owner,
+    abbreviated_repr, classproperty, full_groupby, fullpath, get_method_owner,
     is_parameterized, param_name, recursive_parameterized
 )
 from .reactive import Reactive
@@ -943,7 +943,7 @@ class JSONInit(param.Parameterized):
         if self.json_file or env_var.endswith('.json'):
             try:
                 fname = self.json_file if self.json_file else env_var
-                spec = json.load(open(os.path.abspath(os.path.expanduser(fname)), 'r'))
+                spec = json.load(open(fullpath(fname), 'r'))
             except Exception:
                 warnobj.warning('Could not load JSON file %r' % spec)
         else:

--- a/panel/param.py
+++ b/panel/param.py
@@ -943,7 +943,7 @@ class JSONInit(param.Parameterized):
         if self.json_file or env_var.endswith('.json'):
             try:
                 fname = self.json_file if self.json_file else env_var
-                spec = json.load(open(os.path.abspath(fname), 'r'))
+                spec = json.load(open(os.path.abspath(os.path.expanduser(fname)), 'r'))
             except Exception:
                 warnobj.warning('Could not load JSON file %r' % spec)
         else:

--- a/panel/param.py
+++ b/panel/param.py
@@ -943,7 +943,8 @@ class JSONInit(param.Parameterized):
         if self.json_file or env_var.endswith('.json'):
             try:
                 fname = self.json_file if self.json_file else env_var
-                spec = json.load(open(fullpath(fname), 'r'))
+                with open(fullpath(fname), 'r') as f:
+                    spec = json.load(f)
             except Exception:
                 warnobj.warning('Could not load JSON file %r' % spec)
         else:

--- a/panel/util.py
+++ b/panel/util.py
@@ -401,3 +401,9 @@ def parse_timedelta(time_str):
         if p:
             time_params[name] = float(p)
     return dt.timedelta(**time_params)
+
+
+def fullpath(path):
+    """Expanduser and then abspath for a given path
+    """
+    return os.path.abspath(os.path.expanduser(path))

--- a/panel/widgets/file_selector.py
+++ b/panel/widgets/file_selector.py
@@ -12,6 +12,7 @@ import param
 from ..io import PeriodicCallback
 from ..layout import Column, Divider, Row
 from ..viewable import Layoutable
+from ..util import fullpath
 from .base import CompositeWidget
 from .button import Button
 from .input import TextInput
@@ -92,10 +93,10 @@ class FileSelector(CompositeWidget):
     def __init__(self, directory=None, **params):
         from ..pane import Markdown
         if directory is not None:
-            params['directory'] = os.path.abspath(os.path.expanduser(directory))
+            params['directory'] = fullpath(directory)
         if 'root_directory' in params:
             root = params['root_directory']
-            params['root_directory'] = os.path.abspath(os.path.expanduser(root))
+            params['root_directory'] = fullpath(root)
         if params.get('width') and params.get('height') and 'sizing_mode' not in params:
             params['sizing_mode'] = None
 
@@ -162,7 +163,7 @@ class FileSelector(CompositeWidget):
         self.value = value
 
     def _dir_change(self, event):
-        path = os.path.abspath(os.path.expanduser(self._directory.value))
+        path = fullpath(self._directory.value)
         if not path.startswith(self._root_directory):
             self._directory.value = self._root_directory
             return
@@ -174,7 +175,7 @@ class FileSelector(CompositeWidget):
         self._update_files(refresh=True)
 
     def _update_files(self, event=None, refresh=False):
-        path = os.path.abspath(os.path.expanduser(self._directory.value))
+        path = fullpath(self._directory.value)
         refresh = refresh or (event and getattr(event, 'obj', None) is self._reload)
         if refresh:
             path = self._cwd
@@ -233,7 +234,7 @@ class FileSelector(CompositeWidget):
             return
 
         relpath = event.new[0].replace('📁', '')
-        sel = os.path.abspath(os.path.expanduser(os.path.join(self._cwd, relpath)))
+        sel = fullpath(os.path.join(self._cwd, relpath))
         if os.path.isdir(sel):
             self._directory.value = sel
         else:

--- a/panel/widgets/file_selector.py
+++ b/panel/widgets/file_selector.py
@@ -174,7 +174,7 @@ class FileSelector(CompositeWidget):
         self._update_files(refresh=True)
 
     def _update_files(self, event=None, refresh=False):
-        path = os.path.abspath(self._directory.value)
+        path = os.path.abspath(os.path.expanduser(self._directory.value))
         refresh = refresh or (event and getattr(event, 'obj', None) is self._reload)
         if refresh:
             path = self._cwd
@@ -233,7 +233,7 @@ class FileSelector(CompositeWidget):
             return
 
         relpath = event.new[0].replace('📁', '')
-        sel = os.path.abspath(os.path.join(self._cwd, relpath))
+        sel = os.path.abspath(os.path.expanduser(os.path.join(self._cwd, relpath)))
         if os.path.isdir(sel):
             self._directory.value = sel
         else:


### PR DESCRIPTION
I noticed I couldn't get the Panel widget in jupyter lab to work in a non-base conda environment.
![Screenshot 2022-03-28_13 25 03](https://user-images.githubusercontent.com/19758978/160397766-0f5e5774-28ac-453a-9eae-35cc55bddbf1.png)

With the output in my terminal:
![Screenshot 2022-03-28_13 25 14](https://user-images.githubusercontent.com/19758978/160398072-5adb63e1-c6e3-4389-bb38-b32ce1e0e412.png)

The error is because `~` is present in the path and when `os.path.abspath` is used it gives a wrong result.
``` python
path = "~/hello_there.mp4"
a_path = os.path.abspath(path)
ae_path = os.path.abspath(os.path.expanduser(path))
path, a_path, ae_path
```
![image](https://user-images.githubusercontent.com/19758978/160398340-89dc3326-56f5-45a5-80ca-f34205a20896.png)

The `abspath` command is called from [bokeh](https://github.com/bokeh/bokeh/blob/560a57e166a1f54319df57127502d48ee4ecc72e/bokeh/command/util.py#L117) and a fix should be implemented there too.