### PR TITLE
Replace slickgrid background image in custom FastTemplate CSS

### DIFF
--- a/panel/template/fast/css/fast_bokeh_slickgrid.css
+++ b/panel/template/fast/css/fast_bokeh_slickgrid.css
@@ -69,9 +69,12 @@
   font-weight: 500px;
 }
 
-.bk-root .slick-header-column:hover,
+.bk-root .slick-header-column:hover {
+  filter: brightness(0.98);
+}
+
 .bk-root .slick-header-column-active {
-  background: transparent url('images/header-columns-over-bg.gif') repeat-x center bottom;
+  filter: brightness(0.9);
 }
 
 .bk-root .slick-headerrow {


### PR DESCRIPTION
Replaces an image we can not easily serve with a simple brightness filter. Similar to what this CSS stylesheet does for slickgrid: https://github.com/DimitarChristoff/slickgrid-es6/blob/master/src/slick-default-theme.scss#L26

Fixes https://github.com/holoviz/panel/issues/3455