### PR TITLE
Ensure that only currently visible tabs have elevated zindex

### DIFF
--- a/panel/models/tabs.ts
+++ b/panel/models/tabs.ts
@@ -19,7 +19,7 @@ export class TabsView extends BkTabsView {
       if (view.model.type.endsWith('Tabs')) {
 	view.connect(view.model.properties.active.change, () => this.update_zindex())
       }
-      view = view.parent
+      view = view.parent || view._parent // Handle ReactiveHTML
     }
   }
 
@@ -33,7 +33,7 @@ export class TabsView extends BkTabsView {
         }
       }
       current_view = parent
-      parent = parent.parent
+      parent = parent.parent || parent._parent // Handle ReactiveHTML
     }
     return true
   }

--- a/panel/pane/plotly.py
+++ b/panel/pane/plotly.py
@@ -252,8 +252,6 @@ class Plotly(PaneBase):
             root = model
         self._link_props(model, self._linkable_params, doc, root, comm)
         self._models[root.ref['id']] = (model, parent)
-        if _patch_tabs_plotly not in Viewable._preprocessing_hooks:
-            Viewable._preprocessing_hooks.append(_patch_tabs_plotly)
         return model
 
     def _update(self, ref=None, model=None):
@@ -322,85 +320,3 @@ class Plotly(PaneBase):
         # Check if we should trigger rendering
         if updates or update_sources:
             model._render_count += 1
-
-
-def _patch_tabs_plotly(viewable, root):
-    """
-    A preprocessing hook which ensures that any Plotly panes rendered
-    inside Tabs are only visible when the tab they are in is active.
-    This is a workaround for https://github.com/holoviz/panel/issues/804.
-    """
-    from ..models.plotly import PlotlyPlot
-
-    # Clear args on old callback so references aren't picked up
-    old_callbacks = {}
-    for tmodel in root.select({'type': Tabs}):
-        old_callbacks[tmodel] = {
-            k: [cb for cb in cbs] for k, cbs in tmodel.js_property_callbacks.items()
-        }
-        for cb in tmodel.js_property_callbacks.get('change:active', []):
-            if any(tag.startswith('plotly_tab_fix') for tag in cb.tags):
-                # Have to unset owners so property is not notified
-                owners = cb.args._owners
-                cb.args._owners = set()
-                cb.args.clear()
-                cb.args._owners = owners
-
-    tabs_models = list(root.select({'type': Tabs}))
-    plotly_models = list(root.select({'type': PlotlyPlot}))
-
-    tab_callbacks = {}
-    for model in plotly_models:
-        parent_tabs = [tmodel for tmodel in tabs_models if tmodel.select_one({'id': model.id})]
-        active = True
-        args = {'model': model}
-        tag = f'plotly_tab_fix{model.id}'
-
-        # Generate condition that determines whether tab containing
-        # the plot is active
-        condition = ''
-        for tabs in list(parent_tabs):
-            # Find tab that contains plot
-            found = False
-            for i, tab in enumerate(tabs.tabs):
-                if tab.select_one({'id': model.id}):
-                    found = True
-                    break
-            if not found:
-                parent_tabs.remove(tabs)
-                continue
-            if condition:
-                condition += ' && '
-            condition += f"(tabs_{tabs.id}.active == {i})"
-            args.update({f'tabs_{tabs.id}': tabs})
-            active &= tabs.active == i
-
-        model.visibility = active
-        code = f'try {{ model.visibility = {condition}; }} catch {{ }}'
-        for tabs in parent_tabs:
-            tab_key = f'tabs_{tabs.id}'
-            cb_args = dict(args)
-            cb_code = code.replace(tab_key, 'cb_obj')
-            cb_args.pop(tab_key)
-            callback = CustomJS(args=cb_args, code=cb_code, tags=[tag])
-            if tabs not in tab_callbacks:
-                tab_callbacks[tabs] = []
-            tab_callbacks[tabs].append(callback)
-
-    for tabs, callbacks in tab_callbacks.items():
-        new_cbs = []
-        for cb in callbacks:
-            found = False
-            for old_cb in tabs.js_property_callbacks.get('change:active', []):
-                if cb.tags[0] in old_cb.tags:
-                    found = True
-                    old_cb.update(code=cb.code)
-                    # Reapply args without notifying property system
-                    owners = old_cb.args._owners
-                    old_cb.args._owners = set()
-                    old_cb.args.update(cb.args)
-                    old_cb.args._owners = owners
-            if not found:
-                new_cbs.append(cb)
-        if new_cbs:
-            tabs.js_on_change('active', *new_cbs)

--- a/panel/pane/plotly.py
+++ b/panel/pane/plotly.py
@@ -5,13 +5,12 @@ bokeh model.
 import numpy as np
 import param
 
-from bokeh.models import ColumnDataSource, CustomJS, Tabs
+from bokeh.models import ColumnDataSource
 from pyviz_comms import JupyterComm
 
 from .base import PaneBase
 from ..util import isdatetime, lazy_load
-from ..viewable import Layoutable, Viewable
-
+from ..viewable import Layoutable
 
 
 class Plotly(PaneBase):

--- a/panel/tests/pane/test_plotly.py
+++ b/panel/tests/pane/test_plotly.py
@@ -14,7 +14,6 @@ plotly_available = pytest.mark.skipif(plotly is None, reason="requires plotly")
 import numpy as np
 
 from panel.models.plotly import PlotlyPlot
-from panel.layout import Tabs
 from panel.pane import PaneBase, Plotly
 
 
@@ -183,34 +182,6 @@ def test_plotly_autosize(document, comm):
 
     pane._cleanup(model)
 
-
-@plotly_available
-def test_plotly_tabs(document, comm):
-    trace = go.Scatter(x=[0, 1], y=[2, 3])
-
-    pane1 = Plotly(dict(data=[trace], layout={'autosize': True}))
-    pane2 = Plotly(dict(data=[trace], layout={'autosize': True}))
-
-    tabs = Tabs(pane1, pane2)
-
-    root = tabs.get_root(document, comm)
-
-    model1 = pane1._models[root.id][0]
-    model2 = pane2._models[root.id][0]
-
-    cb1, cb2 = root.js_property_callbacks['change:active']
-    if cb1.args['model'] is model2:
-        cb1, cb2 = cb2, cb1
-    assert model1.visibility
-    assert cb1.args['model'] is model1
-    assert cb1.code == 'try { model.visibility = (cb_obj.active == 0); } catch { }'
-    assert not model2.visibility
-    assert cb2.args['model'] is model2
-    assert cb2.code == 'try { model.visibility = (cb_obj.active == 1); } catch { }'
-
-    tabs.insert(0, 'Blah')
-    assert cb1.code == 'try { model.visibility = (cb_obj.active == 1); } catch { }'
-    assert cb2.code == 'try { model.visibility = (cb_obj.active == 2); } catch { }'
 
 @plotly_available
 def test_clean_relayout_data():


### PR DESCRIPTION
Replaces hacky Plotly specific approach with a general approach that sets elevated z-index only on currently visible tabs (iterating through the entire model hierarchy to achieve this).

Fixes https://github.com/holoviz/panel/issues/3319