### PR TITLE
Tabulator: document how to make a column non-editable

### DIFF
--- a/examples/reference/widgets/Tabulator.ipynb
+++ b/examples/reference/widgets/Tabulator.ipynb
@@ -74,7 +74,7 @@
     "\n",
     "##### Display\n",
     "\n",
-    "* **``disabled``** (``boolean``): Whether the widget is editable\n",
+    "* **``disabled``** (``boolean``): Whether the cells are editable\n",
     "* **``name``** (``str``): The title of the widget\n",
     "\n",
     "##### Properties\n",
@@ -203,7 +203,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Therefore it is often preferable to use one of the [Tabulator editors](http://tabulator.info/docs/5.0/edit#edit) directly. Note that in addition to the standard Tabulator editors the Tabulator widget also supports `'date'` and `'datetime'` editors:"
+    "Therefore it is often preferable to use one of the [Tabulator editors](http://tabulator.info/docs/5.0/edit#edit) directly. Setting the editor of a column to `None` makes that column non-editable. Note that in addition to the standard Tabulator editors the Tabulator widget also supports `'date'` and `'datetime'` editors:"
    ]
   },
   {
@@ -215,6 +215,7 @@
     "from bokeh.models.widgets.tables import CheckboxEditor, NumberEditor, SelectEditor\n",
     "\n",
     "bokeh_editors = {\n",
+    "    'int': None,\n",
     "    'float': {'type': 'number', 'max': 10, 'step': 0.1},\n",
     "    'bool': {'type': 'tickCross', 'tristate': True, 'indeterminateValue': None},\n",
     "    'str': {'type': 'autocomplete', 'values': True},\n",


### PR DESCRIPTION
This is achieved by setting explicitly the editor of a column to `None`: `Tabulator(df, editors={'acolumn': None}`).