### PR TITLE
#3400 Fix VS Code/ Pylance not working

### DIFF
--- a/panel/__init__.py
+++ b/panel/__init__.py
@@ -47,7 +47,6 @@ https://panel.holoviz.org/getting_started/index.html
 from . import layout # noqa
 from . import links # noqa
 from . import pane # noqa
-from . import param # noqa
 from . import pipeline # noqa
 from . import reactive # noqa
 from . import viewable # noqa


### PR DESCRIPTION
Addresses #3400 

It removes the `from . import param` in the panel `__init__.py` root file.

I've tried to search the Panel code including example notebooks and tests. I cannot see any reason to import it.

I don't know why this solves the issues. But the `panel.param.py` file imports a lot of other modules and also the `param` package. So a lot of things could potentially be confusing Pylance and causing it.