### PR TITLE
Move common session cleanup to state._destroy_session

### DIFF
--- a/panel/io/admin.py
+++ b/panel/io/admin.py
@@ -266,8 +266,12 @@ def get_process_info():
     )
     def update_memory(): memory.stream(get_mem())
     def update_cpu(): cpu.stream(get_cpu())
-    state.add_periodic_callback(update_memory, period=1000)
-    state.add_periodic_callback(update_cpu, period=1000)
+    mem_cb = state.add_periodic_callback(update_memory, period=1000, start=False)
+    cpu_cb = state.add_periodic_callback(update_cpu, period=1000, start=False)
+    mem_cb.log = False
+    cpu_cb.log = False
+    mem_cb.start()
+    cpu_cb.start()
     return memory, cpu
 
 def get_session_data():

--- a/panel/io/callbacks.py
+++ b/panel/io/callbacks.py
@@ -37,6 +37,9 @@ class PeriodicCallback(param.Parameterized):
         Number of times the callback will be executed, by default
         this is unlimited.""")
 
+    log = param.Boolean(default=True, doc="""
+        Whether the periodic callback should log its actions.""")
+
     period = param.Integer(default=500, doc="""
         Period in milliseconds at which the callback is executed.""")
 
@@ -86,7 +89,7 @@ class PeriodicCallback(param.Parameterized):
 
     def _post_callback(self):
         cbname = function_name(self.callback)
-        if self._doc:
+        if self._doc and self.log:
             _periodic_logger.info(
                 LOG_PERIODIC_END, id(self._doc), cbname, self._counter
             )
@@ -104,7 +107,7 @@ class PeriodicCallback(param.Parameterized):
         with edit_readonly(state):
             state.busy = True
         cbname = function_name(self.callback)
-        if self._doc:
+        if self._doc and self.log:
             _periodic_logger.info(
                 LOG_PERIODIC_START, id(self._doc), cbname, self._counter
             )
@@ -173,10 +176,6 @@ class PeriodicCallback(param.Parameterized):
             from tornado.ioloop import PeriodicCallback
             self._cb = PeriodicCallback(lambda: asyncio.create_task(self._periodic_callback()), self.period)
             self._cb.start()
-        try:
-            state.on_session_destroyed(self._cleanup)
-        except Exception:
-            pass
 
     def stop(self):
         """

--- a/panel/io/notifications.py
+++ b/panel/io/notifications.py
@@ -1,9 +1,18 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Optional
+
 import param
 
 from ..reactive import ReactiveHTML
 from ..util import classproperty
 from .datamodel import _DATA_MODELS, construct_data_model
 from .resources import bundled_files, CSS_URLS
+
+if TYPE_CHECKING:
+    from bokeh.document import Document
+    from bokeh.model import Model
+    from pyviz_comms import Comm
 
 
 class Notification(param.Parameterized):
@@ -53,6 +62,13 @@ class NotificationAreaBase(ReactiveHTML):
     def __init__(self, **params):
         super().__init__(**params)
         self._notification_watchers = {}
+
+    def get_root(
+        self, doc: Optional['Document'] = None, comm: Optional['Comm'] = None, preprocess: bool = True
+    ) -> 'Model':
+        root = super().get_root(doc, comm, preprocess)
+        self._documents[doc] = root
+        return root
 
     def send(self, message, duration=3000, type=None, background=None, icon=None):
         """

--- a/panel/template/base.py
+++ b/panel/template/base.py
@@ -155,8 +155,6 @@ class BaseTemplate(param.Parameterized, ServableMixin):
     def _server_destroy(self, session_context: BokehSessionContext):
         doc = session_context._document
         self._documents.remove(doc)
-        if doc in state._locations:
-            del state._locations[doc]
 
     def _init_doc(
         self, doc: Optional[Document] = None, comm: Optional[Comm] = None,
@@ -166,8 +164,8 @@ class BaseTemplate(param.Parameterized, ServableMixin):
         doc = doc or _curdoc()
         self._documents.append(doc)
         if location and self.location:
-            loc = self._add_location(doc, location)
-            doc.on_session_destroyed(loc._server_destroy)
+            self._add_location(doc, location)
+        doc.on_session_destroyed(state._destroy_session)
         doc.on_session_destroyed(self._server_destroy)
 
         if title or doc.title == 'Bokeh Application':

--- a/panel/tests/test_server.py
+++ b/panel/tests/test_server.py
@@ -240,6 +240,7 @@ def test_server_session_info():
 
     state.curdoc = None
     html._server_destroy(session_context)
+    state._destroy_session(session_context)
     assert state.session_info['live'] == 0
 
 


### PR DESCRIPTION
Moves cleanup of global state onto `state._destroy_session` and suppresses logging of admin periodic callbacks.