### PR TITLE
Handle pyodide events without setter_id

### DIFF
--- a/panel/io/pyodide.py
+++ b/panel/io/pyodide.py
@@ -55,7 +55,7 @@ def _doc_json(model, target):
 
 def _link_docs(pydoc, jsdoc):
     def jssync(event):
-        if (event.setter_id is not None):
+        if (getattr(event, 'setter_id', None) is not None):
             return
         events = [event]
         json_patch = jsdoc.create_json_patch_string(pyodide.to_js(events))


### PR DESCRIPTION
Various events do not have a `setter_id` and were causing errors.