### PR TITLE
Remove print statement

### DIFF
--- a/panel/io/jupyter_server_extension.py
+++ b/panel/io/jupyter_server_extension.py
@@ -189,8 +189,6 @@ def _load_jupyter_server_extension(notebook_app):
         state.base_url = url_path_join(base_url, '/panel-preview/')
         state.rel_path = url_path_join(base_url, '/panel-preview')
 
-    print(state.base_url, urljoin(base_url, 'panel-preview'))
-
     # Set up handlers
     notebook_app.web_app.add_handlers(
         host_pattern=r".*$",


### PR DESCRIPTION
Noticed when starting jupyterlab I would get the following message:

![2022-05-03 11_18_25](https://user-images.githubusercontent.com/19758978/166522778-578aceb0-947d-42d6-b633-ccee7fbd65e7.png)

