### PR TITLE
Ensure that HoloViews callback events are not auto-dispatched

### DIFF
--- a/panel/pane/holoviews.py
+++ b/panel/pane/holoviews.py
@@ -281,8 +281,11 @@ class HoloViews(PaneBase):
 
     def _get_pane(self, backend, state, **kwargs):
         pane_type = self._panes.get(backend, Pane)
-        if isinstance(pane_type, type) and issubclass(pane_type, Matplotlib):
-            kwargs['tight'] = True
+        if isinstance(pane_type, type):
+            if issubclass(pane_type, Matplotlib):
+                kwargs['tight'] = True
+            if issubclass(pane_type, Bokeh):
+                kwargs['autodispatch'] = False
         return pane_type(state, **kwargs)
 
     def _render(self, doc, comm, root):

--- a/panel/pane/plot.py
+++ b/panel/pane/plot.py
@@ -57,12 +57,16 @@ class Bokeh(PaneBase):
     >>> Bokeh(some_bokeh_figure)
     """
 
+    autodispatch = param.Boolean(default=True, doc="""
+        Whether to automatically dispatch events inside bokeh on_change
+        and on_event callbacks in the notebook.""")
+
     theme = param.ClassSelector(default=None, class_=(Theme, str), doc="""
         Bokeh theme to apply to the plot.""")
 
     priority = 0.8
 
-    _rename = {'theme': None}
+    _rename = {'autodispatch': None, 'theme': None}
 
     @classmethod
     def applies(cls, obj):
@@ -114,7 +118,7 @@ class Bokeh(PaneBase):
                 continue
             properties[p] = value
         model.update(**properties)
-        if comm:
+        if comm and self.autodispatch:
             self._wrap_bokeh_callbacks(root, model, doc, comm)
 
         ref = root.ref['id']


### PR DESCRIPTION
Auto-dispatching, which is very useful for making Bokeh callbacks running inside the notebook behave as if they were running on the server, was causing havoc with HoloViews callback system.