### PR TITLE
Get the notebook download links of the gallery to point to a tag instead of master

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1,3 +1,4 @@
+import os
 import param
 
 param.parameterized.docstring_signature = False
@@ -13,6 +14,10 @@ description = 'High-level dashboarding for python visualization libraries'
 
 import panel
 version = release = base_version(panel.__version__)
+
+# For the interactivity warning box created by nbsite to point to the right
+# git tag instead of the default i.e. master.
+os.environ['BRANCH'] = f"v{release}"
 
 html_static_path += ['_static']
 


### PR DESCRIPTION
Fixes https://github.com/holoviz/panel/issues/3082

Needs also the latest version of nbsite `0.7.2a14`.