### PR TITLE
ci: cache conda envs betweeen successive builds in a day

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '0 19 * * SUN'
-    
+
 env:
   CACHE_VERSION: 1
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,6 +9,9 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '0 19 * * SUN'
+    
+env:
+  CACHE_VERSION: 1
 
 jobs:
   pre_commit:
@@ -35,6 +38,13 @@ jobs:
       matrix:
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
         python-version: [3.7, 3.8, 3.9]
+        include:
+        - os: ubuntu-latest
+          path: /usr/share/miniconda3/envs/
+        - os: macos-latest
+          path: /Users/runner/miniconda3/envs/
+        - os: windows-latest
+          path: C:\Miniconda3\envs\
         exclude:
           - os: windows-latest
             python-version: 3.8
@@ -65,7 +75,18 @@ jobs:
           channels: pyviz/label/dev,bokeh/label/dev,conda-forge,nodefaults
       - name: Fetch unshallow
         run: git fetch --prune --tags --unshallow
+      - name: Get Today's date for cache
+        run: echo "TODAY=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
+      - name: conda cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ matrix.path }}
+          key: ${{ runner.os }}-conda-${{ matrix.python-version }}-${{ hashFiles('setup.py') }}-${{ env.TODAY }}-${{ env.CACHE_VERSION }}
+          restore-keys: |
+           ${{ runner.os }}-conda-${{ matrix.python-version }}-${{ env.TODAY }}-${{ env.CACHE_VERSION }}
+        id: cache
       - name: conda setup
+        if: steps.cache.outputs.cache-hit != 'true'
         run: |
           conda install "pyctdev>=0.5"
           conda install "nodejs=15.3.0"
@@ -80,6 +101,7 @@ jobs:
           /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1280x1024x24
           sleep 3
       - name: doit develop_install
+        if: steps.cache.outputs.cache-hit != 'true'
         run: |
           eval "$(conda shell.bash hook)"
           conda activate test-environment
@@ -99,6 +121,7 @@ jobs:
         run: |
           eval "$(conda shell.bash hook)"
           conda activate test-environment
+          python -m pip install --no-deps --no-build-isolation -e .
           doit env_capture
       - name: doit test_unit
         run: |


### PR DESCRIPTION
Quicker turn around time for github actions. The cache is invalidated every day once (date is used in the key for the cache). It will also rerun if there is any change to setup.py.

There is a similar setup for hvplot.