### PR TITLE
Update to latest version of Perspective

### DIFF
--- a/examples/reference/panes/Perspective.ipynb
+++ b/examples/reference/panes/Perspective.ipynb
@@ -26,15 +26,15 @@
     "* **``aggregates``** (dict): Aggregation spec, e.g. {x: \"distinct count\"}\n",
     "* **``columns``** (list): List of displayed columns.\n",
     "* **``computed_columns``** (list): List of computed columns, e.g. `['\"x\"+\"y\"']`\n",
-    "* **``column_pivots``** (list):  A list of columns to pivot by. e.g. `[\"x\", \"y\"]`\n",
     "* **``filters``** (list): A list of filters, e.g. `[[\"x\", \"<\", 3], [\"y\", \"contains\", \"abc\"]]`.\n",
+    "* **``group_by``** (list): List of columns to group by, e.g. `[\"x\", \"y\"]`\n",
     "* **``object``** (dict or pd.DataFrame): The plot data declared as a dictionary of arrays or a DataFrame.\n",
-    "* **``row_pivots``** (list): List of columns to group by, e.g. `[\"x\", \"y\"]`\n",
     "* **``selectable``** (bool, default=True): Whether rows are selectable\n",
+    "* **``split_by``** (list):  A list of columns to pivot by. e.g. `[\"x\", \"y\"]`\n",
     "* **``sort``** (list): List of sorting specs, e.g. `[[\"x\", \"desc\"]]`\n",
-    "* **``plugin``** (str): The name of a plugin to display the data. For example hypergrid or d3_xy_scatter.\n",
+    "* **``plugin``** (str): The name of a plugin to display the data. For example 'datagrid' or 'd3_xy_scatter'.\n",
     "* **``toggle_config``** (bool): Whether to show the config menu.\n",
-    "* **``theme``** (str): The theme of the viewer, available options include `'material'`, `'material-dark'`, `'material-dense'`, `'material-dense-dark'` and `'vaporwave'`\n",
+    "* **``theme``** (str): The theme of the viewer, available options include `'material'`, `'material-dark'`, `'material-dense'`, `'material-dense-dark'`, `'monokai'`, `'solarized'`, `'solarized-dark'` and `'vaporwave'`\n",
     "\n",
     "___\n",
     "\n",
@@ -49,7 +49,7 @@
    "source": [
     "data = {'x': [1, 2, 3], 'y': [1, 2, 3]}\n",
     "\n",
-    "pn.pane.Perspective(data)"
+    "pn.pane.Perspective(data, width=1000)"
    ]
   },
   {
@@ -67,11 +67,12 @@
    "source": [
     "df = pd.DataFrame(np.random.randn(400, 4), columns=list('ABCD')).cumsum()\n",
     "\n",
-    "perspective = pn.pane.Perspective(\n",
+    "stream_perspective = pn.pane.Perspective(\n",
     "    df, plugin='d3_y_line', columns=['A', 'B', 'C', 'D'], theme='material-dark',\n",
-    "sizing_mode='stretch_width', height=500, margin=0)\n",
+    "    sizing_mode='stretch_width', height=500, margin=0\n",
+    ")\n",
     "\n",
-    "perspective"
+    "stream_perspective"
    ]
   },
   {
@@ -91,7 +92,7 @@
     "\n",
     "def stream():\n",
     "    data = df.iloc[-1] + np.random.randn(4)\n",
-    "    perspective.stream(data, rollover.value)\n",
+    "    stream_perspective.stream(data, rollover.value)\n",
     "\n",
     "cb = pn.state.add_periodic_callback(stream, 50)\n",
     "\n",
@@ -113,7 +114,7 @@
    "source": [
     "mixed_df = pd.DataFrame({'A': np.arange(10), 'B': np.random.rand(10), 'C': [f'foo{i}' for i in range(10)]})\n",
     "\n",
-    "perspective = pn.pane.Perspective(mixed_df)\n",
+    "perspective = pn.pane.Perspective(mixed_df, height=500)\n",
     "\n",
     "perspective"
    ]

--- a/panel/models/perspective.py
+++ b/panel/models/perspective.py
@@ -8,11 +8,11 @@ class Perspective(HTMLBox):
 
     aggregates = Either(Dict(String, Any), Null())
 
-    column_pivots = Either(List(String), Null())
+    split_by = Either(List(String), Null())
 
-    columns = Either(List(String), Null)
+    columns = Either(List(Either(String, Null)), Null)
 
-    computed_columns = Either(List(String), Null())
+    expressions = Either(List(String), Null())
 
     editable = Nullable(Bool())
 
@@ -22,7 +22,7 @@ class Perspective(HTMLBox):
 
     plugin_config = Either(Dict(String, Any), Null)
 
-    row_pivots = Either(List(String), Null())
+    group_by = Either(List(String), Null())
 
     selectable = Nullable(Bool())
 
@@ -38,11 +38,10 @@ class Perspective(HTMLBox):
 
     # pylint: disable=line-too-long
     __javascript__ = [
-        "https://unpkg.com/@finos/perspective@0.5.2/dist/umd/perspective.js",
-        "https://unpkg.com/@finos/perspective-viewer@0.5.2/dist/umd/perspective-viewer.js",
-        "https://unpkg.com/@finos/perspective-viewer-datagrid@0.5.2/dist/umd/perspective-viewer-datagrid.js",
-        "https://unpkg.com/@finos/perspective-viewer-hypergrid@0.5.2/dist/umd/perspective-viewer-hypergrid.js",
-        "https://unpkg.com/@finos/perspective-viewer-d3fc@0.5.2/dist/umd/perspective-viewer-d3fc.js",
+        "https://unpkg.com/@finos/perspective@1.3.6/dist/umd/perspective.js",
+        "https://unpkg.com/@finos/perspective-viewer@1.3.6/dist/umd/perspective-viewer.js",
+        "https://unpkg.com/@finos/perspective-viewer-datagrid@1.3.6/dist/umd/perspective-viewer-datagrid.js",
+        "https://unpkg.com/@finos/perspective-viewer-d3fc@1.3.6/dist/umd/perspective-viewer-d3fc.js",
     ]
 
     __js_skip__ = {
@@ -51,19 +50,17 @@ class Perspective(HTMLBox):
 
     __js_require__ = {
         "paths": {
-            "perspective": "https://unpkg.com/@finos/perspective@0.5.2/dist/umd/perspective",
-            "perspective-viewer": "https://unpkg.com/@finos/perspective-viewer@0.5.2/dist/umd/perspective-viewer",
-            "perspective-viewer-datagrid": "https://unpkg.com/@finos/perspective-viewer-datagrid@0.5.2/dist/umd/perspective-viewer-datagrid",
-            "perspective-viewer-hypergrid": "https://unpkg.com/@finos/perspective-viewer-hypergrid@0.5.2/dist/umd/perspective-viewer-hypergrid",
-            "perspective-viewer-d3fc": "https://unpkg.com/@finos/perspective-viewer-d3fc@0.5.2/dist/umd/perspective-viewer-d3fc",
+            "perspective": "https://unpkg.com/@finos/perspective@1.3.6/dist/umd/perspective",
+            "perspective-viewer": "https://unpkg.com/@finos/perspective-viewer@1.3.6/dist/umd/perspective-viewer",
+            "perspective-viewer-datagrid": "https://unpkg.com/@finos/perspective-viewer-datagrid@1.3.6/dist/umd/perspective-viewer-datagrid",
+            "perspective-viewer-d3fc": "https://unpkg.com/@finos/perspective-viewer-d3fc@1.3.6/dist/umd/perspective-viewer-d3fc",
         },
         "exports": {
             "perspective": "perspective",
             "perspective-viewer": "PerspectiveViewer",
             "perspective-viewer-datagrid": "PerspectiveViewerDatagrid",
-            "perspective-viewer-hypergrid": "PerspectiveViewerHypergrid",
             "perspective-viewer-d3fc": "PerspectiveViewerD3fc",
         },
     }
 
-    __css__ = ["https://unpkg.com/@finos/perspective-viewer@0.5.2/dist/umd/all-themes.css"]
+    __css__ = ["https://unpkg.com/@finos/perspective-viewer@1.3.6/dist/css/themes.css"]

--- a/panel/pane/perspective.py
+++ b/panel/pane/perspective.py
@@ -1,5 +1,6 @@
 import datetime as dt
 import sys
+import warnings
 
 from enum import Enum
 
@@ -21,8 +22,13 @@ THEMES_MAP = {
     "material-dense": "perspective-viewer-material-dense",
     "material-dense-dark": "perspective-viewer-material-dense-dark",
     "vaporwave": "perspective-viewer-vaporwave",
+    "solarized": "solarized",
+    "solarized-dark": "solarized-dark",
+    "monokai": "monokai"
 }
+
 THEMES = [*THEMES_MAP.keys()]
+
 # Hack: When the user drags some of the columns, then the class attribute contains "dragging" also.
 CSS_CLASS_MAP = {v: k for k, v in THEMES_MAP.items()}
 DEFAULT_CSS_CLASS = THEMES_MAP[DEFAULT_THEME]
@@ -36,6 +42,7 @@ class Plugin(Enum):
     GRID = "datagrid"  # hypergrid
     YBAR_D3 = "d3_y_bar"  # d3fc
     XBAR_D3 = "d3_x_bar"  # d3fc
+    XYLINE_D3 = "d3_xy_line"  # d3fc
     YLINE_D3 = "d3_y_line"  # d3fc
     YAREA_D3 = "d3_y_area"  # d3fc
     YSCATTER_D3 = "d3_y_scatter"  # d3fc
@@ -82,11 +89,11 @@ def deconstruct_pandas(data, kwargs=None):
       A flattened version of the DataFrame
     kwargs: dict
       A dictionary containing optional members `columns`,
-      `row_pivots`, and `column_pivots`.
+      `group_by`, and `split_by`.
     """
     import pandas as pd
     kwargs = kwargs or {}
-    kwargs = {"columns": [], "row_pivots": [], "column_pivots": []}
+    kwargs = {"columns": [], "group_by": [], "split_by": []}
 
     if isinstance(data.index, pd.PeriodIndex):
         data.index = data.index.to_timestamp()
@@ -103,7 +110,7 @@ def deconstruct_pandas(data, kwargs=None):
         and isinstance(data.index, pd.MultiIndex)
     ):
         # Row and col pivots
-        kwargs["row_pivots"].extend([str(c) for c in data.index.names])
+        kwargs["group_by"].extend([str(c) for c in data.index.names])
 
         # Two strategies
         if None in data.columns.names:
@@ -118,13 +125,13 @@ def deconstruct_pandas(data, kwargs=None):
             #  US     Region 1
             #
             # We need to transform this to:
-            # row_pivots = ['Country', 'Region']
-            # column_pivots = ['State', 'Quantity']
+            # group_by = ['Country', 'Region']
+            # split_by = ['State', 'Quantity']
             # columns = ['Discount', 'Sales']
-            existent = kwargs["row_pivots"] + data.columns.names
+            existent = kwargs["group_by"] + data.columns.names
             for c in data.columns.names:
                 if c is not None:
-                    kwargs["column_pivots"].append(c)
+                    kwargs["split_by"].append(c)
                     data = data.stack()
             data = pd.DataFrame(data).reset_index()
 
@@ -134,7 +141,7 @@ def deconstruct_pandas(data, kwargs=None):
         else:
             # In this case, we have no need as the values is just a single entry
             # e.g. pt = pd.pivot_table(df, values = 'Discount', index=['Country','Region'], columns = ['Category', 'Segment'])
-            for _ in kwargs["row_pivots"]:
+            for _ in kwargs["group_by"]:
                 # unstack row pivots
                 data = data.unstack()
             data = pd.DataFrame(data)
@@ -149,10 +156,10 @@ def deconstruct_pandas(data, kwargs=None):
             if val is None:
                 new_names[j] = "index" if i == 0 else "index-{}".format(i)
                 i += 1
-                # kwargs['row_pivots'].append(str(new_names[j]))
+                # kwargs['group_by'].append(str(new_names[j]))
             else:
-                if str(val) not in kwargs["row_pivots"]:
-                    kwargs["column_pivots"].append(str(val))
+                if str(val) not in kwargs["group_by"]:
+                    kwargs["split_by"].append(str(val))
 
         # Finally, remap any values columns to have column name 'value'
         data.index.names = new_names
@@ -161,8 +168,8 @@ def deconstruct_pandas(data, kwargs=None):
             str(c)
             if c
             in ["index"]
-            + kwargs["row_pivots"]
-            + kwargs["column_pivots"]
+            + kwargs["group_by"]
+            + kwargs["split_by"]
             + kwargs["columns"]
             else "value"
             for c in data.columns
@@ -173,15 +180,15 @@ def deconstruct_pandas(data, kwargs=None):
                 for c in data.columns
                 if c
                 not in ["index"]
-                + kwargs["row_pivots"]
-                + kwargs["column_pivots"]
+                + kwargs["group_by"]
+                + kwargs["split_by"]
                 + kwargs["columns"]
             ]
         )
     elif isinstance(data, pd.DataFrame) and isinstance(data.columns, pd.MultiIndex):
         # Col pivots
         if data.index.name:
-            kwargs["row_pivots"].append(str(data.index.name))
+            kwargs["group_by"].append(str(data.index.name))
             push_row_pivot = False
         else:
             push_row_pivot = True
@@ -195,15 +202,15 @@ def deconstruct_pandas(data, kwargs=None):
                 new_names[j] = "index" if i == 0 else "index-{}".format(i)
                 i += 1
                 if push_row_pivot:
-                    kwargs["row_pivots"].append(str(new_names[j]))
+                    kwargs["group_by"].append(str(new_names[j]))
             else:
-                if str(val) not in kwargs["row_pivots"]:
-                    kwargs["column_pivots"].append(str(val))
+                if str(val) not in kwargs["group_by"]:
+                    kwargs["split_by"].append(str(val))
 
         data.index.names = new_names
         data.columns = [
             str(c)
-            if c in ["index"] + kwargs["row_pivots"] + kwargs["column_pivots"]
+            if c in ["index"] + kwargs["group_by"] + kwargs["split_by"]
             else "value"
             for c in data.columns
         ]
@@ -211,13 +218,13 @@ def deconstruct_pandas(data, kwargs=None):
             [
                 "value"
                 for c in data.columns
-                if c not in ["index"] + kwargs["row_pivots"] + kwargs["column_pivots"]
+                if c not in ["index"] + kwargs["group_by"] + kwargs["split_by"]
             ]
         )
 
     elif isinstance(data, pd.DataFrame) and isinstance(data.index, pd.MultiIndex):
         # Row pivots
-        kwargs["row_pivots"].extend(list(data.index.names))
+        kwargs["group_by"].extend(list(data.index.names))
         data = data.reset_index()  # copy
 
     if isinstance(data, pd.DataFrame):
@@ -257,10 +264,17 @@ class Perspective(PaneBase, ReactiveData):
     columns = param.List(default=None, doc="""
         A list of source columns to show as columns. For example ["x", "y"]""")
 
-    computed_columns = param.List(default=None, doc="""
-      A list of computed columns. For example [""x"+"index""]""")
+    computed_columns = param.List(default=None, precedence=-1, doc="""
+      Deprecated alias for expressions.""")
 
-    column_pivots = param.List(None, doc="""
+    expressions = param.List(default=None, doc="""
+      A list of expressions computing new columns from existing columns.
+      For example [""x"+"index""]""")
+
+    column_pivots = param.List(None, precedence=-1, doc="""
+      Deprecated alias of split_by.""")
+
+    split_by = param.List(None, doc="""
       A list of source columns to pivot by. For example ["x", "y"]""")
 
     filters = param.List(default=None, doc="""
@@ -269,8 +283,11 @@ class Perspective(PaneBase, ReactiveData):
     object = param.Parameter(doc="""
       The plot data declared as a dictionary of arrays or a DataFrame.""")
 
-    row_pivots = param.List(default=None, doc="""
+    group_by = param.List(default=None, doc="""
       A list of source columns to group by. For example ["x", "y"]""")
+
+    row_pivots = param.List(default=None, precedence=-1, doc="""
+      Deprecated alias of group_by.""")
 
     selectable = param.Boolean(default=True, allow_None=True, doc="""
       Whether items are selectable.""")
@@ -291,8 +308,26 @@ class Perspective(PaneBase, ReactiveData):
 
     _rerender_params = ['object']
 
+    _rename = {
+        'computed_columns': None,
+        'row_pivots': None,
+        'column_pivots': None,
+        'selection': None,
+    }
+
     _updates = True
 
+    _deprecations = {
+        'computed_columns': 'expressions',
+        'column_pivots': 'split_by',
+        'row_pivots': 'group_by'
+    }
+
+    def __init__(self, object=None, **params):
+        super().__init__(object=object, **params)
+        self.param.watch(self._deprecated_warning, ['computed_columns', 'column_pivots', 'row_pivots'])
+
+    @classmethod
     def applies(cls, object):
         if isinstance(object, dict):
             return True
@@ -321,6 +356,14 @@ class Perspective(PaneBase, ReactiveData):
             raise ValueError("Integer columns must be unique when "
                              "converted to strings.")
         return df, {str(k): v for k, v in data.items()}
+
+    def _deprecated_warning(self, event):
+        renamed = self._deprecations[event.name]
+        warnings.warn(
+            f'The {event.name!r} parameter is deprecated use {renamed!r} parameter instead.',
+            DeprecationWarning
+        )
+        self.param.update(**{renamed: event.new})
 
     def _filter_properties(self, properties):
         ignored = list(Viewable.param)
@@ -365,9 +408,9 @@ class Perspective(PaneBase, ReactiveData):
 
     def _process_param_change(self, msg):
         msg = super()._process_param_change(msg)
-        for p in ('columns', 'row_pivots', 'column_pivots'):
-            if msg.get(p):
-                msg[p] = [str(col) for col in msg[p]]
+        for p in ('columns', 'group_by', 'split_by'):
+            if p in msg:
+                msg[p] = [None if col is None else str(col) for col in msg[p]]
         if msg.get('sort'):
             msg['sort'] = [[str(col), *args] for col, *args in msg['sort']]
         if msg.get('filters'):
@@ -377,9 +420,7 @@ class Perspective(PaneBase, ReactiveData):
         return msg
 
     def _as_digit(self, col):
-        if self._processed is None:
-            return col
-        elif col in self._processed:
+        if self._processed is None or col in self._processed or col is None:
             return col
         elif col.isdigit() and int(col) in self._processed:
             return int(col)
@@ -387,9 +428,16 @@ class Perspective(PaneBase, ReactiveData):
 
     def _process_property_change(self, msg):
         msg = super()._process_property_change(msg)
-        for prop in ('columns', 'row_pivots', 'column_pivots'):
-            if msg.get(prop):
-                msg[prop] = [self._as_digit(col) for col in msg[prop]]
+        for prop in ('columns', 'group_by', 'split_by'):
+            if prop not in msg:
+                continue
+            msg[prop] = [self._as_digit(col) for col in msg[prop]]
+            if prop == 'group_by':
+                msg['row_pivots'] = msg['group_by']
+            if prop == 'split_by':
+                msg['column_pivots'] = msg['split_by']
+        if 'expressions' in msg:
+            msg['computed_columns'] = msg['expressions']
         if msg.get('sort'):
             msg['sort'] = [[self._as_digit(col), *args] for col, *args in msg['sort']]
         if msg.get('filters'):
@@ -408,7 +456,7 @@ class Perspective(PaneBase, ReactiveData):
         model = Perspective(**properties)
         if root is None:
             root = model
-        synced = list(set(self.param) ^ (set(PaneBase.param) | set(ReactiveData.param)))
+        synced = list(set([p for p in self.param if (self.param[p].precedence or 0) > -1]) ^ (set(PaneBase.param) | set(ReactiveData.param)))
         self._link_props(model, synced, doc, root, comm)
         self._models[root.ref['id']] = (model, parent)
         return model


### PR DESCRIPTION
We were stuck on a really quite old version of perspective, this updates to latest (1.5.8) and performs renaming they have done internally. This resulted in a few deprecations/renaming:

- `column_pivots` -> `split_by`
- `row_pivots` -> `group_by`
- `computed_columns` -> `expressions`

The PR also cleans up the JS implementation a bit and exposes new themes.