### PR TITLE
Ensure ReactiveHTML template variables only escapes exact matches

### DIFF
--- a/panel/models/reactive_html.ts
+++ b/panel/models/reactive_html.ts
@@ -389,7 +389,7 @@ export class ReactiveHTMLView extends PanelHTMLBoxView {
       for (const callback of this.model.callbacks[elname]) {
         const [cb, method] = callback;
         let definition: string
-        htm = htm.replaceAll('${'+method, '$--{'+method)
+        htm = htm.replaceAll('${'+method+'}', '$--{'+method+'}')
         if (method.startsWith('script(')) {
           const meth = (
             method


### PR DESCRIPTION
If you had both a method and a parameter reference in a ReactiveHTML component that started with the same string it would fail to expand the parameter reference in the template and cause errors.