### PR TITLE
Ensure Tabulator expanded rows are sized correctly after re-render

### DIFF
--- a/panel/models/tabulator.ts
+++ b/panel/models/tabulator.ts
@@ -296,6 +296,8 @@ export class DataTabulatorView extends PanelHTMLBoxView {
 
   invalidate_render(): void {
     this.render()
+    if (this.model.expanded.length)
+      this.relayout()
   }
 
   renderComplete(): void {


### PR DESCRIPTION
Fixes https://github.com/holoviz/panel/issues/3504