### PR TITLE
Adds the remaining widget docstrings

### DIFF
--- a/examples/reference/widgets/DataFrame.ipynb
+++ b/examples/reference/widgets/DataFrame.ipynb
@@ -16,7 +16,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The ``DataFrame`` widget allows displaying and editing a pandas DataFrame. Note that editing is not possible for multi-indexed DataFrames, in which casey ou will need to reduce the DataFrame to a single index. Also note that the `DataFrame` widget will eventually be replaced with the [`Tabulator`](./Tabulator.ipynb) widget, and so new code should be written to use Tabulator instead.\n",
+    "The ``DataFrame`` widget allows displaying and editing a pandas DataFrame. Note that editing is not possible for multi-indexed DataFrames, in which case you will need to reduce the DataFrame to a single index. Also note that the `DataFrame` widget will eventually be replaced with the [`Tabulator`](./Tabulator.ipynb) widget, and so new code should be written to use Tabulator instead.\n",
     "\n",
     "For more information about listening to widget events and laying out widgets refer to the [widgets user guide](../../user_guide/Widgets.ipynb). Alternatively you can learn how to build GUIs by declaring parameters independently of any specific widgets in the [param user guide](../../user_guide/Param.ipynb). To express interactivity entirely using Javascript without the need for a Python server take a look at the [links user guide](../../user_guide/Param.ipynb).\n",
     "\n",

--- a/examples/reference/widgets/JSONEditor.ipynb
+++ b/examples/reference/widgets/JSONEditor.ipynb
@@ -137,9 +137,22 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
    "name": "python",
-   "pygments_lexer": "ipython3"
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.10"
   }
  },
  "nbformat": 4,

--- a/examples/reference/widgets/TextEditor.ipynb
+++ b/examples/reference/widgets/TextEditor.ipynb
@@ -16,7 +16,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The ``TextEditor`` widget allows provides a WYSIWYG (what-you-see-is-what-you-get) rich text editor into a Panel application which outputs HTML. The editor is built on top of the [Quill.js](https://quilljs.com/) library.\n",
+    "The ``TextEditor`` widget provides a WYSIWYG (what-you-see-is-what-you-get) rich text editor into a Panel application which outputs HTML. The editor is built on top of the [Quill.js](https://quilljs.com/) library.\n",
     "\n",
     "#### Parameters:\n",
     "\n",

--- a/examples/reference/widgets/TextToSpeech.ipynb
+++ b/examples/reference/widgets/TextToSpeech.ipynb
@@ -167,9 +167,22 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
    "name": "python",
-   "pygments_lexer": "ipython3"
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.10"
   }
  },
  "nbformat": 4,

--- a/panel/__init__.py
+++ b/panel/__init__.py
@@ -36,7 +36,7 @@ The app will be available in your browser!
 
 The app will reload with your changes!
 
-For more info check out the Getting Started guide
+For more detail check out the Getting Started Guide
 https://panel.holoviz.org/getting_started/index.html
 """
 from . import layout # noqa

--- a/panel/__init__.py
+++ b/panel/__init__.py
@@ -1,9 +1,11 @@
 """Panel is a high level app and dashboarding framework
-====================================================
+=======================================================
 
 Panel is an open-source Python library that lets you create custom
 interactive web apps and dashboards by connecting user-defined widgets
 to plots, images, tables, or text.
+
+Docs: https://panel.holoviz.org/
 
 Panel works with the tools you know and ❤️.
 
@@ -11,6 +13,31 @@ Panel works with the tools you know and ❤️.
    :alt: Panel Dashboard
 
    Panel Dashboard
+
+How to develop a Panel app in 3 simple steps:
+
+1. Write the app
+
+>>> import panel as pn
+>>> pn.extension(sizing_mode="stretch_width", template="fast")
+>>> pn.panel(some_python_object).servable()
+
+2. Run your app
+
+$ panel serve my_script.py --autoreload --show
+
+or
+
+$ panel serve my_notebook.ipynb --autoreload --show
+
+The app will be available in your browser!
+
+3. Change your code and save it
+
+The app will reload with your changes!
+
+For more info check out the Getting Started guide
+https://panel.holoviz.org/getting_started/index.html
 """
 from . import layout # noqa
 from . import links # noqa

--- a/panel/widgets/__init__.py
+++ b/panel/widgets/__init__.py
@@ -1,6 +1,31 @@
 """
-The widgets module contains Widget which provide bi-directional
-communication between a rendered panel and the Widget parameters.
+Panel provides a long range of basic and specialized widgets. 
+
+Widget Gallery: https://panel.holoviz.org/reference/index.html#widgets
+
+How to use Panel widgets in 4 simple steps:
+
+1. Define your function
+
+def my_func(value1, value2):
+    ...
+    return some_python_object
+
+2. Define your widgets
+
+widget1 = pn.widgets.SomeWidget(value=..., ...).servable(area='sidebar')
+widget2 = pn.widgets.AnotherWidget(value=..., ...).servable(area='sidebar')
+
+3. Bind the function to your widgets
+
+interactive_func = pn.bind(my_func, value1=widget1, value2=widget2)
+
+4. Layout your interactive function in a panel, Column, Row or similar
+
+pn.panel(interactive_func).servable()
+
+For more detail see the Getting Started Guide
+https://panel.holoviz.org/getting_started/index.html
 """
 from .ace import Ace  # noqa
 from .base import Widget, CompositeWidget  # noqa

--- a/panel/widgets/speech_to_text.py
+++ b/panel/widgets/speech_to_text.py
@@ -277,6 +277,12 @@ class SpeechToText(Widget):
     It wraps the HTML5 SpeechRecognition API.  See
     https://developer.mozilla.org/en-US/docs/Web/API/SpeechRecognition
 
+    Reference: https://panel.holoviz.org/reference/widgets/SpeechToText.html
+
+    :Example:
+
+    >>> SpeechToText(button_type="light")
+    
     This functionality is **experimental** and only supported by
     Chrome and a few other browsers.  Checkout
     https://caniuse.com/speech-recognition for a up to date list of

--- a/panel/widgets/tables.py
+++ b/panel/widgets/tables.py
@@ -704,6 +704,22 @@ class BaseTable(ReactiveData, Widget):
 
 
 class DataFrame(BaseTable):
+    """
+    The `DataFrame` widget allows displaying and editing a pandas DataFrame.
+    
+    Note that editing is not possible for multi-indexed DataFrames, in which
+    case you will need to reduce the DataFrame to a single index. 
+    
+    Also note that the `DataFrame` widget will eventually be replaced with the
+    `Tabulator` widget, and so new code should be written to use `Tabulator`
+    instead.
+
+    Reference: https://panel.holoviz.org/reference/widgets/DataFrame.html
+
+    :Example:
+
+    >>> DataFrame(df, name='DataFrame')
+    """
 
     auto_edit = param.Boolean(default=False, doc="""
         Whether clicking on a table cell automatically starts edit mode.""")
@@ -847,8 +863,14 @@ class DataFrame(BaseTable):
 
 class Tabulator(BaseTable):
     """
-    The Tabulator Pane wraps the [Tabulator](http://tabulator.info/)
-    table to provide a full-featured interactive table.
+    The `Tabulator` widget wraps the [Tabulator js](http://tabulator.info/)
+    table to provide a full-featured, very powerful interactive table.
+
+    Reference: https://panel.holoviz.org/reference/widgets/Tabulator.html
+
+    :Example:
+
+    >>> Tabulator(df, theme='site', pagination='remote', page_size=25)
     """
 
     buttons = param.Dict(default={}, doc="""

--- a/panel/widgets/terminal.py
+++ b/panel/widgets/terminal.py
@@ -214,7 +214,7 @@ class TerminalSubprocess(param.Parameterized):
 
 class Terminal(Widget):
     """
-    The Terminal widget renders a live terminal in the browser using
+    The `Terminal` widget renders a live terminal in the browser using
     the xterm.js library making it possible to display logs or even
     provide an interactive terminal in a Panel application.
 

--- a/panel/widgets/terminal.py
+++ b/panel/widgets/terminal.py
@@ -217,6 +217,14 @@ class Terminal(Widget):
     The Terminal widget renders a live terminal in the browser using
     the xterm.js library making it possible to display logs or even
     provide an interactive terminal in a Panel application.
+
+    Reference: https://panel.holoviz.org/reference/widgets/Terminal.html
+
+    :Example:
+
+    >>> Terminal(
+    ...     "Welcome to the Panel Terminal!", options={"cursorBlink": True}
+    ... )
     """
 
     clear = param.Action(doc="Clears the Terminal.", constant=True)

--- a/panel/widgets/text_to_speech.py
+++ b/panel/widgets/text_to_speech.py
@@ -167,9 +167,15 @@ class Utterance(param.Parameterized):
 
 class TextToSpeech(Utterance, Widget):
     """
-    The TextToSpeech widget wraps the HTML5 SpeechSynthesis API
+    The `TextToSpeech` widget wraps the HTML5 SpeechSynthesis API
 
     See https://developer.mozilla.org/en-US/docs/Web/API/SpeechSynthesis
+
+    Reference: https://panel.holoviz.org/reference/widgets/TextToSpeech.html
+
+    :Example:
+
+    >>> TextToSpeech(name="Speech Synthesis", value="Data apps are nice")
     """
 
     auto_speak = param.Boolean(default=True, doc="""

--- a/panel/widgets/texteditor.py
+++ b/panel/widgets/texteditor.py
@@ -1,5 +1,5 @@
 """
-Defines a TextEditor widget based on quill.js.
+Defines a WYSIWYG TextEditor widget based on quill.js.
 """
 import param
 
@@ -11,7 +11,16 @@ from .base import Widget
 
 class TextEditor(Widget):
     """
-    TextEditor widget allow editing text using the quill.js library.
+    The `TextEditor` widget provides a WYSIWYG
+    (what-you-see-is-what-you-get) rich text editor which outputs HTML.
+    
+    The editor is built on top of the [Quill.js](https://quilljs.com/) library.
+
+    Reference: https://panel.holoviz.org/reference/widgets/TextEditor.html
+
+    :Example:
+
+    >>> TextEditor(placeholder='Enter some text')
     """
 
     disabled = param.Boolean(default=False, doc="""


### PR DESCRIPTION
Adds the remaining widget docstrings and also docstrings to the `panel` and `widgets` modules.

The purpose is to make it much easier to navigate the code in a modern IDE like VS Code or PyCharm