### PR TITLE
Ensure roots are rendered into GoldenTemplate

### DIFF
--- a/panel/template/golden/__init__.py
+++ b/panel/template/golden/__init__.py
@@ -31,11 +31,11 @@ class GoldenTemplate(BasicTemplate):
 
     _resources = {
         'css': {
-            'goldenlayout': "https://golden-layout.com/files/latest/css/goldenlayout-base.css",
+            'goldenlayout': "https://cdn.jsdelivr.net/npm/golden-layout@1.5.9/src/css/goldenlayout-base.css",
         },
         'js': {
             'jquery': JS_URLS['jQuery'],
-            'goldenlayout': "https://golden-layout.com/files/latest/js/goldenlayout.js"
+            'goldenlayout': 'https://cdn.jsdelivr.net/npm/golden-layout@1.5.9/dist/goldenlayout.min.js'
         }
     }
 

--- a/panel/template/golden/golden.html
+++ b/panel/template/golden/golden.html
@@ -102,7 +102,7 @@
             content: [
               {% for doc in docs %}
               {% for root in doc.roots %}
-              {% if "main" in root.tags%}
+              {% if "main" in root.tags %}
               {
                 type: 'component',
                 componentName: 'view',
@@ -143,6 +143,16 @@
     container.getElement().html(componentState.model);
     container.on("resize", resize_dispatcher)
   })
+
+  // Absolute hackery to get GoldenLayout to initialize even though
+  // document is not ready. Without this bokeh will complain that
+  // DOM nodes to render roots into are not initialized in time.
+  Object.defineProperty(document, 'readyState', {
+    get() { return readyState },
+    set(value) { return readyState = value },
+  });
+  document.readyState = 'complete'
+
   myLayout.init()
   window.addEventListener('resize', (event) => {
     if (!resizing) {


### PR DESCRIPTION
Extremely hacky fix for GoldenTemplate. The problem was that at least in chrome based browsers the Bokeh script would execute before GoldenLayout created the DOM nodes that bokeh wanted to render into. To fix this we hackily override document.readyState ensuring that golden-layout.js initializes the nodes even though the page is not yet fully rendered.

Fixes https://github.com/holoviz/panel/issues/3062