### PR TITLE
Consistently resolve component resources using relative paths

### DIFF
--- a/panel/io/resources.py
+++ b/panel/io/resources.py
@@ -122,7 +122,7 @@ def component_resource_path(component, attr, path):
     component_path = COMPONENT_PATH
     if state.rel_path:
         component_path = f"{state.rel_path}/{component_path}"
-    rel_path = component_rel_path(component, path)
+    rel_path = component_rel_path(component, path).replace(os.path.sep, '/')
     return f'{component_path}{component.__module__}/{component.__name__}/{attr}/{rel_path}'
 
 def loading_css():

--- a/panel/io/server.py
+++ b/panel/io/server.py
@@ -360,6 +360,8 @@ class ComponentResourceHandler(StaticFileHandler):
 
         rel_path = '/'.join(subpath)
 
+        print(rel_path, resources)
+
         # Important: May only access resources explicitly listed on the component
         # Otherwise this potentially exposes all files to the web
         if rel_path not in resources:

--- a/panel/io/server.py
+++ b/panel/io/server.py
@@ -355,7 +355,8 @@ class ComponentResourceHandler(StaticFileHandler):
         elif isinstance(resources, str):
             resources = [resources]
         resources = [
-            component_rel_path(component, resource) for resource in resources
+            component_rel_path(component, resource).replace(os.path.sep, '/')
+            for resource in resources
         ]
 
         rel_path = '/'.join(subpath)

--- a/panel/template/base.py
+++ b/panel/template/base.py
@@ -564,7 +564,7 @@ class BasicTemplate(BaseTemplate):
                 elif isurl(resource):
                     resource_files[rname] = resource
                 elif resolve_custom_path(self, resource):
-                    resource_files[cssname] = component_resource_path(
+                    resource_files[rname] = component_resource_path(
                         self, f'_resources/{resource_type}', resource
                     )
 
@@ -582,7 +582,7 @@ class BasicTemplate(BaseTemplate):
             if not '//' in css and state.rel_path:
                 css = f'{state.rel_path}/{css}'
             extra_css.append(css)
-        resource_types['raw_css'] = raw_css = list(self.config.raw_css)
+        resource_types['raw_css'] = list(self.config.raw_css)
 
         # CSS files
         base_css = self._css
@@ -624,8 +624,6 @@ class BasicTemplate(BaseTemplate):
         theme = self._get_theme()
         if not theme:
             return resource_types
-
-        theme_name = type(theme).__name__
         if theme.base_css:
             basename = os.path.basename(theme.base_css)
             owner = type(theme).param.base_css.owner

--- a/panel/template/base.py
+++ b/panel/template/base.py
@@ -21,7 +21,9 @@ from pyviz_comms import JupyterCommManager as _JupyterCommManager
 from ..config import _base_config, config, panel_extension
 from ..io.model import add_to_doc
 from ..io.notebook import render_template
-from ..io.resources import CDN_DIST, LOCAL_DIST, BUNDLE_DIR, resolve_custom_path
+from ..io.resources import (
+    CDN_DIST, LOCAL_DIST, BUNDLE_DIR, component_resource_path, resolve_custom_path
+)
 from ..io.save import save
 from ..io.state import state
 from ..layout import Column, ListLike, GridSpec
@@ -536,8 +538,7 @@ class BasicTemplate(BaseTemplate):
     def _template_resources(self):
         clsname = type(self).__name__
         name = clsname.lower()
-        resources = _settings.resources(default="server")
-        if resources == 'server':
+        if _settings.resources(default="server") == 'server':
             if state.rel_path:
                 dist_path = f'{state.rel_path}/{self._LOCAL}'
             else:
@@ -545,44 +546,27 @@ class BasicTemplate(BaseTemplate):
         else:
             dist_path = self._CDN
 
-        custom_path = "components"
-        if state.rel_path:
-            custom_path = f"{state.rel_path}/{custom_path}"
-
         # External resources
-        css_files = dict(self._resources.get('css', {}))
-        for cssname, css in css_files.items():
-            css_path = url_path(css)
-            if (BUNDLE_DIR / 'css' / css_path.replace('/', os.path.sep)).is_file():
-                css_files[cssname] = dist_path + f'bundled/css/{css_path}'
-            elif isurl(css):
-                css_files[cssname] = css
-            elif resolve_custom_path(self, css):
-                css_files[cssname] = f'{custom_path}/{self.__module__}/{clsname}/_resources/css/{css}'
-
-        js_files = dict(self._resources.get('js', {}))
-        for jsname, js in js_files.items():
-            js_path = url_path(js)
-            if (BUNDLE_DIR / 'js' / js_path.replace('/', os.path.sep)).is_file():
-                js_files[jsname] = dist_path + f'bundled/js/{js_path}'
-            elif isurl(js):
-                js_files[jsname] = js
-            elif resolve_custom_path(self, js):
-                js_files[jsname] = f'{custom_path}/{self.__module__}/{clsname}/_resources/js/{js}'
-
-        js_modules = dict(self._resources.get('js_modules', {}))
-        for jsname, js in js_modules.items():
-            js_path = url_path(js)
-            if jsname in self._resources.get('tarball', {}):
-                js_path += '/index.mjs'
-            else:
-                js_path += '.mjs'
-            if os.path.isfile(BUNDLE_DIR / js_path.replace('/', os.path.sep)):
-                js_modules[jsname] = dist_path + f'bundled/js/{js_path}'
-            elif isurl(js):
-                js_modules[jsname] = js
-            elif resolve_custom_path(self, js):
-                js_modules[jsname] = f'{custom_path}/{self.__module__}/{clsname}/_resources/js_modules/{js}'
+        css_files, js_files, js_modules = {}, {}, {}
+        resource_types = {'css': css_files, 'js': js_files, 'js_modules': js_modules}
+        for resource_type, files in self._resources.items():
+            if resource_type not in resource_types:
+                continue
+            resource_files = resource_types[resource_type]
+            for rname, resource in files.items():
+                resource_path = url_path(resource)
+                if rname in self._resources.get('tarball', {}):
+                    resource_path += '/index.mjs'
+                else:
+                    resource_path += '.mjs'
+                if (BUNDLE_DIR / rname / resource_path.replace('/', os.path.sep)).is_file():
+                    resource_files[rname] = dist_path + f'bundled/{resource_type}/{resource_path}'
+                elif isurl(resource):
+                    resource_files[rname] = resource
+                elif resolve_custom_path(self, resource):
+                    resource_files[cssname] = component_resource_path(
+                        self, f'_resources/{resource_type}', resource
+                    )
 
         for name, js in self.config.js_files.items():
             if not '//' in js and state.rel_path:
@@ -592,12 +576,13 @@ class BasicTemplate(BaseTemplate):
             if not '//' in js and state.rel_path:
                 js = f'{state.rel_path}/{js}'
             js_modules[name] = js
-        extra_css = []
+
+        resource_types['extra_css'] = extra_css = []
         for css in list(self.config.css_files):
             if not '//' in css and state.rel_path:
                 css = f'{state.rel_path}/{css}'
             extra_css.append(css)
-        raw_css = list(self.config.raw_css)
+        resource_types['raw_css'] = raw_css = list(self.config.raw_css)
 
         # CSS files
         base_css = self._css
@@ -615,7 +600,7 @@ class BasicTemplate(BaseTemplate):
             elif isurl(css):
                 css_files[f'base_{css_file}'] = css
             elif resolve_custom_path(self, css):
-                css_files[f'base_{css_file}' ] = f'{custom_path}/{self.__module__}/{clsname}/_css/{css}'
+                css_files[f'base_{css_file}' ] = component_resource_path(self, '_css', css)
 
         # JS files
         base_js = self._js
@@ -633,37 +618,33 @@ class BasicTemplate(BaseTemplate):
             elif isurl(js):
                 js_files[f'base_{js_name}'] = js
             elif resolve_custom_path(self, js):
-                js_files[f'base_{js_name}' ] = f'{custom_path}/{self.__module__}/{clsname}/_js/{js}'
+                js_files[f'base_{js_name}' ] = component_resource_path(self, '_js', js)
 
-        if self.theme:
-            theme = self._get_theme()
-            theme_name = type(theme).__name__
-            if theme:
-                if theme.base_css:
-                    basename = os.path.basename(theme.base_css)
-                    owner = type(theme.param.base_css.owner).__name__.lower()
-                    if (BUNDLE_DIR / owner / basename).is_file():
-                        css_files['theme_base'] = dist_path + f'bundled/{owner}/{basename}'
-                    elif isurl(theme.base_css):
-                        css_files['theme_base'] = theme.base_css
-                    elif resolve_custom_path(theme, theme.base_css):
-                        css_files['theme_base'] = f'{custom_path}/{theme.__module__}/{theme_name}/base_css/{theme.base_css}'
-                if theme.css:
-                    basename = os.path.basename(theme.css)
-                    if (BUNDLE_DIR / name / basename).is_file():
-                        css_files['theme'] = dist_path + f'bundled/{name}/{basename}'
-                    elif isurl(theme.css):
-                        css_files['theme'] = theme.css
-                    elif resolve_custom_path(theme, theme.css):
-                        css_files['theme'] = f'{custom_path}/{theme.__module__}/{theme_name}/css/{theme.css}'
+    
+        theme = self._get_theme()
+        if not theme:
+            return resource_types
 
-        return {
-            'css': css_files,
-            'extra_css': extra_css,
-            'raw_css': raw_css,
-            'js': js_files,
-            'js_modules': js_modules
-        }
+        theme_name = type(theme).__name__
+        if theme.base_css:
+            basename = os.path.basename(theme.base_css)
+            owner = type(theme).param.base_css.owner
+            owner_name = owner.__name__.lower()
+            if (BUNDLE_DIR / owner_name / basename).is_file():
+                css_files['theme_base'] = dist_path + f'bundled/{owner_name}/{basename}'
+            elif isurl(theme.base_css):
+                css_files['theme_base'] = theme.base_css
+            elif resolve_custom_path(theme, theme.base_css):
+                css_files['theme_base'] = component_resource_path(owner, 'base_css', theme.base_css)
+        if theme.css:
+            basename = os.path.basename(theme.css)
+            if (BUNDLE_DIR / name / basename).is_file():
+                css_files['theme'] = dist_path + f'bundled/{name}/{basename}'
+            elif isurl(theme.css):
+                css_files['theme'] = theme.css
+            elif resolve_custom_path(theme, theme.css):
+                css_files['theme'] = component_resource_path(theme, 'css', theme.css)
+        return resource_types
 
     def _update_vars(self, *args):
         self._render_variables['app_title'] = self.title

--- a/panel/tests/test_server.py
+++ b/panel/tests/test_server.py
@@ -601,7 +601,7 @@ def test_server_template_custom_resources_with_prefix_relative_url():
 
     r = requests.get(f"http://localhost:{port}/prefix/template")
     content = r.content.decode('utf-8')
-    assert 'href="components/panel.tests.test_server/CustomBootstrapTemplate/_css/./assets/custom.css"' in content
+    assert 'href="components/panel.tests.test_server/CustomBootstrapTemplate/_css/assets/custom.css"' in content
 
 
 def test_server_template_custom_resources_with_subpath_and_prefix_relative_url():
@@ -615,7 +615,7 @@ def test_server_template_custom_resources_with_subpath_and_prefix_relative_url()
 
     r = requests.get(f"http://localhost:{port}/prefix/subpath/template")
     content = r.content.decode('utf-8')
-    assert 'href="../components/panel.tests.test_server/CustomBootstrapTemplate/_css/./assets/custom.css"' in content
+    assert 'href="../components/panel.tests.test_server/CustomBootstrapTemplate/_css/assets/custom.css"' in content
 
 
 class CustomComponent(ReactiveHTML):
@@ -662,7 +662,7 @@ def test_server_component_custom_resources_with_prefix_relative_url():
 
     r = requests.get(f"http://localhost:{port}/prefix/component")
     content = r.content.decode('utf-8')
-    assert 'href="components/panel.tests.test_server/CustomComponent/__css__/./assets/custom.css"' in content
+    assert 'href="components/panel.tests.test_server/CustomComponent/__css__/assets/custom.css"' in content
 
 
 def test_server_component_custom_resources_with_subpath_and_prefix_relative_url():
@@ -676,7 +676,8 @@ def test_server_component_custom_resources_with_subpath_and_prefix_relative_url(
 
     r = requests.get(f"http://localhost:{port}/prefix/subpath/component")
     content = r.content.decode('utf-8')
-    assert 'href="../components/panel.tests.test_server/CustomComponent/__css__/./assets/custom.css"' in content
+    print(content)
+    assert 'href="../components/panel.tests.test_server/CustomComponent/__css__/assets/custom.css"' in content
 
 
 def test_server_component_css_with_prefix_relative_url():

--- a/panel/util.py
+++ b/panel/util.py
@@ -315,7 +315,11 @@ class classproperty(object):
 
 
 def url_path(url):
-    return os.path.join(*os.path.join(*url.split('//')[1:]).split('/')[1:])
+    """
+    Strips the protocol and domain from a URL returning just the path.
+    """
+    subpaths = url.split('//')[1:]
+    return '/'.join('/'.join(subpaths).split('/')[1:])
 
 
 # This functionality should be contributed to param


### PR DESCRIPTION
Followup for https://github.com/holoviz/panel/pull/3284

This PR cleans up some of the crufty bits that were in the original `ComponentResourceHandler` PR. Specifically all URLs for custom component resources are now expressed relative to the component. This means we are no longer encoding absolute paths in the URL (and indeed we no longer accept absolute paths either). Additionally this cleans up the code a bit ensuring that everywhere that generates and consumes component URLs uses the same functions to do so.