### PR TITLE
PANEL_COOKIE_SECRET not verified correctly

### DIFF
--- a/panel/command/serve.py
+++ b/panel/command/serve.py
@@ -406,7 +406,7 @@ class Serve(_BkServe):
                         "base64-encoded bytes."
                     )
                 config.oauth_encryption_key = encryption_key
-            else:
+            elif not config.oauth_encryption_key:
                 print("WARNING: OAuth has not been configured with an "
                       "encryption key and will potentially leak "
                       "credentials in cookies and a JWT token embedded "
@@ -435,7 +435,7 @@ class Serve(_BkServe):
                 )
             elif args.cookie_secret:
                 config.cookie_secret = args.cookie_secret
-            else:
+            elif not config.cookie_secret:
                 raise ValueError(
                     "When enabling an OAuth provider you must supply "
                     "a valid cookie_secret either using the --cookie-secret "


### PR DESCRIPTION
Some env variables such as PANEL_COOKIE_SECRET and PANEL_OAUTH_ENCRYPTION are not being verified correctly. This commit fixes that.

Issue#3524