### PR TITLE
Add `execute` method to run callbacks and add support to asynchronous `on_edit`/`on_click` tabulator callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Date: 2022-05-20
 - Add support for Plotly animation frames ([#3449](https://github.com/holoviz/panel/pull/3499))
 - Implement single and multi-selection in Vega pane ([#3470](https://github.com/holoviz/panel/pull/3470), [#3499](https://github.com/holoviz/panel/pull/3499), [#3505](https://github.com/holoviz/panel/pull/3505))
 - Add typehints to help developers and users ([#3476](https://github.com/holoviz/panel/pull/3476))
+- Add `execute` state method to run callbacks in the right context and add support to asynchronous `on_edit`/`on_click` Tabulator callbacks ([#3550](https://github.com/holoviz/panel/pull/3550))
 
 ### Bug fixes
 

--- a/doc/releases.md
+++ b/doc/releases.md
@@ -13,6 +13,7 @@ Date: 2022-05-20
 - Add support for Plotly animation frames ([#3449](https://github.com/holoviz/panel/pull/3499))
 - Implement single and multi-selection in Vega pane ([#3470](https://github.com/holoviz/panel/pull/3470), [#3499](https://github.com/holoviz/panel/pull/3499), [#3505](https://github.com/holoviz/panel/pull/3505))
 - Add typehints to help developers and users ([#3476](https://github.com/holoviz/panel/pull/3476))
+- Add `execute` state method to run callbacks in the right context and add support to asynchronous `on_edit`/`on_click` Tabulator callbacks ([#3550](https://github.com/holoviz/panel/pull/3550))
 
 ### Bug fixes
 

--- a/examples/user_guide/Overview.ipynb
+++ b/examples/user_guide/Overview.ipynb
@@ -220,13 +220,14 @@
     "> \n",
     "> #### Methods\n",
     "> \n",
+    "> - `add_periodic_callback`: Schedules a periodic callback to be run at an interval set by the period\n",
     "> - `as_cached`: Allows caching data across sessions by memoizing on the provided key and keyword arguments to the provided function.\n",
     "> - `cancel_scheduled`: Cancel a scheduled task by name.\n",
-    "> - `add_periodic_callback`: Schedules a periodic callback to be run at an interval set by the period\n",
+    "> - `execute`: Execute a callback appropriately depending on the context the application is running in.\n",
     "> - `kill_all_servers`: Stops all running server sessions.\n",
-    "> - `schedule`: Schedule a callback periodically at a specific time (click [here](./Deploy_and_Export.ipynb#pn.state.schedule) for more details)\n",
     "> - `onload`: Allows defining a callback which is run when a server is fully loaded\n",
-    "> - `sync_busy`: Sync an indicator with a boolean value parameter to the busy property on state"
+    "> - `schedule_task`: Schedule a callback periodically at a specific time (click [here](./Deploy_and_Export.ipynb#pn.state.schedule) for more details)\n",
+    "> - `sync_busy`: Sync an indicator with a boolean value parameter to the busy property on state\n"
    ]
   }
  ],

--- a/examples/user_guide/Overview.ipynb
+++ b/examples/user_guide/Overview.ipynb
@@ -223,11 +223,11 @@
     "> - `add_periodic_callback`: Schedules a periodic callback to be run at an interval set by the period\n",
     "> - `as_cached`: Allows caching data across sessions by memoizing on the provided key and keyword arguments to the provided function.\n",
     "> - `cancel_scheduled`: Cancel a scheduled task by name.\n",
-    "> - `execute`: Execute a callback appropriately depending on the context the application is running in.\n",
+    "> - `execute`: Executes both synchronous and asynchronous callbacks appropriately depending on the context the application is running in.\n",
     "> - `kill_all_servers`: Stops all running server sessions.\n",
     "> - `onload`: Allows defining a callback which is run when a server is fully loaded\n",
-    "> - `schedule_task`: Schedule a callback periodically at a specific time (click [here](./Deploy_and_Export.ipynb#pn.state.schedule) for more details)\n",
-    "> - `sync_busy`: Sync an indicator with a boolean value parameter to the busy property on state\n"
+    "> - `schedule`: Schedule a callback periodically at a specific time (click [here](./Deploy_and_Export.ipynb#pn.state.schedule) for more details)\n",
+    "> - `sync_busy`: Sync an indicator with a boolean value parameter to the busy property on state"
    ]
   }
  ],

--- a/panel/io/state.py
+++ b/panel/io/state.py
@@ -435,10 +435,11 @@ class _state(param.Parameterized):
 
     def execute(self, callback: Callable([], None)) -> None:
         """
-        Executes both synchronous and asynchronous callbacks appropriately depending on
-        the context the application is running in. When running on the server callbacks are
-        scheduled on the event loop ensuring the Bokeh Document lock is acquired and
-        models can be modified directly.
+        Executes both synchronous and asynchronous callbacks
+        appropriately depending on the context the application is
+        running in. When running on the server callbacks are scheduled
+        on the event loop ensuring the Bokeh Document lock is acquired
+        and models can be modified directly.
 
         Arguments
         ---------

--- a/panel/io/state.py
+++ b/panel/io/state.py
@@ -553,6 +553,24 @@ class _state(param.Parameterized):
             self._rest_endpoints[endpoint] = ([parameterized], parameters, cb)
         parameterized.param.watch(cb, parameters)
 
+    def run_callback(self, callback: Callable([], None)) -> None:
+        """
+        Run a synchronous callback immediately or schedule an asynchronous
+        callback on the event loop.
+
+        Arguments
+        ---------
+        callback: callable
+          Callback to execute
+        """
+        if param.parameterized.iscoroutinefunction(callback):
+            print(param.parameterized.async_executor.__module__)
+            param.parameterized.async_executor(callback)
+        elif self.curdoc:
+            self.curdoc.add_next_tick_callback(callback)
+        else:
+            callback()
+
     def schedule_task(
         self, name: str, callback: Callable[[], None], at: Tat =None,
         period: str | dt.timedelta = None, cron: Optional[str] = None

--- a/panel/io/state.py
+++ b/panel/io/state.py
@@ -435,10 +435,10 @@ class _state(param.Parameterized):
 
     def execute(self, callback: Callable([], None)) -> None:
         """
-        Execute a callback.
-        
-        Scheduled on the event loop in a server context or executed
-        immediately in a notebook context.
+        Executes both synchronous and asynchronous callbacks appropriately depending on 
+        the context the application is running in. When running on the server callbacks are 
+        scheduled on the event loop ensuring the Bokeh Document lock is acquired and
+        models can be modified directly.
 
         Arguments
         ---------

--- a/panel/io/state.py
+++ b/panel/io/state.py
@@ -564,7 +564,6 @@ class _state(param.Parameterized):
           Callback to execute
         """
         if param.parameterized.iscoroutinefunction(callback):
-            print(param.parameterized.async_executor.__module__)
             param.parameterized.async_executor(callback)
         elif self.curdoc:
             self.curdoc.add_next_tick_callback(callback)

--- a/panel/io/state.py
+++ b/panel/io/state.py
@@ -435,8 +435,8 @@ class _state(param.Parameterized):
 
     def execute(self, callback: Callable([], None)) -> None:
         """
-        Executes both synchronous and asynchronous callbacks appropriately depending on 
-        the context the application is running in. When running on the server callbacks are 
+        Executes both synchronous and asynchronous callbacks appropriately depending on
+        the context the application is running in. When running on the server callbacks are
         scheduled on the event loop ensuring the Bokeh Document lock is acquired and
         models can be modified directly.
 

--- a/panel/io/state.py
+++ b/panel/io/state.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import asyncio
 import datetime as dt
+import functools
 import inspect
 import json
 import logging
@@ -446,7 +447,10 @@ class _state(param.Parameterized):
         callback: callable
           Callback to execute
         """
-        if param.parameterized.iscoroutinefunction(callback):
+        cb = callback
+        while isinstance(cb, functools.partial):
+            cb = cb.func
+        if param.parameterized.iscoroutinefunction(cb):
             param.parameterized.async_executor(callback)
         elif self.curdoc:
             self.curdoc.add_next_tick_callback(callback)

--- a/panel/widgets/tables.py
+++ b/panel/widgets/tables.py
@@ -1060,13 +1060,13 @@ class Tabulator(BaseTable):
             if self._old is not None:
                 event.old = self._old[event_col].iloc[event.row]
             for cb in self._on_edit_callbacks:
-                cb(event)
+                state.run_callback(partial(cb, event))
             self._update_style()
         else:
             for cb in self._on_click_callbacks.get(None, []):
-                cb(event)
+                state.run_callback(partial(cb, event))
             for cb in self._on_click_callbacks.get(event_col, []):
-                cb(event)
+                state.run_callback(partial(cb, event))
 
     def _get_theme(self, theme, resources=None):
         from ..io.resources import RESOURCE_MODE

--- a/panel/widgets/tables.py
+++ b/panel/widgets/tables.py
@@ -1060,13 +1060,13 @@ class Tabulator(BaseTable):
             if self._old is not None:
                 event.old = self._old[event_col].iloc[event.row]
             for cb in self._on_edit_callbacks:
-                state.run_callback(partial(cb, event))
+                state.execute(partial(cb, event))
             self._update_style()
         else:
             for cb in self._on_click_callbacks.get(None, []):
-                state.run_callback(partial(cb, event))
+                state.execute(partial(cb, event))
             for cb in self._on_click_callbacks.get(event_col, []):
-                state.run_callback(partial(cb, event))
+                state.execute(partial(cb, event))
 
     def _get_theme(self, theme, resources=None):
         from ..io.resources import RESOURCE_MODE


### PR DESCRIPTION
This is achieved through the addition of the `run_callback` method on the states that delegates to the callback call to the right context.

Should there me more usage of `run_callback` throughout the code base? e.g. should the`on_click` button events make use of it?