### PR TITLE
Ensure Tabulator expand icon updates on click

### DIFF
--- a/panel/models/tabulator.ts
+++ b/panel/models/tabulator.ts
@@ -649,6 +649,8 @@ export class DataTabulatorView extends PanelHTMLBoxView {
       }
     }
     this.model.expanded = expanded
+    const icon = expanded.indexOf(index) < 0 ? "\u25ba" : "\u25bc"
+    cell._cell.element.innerText = icon
     if (expanded.indexOf(index) < 0)
       return
     let ready = true


### PR DESCRIPTION
Previously the entire table was redrawn simply to update the single expand icon. Since that redraw no longer occurs we now simply update that one specific cell.