### PR TITLE
Ensure overflow in MaterialTemplate is not clipped

### DIFF
--- a/panel/template/material/material.css
+++ b/panel/template/material/material.css
@@ -85,7 +85,7 @@ img.app-logo {
 
 .main-content {
   overflow-y: scroll;
-  overflow-x: hidden;
+  overflow-x: auto;
 }
 
 #header {


### PR DESCRIPTION
Previously content was simply cut-off in the `MaterialTemplate` making some dashboards unusable.