### PR TITLE
Apply sorting only on the current view

### DIFF
--- a/panel/models/tabulator.ts
+++ b/panel/models/tabulator.ts
@@ -286,8 +286,8 @@ export class DataTabulatorView extends PanelHTMLBoxView {
 
   get sorters(): any[] {
     const sorters = []
-    if (this.model.sorters.length && (this.model.source.columns().indexOf('index') > -1))
-      sorters.push({column: 'index', dir: 'asc'})
+    if (this.model.sorters.length)
+      sorters.push({column: '_index', dir: 'asc'})
     for (const sort of this.model.sorters.reverse()) {
       if (sort.column === undefined)
 	sort.column = sort.field
@@ -478,7 +478,7 @@ export class DataTabulatorView extends PanelHTMLBoxView {
       try {
         if (page != null && sorters != null) {
 	  this._updating_sort = true
-          this.model.sorters = sorters
+          this.model.sorters = sorters.slice(1)
 	  this._updating_sort = false
           this._updating_page = true
           try {
@@ -528,7 +528,7 @@ export class DataTabulatorView extends PanelHTMLBoxView {
 	}
 	if (this.model.pagination !== 'remote') {
 	  this._updating_sort = true
-	  this.model.sorters = sorts
+	  this.model.sorters = sorts.slice(1)
 	  this._updating_sort = false
 	}
       },
@@ -668,6 +668,7 @@ export class DataTabulatorView extends PanelHTMLBoxView {
   getColumns(): any {
     const config_columns: (any[] | undefined) = this.model.configuration?.columns;
     let columns = []
+    columns.push({field: '_index'})
     if (config_columns != null) {
       for (const column of config_columns)
         if (column.columns != null) {
@@ -972,7 +973,8 @@ export class DataTabulatorView extends PanelHTMLBoxView {
 
   setHidden(): void {
     for (const column of this.tabulator.getColumns()) {
-      if (this.model.hidden_columns.indexOf(column._column.field) > -1)
+      const col = column._column
+      if ((col.field == '_index') || (this.model.hidden_columns.indexOf(col.field) > -1))
         column.hide()
       else
         column.show()

--- a/panel/models/tabulator.ts
+++ b/panel/models/tabulator.ts
@@ -478,7 +478,12 @@ export class DataTabulatorView extends PanelHTMLBoxView {
       try {
         if (page != null && sorters != null) {
 	  this._updating_sort = true
-          this.model.sorters = sorters.slice(1)
+	  const sorts = []
+	  for (const s of sorters) {
+	    if (s.field !== '_index')
+	      sorts.push({field: s.field, dir: s.dir})
+	  }
+          this.model.sorters = sorts
 	  this._updating_sort = false
           this._updating_page = true
           try {
@@ -524,11 +529,12 @@ export class DataTabulatorView extends PanelHTMLBoxView {
       dataSorting: (sorters: any[]) => {
 	const sorts = []
 	for (const s of sorters) {
-	  sorts.push({field: s.field, dir: s.dir})
+	  if (s.field !== '_index')
+	    sorts.push({field: s.field, dir: s.dir})
 	}
 	if (this.model.pagination !== 'remote') {
 	  this._updating_sort = true
-	  this.model.sorters = sorts.slice(1)
+	  this.model.sorters = sorts
 	  this._updating_sort = false
 	}
       },

--- a/panel/models/tabulator.ts
+++ b/panel/models/tabulator.ts
@@ -286,7 +286,9 @@ export class DataTabulatorView extends PanelHTMLBoxView {
 
   get sorters(): any[] {
     const sorters = []
-    for (const sort of this.model.sorters) {
+    if (this.model.sorters.length && (this.model.source.columns().indexOf('index') > -1))
+      sorters.push({column: 'index', dir: 'asc'})
+    for (const sort of this.model.sorters.reverse()) {
       if (sort.column === undefined)
 	sort.column = sort.field
       sorters.push(sort)

--- a/panel/models/tabulator.ts
+++ b/panel/models/tabulator.ts
@@ -1093,6 +1093,8 @@ export class DataTabulatorView extends PanelHTMLBoxView {
       this._tabulator_cell_updating = false
     }
     this.model.trigger_event(new TableEditEvent(field, index))
+    this.setSorters()
+    this.tabulator.scrollToRow(index, "top", false)
   }
 }
 

--- a/panel/tests/widgets/test_tables.py
+++ b/panel/tests/widgets/test_tables.py
@@ -1020,14 +1020,14 @@ def test_tabulator_patch_with_sorters(document, comm):
                       dtype='datetime64[ns]')
     }
     expected_src = {
-        'index': np.array([3, 0, 2, 1, 4]),
-        'A': np.array([3, 2, 2, 1, 1]),
-        'B': np.array([1, 0, 0, 1, 0]),
-        'C': np.array(['foo4', 'foo0', 'foo3', 'foo2', 'foo5']),
-        'D': np.array(['2009-01-06T00:00:00.000000000',
-                       '2009-01-01T00:00:00.000000000',
-                       '2009-01-05T00:00:00.000000000',
+        'index': np.array([0, 1, 2, 3, 4]),
+        'A': np.array([2., 1., 2., 3., 1.]),
+        'B': np.array([0., 1., 0., 1., 0.]),
+        'C': np.array(['foo0', 'foo2', 'foo3', 'foo4', 'foo5']),
+        'D': np.array(['2009-01-01T00:00:00.000000000',
                        '2009-01-02T00:00:00.000000000',
+                       '2009-01-05T00:00:00.000000000',
+                       '2009-01-06T00:00:00.000000000',
                        '2009-01-07T00:00:00.000000000'],
                       dtype='datetime64[ns]').astype(np.int64) / 10e5
     }

--- a/panel/tests/widgets/test_tables.py
+++ b/panel/tests/widgets/test_tables.py
@@ -691,7 +691,7 @@ def test_tabulator_sorters_unnamed_index(document, comm):
     table.sorters = [{'field': 'index', 'dir': 'desc'}]
 
     pd.testing.assert_frame_equal(
-        table._processed,
+        table.current_view,
         df.sort_index(ascending=False)
     )
 
@@ -702,7 +702,7 @@ def test_tabulator_sorters_int_name_column(document, comm):
     table.sorters = [{'field': '0', 'dir': 'desc'}]
 
     pd.testing.assert_frame_equal(
-        table._processed,
+        table.current_view,
         df.sort_values([0], ascending=False)
     )
 

--- a/panel/widgets/tables.py
+++ b/panel/widgets/tables.py
@@ -1373,7 +1373,8 @@ class Tabulator(BaseTable):
             'hidden_columns': self.hidden_columns,
             'editable': not self.disabled,
             'select_mode': selectable,
-            'selectable_rows': self._get_selectable()
+            'selectable_rows': self._get_selectable(),
+            'sorters': self.sorters
         })
         process = {'theme': self.theme, 'frozen_rows': self.frozen_rows}
         props.update(self._process_param_change(process))

--- a/panel/widgets/tables.py
+++ b/panel/widgets/tables.py
@@ -447,7 +447,6 @@ class BaseTable(ReactiveData, Widget):
     def _get_data(self):
         import pandas as pd
         df = self._filter_dataframe(self.value)
-        df = self._sort_df(df)
         if df is None:
             return [], {}
         if isinstance(self.value.index, pd.MultiIndex):
@@ -690,7 +689,8 @@ class BaseTable(ReactiveData, Widget):
         Returns the current view of the table after filtering and
         sorting are applied.
         """
-        return self._processed
+        df = self._processed
+        return self._sort_df(df)
 
     @property
     def selected_dataframe(self):
@@ -698,9 +698,8 @@ class BaseTable(ReactiveData, Widget):
         Returns a DataFrame of the currently selected rows.
         """
         if not self.selection:
-            return self._processed.iloc[:0]
-        return self._processed.iloc[self.selection]
-
+            return self.current_view.iloc[:0]
+        return self.current_view.iloc[self.selection]
 
 
 class DataFrame(BaseTable):
@@ -1645,3 +1644,14 @@ class Tabulator(BaseTable):
         if column not in self._on_click_callbacks:
             self._on_click_callbacks[column] = []
         self._on_click_callbacks[column].append(callback)
+
+    @property
+    def current_view(self):
+        """
+        Returns the current view of the table after filtering and
+        sorting are applied.
+        """
+        df = self._processed
+        if self.pagination == 'remote':
+            return df
+        return self._sort_df(df)


### PR DESCRIPTION
Fixes https://github.com/holoviz/panel/issues/3431

Also passes the sorters in the configuration properties on instantiation of the tabulator model, which fixes another bug.