### PR TITLE
Scroll to center selected Tabulator row

### DIFF
--- a/panel/models/tabulator.ts
+++ b/panel/models/tabulator.ts
@@ -982,11 +982,10 @@ export class DataTabulatorView extends PanelHTMLBoxView {
     this._selection_updating = true
     this.tabulator.deselectRow()
     this.tabulator.selectRow(indices)
-    // This actually places the selected row at the top of the table
     for (const index of indices) {
       const row = this.tabulator.rowManager.findRow(index)
       if (row)
-        this.tabulator.scrollToRow(index, "bottom", false).catch(() => {})
+        this.tabulator.scrollToRow(index, "center", false).catch(() => {})
     }
     this._selection_updating = false
   }


### PR DESCRIPTION
When updating row selection, scroll in the widget so that the selected
row is centered. This fixes the current behavior that leaves the
selected row just passed the end of the viewed range.

The original intended behavior was to place the selected row at the top
of the viewed range, but due to a Tabulator bug, we needed to request
"bottom" for that. Now that Tabulator seems to be fixed, use "center" so
that hopefully this issue will not come back.

Signed-off-by: Douglas Raillard <douglas.raillard@arm.com>