### PR TITLE
Add setuptools to the runtime dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -104,7 +104,8 @@ install_requires = [
     'requests',
     'tqdm >=4.48.0',
     'pyct >=0.4.4',
-    'bleach'
+    'bleach',
+    'setuptools',
 ]
 
 _recommended = [


### PR DESCRIPTION
Panel depends on `pkg_resources` which is a module distributed by `setuptools`. I've seen this was missing in the runtime dependencies when playing around with toga/briefcase. Note that `pkg_resources` is deprecated and should be replaced at some point by `importlib.resources` and `importlib.metadat`, and their backports.