### PR TITLE
Add typehints to help developers and users

### DIFF
--- a/panel/io/document.py
+++ b/panel/io/document.py
@@ -5,6 +5,7 @@ import threading
 from contextlib import contextmanager
 from functools import partial, wraps
 
+from bokeh.document.document import Document
 from bokeh.document.events import ModelChangedEvent
 from bokeh.io import curdoc
 
@@ -12,7 +13,7 @@ from .model import patch_events
 from .state import set_curdoc, state
 
 
-def init_doc(doc):
+def init_doc(doc: Optional[Document]) -> Document:
     doc = doc or curdoc()
     if not doc.session_context:
         return doc

--- a/panel/io/document.py
+++ b/panel/io/document.py
@@ -10,14 +10,14 @@ from typing import Callable, List, Optional
 
 from bokeh.document.document import Document
 from bokeh.document.events import DocumentChangedEvent, ModelChangedEvent
-from bokeh.io import curdoc
+from bokeh.io import curdoc as _curdoc
 
 from .model import patch_events
 from .state import set_curdoc, state
 
 
 def init_doc(doc: Optional[Document]) -> Document:
-    curdoc = doc or curdoc()
+    curdoc = doc or _curdoc()
     if not curdoc.session_context:
         return curdoc
 

--- a/panel/io/document.py
+++ b/panel/io/document.py
@@ -1,12 +1,15 @@
+from __future__ import annotations
+
 import datetime as dt
 import inspect
 import threading
 
 from contextlib import contextmanager
 from functools import partial, wraps
+from typing import Callable, List, Optional
 
 from bokeh.document.document import Document
-from bokeh.document.events import ModelChangedEvent
+from bokeh.document.events import DocumentChangedEvent, ModelChangedEvent
 from bokeh.io import curdoc
 
 from .model import patch_events
@@ -14,27 +17,27 @@ from .state import set_curdoc, state
 
 
 def init_doc(doc: Optional[Document]) -> Document:
-    doc = doc or curdoc()
-    if not doc.session_context:
-        return doc
+    curdoc = doc or curdoc()
+    if not curdoc.session_context:
+        return curdoc
 
     thread = threading.current_thread()
     if thread:
-        with set_curdoc(doc):
+        with set_curdoc(curdoc):
             state._thread_id = thread.ident
 
-    session_id = doc.session_context.id
+    session_id = curdoc.session_context.id
     sessions = state.session_info['sessions']
     if session_id not in sessions:
-        return doc
+        return curdoc
 
     sessions[session_id].update({
         'started': dt.datetime.now().timestamp()
     })
-    doc.on_event('document_ready', state._init_session)
-    return doc
+    curdoc.on_event('document_ready', state._init_session)
+    return curdoc
 
-def with_lock(func):
+def with_lock(func: Callable) -> Callable:
     """
     Wrap a callback function to execute with a lock allowing the
     function to modify bokeh models directly.
@@ -57,10 +60,10 @@ def with_lock(func):
         @wraps(func)
         def wrapper(*args, **kw):
             return func(*args, **kw)
-    wrapper.lock = True
+    wrapper.lock = True # type: ignore
     return wrapper
 
-def _dispatch_events(doc, events):
+def _dispatch_events(doc: Document, events: List[DocumentChangedEvent]) -> None:
     """
     Handles dispatch of events which could not be processed in
     unlocked decorator.

--- a/panel/pane/base.py
+++ b/panel/pane/base.py
@@ -26,7 +26,6 @@ from ..viewable import Layoutable, Viewable, Viewer
 if TYPE_CHECKING:
     from bokeh.document import Document
     from bokeh.model import Model
-    from bokeh.models import LayoutDOM
     from pyviz_comms import Comm
 
 
@@ -175,7 +174,9 @@ class PaneBase(Reactive):
         ignored_params = ['name', 'default_layout', 'loading']+self._rerender_params
         return [p for p in self.param if p not in ignored_params]
 
-    def _update_object(self, ref: str, doc: 'Document', root: 'LayoutDOM', parent: 'LayoutDOM', comm: Optional['Comm']) -> None:
+    def _update_object(
+        self, ref: str, doc: 'Document', root: 'Model', parent: 'Model', comm: Optional['Comm']
+    ) -> None:
         old_model = self._models[ref][0]
         if self._updates:
             self._update(ref, old_model)
@@ -259,7 +260,7 @@ class PaneBase(Reactive):
         """
         return None
 
-    def clone(self: T, object: Optional[Any]=None, **params) -> T:
+    def clone(self: T, object: Optional[Any] = None, **params) -> T:
         """
         Makes a copy of the Pane sharing the same parameters.
 
@@ -279,8 +280,8 @@ class PaneBase(Reactive):
         return type(self)(object, **params)
 
     def get_root(
-            self, doc: Optional['Document'] = None,
-            comm: Optional['Comm'] = None, preprocess: bool = True
+        self, doc: Optional['Document'] = None, comm: Optional['Comm'] = None,
+        preprocess: bool = True
     ) -> 'Model':
         """
         Returns the root model and applies pre-processing hooks

--- a/panel/pane/base.py
+++ b/panel/pane/base.py
@@ -2,11 +2,13 @@
 Defines the PaneBase class defining the API for panes which convert
 objects to a visual representation expressed as a bokeh model.
 """
+from __future__ import annotations
+
 import warnings
 
 from functools import partial
 from typing import (
-    TYPE_CHECKING, Any, Callable, List, Optional, TypeVar, Type, Union
+    TYPE_CHECKING, Any, Callable, List, Optional, TypeVar, Type
 )
 
 import param
@@ -116,7 +118,7 @@ class PaneBase(Reactive):
     # numerical priority is selected. The default is an intermediate value.
     # If set to None, applies method will be called to get a priority
     # value for a specific object type.
-    priority: Optional[Union[float, bool]] = 0.5
+    priority: float | bool | None = 0.5
 
     # Whether applies requires full set of keywords
     _applies_kw = False
@@ -181,8 +183,10 @@ class PaneBase(Reactive):
             new_model = self._get_model(doc, root, parent, comm)
             try:
                 if isinstance(parent, _BkGridBox):
-                    indexes = [i for i, child in enumerate(parent.children)
-                               if child[0] is old_model]
+                    indexes = [
+                        i for i, child in enumerate(parent.children)
+                        if child[0] is old_model
+                    ]
                     if indexes:
                         index = indexes[0]
                     else:
@@ -244,7 +248,7 @@ class PaneBase(Reactive):
     #----------------------------------------------------------------
 
     @classmethod
-    def applies(cls, obj: Any) -> Optional[Union[float, bool]]:
+    def applies(cls, obj: Any) -> float | bool | None:
         """
         Returns boolean or float indicating whether the Pane
         can render the object.
@@ -394,7 +398,7 @@ class ReplacementPane(PaneBase):
             links = Link.registry.get(object)
         except TypeError:
             links = []
-        custom_watchers = False
+        custom_watchers = []
         if isinstance(object, Reactive):
             watchers = [
                 w for pwatchers in object._param_watchers.values()
@@ -445,8 +449,8 @@ class ReplacementPane(PaneBase):
         self._internal = internal
 
     def _get_model(
-            self, doc: 'Document', root: Optional['LayoutDOM'] = None,
-            parent: Optional['LayoutDOM'] = None, comm: Optional['Comm'] = None
+        self, doc: 'Document', root: Optional['Model'] = None,
+        parent: Optional['Model'] = None, comm: Optional['Comm'] = None
     ) -> 'Model':
         if root:
             ref = root.ref['id']
@@ -458,11 +462,11 @@ class ReplacementPane(PaneBase):
         self._models[ref] = (model, parent)
         return model
 
-    def _cleanup(self, root: Optional['LayoutDOM'] = None) -> None:
+    def _cleanup(self, root: 'Model' | None = None) -> None:
         self._inner_layout._cleanup(root)
         super()._cleanup(root)
 
-    def select(self, selector: Union[type, Callable, None] = None) -> List[Viewable]:
+    def select(self, selector: type | Callable | None = None) -> List[Viewable]:
         """
         Iterates over the Viewable and any potential children in the
         applying the Selector.

--- a/panel/reactive.py
+++ b/panel/reactive.py
@@ -478,7 +478,7 @@ class Reactive(Syncable, Viewable):
         self._links.append(link)
         return cb
 
-    def controls(self, parameters: List[str]=[], jslink: bool=True, **kwargs) -> Panel:
+    def controls(self, parameters: List[str]=[], jslink: bool=True, **kwargs) -> 'Panel':
         """
         Creates a set of widgets which allow manipulating the parameters
         on this instance. By default all parameters which support
@@ -537,7 +537,7 @@ class Reactive(Syncable, Viewable):
             return controls.layout[0]
         return style.layout[0]
 
-    def jscallback(self, args: Dict={}, **callbacks) -> Callback:
+    def jscallback(self, args: Dict={}, **callbacks) -> 'Callback':
         """
         Allows defining a JS callback to be triggered when a property
         changes on the source object. The keyword arguments define the
@@ -564,7 +564,7 @@ class Reactive(Syncable, Viewable):
         return Callback(self, code=callbacks, args=args)
 
     def jslink(self, target, code: Dict[str,str]=None,
-        args: Optional[Dict]=None, bidirectional=False, **links) -> Link:
+        args: Optional[Dict]=None, bidirectional=False, **links) -> 'Link':
         """
         Links properties on the this Reactive object to those on the
         target Reactive object in JS code.
@@ -758,7 +758,7 @@ class SyncableData(Reactive):
             processed_events.append(e)
         super()._update_manual(*processed_events)
 
-    def stream(self, stream_value: Union[pd.DataFrame, pd.Series, Dict],
+    def stream(self, stream_value: Union['pd.DataFrame', 'pd.Series', Dict],
         rollover: Optional[int]=None, reset_index: bool=True) -> None:
         """
         Streams (appends) the `stream_value` provided to the existing
@@ -866,7 +866,7 @@ class SyncableData(Reactive):
         else:
             raise ValueError("The stream value provided is not a DataFrame, Series or Dict!")
 
-    def patch(self, patch_value: Union[pd.DataFrame, pd.Series, Dict]) -> None:
+    def patch(self, patch_value: Union['pd.DataFrame', 'pd.Series', Dict]) -> None:
         """
         Efficiently patches (updates) the existing value with the `patch_value`.
 

--- a/panel/reactive.py
+++ b/panel/reactive.py
@@ -37,6 +37,10 @@ from .viewable import Layoutable, Renderable, Viewable
 if TYPE_CHECKING:
     import pandas as pd
 
+    from bokeh.document import Document
+    from bokeh.models import LayoutDOM
+    from pyviz_comms import Comm
+
     from .layout.base import Panel
     from .links import Callback, Link
 
@@ -1350,7 +1354,7 @@ class ReactiveHTML(Reactive, metaclass=ReactiveHTMLMetaclass):
             cls._extension_name in ReactiveHTMLMetaclass._loaded_extensions
         )
 
-    def _cleanup(self, root: LayoutDOM) -> None:
+    def _cleanup(self, root: 'LayoutDOM') -> None:
         for child, panes in self._panes.items():
             for pane in panes:
                 pane._cleanup(root)
@@ -1420,7 +1424,7 @@ class ReactiveHTML(Reactive, metaclass=ReactiveHTMLMetaclass):
                     node_events[e] = False
         return events
 
-    def _get_children(self, doc: Document, root: LayoutDOM, model: Model, comm: Optional[Comm]):
+    def _get_children(self, doc: 'Document', root: 'LayoutDOM', model: 'Model', comm: Optional['Comm']):
         from .pane import panel
         old_models = model.children
         new_models = {parent: [] for parent in self._parser.children}

--- a/panel/reactive.py
+++ b/panel/reactive.py
@@ -17,7 +17,7 @@ from functools import partial
 from pprint import pformat
 from typing import (
     TYPE_CHECKING, Any, Callable, Dict, Iterable, List, Mapping,
-    Optional, Set, Tuple, Type
+    Optional, Set, Tuple, Type, Union
 )
 
 import bleach
@@ -651,7 +651,7 @@ class Reactive(Syncable, Viewable):
                     bidirectional=bidirectional)
 
 
-TData = ('pd.DataFrame' | 'DataDict')
+TData = Union['pd.DataFrame', 'DataDict']
 
 
 class SyncableData(Reactive):

--- a/panel/reactive.py
+++ b/panel/reactive.py
@@ -17,8 +17,9 @@ from typing import TYPE_CHECKING, Callable, Dict, List, Optional, Tuple, Union
 
 import bleach
 import numpy as np
-import param
 from bokeh.model import DataModel
+
+import param
 from param.parameterized import ParameterizedMetaclass, Watcher
 
 from .io.document import unlocked
@@ -32,6 +33,9 @@ from .viewable import Layoutable, Renderable, Viewable
 
 if TYPE_CHECKING:
     import pandas as pd
+
+    from .layout.base import Panel
+    from .links import Callback, Link
 
 log = logging.getLogger('panel.reactive')
 
@@ -401,7 +405,7 @@ class Reactive(Syncable, Viewable):
 
     def link(self, target: param.Parameterized,
         callbacks: Optional[Dict[str, Union[str, Callable]]]=None,
-        bidirectional: bool=False,  **links):
+        bidirectional: bool=False,  **links) -> Watcher:
         """
         Links the parameters on this `Reactive` object to attributes on the
         target `Parameterized` object.
@@ -474,7 +478,7 @@ class Reactive(Syncable, Viewable):
         self._links.append(link)
         return cb
 
-    def controls(self, parameters: List[str]=[], jslink: bool=True, **kwargs):
+    def controls(self, parameters: List[str]=[], jslink: bool=True, **kwargs) -> Panel:
         """
         Creates a set of widgets which allow manipulating the parameters
         on this instance. By default all parameters which support
@@ -533,7 +537,7 @@ class Reactive(Syncable, Viewable):
             return controls.layout[0]
         return style.layout[0]
 
-    def jscallback(self, args: Dict={}, **callbacks):
+    def jscallback(self, args: Dict={}, **callbacks) -> Callback:
         """
         Allows defining a JS callback to be triggered when a property
         changes on the source object. The keyword arguments define the
@@ -560,7 +564,7 @@ class Reactive(Syncable, Viewable):
         return Callback(self, code=callbacks, args=args)
 
     def jslink(self, target, code: Dict[str,str]=None,
-        args: Optional[Dict]=None, bidirectional=False, **links):
+        args: Optional[Dict]=None, bidirectional=False, **links) -> Link:
         """
         Links properties on the this Reactive object to those on the
         target Reactive object in JS code.
@@ -755,7 +759,7 @@ class SyncableData(Reactive):
         super()._update_manual(*processed_events)
 
     def stream(self, stream_value: Union[pd.DataFrame, pd.Series, Dict],
-        rollover: Optional[int]=None, reset_index: bool=True):
+        rollover: Optional[int]=None, reset_index: bool=True) -> None:
         """
         Streams (appends) the `stream_value` provided to the existing
         value in an efficient manner.
@@ -862,7 +866,7 @@ class SyncableData(Reactive):
         else:
             raise ValueError("The stream value provided is not a DataFrame, Series or Dict!")
 
-    def patch(self, patch_value: Union[pd.DataFrame, pd.Series, Dict]):
+    def patch(self, patch_value: Union[pd.DataFrame, pd.Series, Dict]) -> None:
         """
         Efficiently patches (updates) the existing value with the `patch_value`.
 
@@ -1666,7 +1670,7 @@ class ReactiveHTML(Reactive, metaclass=ReactiveHTMLMetaclass):
         self._set_on_model(model_msg, root, model)
         self._set_on_model(data_msg, root, model.data)
 
-    def on_event(self, node: str, event: str, callback: Callable):
+    def on_event(self, node: str, event: str, callback: Callable) -> None:
         """
         Registers a callback to be executed when the specified DOM
         event is triggered on the named node. Note that the named node

--- a/panel/reactive.py
+++ b/panel/reactive.py
@@ -38,6 +38,7 @@ if TYPE_CHECKING:
     import pandas as pd
 
     from bokeh.document import Document
+    from bokeh.model import Model
     from bokeh.models import LayoutDOM
     from pyviz_comms import Comm
 

--- a/panel/viewable.py
+++ b/panel/viewable.py
@@ -19,7 +19,7 @@ import uuid
 
 from functools import partial
 from typing import (
-    TYPE_CHECKING, Any, Callable, IO, List, Mapping, Optional, Union
+    TYPE_CHECKING, Any, Callable, IO, List, Mapping, Optional
 )
 
 import param # type: ignore
@@ -249,7 +249,9 @@ class ServableMixin(object):
     Mixin to define methods shared by objects which can served.
     """
 
-    def _modify_doc(self, server_id: str, title: str, doc: Document, location: Optional['Location']) -> Document:
+    def _modify_doc(
+        self, server_id: str, title: str, doc: Document, location: Optional['Location']
+    ) -> Document:
         """
         Callback to handle FunctionHandler document creation.
         """
@@ -257,7 +259,10 @@ class ServableMixin(object):
             state._servers[server_id][2].append(doc)
         return self.server_doc(doc, title, location) # type: ignore
 
-    def _add_location(self, doc: Document, location: Union['Location', bool, None], root: Optional['Model'] = None) -> 'Location':
+    def _add_location(
+        self, doc: Document, location: Optional['Location' | bool],
+        root: Optional['Model'] = None
+    ) -> 'Location':
         from .io.location import Location
         if isinstance(location, Location):
             loc = location
@@ -316,7 +321,9 @@ class ServableMixin(object):
     # Public API
     #----------------------------------------------------------------
 
-    def servable(self, title: Optional[str] = None, location: Union['Location', bool] = True, area: str = 'main') -> 'ServableMixin':
+    def servable(
+        self, title: Optional[str] = None, location: bool | 'Location' = True, area: str = 'main'
+    ) -> 'ServableMixin':
         """
         Serves the object if in a `panel serve` context and returns
         the Panel object to allow it to display itself in a notebook
@@ -357,9 +364,11 @@ class ServableMixin(object):
                 self.server_doc(title=title, location=location) # type: ignore
         return self
 
-    def show(self, title: Optional[str] = None, port: int = 0, address: Optional[str] = None,
-             websocket_origin: Optional[str] = None, threaded: bool = False, verbose: bool = True,
-             open: bool = True, location: Union[bool, 'Location']=True, **kwargs) -> Union[threading.Thread, 'Server']:
+    def show(
+        self, title: Optional[str] = None, port: int = 0, address: Optional[str] = None,
+        websocket_origin: Optional[str] = None, threaded: bool = False, verbose: bool = True,
+        open: bool = True, location: bool | 'Location' = True, **kwargs
+    ) -> threading.Thread | 'Server':
         """
         Starts a Bokeh server and displays the Viewable in a new tab.
 
@@ -678,7 +687,9 @@ class Viewable(Renderable, Layoutable, ServableMixin):
         """
         print(self)
 
-    def select(self, selector: Union[type, Callable[['Viewable'], bool], None] = None) -> List['Viewable']:
+    def select(
+        self, selector: Optional[type | Callable[['Viewable'], bool]] = None
+    ) -> List['Viewable']:
         """
         Iterates over the Viewable and any potential children in the
         applying the Selector.
@@ -713,9 +724,11 @@ class Viewable(Renderable, Layoutable, ServableMixin):
         """
         return show_server(self, notebook_url, port)
 
-    def embed(self, max_states: int = 1000, max_opts: int = 3, json: bool = False,
-              json_prefix: str = '', save_path: str = './', load_path: Optional[str] = None,
-              progress: bool = False, states={}) -> None:
+    def embed(
+        self, max_states: int = 1000, max_opts: int = 3, json: bool = False,
+        json_prefix: str = '', save_path: str = './', load_path: Optional[str] = None,
+        progress: bool = False, states={}
+    ) -> None:
         """
         Renders a static version of a panel in a notebook by evaluating
         the set of states defined by the widgets in the model. Note
@@ -746,7 +759,7 @@ class Viewable(Renderable, Layoutable, ServableMixin):
             load_path, progress, states
         )
 
-    def save(self, filename: Union[str, IO], title: Optional[str] = None,
+    def save(self, filename: str | IO, title: Optional[str] = None,
              resources=None, template=None,
              template_variables=None, embed=False, max_states=1000,
              max_opts=3, embed_json=False, json_prefix='', save_path='./',
@@ -794,8 +807,10 @@ class Viewable(Renderable, Layoutable, ServableMixin):
                     embed_json, json_prefix, save_path, load_path,
                     progress, embed_states, as_png, **kwargs)
 
-    def server_doc(self, doc: Optional[Document] = None, title: Optional[str] = None,
-                   location: Union[bool, 'Location'] = True) -> Document:
+    def server_doc(
+        self, doc: Optional[Document] = None, title: Optional[str] = None,
+        location: bool | 'Location' = True
+    ) -> Document:
         """
         Returns a serveable bokeh Document with the panel attached
 

--- a/panel/viewable.py
+++ b/panel/viewable.py
@@ -256,7 +256,7 @@ class ServableMixin(object):
             state._servers[server_id][2].append(doc)
         return self.server_doc(doc, title, location) # type: ignore
 
-    def _add_location(self, doc: Document, location: Union['Location', bool, None], root: Optional[LayoutDOM] = None) -> 'Location':
+    def _add_location(self, doc: Document, location: Union['Location', bool, None], root: Optional['LayoutDOM'] = None) -> 'Location':
         from .io.location import Location
         if isinstance(location, Location):
             loc = location
@@ -358,7 +358,7 @@ class ServableMixin(object):
 
     def show(self, title: Optional[str] = None, port: int = 0, address: Optional[str] = None,
              websocket_origin: Optional[str] = None, threaded: bool = False, verbose: bool = True,
-             open: bool = True, location: Union[bool, 'Location']=True, **kwargs) -> Union[threading.Thread, Server]:
+             open: bool = True, location: Union[bool, 'Location']=True, **kwargs) -> Union[threading.Thread, 'Server']:
         """
         Starts a Bokeh server and displays the Viewable in a new tab.
 
@@ -422,8 +422,8 @@ class Renderable(param.Parameterized):
     def _log(self, msg: str, *args, level: str = 'debug') -> None:
         getattr(self._logger, level)(f'Session %s {msg}', id(state.curdoc), *args)
 
-    def _get_model(self, doc: Document, root: Optional[LayoutDOM] = None,
-                   parent: Optional[LayoutDOM] = None, comm: Optional[Comm] = None) -> Model:
+    def _get_model(self, doc: Document, root: Optional['LayoutDOM'] = None,
+                   parent: Optional['LayoutDOM'] = None, comm: Optional[Comm] = None) -> 'Model':
         """
         Converts the objects being wrapped by the viewable into a
         bokeh model that can be composed in a bokeh layout.
@@ -445,7 +445,7 @@ class Renderable(param.Parameterized):
         """
         raise NotImplementedError
 
-    def _cleanup(self, root: LayoutDOM) -> None:
+    def _cleanup(self, root: 'LayoutDOM') -> None:
         """
         Clean up method which is called when a Viewable is destroyed.
 
@@ -458,7 +458,7 @@ class Renderable(param.Parameterized):
         if ref in state._handles:
             del state._handles[ref]
 
-    def _preprocess(self, root: LayoutDOM) -> None:
+    def _preprocess(self, root: 'LayoutDOM') -> None:
         """
         Applies preprocessing hooks to the model.
         """
@@ -466,7 +466,7 @@ class Renderable(param.Parameterized):
         for hook in hooks:
             hook(self, root)
 
-    def _render_model(self, doc: Optional[Document] = None, comm: Optional[Comm] = None) -> Model:
+    def _render_model(self, doc: Optional[Document] = None, comm: Optional[Comm] = None) -> 'Model':
         if doc is None:
             doc = Document()
         if comm is None:
@@ -487,7 +487,7 @@ class Renderable(param.Parameterized):
     def _init_params(self) -> Mapping[str, Any]:
         return {k: v for k, v in self.param.values().items() if v is not None}
 
-    def _server_destroy(self, session_context: SessionContext) -> None:
+    def _server_destroy(self, session_context: 'SessionContext') -> None:
         """
         Server lifecycle hook triggered when session is destroyed.
         """
@@ -511,7 +511,7 @@ class Renderable(param.Parameterized):
             loc._cleanup(root)
             del state._locations[doc]
 
-    def get_root(self, doc: Optional[Document] = None, comm: Optional[Comm] = None, preprocess: bool = True) -> Model:
+    def get_root(self, doc: Optional[Document] = None, comm: Optional[Comm] = None, preprocess: bool = True) -> 'Model':
         """
         Returns the root model and applies pre-processing hooks
 
@@ -551,7 +551,7 @@ class Viewable(Renderable, Layoutable, ServableMixin):
         Whether or not the Viewable is loading. If True a loading spinner
         is shown on top of the Viewable.""")
 
-    _preprocessing_hooks: List[Callable[['Viewable', Model], None]] = []
+    _preprocessing_hooks: List[Callable[['Viewable', 'Model'], None]] = []
 
     def __init__(self, **params):
         hooks = params.pop('hooks', [])

--- a/panel/viewable.py
+++ b/panel/viewable.py
@@ -41,8 +41,8 @@ from .util import escape, param_reprs
 
 if TYPE_CHECKING:
     from bokeh.application import SessionContext
-    from bokeh.layout import LayoutDOM
     from bokeh.model import Model
+    from bokeh.models import LayoutDOM
     from bokeh.server import Server
 
     from .io.location import Location

--- a/panel/viewable.py
+++ b/panel/viewable.py
@@ -248,7 +248,7 @@ class ServableMixin(object):
     Mixin to define methods shared by objects which can served.
     """
 
-    def _modify_doc(self, server_id: str, title: str, doc: Document, location: Optional[Location]) -> Document:
+    def _modify_doc(self, server_id: str, title: str, doc: Document, location: Optional['Location']) -> Document:
         """
         Callback to handle FunctionHandler document creation.
         """
@@ -256,7 +256,7 @@ class ServableMixin(object):
             state._servers[server_id][2].append(doc)
         return self.server_doc(doc, title, location) # type: ignore
 
-    def _add_location(self, doc: Document, location: Union[Location, bool, None], root: Optional[LayoutDOM] = None) -> Location:
+    def _add_location(self, doc: Document, location: Union['Location', bool, None], root: Optional[LayoutDOM] = None) -> 'Location':
         from .io.location import Location
         if isinstance(location, Location):
             loc = location
@@ -315,7 +315,7 @@ class ServableMixin(object):
     # Public API
     #----------------------------------------------------------------
 
-    def servable(self, title: Optional[str] = None, location: Union[Location, bool] = True, area: str = 'main') -> 'ServableMixin':
+    def servable(self, title: Optional[str] = None, location: Union['Location', bool] = True, area: str = 'main') -> 'ServableMixin':
         """
         Serves the object if in a `panel serve` context and returns
         the Panel object to allow it to display itself in a notebook
@@ -358,7 +358,7 @@ class ServableMixin(object):
 
     def show(self, title: Optional[str] = None, port: int = 0, address: Optional[str] = None,
              websocket_origin: Optional[str] = None, threaded: bool = False, verbose: bool = True,
-             open: bool = True, location: Union[bool, Location]=True, **kwargs) -> Union[threading.Thread, Server]:
+             open: bool = True, location: Union[bool, 'Location']=True, **kwargs) -> Union[threading.Thread, Server]:
         """
         Starts a Bokeh server and displays the Viewable in a new tab.
 
@@ -794,7 +794,7 @@ class Viewable(Renderable, Layoutable, ServableMixin):
                     progress, embed_states, as_png, **kwargs)
 
     def server_doc(self, doc: Optional[Document] = None, title: Optional[str] = None,
-                   location: Union[bool, Location] = True) -> Document:
+                   location: Union[bool, 'Location'] = True) -> Document:
         """
         Returns a serveable bokeh Document with the panel attached
 

--- a/panel/widgets/base.py
+++ b/panel/widgets/base.py
@@ -109,7 +109,7 @@ class Widget(Reactive):
         return [p for p in properties if p not in ignored]
 
     def _get_embed_state(
-        self, root: 'LayoutDOM', values: Optional[List[Any]] = None, max_opts: int = 3
+        self, root: 'Model', values: Optional[List[Any]] = None, max_opts: int = 3
     ) -> Tuple['Widget', 'Model', List[Any], Callable[['Model'], Any], str, str]:
         """
         Returns the bokeh model and a discrete set of value states

--- a/panel/widgets/base.py
+++ b/panel/widgets/base.py
@@ -5,11 +5,18 @@ parameters.
 """
 import math
 
+from typing import TYPE_CHECKING, List
+
 import param
 
 from ..layout import Row
 from ..reactive import Reactive
 from ..viewable import Layoutable
+
+if TYPE_CHECKING:
+    from bokeh.document import Document
+    from bokeh.model import Model
+    from bokeh.models import LayoutDOM
 
 
 class Widget(Reactive):
@@ -54,7 +61,7 @@ class Widget(Reactive):
         super().__init__(**params)
 
     @classmethod
-    def from_param(cls, parameter, **params):
+    def from_param(cls, parameter: param.Parameter, **params):
         """
         Construct a widget from a Parameter and link the two
         bi-directionally.
@@ -77,7 +84,8 @@ class Widget(Reactive):
         )
         return layout[0]
 
-    def _get_model(self, doc, root=None, parent=None, comm=None):
+    def _get_model(self, doc: Document, root: Optional[LayoutDOM] = None,
+                   parent: Optional[LayoutDOM] = None, comm: Optional[Comm] = None) -> Model:
         model = self._widget_type(**self._process_param_change(self._init_params()))
         if root is None:
             root = model
@@ -88,11 +96,11 @@ class Widget(Reactive):
         self._link_props(model, properties, doc, root, comm)
         return model
 
-    def _filter_properties(self, properties):
+    def _filter_properties(self, properties: List[str]):
         ignored = list(Layoutable.param)+['loading']
         return [p for p in properties if p not in ignored]
 
-    def _get_embed_state(self, root, values=None, max_opts=3):
+    def _get_embed_state(self, root: LayoutDOM, values: Optional[List[Any]] = None, max_opts: int = 3):
         """
         Returns the bokeh model and a discrete set of value states
         for the widget.
@@ -144,11 +152,11 @@ class CompositeWidget(Widget):
         self._models = self._composite._models
         self.param.watch(self._update_layout_params, layout_params)
 
-    def _update_layout_params(self, *events):
+    def _update_layout_params(self, *events) -> None:
         updates = {event.name: event.new for event in events}
         self._composite.param.update(**updates)
 
-    def select(self, selector=None):
+    def select(self, selector=None): List[Viewable]:
         """
         Iterates over the Viewable and any potential children in the
         applying the Selector.
@@ -168,20 +176,21 @@ class CompositeWidget(Widget):
             objects += obj.select(selector)
         return objects
 
-    def _cleanup(self, root):
+    def _cleanup(self, root: LayoutDOM) -> None:
         self._composite._cleanup(root)
         super()._cleanup(root)
 
-    def _get_model(self, doc, root=None, parent=None, comm=None):
+    def _get_model(self, doc: Document, root: Optional[LayoutDOM] = None,
+                   parent: Optional[LayoutDOM] = None, comm: Optional[Comm] = None) -> Model:
         model = self._composite._get_model(doc, root, parent, comm)
         if root is None:
             root = parent = model
         self._models[root.ref['id']] = (model, parent)
         return model
 
-    def __contains__(self, object):
+    def __contains__(self, object: Any) -> bool:
         return object in self._composite.objects
 
     @property
-    def _synced_params(self):
+    def _synced_params(self) -> List[str]:
         return []

--- a/panel/widgets/tables.py
+++ b/panel/widgets/tables.py
@@ -494,7 +494,7 @@ class BaseTable(ReactiveData, Widget):
 
         Arguments
         ---------
-        stream_value: (Union[pd.DataFrame, pd.Series, Dict])
+        stream_value: (pd.DataFrame | pd.Series | Dict)
           The new value(s) to append to the existing value.
         rollover: int
            A maximum column size, above which data from the start of
@@ -598,7 +598,7 @@ class BaseTable(ReactiveData, Widget):
 
         Arguments
         ---------
-        patch_value: (Union[pd.DataFrame, pd.Series, Dict])
+        patch_value: (pd.DataFrame | pd.Series | Dict)
           The value(s) to patch the existing value with.
         as_index: boolean
           Whether to treat the patch index as DataFrame indexes (True)


### PR DESCRIPTION
Fixes one of the issues in #3475.

- I added lots more typehints to `reactive.py`, to give you (@philippjfr ) an idea about what it takes to add typehints to a module as you say are are prepared for in https://github.com/holoviz/panel/issues/2968#issuecomment-983636021
- I also ran `isort` which reorganized some of the imports slightly.
- I focused on adding typehints to public objects.
- In a few places I would not know how to construct the typehint, so I did not add it.
- I don't add typehints to *parameters* on `Parameterized` classes as I assume they will be inferred automatically one day by automated type stub generation or by implementing the PEP on Param for DataClass like classes.
- I tried my best to use type hints support by Python 3.6 as setup.py says we support this. But the github tests only run for python >= 3.7. So I cannot be 100% sure.