### PR TITLE
Do not call an Action with an argument

### DIFF
--- a/panel/param.py
+++ b/panel/param.py
@@ -471,7 +471,7 @@ class Param(PaneBase):
             watcher = widget.param.watch(event, 'clicks')
         elif isinstance(p_obj, param.Action):
             def action(change):
-                value(self.object)
+                value()
             watcher = widget.param.watch(action, 'clicks')
         elif kw_widget.get('throttled', False) and hasattr(widget, 'value_throttled'):
             watcher = widget.param.watch(link_widget, 'value_throttled')


### PR DESCRIPTION
I'm not sure if this is a documentation error or a Panel error, but Param basically says

> `param.Action`: A callable with no arguments, ready to invoke
https://param.holoviz.org/user_guide/Parameter_Types.html#invocations

And Panel clearly invokes the Action with an argument here.