### PR TITLE
fix wrong path given to bokeh ApplicationContext which expect an url fragment

### DIFF
--- a/panel/io/jupyter_server_extension.py
+++ b/panel/io/jupyter_server_extension.py
@@ -94,7 +94,8 @@ class PanelHandler(DocHandler):
         pass
 
     async def get(self, path, *args, **kwargs):
-        path = os.path.join(self.application.root_dir, path)
+        path_url = path
+        path = os.path.join(self.application.root_dir, path)  # path_on_disk
         if path in _APPS:
             app, context = _APPS[path]
         else:
@@ -105,7 +106,7 @@ class PanelHandler(DocHandler):
                 app = build_lumen(path, argv=None)
             else:
                 app = build_single_handler_application(path)
-            context = ApplicationContext(app, url=path)
+            context = ApplicationContext(app, url=path_url)
             context._loop = tornado.ioloop.IOLoop.current()
             _APPS[path] = (app, context)
 


### PR DESCRIPTION
The var `path` is now really "full path on disk", not what `ApplicationContext` expects.

See comment https://github.com/holoviz/panel/pull/3469#issuecomment-1113364333