### PR TITLE
Fix jupyter_server_extension resource handling

### DIFF
--- a/panel/io/resources.py
+++ b/panel/io/resources.py
@@ -204,20 +204,22 @@ def bundle_resources(roots, resources):
 
 class Resources(BkResources):
 
+    def __init__(self, *args, absolute=False, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.absolute = absolute
+
     @classmethod
     def from_bokeh(cls, bkr, absolute=False):
         kwargs = {}
         if bkr.mode.startswith("server"):
             kwargs['root_url'] = bkr.root_url
-        inst = cls(
+        return cls(
             mode=bkr.mode, version=bkr.version, minified=bkr.minified,
             legacy=bkr.legacy, log_level=bkr.log_level,
             path_versioner=bkr.path_versioner,
             components=bkr._components, base_dir=bkr.base_dir,
-            root_dir=bkr.root_dir, **kwargs
+            root_dir=bkr.root_dir, absolute=absolute, **kwargs
         )
-        inst.absolute = absolute
-        return inst
 
     def extra_resources(self, resources, resource_type):
         """


### PR DESCRIPTION
Fixes an error related to `Resource.absolute` not being defined for the `jupyter_server_extension`.