### PR TITLE
fix root_dir support for "Render with Panel" green button 

### DIFF
--- a/panel/io/jupyter_server_extension.py
+++ b/panel/io/jupyter_server_extension.py
@@ -94,9 +94,7 @@ class PanelHandler(DocHandler):
         pass
 
     async def get(self, path, *args, **kwargs):
-        origpath = path
-        path = os.path.join(self.application.root_dir, fullpath(path))
-        raise ValueError(f"{path} {origpath} {self.application.root_dir} {fullpath(origpath)}")
+        path = os.path.join(self.application.root_dir, path)
         if path in _APPS:
             app, context = _APPS[path]
         else:
@@ -138,7 +136,7 @@ class PanelWSHandler(WSHandler):
         pass
 
     async def open(self, path, *args, **kwargs):
-        path = os.path.join(self.application.root_dir, fullpath(path))
+        path = os.path.join(self.application.root_dir, path)
         _, context = _APPS[path]
 
         token = self._token

--- a/panel/io/jupyter_server_extension.py
+++ b/panel/io/jupyter_server_extension.py
@@ -94,7 +94,9 @@ class PanelHandler(DocHandler):
         pass
 
     async def get(self, path, *args, **kwargs):
+        origpath = path
         path = os.path.join(self.application.root_dir, fullpath(path))
+        raise ValueError(f"{path} {origpath} {self.application.root_dir} {fullpath(origpath)}")
         if path in _APPS:
             app, context = _APPS[path]
         else:


### PR DESCRIPTION
Regression introduced when calling `fullpath(path)` when `path` is an URL fragment.  I think `fullpath()` was meant for path on disk only.

See discussion in https://github.com/holoviz/panel/issues/3440#issuecomment-1112616866
