### PR TITLE
Fix styling offset for Tabulator

### DIFF
--- a/panel/tests/widgets/test_tables.py
+++ b/panel/tests/widgets/test_tables.py
@@ -663,11 +663,11 @@ def test_tabulator_styling(document, comm):
     model = table.get_root(document, comm)
 
     assert model.styles['data'] == {
-        0: {1: [('color', 'black')]},
-        1: {1: [('color', 'black')]},
-        2: {1: [('color', 'black')]},
-        3: {1: [('color', 'red')]},
-        4: {1: [('color', 'red')]}
+        0: {2: [('color', 'black')]},
+        1: {2: [('color', 'black')]},
+        2: {2: [('color', 'black')]},
+        3: {2: [('color', 'red')]},
+        4: {2: [('color', 'red')]}
     }
 
 def test_tabulator_empty_table(document, comm):

--- a/panel/widgets/tables.py
+++ b/panel/widgets/tables.py
@@ -1152,7 +1152,7 @@ class Tabulator(BaseTable):
             styler = self._computed_styler
         if styler is None:
             return {}
-        offset = len(self.indexes) + int(self.selectable in ('checkbox', 'checkbox-single')) + int(bool(self.row_content))
+        offset = 1 + len(self.indexes) + int(self.selectable in ('checkbox', 'checkbox-single')) + int(bool(self.row_content))
         if self.pagination == 'remote':
             start = (self.page-1)*self.page_size
             end = start + self.page_size


### PR DESCRIPTION
Styles need to be offset correctly now that we add the _index column.