### PR TITLE
Fixes cross selection disabled

### DIFF
--- a/panel/widgets/select.py
+++ b/panel/widgets/select.py
@@ -636,6 +636,8 @@ class CrossSelector(CompositeWidget, MultiSelect):
         self._selections = {False: [], True: []}
         self._query = {False: '', True: ''}
 
+        self._update_disabled()
+
     @param.depends('size', watch=True)
     def _update_size(self):
         self._lists[False].size = self.size


### PR DESCRIPTION
Fixes #3325 

This is done by calling self._update_disabled at the end of `__init__`

![image](https://user-images.githubusercontent.com/19758978/161977423-1bc3752d-acee-46bb-87fb-f9f02817210a.png)
