### PR TITLE
Auto-pagination allowed to be set to remote and to switch

### DIFF
--- a/panel/widgets/tables.py
+++ b/panel/widgets/tables.py
@@ -990,10 +990,11 @@ class Tabulator(BaseTable):
         """
         if self.value is None or self._explicit_pagination:
             return
-        if len(self.value) > self._MAX_ROW_LIMITS[0]:
-            self.pagination = 'local'
-        elif len(self.value) > self._MAX_ROW_LIMITS[1]:
-            self.pagination = 'remote'
+        with param.parameterized.discard_events(self):
+            if self._MAX_ROW_LIMITS[0] < len(self.value) <= self._MAX_ROW_LIMITS[1]:
+                self.pagination = 'local'
+            elif len(self.value) > self._MAX_ROW_LIMITS[1]:
+                self.pagination = 'remote'
         self._explicit_pagination = False
 
     @param.depends('pagination', watch=True)


### PR DESCRIPTION
Follow-up on https://github.com/holoviz/panel/pull/3306 which always set pagination to `local` if the number of rows in the df was greater than 200. Another change made in this PR is to avoid triggering the `_set_explicict_pagination` callback from `_apply_max_size`, allowing `pagination` to automatically switch from 'local' to 'remote' or inversely when the df size changes.