### PR TITLE
Add downstream tests

### DIFF
--- a/.github/workflows/downstream_tests.yaml
+++ b/.github/workflows/downstream_tests.yaml
@@ -1,0 +1,23 @@
+name: downstream_tests
+
+on:
+  # Run this workflow after the build workflow has completed.
+  workflow_run:
+    workflows: [packages]
+    types: [completed]
+  # Or by triggering it manually via Github's UI
+  workflow_dispatch:
+    inputs:
+      manual:
+        description: don't change me!
+        type: boolean
+        required: true
+        default: true
+
+jobs:
+  downstream_tests:
+    uses: pyviz-dev/holoviz_tasks/.github/workflows/run_downstream_tests.yaml@main
+    with:
+      downstream_repos_as_json: "{\"downstream_repo\":[\"holoviews\", \"lumen\"]}"
+    secrets:
+      ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}


### PR DESCRIPTION
This workflow runs when a new Panel release is made and launches and reports the results of the tests workflows of HoloViews and Lumen, running from their *master* branch.