### PR TITLE
Allow exporting absolute paths when saving

### DIFF
--- a/panel/io/save.py
+++ b/panel/io/save.py
@@ -254,7 +254,7 @@ def save(panel, filename, title=None, resources=None, template=None,
     if template_variables:
         kwargs['template_variables'] = template_variables
 
-    resources = Resources.from_bokeh(resources)
+    resources = Resources.from_bokeh(resources, absolute=True)
 
     # Set resource mode
     with set_resource_mode(resources):

--- a/panel/tests/io/test_save.py
+++ b/panel/tests/io/test_save.py
@@ -1,9 +1,15 @@
 import re
 
 from io import StringIO
+from pathlib import Path
+
+import numpy as np
+
+from bokeh.resources import Resources
 
 from panel.pane import Alert, Vega
 from panel.models.vega import VegaPlot
+from panel.tests.util import hv_available
 
 
 vega_example = {
@@ -52,3 +58,17 @@ def test_save_cdn_resources():
     sio.seek(0)
     html = sio.read()
     assert re.findall('https://unpkg.com/@holoviz/panel@(.*)/dist/css/alerts.css', html)
+
+
+@hv_available
+def test_static_path_in_holoviews_save(tmpdir):
+    import holoviews as hv
+    hv.Store.set_current_backend('bokeh')
+    plot = hv.Curve(np.random.seed(42))
+    res = Resources(mode='server', root_url='/')
+    out_file = Path(tmpdir) / 'plot.html'
+    hv.save(plot, out_file, resources=res)
+    content = out_file.read_text()
+
+    assert 'src="/static/js/bokeh' in content and 'src="static/js/bokeh' not in content
+    assert 'href="/static/extensions/panel/css/' in content and 'href="static/extensions/panel/css/' not in content


### PR DESCRIPTION
Ensures that Resource links are absolute when using 'server' resources for a saved file.

Fixes https://github.com/holoviz/panel/issues/3139