### PR TITLE
Tabulator: allow to set selectable=1

### DIFF
--- a/panel/models/tabulator.py
+++ b/panel/models/tabulator.py
@@ -127,7 +127,7 @@ class DataTabulator(HTMLBox):
 
     sorters = List(Dict(String, String))
 
-    select_mode = Any(default=True)
+    select_mode = Any()
 
     selectable_rows = Nullable(List(Int))
 


### PR DESCRIPTION
Addresses https://github.com/holoviz/panel/issues/3074

By just removing the default value of True of the `select_mode` model property as suggested in the issue which indeed allows to declare that only 1 row can be selected.