### PR TITLE
Enable max row limits for Tabulator

### DIFF
--- a/examples/reference/widgets/Tabulator.ipynb
+++ b/examples/reference/widgets/Tabulator.ipynb
@@ -749,7 +749,9 @@
    "source": [
     "## Pagination\n",
     "\n",
-    "When working with large tables we sometimes can't send all the data to the browser at once. In these scenarios we can enable pagination, which will fetch only the currently viewed data from the server backend. This may be enabled by setting `pagination='remote'` and the size of each page can be set using the `page_size` option:"
+    "When working with large tables it is generally not advisible to display the whole table at once. In these scenarios we can enable either 'local' or 'remote' pagination, which will render only a single page of data at the same time. In the case of 'remote' pagination only the currently viewed data is actually transferred from the backend server to the frontend and new data is fetched dynamically when we switch the page or filter and sort the data. Note that Panel will automatically enable `'local'` pagination for tables larger than 200 rows and enable `'remote'` pagination for tables larger than 10,000 rows. This protection may be overridden by explicitly setting the `pagination` parameter.\n",
+    "\n",
+    "The pagination setting may be enabled by setting `pagination='remote'` or `pagination='local'` and the size of each page can be set using the `page_size` option:"
    ]
   },
   {
@@ -758,7 +760,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "large_df = pd._testing.makeCustomDataframe(100000, 5)"
+    "large_df = pd._testing.makeCustomDataframe(100_000, 5)"
    ]
   },
   {
@@ -776,7 +778,16 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Contrary to the `'remote'` option, `'local'` pagination entirely loads the data but still allows to display it on multiple pages."
+    "Contrary to the `'remote'` option, `'local'` pagination transfers all of the data but still allows to display it on multiple pages:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "medium_df = pd._testing.makeCustomDataframe(10_000, 5)"
    ]
   },
   {
@@ -786,7 +797,6 @@
    "outputs": [],
    "source": [
     "%%time\n",
-    "medium_df = pd._testing.makeCustomDataframe(10000, 5)\n",
     "paginated_table = pn.widgets.Tabulator(large_df, pagination='local', page_size=10)\n",
     "paginated_table"
    ]


### PR DESCRIPTION
This PR automatically toggles `pagination` to either 'local' or `'remote'` if it was not explicitly set and the number of rows in the table exceed certain limits. The default limit for `local'` pagination is 200 and for 'remote' pagination is 10,000.

Fixes https://github.com/holoviz/panel/issues/2841