### PR TITLE
DOC: mention --autoreload

### DIFF
--- a/doc/getting_started/index.rst
+++ b/doc/getting_started/index.rst
@@ -38,7 +38,11 @@ Development
 Editor + Server
 ===============
 
-You can edit your Panel code as a .py file in any text editor, marking the objects you want to render as ``.servable()``, then launch a server with ``panel serve my_script.py --show`` to open a browser tab showing your app or dashboard and backed by a live Python process.
+You can edit your Panel code as a .py file in any text editor, marking the objects you want to render as ``.servable()``, then launch a server with:
+
+  panel serve my_script.py --show --autoreload
+  
+to open a browser tab showing your app or dashboard and backed by a live Python process.
 
 JupyterLab and Classic notebook
 ===============================


### PR DESCRIPTION
Some discussion of the PR at https://discourse.holoviz.org/t/dashboard-development-in-a-py-file/3616

I've put the `panel serve` command in a code block. I'm also adding the `--autoreload` flag which reflects the default of other dashboard tools e.g. streamlit. The goal is make it easier for new users.