### PR TITLE
Ensure IOLoop starting errors are ignored

### DIFF
--- a/panel/io/server.py
+++ b/panel/io/server.py
@@ -13,6 +13,7 @@ import sys
 import traceback
 import threading
 import uuid
+import warnings
 
 from collections import OrderedDict
 from contextlib import contextmanager
@@ -782,8 +783,12 @@ def get_server(panel, port=0, address=None, websocket_origin=None,
         server.start()
         try:
             server.io_loop.start()
-        except RuntimeError:
-            pass
+        except Exception:
+            warnings.warn(
+                "IOLoop couldn't be started. Ensure it is started by "
+                "process invoking the panel.io.server.serve."
+            )
+                
     return server
 
 


### PR DESCRIPTION
Some libraries will patch the event loop (e.g. Beeware toga) and Panel should allow these libraries to start the event loop like they expect.