### PR TITLE
Add type annotation to _rename attribute

### DIFF
--- a/panel/io/location.py
+++ b/panel/io/location.py
@@ -7,7 +7,7 @@ import json
 import urllib.parse as urlparse
 
 from typing import (
-    TYPE_CHECKING, Any, Callable, Dict, List, Mapping, Optional,
+    TYPE_CHECKING, Any, Callable, ClassVar, Dict, List, Mapping, Optional,
 )
 
 import param
@@ -58,7 +58,7 @@ class Location(Syncable):
         should be set to False""")
 
     # Mapping from parameter name to bokeh model property name
-    _rename: Mapping[str, Union[str, None]] = {"name": None}
+    _rename: ClassVar[Mapping[str, str | None]] = {"name": None}
 
     def __init__(self, **params):
         super().__init__(**params)

--- a/panel/io/location.py
+++ b/panel/io/location.py
@@ -5,10 +5,7 @@ from __future__ import annotations
 
 import json
 import urllib.parse as urlparse
-
-from typing import (
-    TYPE_CHECKING, Any, Callable, Dict, List, Mapping, Optional
-)
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Mapping, Optional
 
 import param
 
@@ -58,7 +55,7 @@ class Location(Syncable):
         should be set to False""")
 
     # Mapping from parameter name to bokeh model property name
-    _rename = {"name": None}
+    _rename: Mapping[str, str | None] = {"name": None}
 
     def __init__(self, **params):
         super().__init__(**params)

--- a/panel/io/location.py
+++ b/panel/io/location.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 
 import json
 import urllib.parse as urlparse
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Mapping, Optional
+from typing import (TYPE_CHECKING, Any, Callable, Dict, List, Mapping,
+                    Optional, Union)
 
 import param
 
@@ -55,7 +56,7 @@ class Location(Syncable):
         should be set to False""")
 
     # Mapping from parameter name to bokeh model property name
-    _rename: Mapping[str, str | None] = {"name": None}
+    _rename: Mapping[str, Union[str, None]] = {"name": None}
 
     def __init__(self, **params):
         super().__init__(**params)

--- a/panel/layout/accordion.py
+++ b/panel/layout/accordion.py
@@ -1,6 +1,8 @@
-import param
+from typing import Mapping
 
-from bokeh.models import Column as BkColumn, CustomJS
+import param
+from bokeh.models import Column as BkColumn
+from bokeh.models import CustomJS
 
 from .base import NamedListPanel
 from .card import Card
@@ -42,7 +44,7 @@ class Accordion(NamedListPanel):
 
     _bokeh_model = BkColumn
 
-    _rename = {'active': None, 'active_header_background': None,
+    _rename: Mapping[str, str | None] = {'active': None, 'active_header_background': None,
                'header_background': None, 'objects': 'children',
                'dynamic': None, 'toggle': None, 'header_color': None}
 

--- a/panel/layout/accordion.py
+++ b/panel/layout/accordion.py
@@ -1,8 +1,10 @@
-from typing import Mapping, Union
+from __future__ import annotations
+
+from typing import ClassVar, Mapping
 
 import param
-from bokeh.models import Column as BkColumn
-from bokeh.models import CustomJS
+
+from bokeh.models import Column as BkColumn, CustomJS
 
 from .base import NamedListPanel
 from .card import Card
@@ -44,7 +46,7 @@ class Accordion(NamedListPanel):
 
     _bokeh_model = BkColumn
 
-    _rename: Mapping[str, Union[str, None]] = {'active': None, 'active_header_background': None,
+    _rename: ClassVar[Mapping[str, str | None]] = {'active': None, 'active_header_background': None,
                'header_background': None, 'objects': 'children',
                'dynamic': None, 'toggle': None, 'header_color': None}
 

--- a/panel/layout/accordion.py
+++ b/panel/layout/accordion.py
@@ -1,4 +1,4 @@
-from typing import Mapping
+from typing import Mapping, Union
 
 import param
 from bokeh.models import Column as BkColumn
@@ -44,7 +44,7 @@ class Accordion(NamedListPanel):
 
     _bokeh_model = BkColumn
 
-    _rename: Mapping[str, str | None] = {'active': None, 'active_header_background': None,
+    _rename: Mapping[str, Union[str, None]] = {'active': None, 'active_header_background': None,
                'header_background': None, 'objects': 'children',
                'dynamic': None, 'toggle': None, 'header_color': None}
 

--- a/panel/layout/base.py
+++ b/panel/layout/base.py
@@ -704,7 +704,7 @@ class Row(ListPanel):
 
     _bokeh_model: Type['Model'] = BkRow
 
-    _rename = dict(ListPanel._rename, col_sizing='cols')
+    _rename: Mapping[str, str | None] = dict(ListPanel._rename, col_sizing='cols')
 
 
 class Column(ListPanel):
@@ -727,7 +727,7 @@ class Column(ListPanel):
 
     _bokeh_model: Type['Model'] = BkColumn
 
-    _rename = dict(ListPanel._rename, row_sizing='rows')
+    _rename: Mapping[str, str | None] = dict(ListPanel._rename, row_sizing='rows')
 
 
 class WidgetBox(ListPanel):
@@ -766,7 +766,7 @@ class WidgetBox(ListPanel):
 
     _source_transforms = {'disabled': None, 'horizontal': None}
 
-    _rename = {'objects': 'children', 'horizontal': None}
+    _rename: Mapping[str, str | None] = {'objects': 'children', 'horizontal': None}
 
     @property
     def _bokeh_model(self) -> Type['Model']: # type: ignore

--- a/panel/layout/base.py
+++ b/panel/layout/base.py
@@ -6,13 +6,13 @@ from __future__ import annotations
 
 from collections import defaultdict, namedtuple
 from typing import (
-    TYPE_CHECKING, Any, Dict, Iterable, Iterator, List, Mapping, Optional,
-    Tuple, Type,
+    TYPE_CHECKING, Any, ClassVar, Dict, Iterable, Iterator, List, Mapping,
+    Optional, Tuple, Type,
 )
 
 import param
-from bokeh.models import Column as BkColumn
-from bokeh.models import Row as BkRow
+
+from bokeh.models import Column as BkColumn, Row as BkRow
 
 from ..io.model import hold
 from ..io.state import state
@@ -704,7 +704,7 @@ class Row(ListPanel):
 
     _bokeh_model: Type['Model'] = BkRow
 
-    _rename: Mapping[str, Union[str, None]] = dict(ListPanel._rename, col_sizing='cols')
+    _rename: ClassVar[Mapping[str, str | None]] = dict(ListPanel._rename, col_sizing='cols')
 
 
 class Column(ListPanel):
@@ -727,7 +727,7 @@ class Column(ListPanel):
 
     _bokeh_model: Type['Model'] = BkColumn
 
-    _rename: Mapping[str, Union[str, None]] = dict(ListPanel._rename, row_sizing='rows')
+    _rename: ClassVar[Mapping[str, str | None]] = dict(ListPanel._rename, row_sizing='rows')
 
 
 class WidgetBox(ListPanel):
@@ -766,7 +766,7 @@ class WidgetBox(ListPanel):
 
     _source_transforms = {'disabled': None, 'horizontal': None}
 
-    _rename: Mapping[str, Union[str, None]] = {'objects': 'children', 'horizontal': None}
+    _rename: ClassVar[Mapping[str, str | None]] = {'objects': 'children', 'horizontal': None}
 
     @property
     def _bokeh_model(self) -> Type['Model']: # type: ignore

--- a/panel/layout/base.py
+++ b/panel/layout/base.py
@@ -5,14 +5,12 @@ in flexible ways to build complex dashboards.
 from __future__ import annotations
 
 from collections import defaultdict, namedtuple
-from typing import (
-    TYPE_CHECKING, Any, Dict, Iterable, Iterator, List, Mapping,
-    Optional, Tuple, Type
-)
+from typing import (TYPE_CHECKING, Any, Dict, Iterable, Iterator, List,
+                    Mapping, Optional, Tuple, Type, Union)
 
 import param
-
-from bokeh.models import Column as BkColumn, Row as BkRow
+from bokeh.models import Column as BkColumn
+from bokeh.models import Row as BkRow
 
 from ..io.model import hold
 from ..io.state import state
@@ -112,7 +110,7 @@ class Panel(Reactive):
         Returns new child models for the layout while reusing unchanged
         models and cleaning up any dropped objects.
         """
-        from ..pane.base import panel, RerenderError
+        from ..pane.base import RerenderError, panel
         new_models = []
         for i, pane in enumerate(self.objects):
             pane = panel(pane)
@@ -704,7 +702,7 @@ class Row(ListPanel):
 
     _bokeh_model: Type['Model'] = BkRow
 
-    _rename: Mapping[str, str | None] = dict(ListPanel._rename, col_sizing='cols')
+    _rename: Mapping[str, Union[str, None]] = dict(ListPanel._rename, col_sizing='cols')
 
 
 class Column(ListPanel):
@@ -727,7 +725,7 @@ class Column(ListPanel):
 
     _bokeh_model: Type['Model'] = BkColumn
 
-    _rename: Mapping[str, str | None] = dict(ListPanel._rename, row_sizing='rows')
+    _rename: Mapping[str, Union[str, None]] = dict(ListPanel._rename, row_sizing='rows')
 
 
 class WidgetBox(ListPanel):
@@ -766,7 +764,7 @@ class WidgetBox(ListPanel):
 
     _source_transforms = {'disabled': None, 'horizontal': None}
 
-    _rename: Mapping[str, str | None] = {'objects': 'children', 'horizontal': None}
+    _rename: Mapping[str, Union[str, None]] = {'objects': 'children', 'horizontal': None}
 
     @property
     def _bokeh_model(self) -> Type['Model']: # type: ignore

--- a/panel/layout/card.py
+++ b/panel/layout/card.py
@@ -1,7 +1,9 @@
+from typing import Mapping
+
 import param
 
 from ..models import Card as BkCard
-from .base import Column, Row, ListPanel
+from .base import Column, ListPanel, Row
 
 
 class Card(Column):
@@ -63,7 +65,7 @@ class Card(Column):
 
     _linked_props = ['collapsed']
 
-    _rename = dict(Column._rename, title=None, header=None, title_css_classes=None)
+    _rename: Mapping[str, str | None] = dict(Column._rename, title=None, header=None, title_css_classes=None)
 
     def __init__(self, *objects, **params):
         self._header_layout = Row(css_classes=['card-header-row'],

--- a/panel/layout/card.py
+++ b/panel/layout/card.py
@@ -1,4 +1,6 @@
-from typing import Mapping, Union
+from __future__ import annotations
+
+from typing import ClassVar, Mapping
 
 import param
 
@@ -65,7 +67,7 @@ class Card(Column):
 
     _linked_props = ['collapsed']
 
-    _rename: Mapping[str, Union[str, None]] = dict(Column._rename, title=None, header=None, title_css_classes=None)
+    _rename: ClassVar[Mapping[str, str | None]] = dict(Column._rename, title=None, header=None, title_css_classes=None)
 
     def __init__(self, *objects, **params):
         self._header_layout = Row(css_classes=['card-header-row'],

--- a/panel/layout/card.py
+++ b/panel/layout/card.py
@@ -1,4 +1,4 @@
-from typing import Mapping
+from typing import Mapping, Union
 
 import param
 
@@ -65,7 +65,7 @@ class Card(Column):
 
     _linked_props = ['collapsed']
 
-    _rename: Mapping[str, str | None] = dict(Column._rename, title=None, header=None, title_css_classes=None)
+    _rename: Mapping[str, Union[str, None]] = dict(Column._rename, title=None, header=None, title_css_classes=None)
 
     def __init__(self, *objects, **params):
         self._header_layout = Row(css_classes=['card-header-row'],

--- a/panel/layout/grid.py
+++ b/panel/layout/grid.py
@@ -7,7 +7,7 @@ import math
 
 from collections import OrderedDict, namedtuple
 from functools import partial
-from typing import ClassVar, Mapping, Union
+from typing import ClassVar, Mapping
 
 import numpy as np
 import param

--- a/panel/layout/grid.py
+++ b/panel/layout/grid.py
@@ -2,18 +2,17 @@
 Layout components to lay out objects in a grid.
 """
 import math
-
 from collections import OrderedDict, namedtuple
 from functools import partial
+from typing import Mapping
 
 import numpy as np
 import param
-
-from bokeh.models import Box as BkBox, GridBox as BkGridBox
+from bokeh.models import Box as BkBox
+from bokeh.models import GridBox as BkGridBox
 
 from ..io.model import hold
-from .base import _col, _row, ListPanel, Panel
-
+from .base import ListPanel, Panel, _col, _row
 
 
 class GridBox(ListPanel):
@@ -43,7 +42,7 @@ class GridBox(ListPanel):
 
     _bokeh_model = BkGridBox
 
-    _rename = {'objects': 'children', 'nrows': None, 'ncols': None}
+    _rename: Mapping[str, str | None] = {'objects': 'children', 'nrows': None, 'ncols': None}
 
     _source_transforms = {'scroll': None, 'objects': None}
 
@@ -202,7 +201,7 @@ class GridSpec(Panel):
 
     _source_transforms = {'objects': None, 'mode': None}
 
-    _rename = {'objects': 'children', 'mode': None, 'ncols': None, 'nrows': None}
+    _rename: Mapping[str, str | None] = {'objects': 'children', 'mode': None, 'ncols': None, 'nrows': None}
 
     _preprocess_params = ['objects']
 

--- a/panel/layout/grid.py
+++ b/panel/layout/grid.py
@@ -1,15 +1,18 @@
 """
 Layout components to lay out objects in a grid.
 """
+from __future__ import annotations
+
 import math
+
 from collections import OrderedDict, namedtuple
 from functools import partial
-from typing import Mapping, Union
+from typing import ClassVar, Mapping, Union
 
 import numpy as np
 import param
-from bokeh.models import Box as BkBox
-from bokeh.models import GridBox as BkGridBox
+
+from bokeh.models import Box as BkBox, GridBox as BkGridBox
 
 from ..io.model import hold
 from .base import (
@@ -44,7 +47,7 @@ class GridBox(ListPanel):
 
     _bokeh_model = BkGridBox
 
-    _rename: Mapping[str, Union[str, None]] = {'objects': 'children', 'nrows': None, 'ncols': None}
+    _rename: ClassVar[Mapping[str, str | None]] = {'objects': 'children', 'nrows': None, 'ncols': None}
 
     _source_transforms = {'scroll': None, 'objects': None}
 
@@ -203,7 +206,7 @@ class GridSpec(Panel):
 
     _source_transforms = {'objects': None, 'mode': None}
 
-    _rename: Mapping[str, Union[str, None]] = {'objects': 'children', 'mode': None, 'ncols': None, 'nrows': None}
+    _rename: ClassVar[Mapping[str, str | None]] = {'objects': 'children', 'mode': None, 'ncols': None, 'nrows': None}
 
     _preprocess_params = ['objects']
 

--- a/panel/layout/grid.py
+++ b/panel/layout/grid.py
@@ -4,7 +4,7 @@ Layout components to lay out objects in a grid.
 import math
 from collections import OrderedDict, namedtuple
 from functools import partial
-from typing import Mapping
+from typing import Mapping, Union
 
 import numpy as np
 import param
@@ -42,7 +42,7 @@ class GridBox(ListPanel):
 
     _bokeh_model = BkGridBox
 
-    _rename: Mapping[str, str | None] = {'objects': 'children', 'nrows': None, 'ncols': None}
+    _rename: Mapping[str, Union[str, None]] = {'objects': 'children', 'nrows': None, 'ncols': None}
 
     _source_transforms = {'scroll': None, 'objects': None}
 
@@ -201,7 +201,7 @@ class GridSpec(Panel):
 
     _source_transforms = {'objects': None, 'mode': None}
 
-    _rename: Mapping[str, str | None] = {'objects': 'children', 'mode': None, 'ncols': None, 'nrows': None}
+    _rename: Mapping[str, Union[str, None]] = {'objects': 'children', 'mode': None, 'ncols': None, 'nrows': None}
 
     _preprocess_params = ['objects']
 

--- a/panel/layout/gridstack.py
+++ b/panel/layout/gridstack.py
@@ -1,5 +1,5 @@
 from collections import OrderedDict
-from typing import Mapping
+from typing import Mapping, Union
 
 import param
 
@@ -129,7 +129,7 @@ class GridStack(ReactiveHTML, GridSpec):
             'GridStack': cls.__javascript__[0:1],
         }
 
-    _rename: Mapping[str, str | None] = {}
+    _rename: Mapping[str, Union[str, None]] = {}
 
     @classproperty
     def __javascript__(cls):

--- a/panel/layout/gridstack.py
+++ b/panel/layout/gridstack.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections import OrderedDict
-from typing import ClassVar, Mapping, Union
+from typing import ClassVar, Mapping
 
 import param
 

--- a/panel/layout/gridstack.py
+++ b/panel/layout/gridstack.py
@@ -1,4 +1,5 @@
 from collections import OrderedDict
+from typing import Mapping
 
 import param
 
@@ -128,7 +129,7 @@ class GridStack(ReactiveHTML, GridSpec):
             'GridStack': cls.__javascript__[0:1],
         }
 
-    _rename = {}
+    _rename: Mapping[str, str | None] = {}
 
     @classproperty
     def __javascript__(cls):

--- a/panel/layout/gridstack.py
+++ b/panel/layout/gridstack.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 from collections import OrderedDict
-from typing import Mapping, Union
+from typing import ClassVar, Mapping, Union
 
 import param
 
@@ -129,7 +131,7 @@ class GridStack(ReactiveHTML, GridSpec):
             'GridStack': cls.__javascript__[0:1],
         }
 
-    _rename: Mapping[str, Union[str, None]] = {}
+    _rename: ClassVar[Mapping[str, str | None]] = {}
 
     @classproperty
     def __javascript__(cls):

--- a/panel/layout/tabs.py
+++ b/panel/layout/tabs.py
@@ -1,8 +1,10 @@
 """
 Layout component to lay out objects in a set of tabs.
 """
+from __future__ import annotations
+
 from collections import defaultdict
-from typing import Mapping, Union
+from typing import ClassVar, Mapping
 
 import param
 
@@ -58,7 +60,7 @@ class Tabs(NamedListPanel):
 
     _manual_params = ['closable']
 
-    _rename: Mapping[str, Union[str, None]] = {'name': None, 'objects': 'tabs', 'dynamic': None}
+    _rename: ClassVar[Mapping[str, str | None]] = {'name': None, 'objects': 'tabs', 'dynamic': None}
 
     _source_transforms = {'dynamic': None, 'objects': None}
 

--- a/panel/layout/tabs.py
+++ b/panel/layout/tabs.py
@@ -2,7 +2,7 @@
 Layout component to lay out objects in a set of tabs.
 """
 from collections import defaultdict
-from typing import Mapping
+from typing import Mapping, Union
 
 import param
 from bokeh.models import Panel as BkPanel
@@ -58,7 +58,7 @@ class Tabs(NamedListPanel):
 
     _manual_params = ['closable']
 
-    _rename: Mapping[str, str | None] = {'name': None, 'objects': 'tabs', 'dynamic': None}
+    _rename: Mapping[str, Union[str, None]] = {'name': None, 'objects': 'tabs', 'dynamic': None}
 
     _source_transforms = {'dynamic': None, 'objects': None}
 

--- a/panel/layout/tabs.py
+++ b/panel/layout/tabs.py
@@ -2,12 +2,11 @@
 Layout component to lay out objects in a set of tabs.
 """
 from collections import defaultdict
+from typing import Mapping
 
 import param
-
-from bokeh.models import (
-    Spacer as BkSpacer, Panel as BkPanel
-)
+from bokeh.models import Panel as BkPanel
+from bokeh.models import Spacer as BkSpacer
 
 from ..models import Tabs as BkTabs
 from ..viewable import Layoutable
@@ -59,7 +58,7 @@ class Tabs(NamedListPanel):
 
     _manual_params = ['closable']
 
-    _rename = {'name': None, 'objects': 'tabs', 'dynamic': None}
+    _rename: Mapping[str, str | None] = {'name': None, 'objects': 'tabs', 'dynamic': None}
 
     _source_transforms = {'dynamic': None, 'objects': None}
 

--- a/panel/pane/alert.py
+++ b/panel/pane/alert.py
@@ -3,8 +3,9 @@ Bootstrap inspired Alerts
 
 See https://getbootstrap.com/docs/4.0/components/alerts/
 """
-import param
+from typing import Mapping
 
+import param
 from panel.pane.markup import Markdown
 
 ALERT_TYPES = ["primary", "secondary", "success", "danger", "warning", "info", "light", "dark"]
@@ -26,7 +27,7 @@ class Alert(Markdown):
 
     priority = 0
 
-    _rename = dict(Markdown._rename, alert_type=None)
+    _rename: Mapping[str, str | None] = dict(Markdown._rename, alert_type=None)
 
     @classmethod
     def applies(cls, obj):

--- a/panel/pane/alert.py
+++ b/panel/pane/alert.py
@@ -3,9 +3,12 @@ Bootstrap inspired Alerts
 
 See https://getbootstrap.com/docs/4.0/components/alerts/
 """
-from typing import Mapping, Union
+from __future__ import annotations
+
+from typing import ClassVar, Mapping
 
 import param
+
 from panel.pane.markup import Markdown
 
 ALERT_TYPES = ["primary", "secondary", "success", "danger", "warning", "info", "light", "dark"]
@@ -27,7 +30,7 @@ class Alert(Markdown):
 
     priority = 0
 
-    _rename: Mapping[str, Union[str, None]] = dict(Markdown._rename, alert_type=None)
+    _rename: ClassVar[Mapping[str, str | None]] = dict(Markdown._rename, alert_type=None)
 
     @classmethod
     def applies(cls, obj):

--- a/panel/pane/alert.py
+++ b/panel/pane/alert.py
@@ -3,7 +3,7 @@ Bootstrap inspired Alerts
 
 See https://getbootstrap.com/docs/4.0/components/alerts/
 """
-from typing import Mapping
+from typing import Mapping, Union
 
 import param
 from panel.pane.markup import Markdown
@@ -27,7 +27,7 @@ class Alert(Markdown):
 
     priority = 0
 
-    _rename: Mapping[str, str | None] = dict(Markdown._rename, alert_type=None)
+    _rename: Mapping[str, Union[str, None]] = dict(Markdown._rename, alert_type=None)
 
     @classmethod
     def applies(cls, obj):

--- a/panel/pane/deckgl.py
+++ b/panel/pane/deckgl.py
@@ -3,12 +3,11 @@ Defines a PyDeck Pane which renders a PyDeck plot using a PyDeckPlot
 bokeh model.
 """
 import json
-
 from collections import defaultdict
+from typing import Mapping
 
 import numpy as np
 import param
-
 from bokeh.models import ColumnDataSource
 from pyviz_comms import JupyterComm
 
@@ -106,7 +105,7 @@ class DeckGL(PaneBase):
         Throttling timeout (in milliseconds) for view state and hover
         events sent from the frontend.""")
 
-    _rename = {
+    _rename: Mapping[str, str | None] = {
         'click_state': 'clickState', 'hover_state': 'hoverState',
         'view_state': 'viewState', 'tooltips': 'tooltip'
     }

--- a/panel/pane/deckgl.py
+++ b/panel/pane/deckgl.py
@@ -2,12 +2,16 @@
 Defines a PyDeck Pane which renders a PyDeck plot using a PyDeckPlot
 bokeh model.
 """
+from __future__ import annotations
+
 import json
+
 from collections import defaultdict
-from typing import Mapping, Union
+from typing import ClassVar, Mapping
 
 import numpy as np
 import param
+
 from bokeh.models import ColumnDataSource
 from pyviz_comms import JupyterComm
 
@@ -105,7 +109,7 @@ class DeckGL(PaneBase):
         Throttling timeout (in milliseconds) for view state and hover
         events sent from the frontend.""")
 
-    _rename: Mapping[str, Union[str, None]] = {
+    _rename: ClassVar[Mapping[str, str | None]] = {
         'click_state': 'clickState', 'hover_state': 'hoverState',
         'view_state': 'viewState', 'tooltips': 'tooltip'
     }

--- a/panel/pane/deckgl.py
+++ b/panel/pane/deckgl.py
@@ -4,7 +4,7 @@ bokeh model.
 """
 import json
 from collections import defaultdict
-from typing import Mapping
+from typing import Mapping, Union
 
 import numpy as np
 import param
@@ -105,7 +105,7 @@ class DeckGL(PaneBase):
         Throttling timeout (in milliseconds) for view state and hover
         events sent from the frontend.""")
 
-    _rename: Mapping[str, str | None] = {
+    _rename: Mapping[str, Union[str, None]] = {
         'click_state': 'clickState', 'hover_state': 'hoverState',
         'view_state': 'viewState', 'tooltips': 'tooltip'
     }

--- a/panel/pane/echarts.py
+++ b/panel/pane/echarts.py
@@ -1,7 +1,12 @@
+from __future__ import annotations
+
 import json
 import sys
 
+from typing import ClassVar, Mapping
+
 import param
+
 from pyviz_comms import JupyterComm
 
 from ..util import lazy_load
@@ -31,7 +36,7 @@ class ECharts(PaneBase):
 
     priority = None
 
-    _rename: Mapping[str, Union[str, None]] = {"object": "data"}
+    _rename: ClassVar[Mapping[str, str | None]] = {"object": "data"}
 
     _rerender_params = []
 

--- a/panel/pane/echarts.py
+++ b/panel/pane/echarts.py
@@ -1,6 +1,6 @@
 import json
 import sys
-from typing import Mapping
+from typing import Mapping, Union
 
 import param
 from pyviz_comms import JupyterComm
@@ -32,7 +32,7 @@ class ECharts(PaneBase):
 
     priority = None
 
-    _rename: Mapping[str, str | None] = {"object": "data"}
+    _rename: Mapping[str, Union[str, None]] = {"object": "data"}
 
     _rerender_params = []
 

--- a/panel/pane/echarts.py
+++ b/panel/pane/echarts.py
@@ -1,8 +1,8 @@
-import sys
 import json
+import sys
+from typing import Mapping
 
 import param
-
 from pyviz_comms import JupyterComm
 
 from ..util import lazy_load
@@ -32,7 +32,7 @@ class ECharts(PaneBase):
 
     priority = None
 
-    _rename = {"object": "data"}
+    _rename: Mapping[str, str | None] = {"object": "data"}
 
     _rerender_params = []
 

--- a/panel/pane/equation.py
+++ b/panel/pane/equation.py
@@ -3,9 +3,9 @@ Renders objects representing equations including LaTeX strings and
 SymPy objects.
 """
 import sys
+from typing import Mapping
 
 import param
-
 from pyviz_comms import JupyterComm
 
 from ..util import lazy_load
@@ -47,7 +47,7 @@ class LaTeX(DivPaneBase):
     # Priority is dependent on the data type
     priority = None
 
-    _rename = {"renderer": None}
+    _rename: Mapping[str, str | None] = {"renderer": None}
 
     @classmethod
     def applies(cls, obj):

--- a/panel/pane/equation.py
+++ b/panel/pane/equation.py
@@ -2,10 +2,14 @@
 Renders objects representing equations including LaTeX strings and
 SymPy objects.
 """
+from __future__ import annotations
+
 import sys
-from typing import Mapping, Union
+
+from typing import ClassVar, Mapping
 
 import param
+
 from pyviz_comms import JupyterComm
 
 from ..util import lazy_load
@@ -47,7 +51,7 @@ class LaTeX(DivPaneBase):
     # Priority is dependent on the data type
     priority = None
 
-    _rename: Mapping[str, Union[str, None]] = {"renderer": None}
+    _rename: ClassVar[Mapping[str, str | None]] = {"renderer": None}
 
     @classmethod
     def applies(cls, obj):

--- a/panel/pane/equation.py
+++ b/panel/pane/equation.py
@@ -3,7 +3,7 @@ Renders objects representing equations including LaTeX strings and
 SymPy objects.
 """
 import sys
-from typing import Mapping
+from typing import Mapping, Union
 
 import param
 from pyviz_comms import JupyterComm
@@ -47,7 +47,7 @@ class LaTeX(DivPaneBase):
     # Priority is dependent on the data type
     priority = None
 
-    _rename: Mapping[str, str | None] = {"renderer": None}
+    _rename: Mapping[str, Union[str, None]] = {"renderer": None}
 
     @classmethod
     def applies(cls, obj):

--- a/panel/pane/holoviews.py
+++ b/panel/pane/holoviews.py
@@ -5,7 +5,7 @@ objects and their widgets and support for Links
 import sys
 from collections import OrderedDict, defaultdict
 from functools import partial
-from typing import Mapping
+from typing import Mapping, Union
 
 import param
 from bokeh.models import Range1d
@@ -81,7 +81,7 @@ class HoloViews(PaneBase):
 
     _panes = {'bokeh': Bokeh, 'matplotlib': Matplotlib, 'plotly': Plotly}
 
-    _rename: Mapping[str, str | None] = {
+    _rename: Mapping[str, Union[str, None]] = {
         'backend': None, 'center': None, 'linked_axes': None,
         'renderer': None, 'theme': None, 'widgets': None,
         'widget_layout': None, 'widget_location': None,

--- a/panel/pane/holoviews.py
+++ b/panel/pane/holoviews.py
@@ -2,10 +2,13 @@
 HoloViews integration for Panel including a Pane to render HoloViews
 objects and their widgets and support for Links
 """
+from __future__ import annotations
+
 import sys
+
 from collections import OrderedDict, defaultdict
 from functools import partial
-from typing import Mapping, Union
+from typing import ClassVar, Mapping
 
 import param
 
@@ -83,7 +86,7 @@ class HoloViews(PaneBase):
 
     _panes = {'bokeh': Bokeh, 'matplotlib': Matplotlib, 'plotly': Plotly}
 
-    _rename: Mapping[str, Union[str, None]] = {
+    _rename: ClassVar[Mapping[str, str | None]] = {
         'backend': None, 'center': None, 'linked_axes': None,
         'renderer': None, 'theme': None, 'widgets': None,
         'widget_layout': None, 'widget_location': None,

--- a/panel/pane/holoviews.py
+++ b/panel/pane/holoviews.py
@@ -3,21 +3,21 @@ HoloViews integration for Panel including a Pane to render HoloViews
 objects and their widgets and support for Links
 """
 import sys
-
 from collections import OrderedDict, defaultdict
-from packaging.version import Version
 from functools import partial
+from typing import Mapping
 
 import param
-
-from bokeh.models import Spacer as _BkSpacer, Range1d
+from bokeh.models import Range1d
+from bokeh.models import Spacer as _BkSpacer
 from bokeh.themes.theme import Theme
+from packaging.version import Version
 
 from ..io import state, unlocked
-from ..layout import Column, WidgetBox, HSpacer, VSpacer, Row
+from ..layout import Column, HSpacer, Row, VSpacer, WidgetBox
 from ..viewable import Layoutable, Viewable
 from ..widgets import Player
-from .base import PaneBase, Pane, RerenderError
+from .base import Pane, PaneBase, RerenderError
 from .plot import Bokeh, Matplotlib
 from .plotly import Plotly
 
@@ -81,7 +81,7 @@ class HoloViews(PaneBase):
 
     _panes = {'bokeh': Bokeh, 'matplotlib': Matplotlib, 'plotly': Plotly}
 
-    _rename = {
+    _rename: Mapping[str, str | None] = {
         'backend': None, 'center': None, 'linked_axes': None,
         'renderer': None, 'theme': None, 'widgets': None,
         'widget_layout': None, 'widget_location': None,
@@ -290,7 +290,8 @@ class HoloViews(PaneBase):
 
     def _render(self, doc, comm, root):
         import holoviews as hv
-        from holoviews import Store, renderer as load_renderer
+        from holoviews import Store
+        from holoviews import renderer as load_renderer
 
         if self.renderer:
             renderer = self.renderer
@@ -368,11 +369,14 @@ class HoloViews(PaneBase):
     def widgets_from_dimensions(cls, object, widget_types=None, widgets_type='individual'):
         from holoviews.core import Dimension, DynamicMap
         from holoviews.core.options import SkipRendering
-        from holoviews.core.util import isnumeric, datetime_types, unique_iterator
         from holoviews.core.traversal import unique_dimkeys
-        from holoviews.plotting.plot import Plot, GenericCompositePlot
+        from holoviews.core.util import (datetime_types, isnumeric,
+                                         unique_iterator)
+        from holoviews.plotting.plot import GenericCompositePlot, Plot
         from holoviews.plotting.util import get_dynamic_mode
-        from ..widgets import Widget, DiscreteSlider, Select, FloatSlider, DatetimeInput, IntSlider
+
+        from ..widgets import (DatetimeInput, DiscreteSlider, FloatSlider,
+                               IntSlider, Select, Widget)
 
         if widget_types is None:
             widget_types = {}
@@ -539,7 +543,8 @@ def is_bokeh_element_plot(plot):
     Checks whether plotting instance is a HoloViews ElementPlot rendered
     with the bokeh backend.
     """
-    from holoviews.plotting.plot import GenericElementPlot, GenericOverlayPlot, Plot
+    from holoviews.plotting.plot import (GenericElementPlot,
+                                         GenericOverlayPlot, Plot)
     if not isinstance(plot, Plot):
         return False
     return (plot.renderer.backend == 'bokeh' and isinstance(plot, GenericElementPlot)
@@ -577,8 +582,8 @@ def find_links(root_view, root_model):
         return
 
     try:
-        from holoviews.plotting.links import Link
         from holoviews.plotting.bokeh.callbacks import LinkCallback
+        from holoviews.plotting.links import Link
     except Exception:
         return
 
@@ -624,7 +629,7 @@ def link_axes(root_view, root_model):
         return
 
     from holoviews.core.options import Store
-    from holoviews.core.util import unique_iterator, max_range
+    from holoviews.core.util import max_range, unique_iterator
     from holoviews.plotting.bokeh.element import ElementPlot
 
     ref = root_model.ref['id']

--- a/panel/pane/markup.py
+++ b/panel/pane/markup.py
@@ -4,7 +4,7 @@ Markdown, and also regular strings.
 """
 import json
 import textwrap
-from typing import Mapping
+from typing import Mapping, Union
 
 import param
 
@@ -27,7 +27,7 @@ class DivPaneBase(PaneBase):
 
     _bokeh_model = _BkHTML
 
-    _rename: Mapping[str, str | None] = {'object': 'text'}
+    _rename: Mapping[str, Union[str, None]] = {'object': 'text'}
 
     _updates = True
 
@@ -376,7 +376,7 @@ class JSON(DivPaneBase):
 
     _applies_kw = True
     _bokeh_model = _BkJSON
-    _rename: Mapping[str, str | None] = {"name": None, "object": "text", "encoder": None}
+    _rename: Mapping[str, Union[str, None]] = {"name": None, "object": "text", "encoder": None}
 
     _rerender_params = ['object', 'depth', 'encoder', 'hover_preview', 'theme']
 

--- a/panel/pane/markup.py
+++ b/panel/pane/markup.py
@@ -4,10 +4,12 @@ Markdown, and also regular strings.
 """
 import json
 import textwrap
+from typing import Mapping
 
 import param
 
-from ..models import HTML as _BkHTML, JSON as _BkJSON
+from ..models import HTML as _BkHTML
+from ..models import JSON as _BkJSON
 from ..util import escape
 from ..viewable import Layoutable
 from .base import PaneBase
@@ -25,7 +27,7 @@ class DivPaneBase(PaneBase):
 
     _bokeh_model = _BkHTML
 
-    _rename = {'object': 'text'}
+    _rename: Mapping[str, str | None] = {'object': 'text'}
 
     _updates = True
 
@@ -374,7 +376,7 @@ class JSON(DivPaneBase):
 
     _applies_kw = True
     _bokeh_model = _BkJSON
-    _rename = {"name": None, "object": "text", "encoder": None}
+    _rename: Mapping[str, str | None] = {"name": None, "object": "text", "encoder": None}
 
     _rerender_params = ['object', 'depth', 'encoder', 'hover_preview', 'theme']
 

--- a/panel/pane/markup.py
+++ b/panel/pane/markup.py
@@ -2,14 +2,16 @@
 Pane class which render various markup languages including HTML,
 Markdown, and also regular strings.
 """
+from __future__ import annotations
+
 import json
 import textwrap
-from typing import Mapping, Union
+
+from typing import ClassVar, Mapping
 
 import param
 
-from ..models import HTML as _BkHTML
-from ..models import JSON as _BkJSON
+from ..models import HTML as _BkHTML, JSON as _BkJSON
 from ..util import escape
 from ..viewable import Layoutable
 from .base import PaneBase
@@ -27,7 +29,7 @@ class DivPaneBase(PaneBase):
 
     _bokeh_model = _BkHTML
 
-    _rename: Mapping[str, Union[str, None]] = {'object': 'text'}
+    _rename: ClassVar[Mapping[str, str | None]] = {'object': 'text'}
 
     _updates = True
 
@@ -376,7 +378,7 @@ class JSON(DivPaneBase):
 
     _applies_kw = True
     _bokeh_model = _BkJSON
-    _rename: Mapping[str, Union[str, None]] = {"name": None, "object": "text", "encoder": None}
+    _rename: ClassVar[Mapping[str, str | None]] = {"name": None, "object": "text", "encoder": None}
 
     _rerender_params = ['object', 'depth', 'encoder', 'hover_preview', 'theme']
 

--- a/panel/pane/media.py
+++ b/panel/pane/media.py
@@ -1,16 +1,18 @@
 """
 Contains Media panes including renderers for Audio and Video content.
 """
+from __future__ import annotations
+
 import os
+
 from base64 import b64encode
 from io import BytesIO
-from typing import Mapping, Union
+from typing import ClassVar, Mapping
 
 import numpy as np
 import param
 
-from ..models import Audio as _BkAudio
-from ..models import Video as _BkVideo
+from ..models import Audio as _BkAudio, Video as _BkVideo
 from ..util import isfile, isurl
 from .base import PaneBase
 
@@ -48,7 +50,7 @@ class _MediaBase(PaneBase):
 
     _media_type = None
 
-    _rename: Mapping[str, Union[str, None]] = {'name': None, 'sample_rate': None, 'object': 'value'}
+    _rename: ClassVar[Mapping[str, str | None]] = {'name': None, 'sample_rate': None, 'object': 'value'}
 
     _rerender_params = []
 

--- a/panel/pane/media.py
+++ b/panel/pane/media.py
@@ -2,14 +2,15 @@
 Contains Media panes including renderers for Audio and Video content.
 """
 import os
-
 from base64 import b64encode
 from io import BytesIO
+from typing import Mapping
 
 import numpy as np
 import param
 
-from ..models import Audio as _BkAudio, Video as _BkVideo
+from ..models import Audio as _BkAudio
+from ..models import Video as _BkVideo
 from ..util import isfile, isurl
 from .base import PaneBase
 
@@ -47,7 +48,7 @@ class _MediaBase(PaneBase):
 
     _media_type = None
 
-    _rename = {'name': None, 'sample_rate': None, 'object': 'value'}
+    _rename: Mapping[str, str | None] = {'name': None, 'sample_rate': None, 'object': 'value'}
 
     _rerender_params = []
 

--- a/panel/pane/media.py
+++ b/panel/pane/media.py
@@ -4,7 +4,7 @@ Contains Media panes including renderers for Audio and Video content.
 import os
 from base64 import b64encode
 from io import BytesIO
-from typing import Mapping
+from typing import Mapping, Union
 
 import numpy as np
 import param
@@ -48,7 +48,7 @@ class _MediaBase(PaneBase):
 
     _media_type = None
 
-    _rename: Mapping[str, str | None] = {'name': None, 'sample_rate': None, 'object': 'value'}
+    _rename: Mapping[str, Union[str, None]] = {'name': None, 'sample_rate': None, 'object': 'value'}
 
     _rerender_params = []
 

--- a/panel/pane/perspective.py
+++ b/panel/pane/perspective.py
@@ -1,12 +1,11 @@
 import datetime as dt
 import sys
 import warnings
-
 from enum import Enum
+from typing import Mapping
 
-import param
 import numpy as np
-
+import param
 from bokeh.models import ColumnDataSource
 from pyviz_comms import JupyterComm
 
@@ -320,7 +319,7 @@ class Perspective(PaneBase, ReactiveData):
 
     _rerender_params = ['object']
 
-    _rename = {
+    _rename: Mapping[str, str | None] = {
         'computed_columns': None,
         'row_pivots': None,
         'column_pivots': None,

--- a/panel/pane/perspective.py
+++ b/panel/pane/perspective.py
@@ -1,11 +1,15 @@
+from __future__ import annotations
+
 import datetime as dt
 import sys
 import warnings
+
 from enum import Enum
-from typing import Mapping, Union
+from typing import ClassVar, Mapping
 
 import numpy as np
 import param
+
 from bokeh.models import ColumnDataSource
 from pyviz_comms import JupyterComm
 
@@ -319,7 +323,7 @@ class Perspective(PaneBase, ReactiveData):
 
     _rerender_params = ['object']
 
-    _rename: Mapping[str, Union[str, None]] = {
+    _rename: ClassVar[Mapping[str, str | None]] = {
         'computed_columns': None,
         'row_pivots': None,
         'column_pivots': None,

--- a/panel/pane/perspective.py
+++ b/panel/pane/perspective.py
@@ -2,7 +2,7 @@ import datetime as dt
 import sys
 import warnings
 from enum import Enum
-from typing import Mapping
+from typing import Mapping, Union
 
 import numpy as np
 import param
@@ -319,7 +319,7 @@ class Perspective(PaneBase, ReactiveData):
 
     _rerender_params = ['object']
 
-    _rename: Mapping[str, str | None] = {
+    _rename: Mapping[str, Union[str, None]] = {
         'computed_columns': None,
         'row_pivots': None,
         'column_pivots': None,

--- a/panel/pane/plot.py
+++ b/panel/pane/plot.py
@@ -1,11 +1,13 @@
 """
 Pane class which render plots from different libraries
 """
+from __future__ import annotations
+
 import sys
 
 from contextlib import contextmanager
 from io import BytesIO
-from typing import Mapping, Union
+from typing import ClassVar, Mapping
 
 import param
 
@@ -68,7 +70,7 @@ class Bokeh(PaneBase):
 
     priority = 0.8
 
-    _rename: Mapping[str, Union[str, None]] = {'autodispatch': None, 'theme': None}
+    _rename: ClassVar[Mapping[str, str | None]] = {'autodispatch': None, 'theme': None}
 
     @classmethod
     def applies(cls, obj):
@@ -166,7 +168,7 @@ class Matplotlib(PNG, IPyWidget):
         Automatically adjust the figure size to fit the
         subplots and other artist elements.""")
 
-    _rename: Mapping[str, Union[str, None]] = {'object': 'text', 'interactive': None, 'dpi': None,  'tight': None}
+    _rename: ClassVar[Mapping[str, str | None]] = {'object': 'text', 'interactive': None, 'dpi': None,  'tight': None}
 
     _rerender_params = PNG._rerender_params + ['object', 'dpi', 'tight']
 

--- a/panel/pane/plot.py
+++ b/panel/pane/plot.py
@@ -2,14 +2,13 @@
 Pane class which render plots from different libraries
 """
 import sys
-
-from io import BytesIO
-
 from contextlib import contextmanager
+from io import BytesIO
+from typing import Mapping
 
 import param
-
-from bokeh.models import CustomJS, LayoutDOM, Model, Spacer as BkSpacer
+from bokeh.models import CustomJS, LayoutDOM, Model
+from bokeh.models import Spacer as BkSpacer
 from bokeh.themes import Theme
 
 from ..io import remove_root
@@ -17,9 +16,9 @@ from ..io.notebook import push
 from ..util import escape
 from ..viewable import Layoutable
 from .base import PaneBase
+from .image import PNG
 from .ipywidget import IPyWidget
 from .markup import HTML
-from .image import PNG
 
 FOLIUM_BEFORE = '<div style="width:100%;"><div style="position:relative;width:100%;height:0;padding-bottom:60%;">'
 FOLIUM_AFTER = '<div style="width:100%;height:100%"><div style="position:relative;width:100%;height:100%;padding-bottom:0%;">'
@@ -66,7 +65,7 @@ class Bokeh(PaneBase):
 
     priority = 0.8
 
-    _rename = {'autodispatch': None, 'theme': None}
+    _rename: Mapping[str, str | None] = {'autodispatch': None, 'theme': None}
 
     @classmethod
     def applies(cls, obj):
@@ -164,7 +163,7 @@ class Matplotlib(PNG, IPyWidget):
         Automatically adjust the figure size to fit the
         subplots and other artist elements.""")
 
-    _rename = {'object': 'text', 'interactive': None, 'dpi': None,  'tight': None}
+    _rename: Mapping[str, str | None] = {'object': 'text', 'interactive': None, 'dpi': None,  'tight': None}
 
     _rerender_params = PNG._rerender_params + ['object', 'dpi', 'tight']
 
@@ -187,7 +186,7 @@ class Matplotlib(PNG, IPyWidget):
         import matplotlib.backends
         old_backend = getattr(matplotlib.backends, 'backend', 'agg')
 
-        from ipympl.backend_nbagg import FigureManager, Canvas, is_interactive
+        from ipympl.backend_nbagg import Canvas, FigureManager, is_interactive
         from matplotlib._pylab_helpers import Gcf
 
         matplotlib.use(old_backend)
@@ -272,8 +271,8 @@ class RGGPlot(PNG):
         return type(obj).__name__ == 'GGPlot' and hasattr(obj, 'r_repr')
 
     def _img(self):
-        from rpy2.robjects.lib import grdevices
         from rpy2 import robjects
+        from rpy2.robjects.lib import grdevices
         with grdevices.render_to_bytesio(grdevices.png,
                  type="cairo-png", width=self.width, height=self.height,
                  res=self.dpi, antialias="subpixel") as b:

--- a/panel/pane/plot.py
+++ b/panel/pane/plot.py
@@ -4,7 +4,7 @@ Pane class which render plots from different libraries
 import sys
 from contextlib import contextmanager
 from io import BytesIO
-from typing import Mapping
+from typing import Mapping, Union
 
 import param
 from bokeh.models import CustomJS, LayoutDOM, Model
@@ -65,7 +65,7 @@ class Bokeh(PaneBase):
 
     priority = 0.8
 
-    _rename: Mapping[str, str | None] = {'autodispatch': None, 'theme': None}
+    _rename: Mapping[str, Union[str, None]] = {'autodispatch': None, 'theme': None}
 
     @classmethod
     def applies(cls, obj):
@@ -163,7 +163,7 @@ class Matplotlib(PNG, IPyWidget):
         Automatically adjust the figure size to fit the
         subplots and other artist elements.""")
 
-    _rename: Mapping[str, str | None] = {'object': 'text', 'interactive': None, 'dpi': None,  'tight': None}
+    _rename: Mapping[str, Union[str, None]] = {'object': 'text', 'interactive': None, 'dpi': None,  'tight': None}
 
     _rerender_params = PNG._rerender_params + ['object', 'dpi', 'tight']
 

--- a/panel/pane/streamz.py
+++ b/panel/pane/streamz.py
@@ -2,7 +2,7 @@
 Renders Streamz Stream objects.
 """
 import sys
-from typing import Mapping
+from typing import Mapping, Union
 
 import param
 
@@ -28,7 +28,7 @@ class Streamz(ReplacementPane):
     rate_limit = param.Number(default=0.1, bounds=(0, None), doc="""
         The minimum interval between events.""")
 
-    _rename: Mapping[str, str | None] = {'rate_limit': None, 'always_watch': None}
+    _rename: Mapping[str, Union[str, None]] = {'rate_limit': None, 'always_watch': None}
 
     def __init__(self, object=None, **params):
         super().__init__(object, **params)

--- a/panel/pane/streamz.py
+++ b/panel/pane/streamz.py
@@ -1,8 +1,11 @@
 """
 Renders Streamz Stream objects.
 """
+from __future__ import annotations
+
 import sys
-from typing import Mapping, Union
+
+from typing import ClassVar, Mapping
 
 import param
 
@@ -28,7 +31,7 @@ class Streamz(ReplacementPane):
     rate_limit = param.Number(default=0.1, bounds=(0, None), doc="""
         The minimum interval between events.""")
 
-    _rename: Mapping[str, Union[str, None]] = {'rate_limit': None, 'always_watch': None}
+    _rename: ClassVar[Mapping[str, str | None]] = {'rate_limit': None, 'always_watch': None}
 
     def __init__(self, object=None, **params):
         super().__init__(object, **params)

--- a/panel/pane/streamz.py
+++ b/panel/pane/streamz.py
@@ -2,6 +2,7 @@
 Renders Streamz Stream objects.
 """
 import sys
+from typing import Mapping
 
 import param
 
@@ -27,7 +28,7 @@ class Streamz(ReplacementPane):
     rate_limit = param.Number(default=0.1, bounds=(0, None), doc="""
         The minimum interval between events.""")
 
-    _rename = {'rate_limit': None, 'always_watch': None}
+    _rename: Mapping[str, str | None] = {'rate_limit': None, 'always_watch': None}
 
     def __init__(self, object=None, **params):
         super().__init__(object, **params)

--- a/panel/pane/vega.py
+++ b/panel/pane/vega.py
@@ -1,9 +1,13 @@
+from __future__ import annotations
+
 import sys
+
 from functools import partial
-from typing import Mapping, Union
+from typing import ClassVar, Mapping
 
 import numpy as np
 import param
+
 from bokeh.models import ColumnDataSource
 from pyviz_comms import JupyterComm
 
@@ -104,7 +108,7 @@ class Vega(PaneBase):
 
     priority = 0.8
 
-    _rename: Mapping[str, Union[str, None]] = {'selection': None, 'debounce': None}
+    _rename: ClassVar[Mapping[str, str | None]] = {'selection': None, 'debounce': None}
 
     _updates = True
 

--- a/panel/pane/vega.py
+++ b/panel/pane/vega.py
@@ -1,6 +1,6 @@
 import sys
 from functools import partial
-from typing import Mapping
+from typing import Mapping, Union
 
 import numpy as np
 import param
@@ -104,7 +104,7 @@ class Vega(PaneBase):
 
     priority = 0.8
 
-    _rename: Mapping[str, str | None] = {'selection': None, 'debounce': None}
+    _rename: Mapping[str, Union[str, None]] = {'selection': None, 'debounce': None}
 
     _updates = True
 

--- a/panel/pane/vega.py
+++ b/panel/pane/vega.py
@@ -1,15 +1,14 @@
 import sys
-
 from functools import partial
+from typing import Mapping
 
-import param
 import numpy as np
-
+import param
 from bokeh.models import ColumnDataSource
 from pyviz_comms import JupyterComm
 
-from ..viewable import Layoutable
 from ..util import lazy_load
+from ..viewable import Layoutable
 from .base import PaneBase
 
 
@@ -105,7 +104,7 @@ class Vega(PaneBase):
 
     priority = 0.8
 
-    _rename = {'selection': None, 'debounce': None}
+    _rename: Mapping[str, str | None] = {'selection': None, 'debounce': None}
 
     _updates = True
 

--- a/panel/pane/vtk/vtk.py
+++ b/panel/pane/vtk/vtk.py
@@ -1,16 +1,20 @@
 """
 Defines a VTKPane which renders a vtk plot using VTKPlot bokeh model.
 """
+from __future__ import annotations
+
 import base64
 import json
 import sys
 import zipfile
+
 from abc import abstractmethod
-from typing import Mapping, Union
+from typing import ClassVar, Mapping
 from urllib.request import urlopen
 
 import numpy as np
 import param
+
 from bokeh.models import LinearColorMapper
 from bokeh.util.serialization import make_globally_unique_id
 from pyviz_comms import JupyterComm
@@ -223,7 +227,7 @@ class BaseVTKRenderWindow(AbstractVTK):
 
     _applies_kw = True
 
-    _rename: Mapping[str, Union[str, None]] = {'serialize_on_instantiation': None, 'serialize_all_data_arrays': None}
+    _rename: ClassVar[Mapping[str, str | None]] = {'serialize_on_instantiation': None, 'serialize_all_data_arrays': None}
 
     __abstract = True
 
@@ -409,7 +413,7 @@ class VTKRenderWindowSynchronized(BaseVTKRenderWindow, SyncHelpers):
 
     _one_time_reset = param.Boolean(default=False)
 
-    _rename: Mapping[str, Union[str, None]] = dict(_one_time_reset='one_time_reset',
+    _rename: ClassVar[Mapping[str, str | None]] = dict(_one_time_reset='one_time_reset',
                    **BaseVTKRenderWindow._rename)
 
     _updates = True
@@ -623,7 +627,7 @@ class VTKVolume(AbstractVTK):
 
     _serializers = {}
 
-    _rename: Mapping[str, Union[str, None]] = {'max_data_size': None, 'spacing': None, 'origin': None}
+    _rename: ClassVar[Mapping[str, str | None]] = {'max_data_size': None, 'spacing': None, 'origin': None}
 
     _updates = True
 

--- a/panel/pane/vtk/vtk.py
+++ b/panel/pane/vtk/vtk.py
@@ -6,7 +6,7 @@ import json
 import sys
 import zipfile
 from abc import abstractmethod
-from typing import Mapping
+from typing import Mapping, Union
 from urllib.request import urlopen
 
 import numpy as np
@@ -223,7 +223,7 @@ class BaseVTKRenderWindow(AbstractVTK):
 
     _applies_kw = True
 
-    _rename: Mapping[str, str | None] = {'serialize_on_instantiation': None, 'serialize_all_data_arrays': None}
+    _rename: Mapping[str, Union[str, None]] = {'serialize_on_instantiation': None, 'serialize_all_data_arrays': None}
 
     __abstract = True
 
@@ -409,7 +409,7 @@ class VTKRenderWindowSynchronized(BaseVTKRenderWindow, SyncHelpers):
 
     _one_time_reset = param.Boolean(default=False)
 
-    _rename: Mapping[str, str | None] = dict(_one_time_reset='one_time_reset',
+    _rename: Mapping[str, Union[str, None]] = dict(_one_time_reset='one_time_reset',
                    **BaseVTKRenderWindow._rename)
 
     _updates = True
@@ -623,7 +623,7 @@ class VTKVolume(AbstractVTK):
 
     _serializers = {}
 
-    _rename: Mapping[str, str | None] = {'max_data_size': None, 'spacing': None, 'origin': None}
+    _rename: Mapping[str, Union[str, None]] = {'max_data_size': None, 'spacing': None, 'origin': None}
 
     _updates = True
 

--- a/panel/pane/vtk/vtk.py
+++ b/panel/pane/vtk/vtk.py
@@ -1,23 +1,22 @@
 """
 Defines a VTKPane which renders a vtk plot using VTKPlot bokeh model.
 """
-import sys
-import json
 import base64
+import json
+import sys
 import zipfile
-
 from abc import abstractmethod
+from typing import Mapping
 from urllib.request import urlopen
 
-import param
 import numpy as np
-
-from bokeh.util.serialization import make_globally_unique_id
+import param
 from bokeh.models import LinearColorMapper
+from bokeh.util.serialization import make_globally_unique_id
 from pyviz_comms import JupyterComm
 
 from ...util import isfile, lazy_load
-from ..base import PaneBase, Pane
+from ..base import Pane, PaneBase
 from .enums import PRESET_CMAPS
 
 base64encode = lambda x: base64.b64encode(x).decode('utf-8')
@@ -224,7 +223,7 @@ class BaseVTKRenderWindow(AbstractVTK):
 
     _applies_kw = True
 
-    _rename = {'serialize_on_instantiation': None, 'serialize_all_data_arrays': None}
+    _rename: Mapping[str, str | None] = {'serialize_on_instantiation': None, 'serialize_all_data_arrays': None}
 
     __abstract = True
 
@@ -278,7 +277,7 @@ class BaseVTKRenderWindow(AbstractVTK):
     def _construct_colorbars(self, color_mappers=None):
         if not color_mappers:
             color_mappers = self.color_mappers
-        from bokeh.models import Plot, ColorBar, FixedTicker
+        from bokeh.models import ColorBar, FixedTicker, Plot
         cbs = []
         for color_mapper in color_mappers:
             ticks = np.linspace(color_mapper.low, color_mapper.high, 5)
@@ -410,7 +409,7 @@ class VTKRenderWindowSynchronized(BaseVTKRenderWindow, SyncHelpers):
 
     _one_time_reset = param.Boolean(default=False)
 
-    _rename = dict(_one_time_reset='one_time_reset',
+    _rename: Mapping[str, str | None] = dict(_one_time_reset='one_time_reset',
                    **BaseVTKRenderWindow._rename)
 
     _updates = True
@@ -624,7 +623,7 @@ class VTKVolume(AbstractVTK):
 
     _serializers = {}
 
-    _rename = {'max_data_size': None, 'spacing': None, 'origin': None}
+    _rename: Mapping[str, str | None] = {'max_data_size': None, 'spacing': None, 'origin': None}
 
     _updates = True
 

--- a/panel/reactive.py
+++ b/panel/reactive.py
@@ -16,8 +16,8 @@ from collections import Counter, defaultdict, namedtuple
 from functools import partial
 from pprint import pformat
 from typing import (
-    TYPE_CHECKING, Any, Callable, Dict, List, Mapping, Optional, Set, Tuple,
-    Type, Union,
+    TYPE_CHECKING, Any, Callable, ClassVar, Dict, List, Mapping, Optional, Set,
+    Tuple, Type, Union,
 )
 
 import bleach
@@ -85,7 +85,7 @@ class Syncable(Renderable):
     _manual_params: List[str] = []
 
     # Mapping from parameter name to bokeh model property name
-    _rename: Mapping[str, Union[str, None]] = {}
+    _rename: ClassVar[Mapping[str, str | None]] = {}
 
     # Allows defining a mapping from model property name to a JS code
     # snippet that transforms the object before serialization
@@ -675,7 +675,7 @@ class SyncableData(Reactive):
     # Parameters which when changed require an update of the data
     _data_params: List[str] = []
 
-    _rename: Mapping[str, Union[str, None]] = {'selection': None}
+    _rename: ClassVar[Mapping[str, str | None]] = {'selection': None}
 
     __abstract = True
 

--- a/panel/reactive.py
+++ b/panel/reactive.py
@@ -85,7 +85,7 @@ class Syncable(Renderable):
     _manual_params: List[str] = []
 
     # Mapping from parameter name to bokeh model property name
-    _rename: Mapping[str, str | None] = {}
+    _rename: Mapping[str, Union[str, None]] = {}
 
     # Allows defining a mapping from model property name to a JS code
     # snippet that transforms the object before serialization
@@ -675,7 +675,7 @@ class SyncableData(Reactive):
     # Parameters which when changed require an update of the data
     _data_params: List[str] = []
 
-    _rename: Mapping[str, str | None] = {'selection': None}
+    _rename: Mapping[str, Union[str, None]] = {'selection': None}
 
     __abstract = True
 

--- a/panel/tests/test_reactive.py
+++ b/panel/tests/test_reactive.py
@@ -1,6 +1,6 @@
 import unittest.mock
 from functools import partial
-from typing import Mapping
+from typing import Mapping, Union
 
 import bokeh.core.properties as bp
 import param
@@ -56,7 +56,7 @@ def test_param_rename():
 
         a = param.Parameter()
 
-        _rename: Mapping[str, str | None] = {'a': 'b'}
+        _rename: Mapping[str, Union[str, None]] = {'a': 'b'}
 
     obj = ReactiveRename()
 

--- a/panel/tests/test_reactive.py
+++ b/panel/tests/test_reactive.py
@@ -1,10 +1,14 @@
+from __future__ import annotations
+
 import unittest.mock
+
 from functools import partial
-from typing import Mapping, Union
+from typing import ClassVar, Mapping
 
 import bokeh.core.properties as bp
 import param
 import pytest
+
 from bokeh.document import Document
 from bokeh.io.doc import patch_curdoc
 from bokeh.models import Div
@@ -59,7 +63,7 @@ def test_param_rename():
 
         a = param.Parameter()
 
-        _rename: Mapping[str, Union[str, None]] = {'a': 'b'}
+        _rename: ClassVar[Mapping[str, str | None]] = {'a': 'b'}
 
     obj = ReactiveRename()
 

--- a/panel/tests/test_reactive.py
+++ b/panel/tests/test_reactive.py
@@ -1,18 +1,17 @@
 import unittest.mock
-
 from functools import partial
+from typing import Mapping
 
 import bokeh.core.properties as bp
 import param
 import pytest
-
 from bokeh.document import Document
 from bokeh.io.doc import patch_curdoc
 from bokeh.models import Div
 from panel.layout import Tabs, WidgetBox
 from panel.reactive import Reactive, ReactiveHTML
 from panel.viewable import Viewable
-from panel.widgets import Checkbox, StaticText, TextInput, IntInput
+from panel.widgets import Checkbox, IntInput, StaticText, TextInput
 
 
 def test_reactive_default_title():
@@ -57,7 +56,7 @@ def test_param_rename():
 
         a = param.Parameter()
 
-        _rename = {'a': 'b'}
+        _rename: Mapping[str, str | None] = {'a': 'b'}
 
     obj = ReactiveRename()
 

--- a/panel/widgets/ace.py
+++ b/panel/widgets/ace.py
@@ -1,7 +1,7 @@
 """
 Defines the Ace code editor widget.
 """
-from typing import Mapping
+from typing import Mapping, Union
 
 import param
 from pyviz_comms import JupyterComm
@@ -41,7 +41,7 @@ class Ace(Widget):
 
     value = param.String(doc="State of the current code in the editor")
 
-    _rename: Mapping[str, str | None] = {"value": "code", "name": None}
+    _rename: Mapping[str, Union[str, None]] = {"value": "code", "name": None}
 
     def __init__(self, **params):
         if 'readonly' in params:

--- a/panel/widgets/ace.py
+++ b/panel/widgets/ace.py
@@ -1,8 +1,9 @@
 """
 Defines the Ace code editor widget.
 """
-import param
+from typing import Mapping
 
+import param
 from pyviz_comms import JupyterComm
 
 from ..models.enums import ace_themes
@@ -40,7 +41,7 @@ class Ace(Widget):
 
     value = param.String(doc="State of the current code in the editor")
 
-    _rename = {"value": "code", "name": None}
+    _rename: Mapping[str, str | None] = {"value": "code", "name": None}
 
     def __init__(self, **params):
         if 'readonly' in params:

--- a/panel/widgets/ace.py
+++ b/panel/widgets/ace.py
@@ -1,9 +1,12 @@
 """
 Defines the Ace code editor widget.
 """
-from typing import Mapping, Union
+from __future__ import annotations
+
+from typing import ClassVar, Mapping
 
 import param
+
 from pyviz_comms import JupyterComm
 
 from ..models.enums import ace_themes
@@ -41,7 +44,7 @@ class Ace(Widget):
 
     value = param.String(doc="State of the current code in the editor")
 
-    _rename: Mapping[str, Union[str, None]] = {"value": "code", "name": None}
+    _rename: ClassVar[Mapping[str, str | None]] = {"value": "code", "name": None}
 
     def __init__(self, **params):
         if 'readonly' in params:

--- a/panel/widgets/base.py
+++ b/panel/widgets/base.py
@@ -6,11 +6,9 @@ parameters.
 from __future__ import annotations
 
 import math
-from typing import (TYPE_CHECKING, Any, Callable, List, Mapping, Optional,
-                    Tuple, Union)
 
 from typing import (
-    TYPE_CHECKING, Any, Callable, List, Mapping, Optional, Tuple,
+    TYPE_CHECKING, Any, Callable, ClassVar, List, Mapping, Optional, Tuple,
 )
 
 import param  # type: ignore
@@ -47,7 +45,7 @@ class Widget(Reactive):
         be specified as a two-tuple of the form (vertical, horizontal)
         or a four-tuple (top, right, bottom, left).""")
 
-    _rename: Mapping[str, Union[str, None]] = {'name': 'title'}
+    _rename: ClassVar[Mapping[str, str | None]] = {'name': 'title'}
 
     # Whether the widget supports embedding
     _supports_embed: bool = False

--- a/panel/widgets/base.py
+++ b/panel/widgets/base.py
@@ -6,12 +6,10 @@ parameters.
 from __future__ import annotations
 
 import math
+from typing import (TYPE_CHECKING, Any, Callable, List, Mapping, Optional,
+                    Tuple, Union)
 
-from typing import (
-    TYPE_CHECKING, Any, Callable, List, Mapping, Optional, Tuple
-)
-
-import param # type: ignore
+import param  # type: ignore
 
 from ..layout import Row
 from ..reactive import Reactive
@@ -45,7 +43,7 @@ class Widget(Reactive):
         be specified as a two-tuple of the form (vertical, horizontal)
         or a four-tuple (top, right, bottom, left).""")
 
-    _rename: Mapping[str, str | None] = {'name': 'title'}
+    _rename: Mapping[str, Union[str, None]] = {'name': 'title'}
 
     # Whether the widget supports embedding
     _supports_embed: bool = False

--- a/panel/widgets/button.py
+++ b/panel/widgets/button.py
@@ -5,7 +5,8 @@ events or merely toggling between on-off states.
 from __future__ import annotations
 
 from functools import partial
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Mapping, Optional
+from typing import (TYPE_CHECKING, Any, Callable, Dict, List, Mapping,
+                    Optional, Union)
 
 import param
 from bokeh.events import ButtonClick, MenuItemClick
@@ -32,7 +33,7 @@ class _ButtonBase(Widget):
         (blue), 'success' (green), 'info' (yellow), 'light' (light),
         or 'danger' (red).""")
 
-    _rename: Mapping[str, str | None] = {'name': 'label'}
+    _rename: Mapping[str, Union[str, None]] = {'name': 'label'}
 
     __abstract = True
 
@@ -122,7 +123,7 @@ class Button(_ClickButton):
     value = param.Event(doc="""
         Toggles from False to True while the event is being processed.""")
 
-    _rename: Mapping[str, str | None] = {'clicks': None, 'name': 'label', 'value': None}
+    _rename: Mapping[str, Union[str, None]] = {'clicks': None, 'name': 'label', 'value': None}
 
     _target_transforms = {'event:button_click': None, 'value': None}
 
@@ -210,7 +211,7 @@ class Toggle(_ButtonBase):
     value = param.Boolean(default=False, doc="""
         Whether the button is currently toggled.""")
 
-    _rename: Mapping[str, str | None] = {'value': 'active', 'name': 'label'}
+    _rename: Mapping[str, Union[str, None]] = {'value': 'active', 'name': 'label'}
 
     _supports_embed = True
 
@@ -251,7 +252,7 @@ class MenuButton(_ClickButton):
 
     _widget_type = _BkDropdown
 
-    _rename: Mapping[str, str | None] = {'name': 'label', 'items': 'menu', 'clicked': None}
+    _rename: Mapping[str, Union[str, None]] = {'name': 'label', 'items': 'menu', 'clicked': None}
 
     _event = 'menu_item_click'
 

--- a/panel/widgets/button.py
+++ b/panel/widgets/button.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from functools import partial
 from typing import (
-    TYPE_CHECKING, Any, Callable, Dict, List, Mapping, Optional, Union,
+    TYPE_CHECKING, Any, Callable, ClassVar, Dict, List, Mapping, Optional,
 )
 
 import param
@@ -35,7 +35,7 @@ class _ButtonBase(Widget):
         (blue), 'success' (green), 'info' (yellow), 'light' (light),
         or 'danger' (red).""")
 
-    _rename: Mapping[str, Union[str, None]] = {'name': 'label'}
+    _rename: ClassVar[Mapping[str, str | None]] = {'name': 'label'}
 
     __abstract = True
 
@@ -125,7 +125,7 @@ class Button(_ClickButton):
     value = param.Event(doc="""
         Toggles from False to True while the event is being processed.""")
 
-    _rename: Mapping[str, Union[str, None]] = {'clicks': None, 'name': 'label', 'value': None}
+    _rename: ClassVar[Mapping[str, str | None]] = {'clicks': None, 'name': 'label', 'value': None}
 
     _target_transforms = {'event:button_click': None, 'value': None}
 
@@ -213,7 +213,7 @@ class Toggle(_ButtonBase):
     value = param.Boolean(default=False, doc="""
         Whether the button is currently toggled.""")
 
-    _rename: Mapping[str, Union[str, None]] = {'value': 'active', 'name': 'label'}
+    _rename: ClassVar[Mapping[str, str | None]] = {'value': 'active', 'name': 'label'}
 
     _supports_embed = True
 
@@ -254,7 +254,7 @@ class MenuButton(_ClickButton):
 
     _widget_type = _BkDropdown
 
-    _rename: Mapping[str, Union[str, None]] = {'name': 'label', 'items': 'menu', 'clicked': None}
+    _rename: ClassVar[Mapping[str, str | None]] = {'name': 'label', 'items': 'menu', 'clicked': None}
 
     _event = 'menu_item_click'
 

--- a/panel/widgets/button.py
+++ b/panel/widgets/button.py
@@ -5,14 +5,13 @@ events or merely toggling between on-off states.
 from __future__ import annotations
 
 from functools import partial
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Mapping, Optional
 
 import param
-
 from bokeh.events import ButtonClick, MenuItemClick
-from bokeh.models import (
-    Button as _BkButton, Dropdown as _BkDropdown, Toggle as _BkToggle
-)
+from bokeh.models import Button as _BkButton
+from bokeh.models import Dropdown as _BkDropdown
+from bokeh.models import Toggle as _BkToggle
 
 from ..links import Callback
 from .base import Widget
@@ -33,7 +32,7 @@ class _ButtonBase(Widget):
         (blue), 'success' (green), 'info' (yellow), 'light' (light),
         or 'danger' (red).""")
 
-    _rename = {'name': 'label'}
+    _rename: Mapping[str, str | None] = {'name': 'label'}
 
     __abstract = True
 
@@ -123,7 +122,7 @@ class Button(_ClickButton):
     value = param.Event(doc="""
         Toggles from False to True while the event is being processed.""")
 
-    _rename = {'clicks': None, 'name': 'label', 'value': None}
+    _rename: Mapping[str, str | None] = {'clicks': None, 'name': 'label', 'value': None}
 
     _target_transforms = {'event:button_click': None, 'value': None}
 
@@ -211,7 +210,7 @@ class Toggle(_ButtonBase):
     value = param.Boolean(default=False, doc="""
         Whether the button is currently toggled.""")
 
-    _rename = {'value': 'active', 'name': 'label'}
+    _rename: Mapping[str, str | None] = {'value': 'active', 'name': 'label'}
 
     _supports_embed = True
 
@@ -252,7 +251,7 @@ class MenuButton(_ClickButton):
 
     _widget_type = _BkDropdown
 
-    _rename = {'name': 'label', 'items': 'menu', 'clicked': None}
+    _rename: Mapping[str, str | None] = {'name': 'label', 'items': 'menu', 'clicked': None}
 
     _event = 'menu_item_click'
 

--- a/panel/widgets/debugger.py
+++ b/panel/widgets/debugger.py
@@ -2,13 +2,15 @@
 The Debugger Widget is an uneditable Card that gives you feedback on errors
 thrown by your Panel callbacks.
 """
-import param
 import logging
+from typing import Mapping
 
+import param
+
+from ..io.state import state
+from ..layout import HSpacer, Row
 from ..layout.card import Card
 from ..reactive import ReactiveHTML
-from ..io.state import state
-from ..layout import Row, HSpacer
 from .terminal import Terminal
 
 
@@ -201,7 +203,7 @@ class Debugger(Card):
         Loggers which will be prompted in the debugger terminal."""
     )
 
-    _rename = Card._rename.copy()
+    _rename: Mapping[str, str | None] = Card._rename.copy()
 
     _rename.update({
         '_number_of_errors': None,

--- a/panel/widgets/debugger.py
+++ b/panel/widgets/debugger.py
@@ -3,7 +3,7 @@ The Debugger Widget is an uneditable Card that gives you feedback on errors
 thrown by your Panel callbacks.
 """
 import logging
-from typing import Mapping
+from typing import Mapping, Union
 
 import param
 
@@ -203,7 +203,7 @@ class Debugger(Card):
         Loggers which will be prompted in the debugger terminal."""
     )
 
-    _rename: Mapping[str, str | None] = Card._rename.copy()
+    _rename: Mapping[str, Union[str, None]] = Card._rename.copy()
 
     _rename.update({
         '_number_of_errors': None,

--- a/panel/widgets/debugger.py
+++ b/panel/widgets/debugger.py
@@ -2,9 +2,11 @@
 The Debugger Widget is an uneditable Card that gives you feedback on errors
 thrown by your Panel callbacks.
 """
+from __future__ import annotations
+
 import logging
 
-from typing import Mapping, Union
+from typing import ClassVar, Mapping
 
 import param
 
@@ -203,7 +205,7 @@ class Debugger(Card):
         Loggers which will be prompted in the debugger terminal."""
     )
 
-    _rename: Mapping[str, Union[str, None]] = Card._rename.copy()
+    _rename: ClassVar[Mapping[str, str | None]] = Card._rename.copy()
 
     _rename.update({
         '_number_of_errors': None,

--- a/panel/widgets/indicators.py
+++ b/panel/widgets/indicators.py
@@ -15,12 +15,14 @@ How to use indicators
 ...    colors=[(80, 'green'), (100, 'red')]
 ... )
 """
+from __future__ import annotations
+
 import math
 import os
 import sys
 
 from math import pi
-from typing import Mapping, Union
+from typing import ClassVar, Mapping
 
 import numpy as np
 import param
@@ -95,7 +97,7 @@ class BooleanStatus(BooleanIndicator):
     value = param.Boolean(default=False, doc="""
         Whether the indicator is active or not.""")
 
-    _rename: Mapping[str, Union[str, None]] = {}
+    _rename: ClassVar[Mapping[str, str | None]] = {}
 
     _source_transforms = {'value': None, 'color': None}
 
@@ -141,7 +143,7 @@ class LoadingSpinner(BooleanIndicator):
     value = param.Boolean(default=False, doc="""
         Whether the indicator is active or not.""")
 
-    _rename: Mapping[str, Union[str, None]] = {}
+    _rename: ClassVar[Mapping[str, str | None]] = {}
 
     _source_transforms = {'value': None, 'color': None, 'bgcolor': None}
 
@@ -202,7 +204,7 @@ class Progress(ValueIndicator):
         bar will be indeterminate and animate depending on the active
         parameter.""")
 
-    _rename: Mapping[str, Union[str, None]] = {'name': None}
+    _rename: ClassVar[Mapping[str, str | None]] = {'name': None}
 
     _widget_type = _BkProgress
 
@@ -246,7 +248,7 @@ class Number(ValueIndicator):
     title_size = param.String(default='18pt', doc="""
         The size of the title given by the name.""")
 
-    _rename: Mapping[str, Union[str, None]] = {}
+    _rename: ClassVar[Mapping[str, str | None]] = {}
 
     _source_transforms = {
         'value': None, 'colors': None, 'default_color': None,
@@ -297,7 +299,7 @@ class String(ValueIndicator):
     value = param.String(default=None, allow_None=True, doc="""
         The string to display""")
 
-    _rename: Mapping[str, Union[str, None]] = {}
+    _rename: ClassVar[Mapping[str, str | None]] = {}
 
     _source_transforms = {
         'value': None, 'default_color': None, 'font_size': None, 'title_size': None
@@ -377,7 +379,7 @@ class Gauge(ValueIndicator):
 
     width = param.Integer(default=300, bounds=(0, None))
 
-    _rename: Mapping[str, Union[str, None]] = {}
+    _rename: ClassVar[Mapping[str, str | None]] = {}
 
     _source_transforms = {
         'annulus_width': None, 'bounds': None, 'colors': None,
@@ -519,7 +521,7 @@ class Dial(ValueIndicator):
 
     _data_params = _manual_params
 
-    _rename: Mapping[str, Union[str, None]] = {'background': 'background_fill_color'}
+    _rename: ClassVar[Mapping[str, str | None]] = {'background': 'background_fill_color'}
 
     def __init__(self, **params):
         super().__init__(**params)
@@ -746,7 +748,7 @@ class LinearGauge(ValueIndicator):
 
     _rerender_params = ['horizontal']
 
-    _rename: Mapping[str, Union[str, None]] = {
+    _rename: ClassVar[Mapping[str, str | None]] = {
         'background': 'background_fill_color', 'show_boundaries': None,
         'default_color': None
     }
@@ -1008,7 +1010,7 @@ class Trend(SyncableData, Indicator):
 
     _manual_params = ['data']
 
-    _rename: Mapping[str, Union[str, None]] = {'data': None, 'selection': None}
+    _rename: ClassVar[Mapping[str, str | None]] = {'data': None, 'selection': None}
 
     _widget_type = _BkTrendIndicator
 
@@ -1148,7 +1150,7 @@ class Tqdm(Indicator):
 
     _layouts = {Row: 'row', Column: 'column'}
 
-    _rename: Mapping[str, Union[str, None]] = {'value': None, 'min': None, 'max': None, 'text': None}
+    _rename: ClassVar[Mapping[str, str | None]] = {'value': None, 'min': None, 'max': None, 'text': None}
 
     def __init__(self, **params):
         layout = params.pop('layout', 'column')

--- a/panel/widgets/indicators.py
+++ b/panel/widgets/indicators.py
@@ -18,20 +18,19 @@ How to use indicators
 import math
 import os
 import sys
-
 from math import pi
+from typing import Mapping
 
 import numpy as np
 import param
-
-from bokeh.plotting import figure
 from bokeh.models import ColumnDataSource, FixedTicker
+from bokeh.plotting import figure
 from tqdm.asyncio import tqdm as _tqdm
 
 from ..layout import Column, Row
-from ..models import (
-    HTML, Progress as _BkProgress, TrendIndicator as _BkTrendIndicator
-)
+from ..models import HTML
+from ..models import Progress as _BkProgress
+from ..models import TrendIndicator as _BkTrendIndicator
 from ..pane.markup import Str
 from ..reactive import SyncableData
 from ..util import escape, updating
@@ -94,7 +93,7 @@ class BooleanStatus(BooleanIndicator):
     value = param.Boolean(default=False, doc="""
         Whether the indicator is active or not.""")
 
-    _rename = {}
+    _rename: Mapping[str, str | None] = {}
 
     _source_transforms = {'value': None, 'color': None}
 
@@ -140,7 +139,7 @@ class LoadingSpinner(BooleanIndicator):
     value = param.Boolean(default=False, doc="""
         Whether the indicator is active or not.""")
 
-    _rename = {}
+    _rename: Mapping[str, str | None] = {}
 
     _source_transforms = {'value': None, 'color': None, 'bgcolor': None}
 
@@ -201,7 +200,7 @@ class Progress(ValueIndicator):
         bar will be indeterminate and animate depending on the active
         parameter.""")
 
-    _rename = {'name': None}
+    _rename: Mapping[str, str | None] = {'name': None}
 
     _widget_type = _BkProgress
 
@@ -245,7 +244,7 @@ class Number(ValueIndicator):
     title_size = param.String(default='18pt', doc="""
         The size of the title given by the name.""")
 
-    _rename = {}
+    _rename: Mapping[str, str | None] = {}
 
     _source_transforms = {
         'value': None, 'colors': None, 'default_color': None,
@@ -296,7 +295,7 @@ class String(ValueIndicator):
     value = param.String(default=None, allow_None=True, doc="""
         The string to display""")
 
-    _rename = {}
+    _rename: Mapping[str, str | None] = {}
 
     _source_transforms = {
         'value': None, 'default_color': None, 'font_size': None, 'title_size': None
@@ -376,7 +375,7 @@ class Gauge(ValueIndicator):
 
     width = param.Integer(default=300, bounds=(0, None))
 
-    _rename = {}
+    _rename: Mapping[str, str | None] = {}
 
     _source_transforms = {
         'annulus_width': None, 'bounds': None, 'colors': None,
@@ -518,7 +517,7 @@ class Dial(ValueIndicator):
 
     _data_params = _manual_params
 
-    _rename = {'background': 'background_fill_color'}
+    _rename: Mapping[str, str | None] = {'background': 'background_fill_color'}
 
     def __init__(self, **params):
         super().__init__(**params)
@@ -745,7 +744,7 @@ class LinearGauge(ValueIndicator):
 
     _rerender_params = ['horizontal']
 
-    _rename = {
+    _rename: Mapping[str, str | None] = {
         'background': 'background_fill_color', 'show_boundaries': None,
         'default_color': None
     }
@@ -1007,7 +1006,7 @@ class Trend(SyncableData, Indicator):
 
     _manual_params = ['data']
 
-    _rename = {'data': None, 'selection': None}
+    _rename: Mapping[str, str | None] = {'data': None, 'selection': None}
 
     _widget_type = _BkTrendIndicator
 
@@ -1147,7 +1146,7 @@ class Tqdm(Indicator):
 
     _layouts = {Row: 'row', Column: 'column'}
 
-    _rename = {'value': None, 'min': None, 'max': None, 'text': None}
+    _rename: Mapping[str, str | None] = {'value': None, 'min': None, 'max': None, 'text': None}
 
     def __init__(self, **params):
         layout = params.pop('layout', 'column')

--- a/panel/widgets/indicators.py
+++ b/panel/widgets/indicators.py
@@ -35,7 +35,7 @@ from ..layout import Column, Row
 from ..models import (
     HTML, Progress as _BkProgress, TrendIndicator as _BkTrendIndicator,
 )
-from ..pane import Str
+from ..pane.markup import Str
 from ..reactive import SyncableData
 from ..util import escape, updating
 from ..viewable import Viewable

--- a/panel/widgets/indicators.py
+++ b/panel/widgets/indicators.py
@@ -19,7 +19,7 @@ import math
 import os
 import sys
 from math import pi
-from typing import Mapping
+from typing import Mapping, Union
 
 import numpy as np
 import param
@@ -93,7 +93,7 @@ class BooleanStatus(BooleanIndicator):
     value = param.Boolean(default=False, doc="""
         Whether the indicator is active or not.""")
 
-    _rename: Mapping[str, str | None] = {}
+    _rename: Mapping[str, Union[str, None]] = {}
 
     _source_transforms = {'value': None, 'color': None}
 
@@ -139,7 +139,7 @@ class LoadingSpinner(BooleanIndicator):
     value = param.Boolean(default=False, doc="""
         Whether the indicator is active or not.""")
 
-    _rename: Mapping[str, str | None] = {}
+    _rename: Mapping[str, Union[str, None]] = {}
 
     _source_transforms = {'value': None, 'color': None, 'bgcolor': None}
 
@@ -200,7 +200,7 @@ class Progress(ValueIndicator):
         bar will be indeterminate and animate depending on the active
         parameter.""")
 
-    _rename: Mapping[str, str | None] = {'name': None}
+    _rename: Mapping[str, Union[str, None]] = {'name': None}
 
     _widget_type = _BkProgress
 
@@ -244,7 +244,7 @@ class Number(ValueIndicator):
     title_size = param.String(default='18pt', doc="""
         The size of the title given by the name.""")
 
-    _rename: Mapping[str, str | None] = {}
+    _rename: Mapping[str, Union[str, None]] = {}
 
     _source_transforms = {
         'value': None, 'colors': None, 'default_color': None,
@@ -295,7 +295,7 @@ class String(ValueIndicator):
     value = param.String(default=None, allow_None=True, doc="""
         The string to display""")
 
-    _rename: Mapping[str, str | None] = {}
+    _rename: Mapping[str, Union[str, None]] = {}
 
     _source_transforms = {
         'value': None, 'default_color': None, 'font_size': None, 'title_size': None
@@ -375,7 +375,7 @@ class Gauge(ValueIndicator):
 
     width = param.Integer(default=300, bounds=(0, None))
 
-    _rename: Mapping[str, str | None] = {}
+    _rename: Mapping[str, Union[str, None]] = {}
 
     _source_transforms = {
         'annulus_width': None, 'bounds': None, 'colors': None,
@@ -517,7 +517,7 @@ class Dial(ValueIndicator):
 
     _data_params = _manual_params
 
-    _rename: Mapping[str, str | None] = {'background': 'background_fill_color'}
+    _rename: Mapping[str, Union[str, None]] = {'background': 'background_fill_color'}
 
     def __init__(self, **params):
         super().__init__(**params)
@@ -744,7 +744,7 @@ class LinearGauge(ValueIndicator):
 
     _rerender_params = ['horizontal']
 
-    _rename: Mapping[str, str | None] = {
+    _rename: Mapping[str, Union[str, None]] = {
         'background': 'background_fill_color', 'show_boundaries': None,
         'default_color': None
     }
@@ -1006,7 +1006,7 @@ class Trend(SyncableData, Indicator):
 
     _manual_params = ['data']
 
-    _rename: Mapping[str, str | None] = {'data': None, 'selection': None}
+    _rename: Mapping[str, Union[str, None]] = {'data': None, 'selection': None}
 
     _widget_type = _BkTrendIndicator
 
@@ -1146,7 +1146,7 @@ class Tqdm(Indicator):
 
     _layouts = {Row: 'row', Column: 'column'}
 
-    _rename: Mapping[str, str | None] = {'value': None, 'min': None, 'max': None, 'text': None}
+    _rename: Mapping[str, Union[str, None]] = {'value': None, 'min': None, 'max': None, 'text': None}
 
     def __init__(self, **params):
         layout = params.pop('layout', 'column')

--- a/panel/widgets/input.py
+++ b/panel/widgets/input.py
@@ -6,7 +6,7 @@ import ast
 import json
 from base64 import b64decode
 from datetime import date, datetime
-from typing import Mapping
+from typing import Mapping, Union
 
 import numpy as np
 import param
@@ -125,7 +125,7 @@ class FileInput(Widget):
 
     _source_transforms = {'value': "'data:' + source.mime_type + ';base64,' + value"}
 
-    _rename: Mapping[str, str | None] = {'name': None, 'filename': None}
+    _rename: Mapping[str, Union[str, None]] = {'name': None, 'filename': None}
 
     def _process_param_change(self, msg):
         msg = super()._process_param_change(msg)
@@ -203,7 +203,7 @@ class StaticText(Widget):
 
     _format = '<b>{title}</b>: {value}'
 
-    _rename: Mapping[str, str | None] = {'name': None, 'value': 'text'}
+    _rename: Mapping[str, Union[str, None]] = {'name': None, 'value': 'text'}
 
     _target_transforms = {'value': 'target.text.split(": ")[0]+": "+value'}
 
@@ -253,7 +253,7 @@ class DatePicker(Widget):
 
     _source_transforms = {}
 
-    _rename: Mapping[str, str | None] = {'start': 'min_date', 'end': 'max_date', 'name': 'title'}
+    _rename: Mapping[str, Union[str, None]] = {'start': 'min_date', 'end': 'max_date', 'name': 'title'}
 
     _widget_type = _BkDatePicker
 
@@ -294,7 +294,7 @@ class _DatetimePickerBase(Widget):
 
     _source_transforms = {'value': None, 'start': None, 'end': None, 'mode': None}
 
-    _rename: Mapping[str, str | None] = {'start': 'min_date', 'end': 'max_date', 'name': 'title'}
+    _rename: Mapping[str, Union[str, None]] = {'start': 'min_date', 'end': 'max_date', 'name': 'title'}
 
     _widget_type = _bkDatetimePicker
 
@@ -436,7 +436,7 @@ class ColorPicker(Widget):
 
     _widget_type = _BkColorPicker
 
-    _rename: Mapping[str, str | None] = {'value': 'color', 'name': 'title'}
+    _rename: Mapping[str, Union[str, None]] = {'value': 'color', 'name': 'title'}
 
 
 class _NumericInputBase(Widget):
@@ -456,7 +456,7 @@ class _NumericInputBase(Widget):
     end = param.Parameter(default=None, allow_None=True, doc="""
         Optional maximum allowable value.""")
 
-    _rename: Mapping[str, str | None] = {'name': 'title', 'start': 'low', 'end': 'high'}
+    _rename: Mapping[str, Union[str, None]] = {'name': 'title', 'start': 'low', 'end': 'high'}
 
     _widget_type = _BkNumericInput
 
@@ -633,7 +633,7 @@ class LiteralInput(Widget):
 
     value = param.Parameter(default=None)
 
-    _rename: Mapping[str, str | None] = {'name': 'title', 'type': None, 'serializer': None}
+    _rename: Mapping[str, Union[str, None]] = {'name': 'title', 'type': None, 'serializer': None}
 
     _source_transforms = {'value': """JSON.parse(value.replace(/'/g, '"'))"""}
 
@@ -730,7 +730,7 @@ class ArrayInput(LiteralInput):
         restriction helps avoid overwhelming the browser and lets
         other widgets remain usable.""")
 
-    _rename: Mapping[str, str | None] = dict(LiteralInput._rename, max_array_size=None)
+    _rename: Mapping[str, Union[str, None]] = dict(LiteralInput._rename, max_array_size=None)
 
     _source_transforms = {'value': None}
 
@@ -805,7 +805,7 @@ class DatetimeInput(LiteralInput):
 
     _source_transforms = {'value': None, 'start': None, 'end': None}
 
-    _rename: Mapping[str, str | None] = {'format': None, 'type': None, 'name': 'title',
+    _rename: Mapping[str, Union[str, None]] = {'format': None, 'type': None, 'name': 'title',
                'start': None, 'end': None, 'serializer': None}
 
     def __init__(self, **params):
@@ -962,7 +962,7 @@ class Checkbox(Widget):
 
     _supports_embed = True
 
-    _rename: Mapping[str, str | None] = {'value': 'active', 'name': 'labels'}
+    _rename: Mapping[str, Union[str, None]] = {'value': 'active', 'name': 'labels'}
 
     _source_transforms = {'value': "value.indexOf(0) >= 0", 'name': "value[0]"}
 

--- a/panel/widgets/input.py
+++ b/panel/widgets/input.py
@@ -4,27 +4,29 @@ a text field or similar.
 """
 import ast
 import json
-
 from base64 import b64decode
-from datetime import datetime, date
+from datetime import date, datetime
+from typing import Mapping
 
 import numpy as np
 import param
-
 from bokeh.models.formatters import TickFormatter
-from bokeh.models.widgets import (
-    CheckboxGroup as _BkCheckboxGroup, ColorPicker as _BkColorPicker,
-    DatePicker as _BkDatePicker, Div as _BkDiv, TextInput as _BkTextInput,
-    PasswordInput as _BkPasswordInput, Spinner as _BkSpinner,
-    FileInput as _BkFileInput, TextAreaInput as _BkTextAreaInput,
-    NumericInput as _BkNumericInput
-)
+from bokeh.models.widgets import CheckboxGroup as _BkCheckboxGroup
+from bokeh.models.widgets import ColorPicker as _BkColorPicker
+from bokeh.models.widgets import DatePicker as _BkDatePicker
+from bokeh.models.widgets import Div as _BkDiv
+from bokeh.models.widgets import FileInput as _BkFileInput
+from bokeh.models.widgets import NumericInput as _BkNumericInput
+from bokeh.models.widgets import PasswordInput as _BkPasswordInput
+from bokeh.models.widgets import Spinner as _BkSpinner
+from bokeh.models.widgets import TextAreaInput as _BkTextAreaInput
+from bokeh.models.widgets import TextInput as _BkTextInput
 
 from ..config import config
 from ..layout import Column
-from ..util import param_reprs
-from .base import Widget, CompositeWidget
 from ..models import DatetimePicker as _bkDatetimePicker
+from ..util import param_reprs
+from .base import CompositeWidget, Widget
 
 
 class TextInput(Widget):
@@ -123,7 +125,7 @@ class FileInput(Widget):
 
     _source_transforms = {'value': "'data:' + source.mime_type + ';base64,' + value"}
 
-    _rename = {'name': None, 'filename': None}
+    _rename: Mapping[str, str | None] = {'name': None, 'filename': None}
 
     def _process_param_change(self, msg):
         msg = super()._process_param_change(msg)
@@ -201,7 +203,7 @@ class StaticText(Widget):
 
     _format = '<b>{title}</b>: {value}'
 
-    _rename = {'name': None, 'value': 'text'}
+    _rename: Mapping[str, str | None] = {'name': None, 'value': 'text'}
 
     _target_transforms = {'value': 'target.text.split(": ")[0]+": "+value'}
 
@@ -251,7 +253,7 @@ class DatePicker(Widget):
 
     _source_transforms = {}
 
-    _rename = {'start': 'min_date', 'end': 'max_date', 'name': 'title'}
+    _rename: Mapping[str, str | None] = {'start': 'min_date', 'end': 'max_date', 'name': 'title'}
 
     _widget_type = _BkDatePicker
 
@@ -292,7 +294,7 @@ class _DatetimePickerBase(Widget):
 
     _source_transforms = {'value': None, 'start': None, 'end': None, 'mode': None}
 
-    _rename = {'start': 'min_date', 'end': 'max_date', 'name': 'title'}
+    _rename: Mapping[str, str | None] = {'start': 'min_date', 'end': 'max_date', 'name': 'title'}
 
     _widget_type = _bkDatetimePicker
 
@@ -434,7 +436,7 @@ class ColorPicker(Widget):
 
     _widget_type = _BkColorPicker
 
-    _rename = {'value': 'color', 'name': 'title'}
+    _rename: Mapping[str, str | None] = {'value': 'color', 'name': 'title'}
 
 
 class _NumericInputBase(Widget):
@@ -454,7 +456,7 @@ class _NumericInputBase(Widget):
     end = param.Parameter(default=None, allow_None=True, doc="""
         Optional maximum allowable value.""")
 
-    _rename = {'name': 'title', 'start': 'low', 'end': 'high'}
+    _rename: Mapping[str, str | None] = {'name': 'title', 'start': 'low', 'end': 'high'}
 
     _widget_type = _BkNumericInput
 
@@ -631,7 +633,7 @@ class LiteralInput(Widget):
 
     value = param.Parameter(default=None)
 
-    _rename = {'name': 'title', 'type': None, 'serializer': None}
+    _rename: Mapping[str, str | None] = {'name': 'title', 'type': None, 'serializer': None}
 
     _source_transforms = {'value': """JSON.parse(value.replace(/'/g, '"'))"""}
 
@@ -728,7 +730,7 @@ class ArrayInput(LiteralInput):
         restriction helps avoid overwhelming the browser and lets
         other widgets remain usable.""")
 
-    _rename = dict(LiteralInput._rename, max_array_size=None)
+    _rename: Mapping[str, str | None] = dict(LiteralInput._rename, max_array_size=None)
 
     _source_transforms = {'value': None}
 
@@ -803,7 +805,7 @@ class DatetimeInput(LiteralInput):
 
     _source_transforms = {'value': None, 'start': None, 'end': None}
 
-    _rename = {'format': None, 'type': None, 'name': 'title',
+    _rename: Mapping[str, str | None] = {'format': None, 'type': None, 'name': 'title',
                'start': None, 'end': None, 'serializer': None}
 
     def __init__(self, **params):
@@ -960,7 +962,7 @@ class Checkbox(Widget):
 
     _supports_embed = True
 
-    _rename = {'value': 'active', 'name': 'labels'}
+    _rename: Mapping[str, str | None] = {'value': 'active', 'name': 'labels'}
 
     _source_transforms = {'value': "value.indexOf(0) >= 0", 'name': "value[0]"}
 

--- a/panel/widgets/input.py
+++ b/panel/widgets/input.py
@@ -2,12 +2,14 @@
 The input widgets generally allow entering arbitrary information into
 a text field or similar.
 """
+from __future__ import annotations
+
 import ast
 import json
 
 from base64 import b64decode
 from datetime import date, datetime
-from typing import Mapping, Union
+from typing import ClassVar, Mapping
 
 import numpy as np
 import param
@@ -124,7 +126,7 @@ class FileInput(Widget):
 
     _source_transforms = {'value': "'data:' + source.mime_type + ';base64,' + value"}
 
-    _rename: Mapping[str, Union[str, None]] = {'name': None, 'filename': None}
+    _rename: ClassVar[Mapping[str, str | None]] = {'name': None, 'filename': None}
 
     def _process_param_change(self, msg):
         msg = super()._process_param_change(msg)
@@ -202,7 +204,7 @@ class StaticText(Widget):
 
     _format = '<b>{title}</b>: {value}'
 
-    _rename: Mapping[str, Union[str, None]] = {'name': None, 'value': 'text'}
+    _rename: ClassVar[Mapping[str, str | None]] = {'name': None, 'value': 'text'}
 
     _target_transforms = {'value': 'target.text.split(": ")[0]+": "+value'}
 
@@ -252,7 +254,7 @@ class DatePicker(Widget):
 
     _source_transforms = {}
 
-    _rename: Mapping[str, Union[str, None]] = {'start': 'min_date', 'end': 'max_date', 'name': 'title'}
+    _rename: ClassVar[Mapping[str, str | None]] = {'start': 'min_date', 'end': 'max_date', 'name': 'title'}
 
     _widget_type = _BkDatePicker
 
@@ -293,7 +295,7 @@ class _DatetimePickerBase(Widget):
 
     _source_transforms = {'value': None, 'start': None, 'end': None, 'mode': None}
 
-    _rename: Mapping[str, Union[str, None]] = {'start': 'min_date', 'end': 'max_date', 'name': 'title'}
+    _rename: ClassVar[Mapping[str, str | None]] = {'start': 'min_date', 'end': 'max_date', 'name': 'title'}
 
     _widget_type = _bkDatetimePicker
 
@@ -435,7 +437,7 @@ class ColorPicker(Widget):
 
     _widget_type = _BkColorPicker
 
-    _rename: Mapping[str, Union[str, None]] = {'value': 'color', 'name': 'title'}
+    _rename: ClassVar[Mapping[str, str | None]] = {'value': 'color', 'name': 'title'}
 
 
 class _NumericInputBase(Widget):
@@ -455,7 +457,7 @@ class _NumericInputBase(Widget):
     end = param.Parameter(default=None, allow_None=True, doc="""
         Optional maximum allowable value.""")
 
-    _rename: Mapping[str, Union[str, None]] = {'name': 'title', 'start': 'low', 'end': 'high'}
+    _rename: ClassVar[Mapping[str, str | None]] = {'name': 'title', 'start': 'low', 'end': 'high'}
 
     _widget_type = _BkNumericInput
 
@@ -632,7 +634,7 @@ class LiteralInput(Widget):
 
     value = param.Parameter(default=None)
 
-    _rename: Mapping[str, Union[str, None]] = {'name': 'title', 'type': None, 'serializer': None}
+    _rename: ClassVar[Mapping[str, str | None]] = {'name': 'title', 'type': None, 'serializer': None}
 
     _source_transforms = {'value': """JSON.parse(value.replace(/'/g, '"'))"""}
 
@@ -729,7 +731,7 @@ class ArrayInput(LiteralInput):
         restriction helps avoid overwhelming the browser and lets
         other widgets remain usable.""")
 
-    _rename: Mapping[str, Union[str, None]] = dict(LiteralInput._rename, max_array_size=None)
+    _rename: ClassVar[Mapping[str, str | None]] = dict(LiteralInput._rename, max_array_size=None)
 
     _source_transforms = {'value': None}
 
@@ -804,7 +806,7 @@ class DatetimeInput(LiteralInput):
 
     _source_transforms = {'value': None, 'start': None, 'end': None}
 
-    _rename: Mapping[str, Union[str, None]] = {'format': None, 'type': None, 'name': 'title',
+    _rename: ClassVar[Mapping[str, str | None]] = {'format': None, 'type': None, 'name': 'title',
                'start': None, 'end': None, 'serializer': None}
 
     def __init__(self, **params):
@@ -961,7 +963,7 @@ class Checkbox(Widget):
 
     _supports_embed = True
 
-    _rename: Mapping[str, Union[str, None]] = {'value': 'active', 'name': 'labels'}
+    _rename: ClassVar[Mapping[str, str | None]] = {'value': 'active', 'name': 'labels'}
 
     _source_transforms = {'value': "value.indexOf(0) >= 0", 'name': "value[0]"}
 

--- a/panel/widgets/misc.py
+++ b/panel/widgets/misc.py
@@ -1,10 +1,12 @@
 """
 Miscellaneous widgets which do not fit into the other main categories.
 """
+from __future__ import annotations
+
 import os
 
 from base64 import b64encode
-from typing import Mapping, Union
+from typing import ClassVar, Mapping
 
 import param
 
@@ -47,7 +49,7 @@ class VideoStream(Widget):
 
     _widget_type = _BkVideoStream
 
-    _rename: Mapping[str, Union[str, None]] = {'name': None}
+    _rename: ClassVar[Mapping[str, str | None]] = {'name': None}
 
     def snapshot(self):
         """
@@ -130,7 +132,7 @@ class FileDownload(Widget):
 
     _widget_type = _BkFileDownload
 
-    _rename: Mapping[str, Union[str, None]] = {
+    _rename: ClassVar[Mapping[str, str | None]] = {
         'callback': None, 'embed': None, 'file': None,
         '_clicks': 'clicks', 'name': 'title'
     }
@@ -285,7 +287,7 @@ class JSONEditor(Widget):
     value = param.Parameter(default={}, doc="""
         JSON data to be edited.""")
 
-    _rename: Mapping[str, Union[str, None]] = {'value': 'data'}
+    _rename: ClassVar[Mapping[str, str | None]] = {'value': 'data'}
 
     def _get_model(self, doc, root=None, parent=None, comm=None):
         if self._widget_type is None:

--- a/panel/widgets/misc.py
+++ b/panel/widgets/misc.py
@@ -2,21 +2,19 @@
 Miscellaneous widgets which do not fit into the other main categories.
 """
 import os
-
 from base64 import b64encode
+from typing import Mapping
 
 import param
-
 from pyviz_comms import JupyterComm
 
 from ..io.notebook import push
 from ..io.state import state
-from ..models import (
-    VideoStream as _BkVideoStream, FileDownload as _BkFileDownload
-)
+from ..models import FileDownload as _BkFileDownload
+from ..models import VideoStream as _BkVideoStream
 from ..util import lazy_load
 from .base import Widget
-from .indicators import Progress # noqa
+from .indicators import Progress  # noqaf
 
 
 class VideoStream(Widget):
@@ -46,7 +44,7 @@ class VideoStream(Widget):
 
     _widget_type = _BkVideoStream
 
-    _rename = {'name': None}
+    _rename: Mapping[str, str | None] = {'name': None}
 
     def snapshot(self):
         """
@@ -129,7 +127,7 @@ class FileDownload(Widget):
 
     _widget_type = _BkFileDownload
 
-    _rename = {
+    _rename: Mapping[str, str | None] = {
         'callback': None, 'embed': None, 'file': None,
         '_clicks': 'clicks', 'name': 'title'
     }
@@ -284,7 +282,7 @@ class JSONEditor(Widget):
     value = param.Parameter(default={}, doc="""
         JSON data to be edited.""")
 
-    _rename = {'value': 'data'}
+    _rename: Mapping[str, str | None] = {'value': 'data'}
 
     def _get_model(self, doc, root=None, parent=None, comm=None):
         if self._widget_type is None:

--- a/panel/widgets/misc.py
+++ b/panel/widgets/misc.py
@@ -3,7 +3,7 @@ Miscellaneous widgets which do not fit into the other main categories.
 """
 import os
 from base64 import b64encode
-from typing import Mapping
+from typing import Mapping, Union
 
 import param
 from pyviz_comms import JupyterComm
@@ -44,7 +44,7 @@ class VideoStream(Widget):
 
     _widget_type = _BkVideoStream
 
-    _rename: Mapping[str, str | None] = {'name': None}
+    _rename: Mapping[str, Union[str, None]] = {'name': None}
 
     def snapshot(self):
         """
@@ -127,7 +127,7 @@ class FileDownload(Widget):
 
     _widget_type = _BkFileDownload
 
-    _rename: Mapping[str, str | None] = {
+    _rename: Mapping[str, Union[str, None]] = {
         'callback': None, 'embed': None, 'file': None,
         '_clicks': 'clicks', 'name': 'title'
     }
@@ -282,7 +282,7 @@ class JSONEditor(Widget):
     value = param.Parameter(default={}, doc="""
         JSON data to be edited.""")
 
-    _rename: Mapping[str, str | None] = {'value': 'data'}
+    _rename: Mapping[str, Union[str, None]] = {'value': 'data'}
 
     def _get_model(self, doc, root=None, parent=None, comm=None):
         if self._widget_type is None:

--- a/panel/widgets/player.py
+++ b/panel/widgets/player.py
@@ -1,10 +1,12 @@
 """
 Defines Player widgets which offer media-player like controls.
 """
+from typing import Mapping
+
 import param
 
 from ..models.widgets import Player as _BkPlayer
-from ..util import isIn, indexOf
+from ..util import indexOf, isIn
 from .base import Widget
 from .select import SelectBase
 
@@ -33,7 +35,7 @@ class PlayerBase(Widget):
 
     _widget_type = _BkPlayer
 
-    _rename = {'name': None}
+    _rename: Mapping[str, str | None] = {'name': None}
 
     __abstract = True
 
@@ -110,7 +112,7 @@ class DiscretePlayer(PlayerBase, SelectBase):
 
     value = param.Parameter(doc="Current player value")
 
-    _rename = {'name': None, 'options': None}
+    _rename: Mapping[str, str | None] = {'name': None, 'options': None}
 
     _source_transforms = {'value': None}
 

--- a/panel/widgets/player.py
+++ b/panel/widgets/player.py
@@ -1,7 +1,9 @@
 """
 Defines Player widgets which offer media-player like controls.
 """
-from typing import Mapping, Union
+from __future__ import annotations
+
+from typing import ClassVar, Mapping
 
 import param
 
@@ -35,7 +37,7 @@ class PlayerBase(Widget):
 
     _widget_type = _BkPlayer
 
-    _rename: Mapping[str, Union[str, None]] = {'name': None}
+    _rename: ClassVar[Mapping[str, str | None]] = {'name': None}
 
     __abstract = True
 
@@ -112,7 +114,7 @@ class DiscretePlayer(PlayerBase, SelectBase):
 
     value = param.Parameter(doc="Current player value")
 
-    _rename: Mapping[str, Union[str, None]] = {'name': None, 'options': None}
+    _rename: ClassVar[Mapping[str, str | None]] = {'name': None, 'options': None}
 
     _source_transforms = {'value': None}
 

--- a/panel/widgets/player.py
+++ b/panel/widgets/player.py
@@ -1,7 +1,7 @@
 """
 Defines Player widgets which offer media-player like controls.
 """
-from typing import Mapping
+from typing import Mapping, Union
 
 import param
 
@@ -35,7 +35,7 @@ class PlayerBase(Widget):
 
     _widget_type = _BkPlayer
 
-    _rename: Mapping[str, str | None] = {'name': None}
+    _rename: Mapping[str, Union[str, None]] = {'name': None}
 
     __abstract = True
 
@@ -112,7 +112,7 @@ class DiscretePlayer(PlayerBase, SelectBase):
 
     value = param.Parameter(doc="Current player value")
 
-    _rename: Mapping[str, str | None] = {'name': None, 'options': None}
+    _rename: Mapping[str, Union[str, None]] = {'name': None, 'options': None}
 
     _source_transforms = {'value': None}
 

--- a/panel/widgets/select.py
+++ b/panel/widgets/select.py
@@ -2,26 +2,27 @@
 Defines various Select widgets which allow choosing one or more items
 from a list of options.
 """
-import re
-
-from collections import OrderedDict
 import itertools
+import re
+from collections import OrderedDict
+from typing import Mapping
 
 import param
-
-from bokeh.models.widgets import (
-    AutocompleteInput as _BkAutocompleteInput, CheckboxGroup as _BkCheckboxGroup,
-    CheckboxButtonGroup as _BkCheckboxButtonGroup, MultiSelect as _BkMultiSelect,
-    RadioButtonGroup as _BkRadioButtonGroup, RadioGroup as _BkRadioBoxGroup,
-    MultiChoice as _BkMultiChoice
-)
+from bokeh.models.widgets import AutocompleteInput as _BkAutocompleteInput
+from bokeh.models.widgets import CheckboxButtonGroup as _BkCheckboxButtonGroup
+from bokeh.models.widgets import CheckboxGroup as _BkCheckboxGroup
+from bokeh.models.widgets import MultiChoice as _BkMultiChoice
+from bokeh.models.widgets import MultiSelect as _BkMultiSelect
+from bokeh.models.widgets import RadioButtonGroup as _BkRadioButtonGroup
+from bokeh.models.widgets import RadioGroup as _BkRadioBoxGroup
 
 from ..layout import Column, VSpacer
-from ..models import SingleSelect as _BkSingleSelect, CustomSelect
-from ..util import isIn, indexOf
-from .base import Widget, CompositeWidget
-from .button import _ButtonBase, Button
-from .input import TextInput, TextAreaInput
+from ..models import CustomSelect
+from ..models import SingleSelect as _BkSingleSelect
+from ..util import indexOf, isIn
+from .base import CompositeWidget, Widget
+from .button import Button, _ButtonBase
+from .input import TextAreaInput, TextInput
 
 
 class SelectBase(Widget):
@@ -386,7 +387,7 @@ class MultiChoice(_MultiSelectBase):
     _widget_type = _BkMultiChoice
 
 
-_AutocompleteInput_rename = {'name': 'title', 'options': 'completions'}
+_AutocompleteInput_rename: Mapping[str, str | None] = {'name': 'title', 'options': 'completions'}
 
 
 class AutocompleteInput(Widget):
@@ -437,7 +438,7 @@ class AutocompleteInput(Widget):
 
     _widget_type = _BkAutocompleteInput
 
-    _rename = _AutocompleteInput_rename
+    _rename: Mapping[str, str | None] = _AutocompleteInput_rename
 
     def _process_param_change(self, msg):
         msg = super()._process_param_change(msg)
@@ -451,7 +452,7 @@ class _RadioGroupBase(SingleSelectBase):
 
     _supports_embed = False
 
-    _rename = {'name': None, 'options': 'labels', 'value': 'active'}
+    _rename: Mapping[str, str | None] = {'name': None, 'options': 'labels', 'value': 'active'}
 
     _source_transforms = {'value': "source.labels[value]"}
 
@@ -561,7 +562,7 @@ class _CheckGroupBase(SingleSelectBase):
 
     value = param.List(default=[])
 
-    _rename = {'name': None, 'options': 'labels', 'value': 'active'}
+    _rename: Mapping[str, str | None] = {'name': None, 'options': 'labels', 'value': 'active'}
 
     _source_transforms = {'value': "value.map((index) => source.labels[index])"}
 

--- a/panel/widgets/select.py
+++ b/panel/widgets/select.py
@@ -5,7 +5,7 @@ from a list of options.
 import itertools
 import re
 from collections import OrderedDict
-from typing import Mapping
+from typing import Mapping, Union
 
 import param
 from bokeh.models.widgets import AutocompleteInput as _BkAutocompleteInput
@@ -387,7 +387,7 @@ class MultiChoice(_MultiSelectBase):
     _widget_type = _BkMultiChoice
 
 
-_AutocompleteInput_rename: Mapping[str, str | None] = {'name': 'title', 'options': 'completions'}
+_AutocompleteInput_rename: Mapping[str, Union[str, None]] = {'name': 'title', 'options': 'completions'}
 
 
 class AutocompleteInput(Widget):
@@ -438,7 +438,7 @@ class AutocompleteInput(Widget):
 
     _widget_type = _BkAutocompleteInput
 
-    _rename: Mapping[str, str | None] = _AutocompleteInput_rename
+    _rename: Mapping[str, Union[str, None]] = _AutocompleteInput_rename
 
     def _process_param_change(self, msg):
         msg = super()._process_param_change(msg)
@@ -452,7 +452,7 @@ class _RadioGroupBase(SingleSelectBase):
 
     _supports_embed = False
 
-    _rename: Mapping[str, str | None] = {'name': None, 'options': 'labels', 'value': 'active'}
+    _rename: Mapping[str, Union[str, None]] = {'name': None, 'options': 'labels', 'value': 'active'}
 
     _source_transforms = {'value': "source.labels[value]"}
 
@@ -562,7 +562,7 @@ class _CheckGroupBase(SingleSelectBase):
 
     value = param.List(default=[])
 
-    _rename: Mapping[str, str | None] = {'name': None, 'options': 'labels', 'value': 'active'}
+    _rename: Mapping[str, Union[str, None]] = {'name': None, 'options': 'labels', 'value': 'active'}
 
     _source_transforms = {'value': "value.map((index) => source.labels[index])"}
 

--- a/panel/widgets/select.py
+++ b/panel/widgets/select.py
@@ -390,10 +390,6 @@ class MultiChoice(_MultiSelectBase):
     _widget_type = _BkMultiChoice
 
 
-    _rename: ClassVar[Mapping[str, str | None]] = {'name': 'title', 'options': 'completions'}
-
-_AutocompleteInput_rename = {'name': 'title', 'options': 'completions'}
-
 class AutocompleteInput(Widget):
     """
     The `MultiChoice` widget allows selecting multiple values from a list of
@@ -442,7 +438,7 @@ class AutocompleteInput(Widget):
 
     _widget_type = _BkAutocompleteInput
 
-    _rename: ClassVar[Mapping[str, str | None]] = _AutocompleteInput_rename
+    _rename: ClassVar[Mapping[str, str | None]] = {'name': 'title', 'options': 'completions'}
 
     def _process_param_change(self, msg):
         msg = super()._process_param_change(msg)

--- a/panel/widgets/select.py
+++ b/panel/widgets/select.py
@@ -2,11 +2,13 @@
 Defines various Select widgets which allow choosing one or more items
 from a list of options.
 """
+from __future__ import annotations
+
 import itertools
 import re
 
 from collections import OrderedDict
-from typing import Mapping, Union
+from typing import ClassVar, Mapping
 
 import param
 
@@ -388,8 +390,9 @@ class MultiChoice(_MultiSelectBase):
     _widget_type = _BkMultiChoice
 
 
-_AutocompleteInput_rename: Mapping[str, Union[str, None]] = {'name': 'title', 'options': 'completions'}
+    _rename: ClassVar[Mapping[str, str | None]] = {'name': 'title', 'options': 'completions'}
 
+_AutocompleteInput_rename = {'name': 'title', 'options': 'completions'}
 
 class AutocompleteInput(Widget):
     """
@@ -439,7 +442,7 @@ class AutocompleteInput(Widget):
 
     _widget_type = _BkAutocompleteInput
 
-    _rename: Mapping[str, Union[str, None]] = _AutocompleteInput_rename
+    _rename: ClassVar[Mapping[str, str | None]] = _AutocompleteInput_rename
 
     def _process_param_change(self, msg):
         msg = super()._process_param_change(msg)
@@ -453,7 +456,7 @@ class _RadioGroupBase(SingleSelectBase):
 
     _supports_embed = False
 
-    _rename: Mapping[str, Union[str, None]] = {'name': None, 'options': 'labels', 'value': 'active'}
+    _rename: ClassVar[Mapping[str, str | None]] = {'name': None, 'options': 'labels', 'value': 'active'}
 
     _source_transforms = {'value': "source.labels[value]"}
 
@@ -563,7 +566,7 @@ class _CheckGroupBase(SingleSelectBase):
 
     value = param.List(default=[])
 
-    _rename: Mapping[str, Union[str, None]] = {'name': None, 'options': 'labels', 'value': 'active'}
+    _rename: ClassVar[Mapping[str, str | None]] = {'name': None, 'options': 'labels', 'value': 'active'}
 
     _source_transforms = {'value': "value.map((index) => source.labels[index])"}
 

--- a/panel/widgets/slider.py
+++ b/panel/widgets/slider.py
@@ -6,7 +6,7 @@ moving one or more handle(s).
 - The `value_throttled`will update when a handle is released.
 """
 import datetime as dt
-from typing import Mapping
+from typing import Mapping, Union
 
 import numpy as np
 import param
@@ -156,7 +156,7 @@ class FloatSlider(ContinuousSlider):
     step = param.Number(default=0.1, doc="""
         The step size.""")
 
-    _rename: Mapping[str, str | None] = {'name': 'title'}
+    _rename: Mapping[str, Union[str, None]] = {'name': 'title'}
 
 
 class IntSlider(ContinuousSlider):
@@ -186,7 +186,7 @@ class IntSlider(ContinuousSlider):
     value_throttled = param.Integer(default=None, constant=True, doc="""
         The value of the slider. Updated when the handle is released""")
 
-    _rename: Mapping[str, str | None] = {'name': 'title'}
+    _rename: Mapping[str, Union[str, None]] = {'name': 'title'}
 
     def _process_property_change(self, msg):
         msg = super()._process_property_change(msg)
@@ -234,7 +234,7 @@ class DateSlider(_SliderBase):
     as_datetime = param.Boolean(default=False, doc="""
         Whether to store the date as a datetime.""")
 
-    _rename: Mapping[str, str | None] = {'name': 'title', 'as_datetime': None}
+    _rename: Mapping[str, Union[str, None]] = {'name': 'title', 'as_datetime': None}
 
     _source_transforms = {'value': None, 'value_throttled': None, 'start': None, 'end': None}
 
@@ -296,7 +296,7 @@ class DiscreteSlider(CompositeWidget, _SliderBase):
 
     _source_transforms = {'value': None, 'value_throttled': None, 'options': None}
 
-    _rename: Mapping[str, str | None] = {'formatter': None}
+    _rename: Mapping[str, Union[str, None]] = {'formatter': None}
 
     _supports_embed = True
 
@@ -527,7 +527,7 @@ class RangeSlider(_RangeSliderBase):
     format = param.ClassSelector(class_=(str, TickFormatter,), doc="""
         A format string or bokeh TickFormatter.""")
 
-    _rename: Mapping[str, str | None] = {'name': 'title', 'value_start': None, 'value_end': None}
+    _rename: Mapping[str, Union[str, None]] = {'name': 'title', 'value_start': None, 'value_end': None}
 
     _widget_type = _BkRangeSlider
 
@@ -619,7 +619,7 @@ class DateRangeSlider(_SliderBase):
     _source_transforms = {'value': None, 'value_throttled': None,
                          'start': None, 'end': None, 'step': None}
 
-    _rename: Mapping[str, str | None] = {'name': 'title', 'value_start': None, 'value_end': None}
+    _rename: Mapping[str, Union[str, None]] = {'name': 'title', 'value_start': None, 'value_end': None}
 
     _widget_type = _BkDateRangeSlider
 

--- a/panel/widgets/slider.py
+++ b/panel/widgets/slider.py
@@ -14,7 +14,6 @@ from typing import ClassVar, Mapping
 import numpy as np
 import param
 
-from base import Widget
 from bokeh.models import CustomJS
 from bokeh.models.formatters import TickFormatter
 from bokeh.models.widgets import (
@@ -31,7 +30,7 @@ from ..util import (
 )
 from ..viewable import Layoutable
 from ..widgets import FloatInput, IntInput
-from .base import CompositeWidget
+from .base import CompositeWidget, Widget
 from .input import StaticText
 
 

--- a/panel/widgets/slider.py
+++ b/panel/widgets/slider.py
@@ -6,26 +6,25 @@ moving one or more handle(s).
 - The `value_throttled`will update when a handle is released.
 """
 import datetime as dt
+from typing import Mapping
 
-import param
 import numpy as np
-
+import param
 from bokeh.models import CustomJS
 from bokeh.models.formatters import TickFormatter
-from bokeh.models.widgets import (
-    DateSlider as _BkDateSlider, DateRangeSlider as _BkDateRangeSlider,
-    RangeSlider as _BkRangeSlider, Slider as _BkSlider)
+from bokeh.models.widgets import DateRangeSlider as _BkDateRangeSlider
+from bokeh.models.widgets import DateSlider as _BkDateSlider
+from bokeh.models.widgets import RangeSlider as _BkRangeSlider
+from bokeh.models.widgets import Slider as _BkSlider
 
 from ..config import config
 from ..io import state
-from ..util import (
-    datetime_as_utctimestamp, edit_readonly, param_reprs,
-    value_as_datetime, value_as_date
-)
-from ..viewable import Layoutable
 from ..layout import Column, Row
-from .base import Widget, CompositeWidget
-from .input import IntInput, FloatInput, StaticText
+from ..util import (datetime_as_utctimestamp, edit_readonly, param_reprs,
+                    value_as_date, value_as_datetime)
+from ..viewable import Layoutable
+from .base import CompositeWidget, Widget
+from .input import FloatInput, IntInput, StaticText
 
 
 class _SliderBase(Widget):
@@ -157,7 +156,7 @@ class FloatSlider(ContinuousSlider):
     step = param.Number(default=0.1, doc="""
         The step size.""")
 
-    _rename = {'name': 'title'}
+    _rename: Mapping[str, str | None] = {'name': 'title'}
 
 
 class IntSlider(ContinuousSlider):
@@ -187,7 +186,7 @@ class IntSlider(ContinuousSlider):
     value_throttled = param.Integer(default=None, constant=True, doc="""
         The value of the slider. Updated when the handle is released""")
 
-    _rename = {'name': 'title'}
+    _rename: Mapping[str, str | None] = {'name': 'title'}
 
     def _process_property_change(self, msg):
         msg = super()._process_property_change(msg)
@@ -235,7 +234,7 @@ class DateSlider(_SliderBase):
     as_datetime = param.Boolean(default=False, doc="""
         Whether to store the date as a datetime.""")
 
-    _rename = {'name': 'title', 'as_datetime': None}
+    _rename: Mapping[str, str | None] = {'name': 'title', 'as_datetime': None}
 
     _source_transforms = {'value': None, 'value_throttled': None, 'start': None, 'end': None}
 
@@ -297,7 +296,7 @@ class DiscreteSlider(CompositeWidget, _SliderBase):
 
     _source_transforms = {'value': None, 'value_throttled': None, 'options': None}
 
-    _rename = {'formatter': None}
+    _rename: Mapping[str, str | None] = {'formatter': None}
 
     _supports_embed = True
 
@@ -528,7 +527,7 @@ class RangeSlider(_RangeSliderBase):
     format = param.ClassSelector(class_=(str, TickFormatter,), doc="""
         A format string or bokeh TickFormatter.""")
 
-    _rename = {'name': 'title', 'value_start': None, 'value_end': None}
+    _rename: Mapping[str, str | None] = {'name': 'title', 'value_start': None, 'value_end': None}
 
     _widget_type = _BkRangeSlider
 
@@ -620,7 +619,7 @@ class DateRangeSlider(_SliderBase):
     _source_transforms = {'value': None, 'value_throttled': None,
                          'start': None, 'end': None, 'step': None}
 
-    _rename = {'name': 'title', 'value_start': None, 'value_end': None}
+    _rename: Mapping[str, str | None] = {'name': 'title', 'value_start': None, 'value_end': None}
 
     _widget_type = _BkDateRangeSlider
 

--- a/panel/widgets/slider.py
+++ b/panel/widgets/slider.py
@@ -5,9 +5,11 @@ moving one or more handle(s).
 - The `value` will update when a handle is dragged.
 - The `value_throttled`will update when a handle is released.
 """
+from __future__ import annotations
+
 import datetime as dt
 
-from typing import Mapping, Union
+from typing import ClassVar, Mapping
 
 import numpy as np
 import param
@@ -161,7 +163,7 @@ class FloatSlider(ContinuousSlider):
     step = param.Number(default=0.1, doc="""
         The step size.""")
 
-    _rename: Mapping[str, Union[str, None]] = {'name': 'title'}
+    _rename: ClassVar[Mapping[str, str | None]] = {'name': 'title'}
 
 
 class IntSlider(ContinuousSlider):
@@ -191,7 +193,7 @@ class IntSlider(ContinuousSlider):
     value_throttled = param.Integer(default=None, constant=True, doc="""
         The value of the slider. Updated when the handle is released""")
 
-    _rename: Mapping[str, Union[str, None]] = {'name': 'title'}
+    _rename: ClassVar[Mapping[str, str | None]] = {'name': 'title'}
 
     def _process_property_change(self, msg):
         msg = super()._process_property_change(msg)
@@ -239,7 +241,7 @@ class DateSlider(_SliderBase):
     as_datetime = param.Boolean(default=False, doc="""
         Whether to store the date as a datetime.""")
 
-    _rename: Mapping[str, Union[str, None]] = {'name': 'title', 'as_datetime': None}
+    _rename: ClassVar[Mapping[str, str | None]] = {'name': 'title', 'as_datetime': None}
 
     _source_transforms = {'value': None, 'value_throttled': None, 'start': None, 'end': None}
 
@@ -301,7 +303,7 @@ class DiscreteSlider(CompositeWidget, _SliderBase):
 
     _source_transforms = {'value': None, 'value_throttled': None, 'options': None}
 
-    _rename: Mapping[str, Union[str, None]] = {'formatter': None}
+    _rename: ClassVar[Mapping[str, str | None]] = {'formatter': None}
 
     _supports_embed = True
 
@@ -532,7 +534,7 @@ class RangeSlider(_RangeSliderBase):
     format = param.ClassSelector(class_=(str, TickFormatter,), doc="""
         A format string or bokeh TickFormatter.""")
 
-    _rename: Mapping[str, Union[str, None]] = {'name': 'title', 'value_start': None, 'value_end': None}
+    _rename: ClassVar[Mapping[str, str | None]] = {'name': 'title', 'value_start': None, 'value_end': None}
 
     _widget_type = _BkRangeSlider
 
@@ -624,7 +626,7 @@ class DateRangeSlider(_SliderBase):
     _source_transforms = {'value': None, 'value_throttled': None,
                          'start': None, 'end': None, 'step': None}
 
-    _rename: Mapping[str, Union[str, None]] = {'name': 'title', 'value_start': None, 'value_end': None}
+    _rename: ClassVar[Mapping[str, str | None]] = {'name': 'title', 'value_start': None, 'value_end': None}
 
     _widget_type = _BkDateRangeSlider
 

--- a/panel/widgets/speech_to_text.py
+++ b/panel/widgets/speech_to_text.py
@@ -18,7 +18,7 @@ offline. Whether this is secure and confidential enough for your use
 case is up to you to evaluate.
 """
 
-from typing import Mapping
+from typing import Mapping, Union
 
 import param
 
@@ -388,7 +388,7 @@ class SpeechToText(Widget):
 
     _widget_type = _BkSpeechToText
 
-    _rename: Mapping[str, str | None] = {
+    _rename: Mapping[str, Union[str, None]] = {
         "value": None,
         "grammars": None,
         "_grammars": "grammars",

--- a/panel/widgets/speech_to_text.py
+++ b/panel/widgets/speech_to_text.py
@@ -18,7 +18,9 @@ offline. Whether this is secure and confidential enough for your use
 case is up to you to evaluate.
 """
 
-from typing import Mapping, Union
+from __future__ import annotations
+
+from typing import ClassVar, Mapping
 
 import param
 
@@ -388,7 +390,7 @@ class SpeechToText(Widget):
 
     _widget_type = _BkSpeechToText
 
-    _rename: Mapping[str, Union[str, None]] = {
+    _rename: ClassVar[Mapping[str, str | None]] = {
         "value": None,
         "grammars": None,
         "_grammars": "grammars",

--- a/panel/widgets/speech_to_text.py
+++ b/panel/widgets/speech_to_text.py
@@ -18,6 +18,8 @@ offline. Whether this is secure and confidential enough for your use
 case is up to you to evaluate.
 """
 
+from typing import Mapping
+
 import param
 
 from ..models.speech_to_text import SpeechToText as _BkSpeechToText
@@ -386,7 +388,7 @@ class SpeechToText(Widget):
 
     _widget_type = _BkSpeechToText
 
-    _rename = {
+    _rename: Mapping[str, str | None] = {
         "value": None,
         "grammars": None,
         "_grammars": "grammars",

--- a/panel/widgets/tables.py
+++ b/panel/widgets/tables.py
@@ -1,20 +1,21 @@
 import datetime as dt
 import uuid
-
 from functools import partial
 from types import FunctionType, MethodType
+from typing import Mapping
 
 import numpy as np
 import param
-
 from bokeh.models import ColumnDataSource
-from bokeh.models.widgets.tables import (
-    AvgAggregator, CellEditor, CellFormatter, CheckboxEditor,
-    DataCube, DataTable, DateEditor, DateFormatter, GroupingInfo,
-    IntEditor, MaxAggregator, MinAggregator, NumberEditor,
-    NumberFormatter, RowAggregator, StringEditor, StringFormatter,
-    SumAggregator, TableColumn
-)
+from bokeh.models.widgets.tables import (AvgAggregator, CellEditor,
+                                         CellFormatter, CheckboxEditor,
+                                         DataCube, DataTable, DateEditor,
+                                         DateFormatter, GroupingInfo,
+                                         IntEditor, MaxAggregator,
+                                         MinAggregator, NumberEditor,
+                                         NumberFormatter, RowAggregator,
+                                         StringEditor, StringFormatter,
+                                         SumAggregator, TableColumn)
 from bokeh.util.serialization import convert_datetime_array
 from pyviz_comms import JupyterComm
 
@@ -22,8 +23,8 @@ from ..depends import param_value_if_widget
 from ..io.resources import LOCAL_DIST, set_resource_mode
 from ..io.state import state
 from ..reactive import ReactiveData
-from ..viewable import Layoutable
 from ..util import clone_model, isdatetime, lazy_load, updating
+from ..viewable import Layoutable
 from .base import Widget
 from .button import Button
 from .input import TextInput
@@ -78,7 +79,7 @@ class BaseTable(ReactiveData, Widget):
 
     _manual_params = ['formatters', 'editors', 'widths', 'titles', 'value', 'show_index']
 
-    _rename = {'disabled': 'editable', 'selection': None}
+    _rename: Mapping[str, str | None] = {'disabled': 'editable', 'selection': None}
 
     __abstract = True
 
@@ -783,7 +784,7 @@ class DataFrame(BaseTable):
 
     _source_transforms = {'hierarchical': None}
 
-    _rename = {
+    _rename: Mapping[str, str | None] = {
         'disabled': 'editable', 'selection': None, 'sorters': None,
         'text_align': None
     }
@@ -980,7 +981,7 @@ class Tabulator(BaseTable):
 
     _priority_changes = ['data']
 
-    _rename = {
+    _rename: Mapping[str, str | None] = {
         'disabled': 'editable', 'selection': None, 'selectable': 'select_mode',
         'row_content': None
     }
@@ -1070,7 +1071,7 @@ class Tabulator(BaseTable):
 
     def _get_theme(self, theme, resources=None):
         from ..io.resources import RESOURCE_MODE
-        from ..models.tabulator import _get_theme_url, THEME_PATH, THEME_URL
+        from ..models.tabulator import THEME_PATH, THEME_URL, _get_theme_url
         if RESOURCE_MODE == 'server' and resources in (None, 'server'):
             theme_url = f'{LOCAL_DIST}bundled/datatabulator/{THEME_PATH}'
             if state.rel_path:

--- a/panel/widgets/tables.py
+++ b/panel/widgets/tables.py
@@ -2,7 +2,7 @@ import datetime as dt
 import uuid
 from functools import partial
 from types import FunctionType, MethodType
-from typing import Mapping
+from typing import Mapping, Union
 
 import numpy as np
 import param
@@ -79,7 +79,7 @@ class BaseTable(ReactiveData, Widget):
 
     _manual_params = ['formatters', 'editors', 'widths', 'titles', 'value', 'show_index']
 
-    _rename: Mapping[str, str | None] = {'disabled': 'editable', 'selection': None}
+    _rename: Mapping[str, Union[str, None]] = {'disabled': 'editable', 'selection': None}
 
     __abstract = True
 
@@ -784,7 +784,7 @@ class DataFrame(BaseTable):
 
     _source_transforms = {'hierarchical': None}
 
-    _rename: Mapping[str, str | None] = {
+    _rename: Mapping[str, Union[str, None]] = {
         'disabled': 'editable', 'selection': None, 'sorters': None,
         'text_align': None
     }
@@ -981,7 +981,7 @@ class Tabulator(BaseTable):
 
     _priority_changes = ['data']
 
-    _rename: Mapping[str, str | None] = {
+    _rename: Mapping[str, Union[str, None]] = {
         'disabled': 'editable', 'selection': None, 'selectable': 'select_mode',
         'row_content': None
     }

--- a/panel/widgets/tables.py
+++ b/panel/widgets/tables.py
@@ -1,9 +1,11 @@
+from __future__ import annotations
+
 import datetime as dt
 import uuid
 
 from functools import partial
 from types import FunctionType, MethodType
-from typing import Mapping, Union
+from typing import ClassVar, Mapping
 
 import numpy as np
 import param
@@ -80,7 +82,7 @@ class BaseTable(ReactiveData, Widget):
 
     _manual_params = ['formatters', 'editors', 'widths', 'titles', 'value', 'show_index']
 
-    _rename: Mapping[str, Union[str, None]] = {'disabled': 'editable', 'selection': None}
+    _rename: ClassVar[Mapping[str, str | None]] = {'disabled': 'editable', 'selection': None}
 
     __abstract = True
 
@@ -785,7 +787,7 @@ class DataFrame(BaseTable):
 
     _source_transforms = {'hierarchical': None}
 
-    _rename: Mapping[str, Union[str, None]] = {
+    _rename: ClassVar[Mapping[str, str | None]] = {
         'disabled': 'editable', 'selection': None, 'sorters': None,
         'text_align': None
     }
@@ -982,7 +984,7 @@ class Tabulator(BaseTable):
 
     _priority_changes = ['data']
 
-    _rename: Mapping[str, Union[str, None]] = {
+    _rename: ClassVar[Mapping[str, str | None]] = {
         'disabled': 'editable', 'selection': None, 'selectable': 'select_mode',
         'row_content': None
     }

--- a/panel/widgets/terminal.py
+++ b/panel/widgets/terminal.py
@@ -10,11 +10,10 @@ import shlex
 import signal
 import subprocess
 import sys
-
 from functools import partial
+from typing import Mapping
 
 import param
-
 from pyviz_comms import JupyterComm
 
 from ..io.callbacks import PeriodicCallback
@@ -79,6 +78,7 @@ class TerminalSubprocess(param.Parameterized):
         Runs a subprocess command.
         """
         import pty
+
         # Inspiration: https://github.com/cs01/pyxtermjs
         # Inspiration: https://github.com/jupyter/terminado
         if not args:
@@ -134,9 +134,9 @@ class TerminalSubprocess(param.Parameterized):
     def _set_winsize(self):
         if self._fd is None:
             return
-        import termios
-        import struct
         import fcntl
+        import struct
+        import termios
         winsize = struct.pack("HHHH", self._terminal.nrows, self._terminal.ncols, 0, 0)
         fcntl.ioctl(self._fd, termios.TIOCSWINSZ, winsize)
 
@@ -252,7 +252,7 @@ class Terminal(Widget):
 
     _output = param.String(default="")
 
-    _rename = {
+    _rename: Mapping[str, str | None] = {
         "clear": None,
         "output": None,
         "_output": "output",

--- a/panel/widgets/terminal.py
+++ b/panel/widgets/terminal.py
@@ -11,7 +11,7 @@ import signal
 import subprocess
 import sys
 from functools import partial
-from typing import Mapping
+from typing import Mapping, Union
 
 import param
 from pyviz_comms import JupyterComm
@@ -252,7 +252,7 @@ class Terminal(Widget):
 
     _output = param.String(default="")
 
-    _rename: Mapping[str, str | None] = {
+    _rename: Mapping[str, Union[str, None]] = {
         "clear": None,
         "output": None,
         "_output": "output",

--- a/panel/widgets/terminal.py
+++ b/panel/widgets/terminal.py
@@ -4,16 +4,20 @@ The Terminal Widget makes it easy to create Panel Applications with Terminals.
 - For example apps which streams the output of processes or logs.
 - For example apps which provide interactive bash, python or ipython terminals
 """
+from __future__ import annotations
+
 import os
 import select
 import shlex
 import signal
 import subprocess
 import sys
+
 from functools import partial
-from typing import Mapping, Union
+from typing import ClassVar, Mapping
 
 import param
+
 from pyviz_comms import JupyterComm
 
 from ..io.callbacks import PeriodicCallback
@@ -252,7 +256,7 @@ class Terminal(Widget):
 
     _output = param.String(default="")
 
-    _rename: Mapping[str, Union[str, None]] = {
+    _rename: ClassVar[Mapping[str, str | None]] = {
         "clear": None,
         "output": None,
         "_output": "output",

--- a/panel/widgets/text_to_speech.py
+++ b/panel/widgets/text_to_speech.py
@@ -8,7 +8,7 @@ The term *utterance* is used throughout the API. It is the smallest
 unit of speech in spoken language analysis.
 """
 import uuid
-from typing import Mapping
+from typing import Mapping, Union
 
 import param
 from panel.widgets import Widget
@@ -216,7 +216,7 @@ class TextToSpeech(Utterance, Widget):
 
     _widget_type = _BkTextToSpeech
 
-    _rename: Mapping[str, str | None] = {
+    _rename: Mapping[str, Union[str, None]] = {
         "auto_speak": None,
         "lang": None,
         "pitch": None,

--- a/panel/widgets/text_to_speech.py
+++ b/panel/widgets/text_to_speech.py
@@ -8,11 +8,12 @@ The term *utterance* is used throughout the API. It is the smallest
 unit of speech in spoken language analysis.
 """
 import uuid
+from typing import Mapping
 
 import param
+from panel.widgets import Widget
 
 from ..models.text_to_speech import TextToSpeech as _BkTextToSpeech
-from panel.widgets import Widget
 
 
 class Voice(param.Parameterized):
@@ -215,7 +216,7 @@ class TextToSpeech(Utterance, Widget):
 
     _widget_type = _BkTextToSpeech
 
-    _rename = {
+    _rename: Mapping[str, str | None] = {
         "auto_speak": None,
         "lang": None,
         "pitch": None,

--- a/panel/widgets/text_to_speech.py
+++ b/panel/widgets/text_to_speech.py
@@ -7,9 +7,11 @@ See https://developer.mozilla.org/en-US/docs/Web/API/SpeechSynthesis
 The term *utterance* is used throughout the API. It is the smallest
 unit of speech in spoken language analysis.
 """
+from __future__ import annotations
+
 import uuid
 
-from typing import Mapping, Union
+from typing import ClassVar, Mapping
 
 import param
 
@@ -218,7 +220,7 @@ class TextToSpeech(Utterance, Widget):
 
     _widget_type = _BkTextToSpeech
 
-    _rename: Mapping[str, Union[str, None]] = {
+    _rename: ClassVar[Mapping[str, str | None]] = {
         "auto_speak": None,
         "lang": None,
         "pitch": None,

--- a/panel/widgets/texteditor.py
+++ b/panel/widgets/texteditor.py
@@ -1,7 +1,7 @@
 """
 Defines a WYSIWYG TextEditor widget based on quill.js.
 """
-from typing import Mapping
+from typing import Mapping, Union
 
 import param
 from pyviz_comms import JupyterComm
@@ -38,7 +38,7 @@ class TextEditor(Widget):
 
     value = param.String(doc="State of the current text in the editor")
 
-    _rename: Mapping[str, str | None] = {"value": "text"}
+    _rename: Mapping[str, Union[str, None]] = {"value": "text"}
 
     def _get_model(self, doc, root=None, parent=None, comm=None):
         if self._widget_type is None:

--- a/panel/widgets/texteditor.py
+++ b/panel/widgets/texteditor.py
@@ -1,8 +1,9 @@
 """
 Defines a WYSIWYG TextEditor widget based on quill.js.
 """
-import param
+from typing import Mapping
 
+import param
 from pyviz_comms import JupyterComm
 
 from ..util import lazy_load
@@ -37,7 +38,7 @@ class TextEditor(Widget):
 
     value = param.String(doc="State of the current text in the editor")
 
-    _rename = {"value": "text"}
+    _rename: Mapping[str, str | None] = {"value": "text"}
 
     def _get_model(self, doc, root=None, parent=None, comm=None):
         if self._widget_type is None:

--- a/panel/widgets/texteditor.py
+++ b/panel/widgets/texteditor.py
@@ -1,9 +1,12 @@
 """
 Defines a WYSIWYG TextEditor widget based on quill.js.
 """
-from typing import Mapping, Union
+from __future__ import annotations
+
+from typing import ClassVar, Mapping
 
 import param
+
 from pyviz_comms import JupyterComm
 
 from ..util import lazy_load
@@ -38,7 +41,7 @@ class TextEditor(Widget):
 
     value = param.String(doc="State of the current text in the editor")
 
-    _rename: Mapping[str, Union[str, None]] = {"value": "text"}
+    _rename: ClassVar[Mapping[str, str | None]] = {"value": "text"}
 
     def _get_model(self, doc, root=None, parent=None, comm=None):
         if self._widget_type is None:


### PR DESCRIPTION
Fixes typing errors when trying to inherit from Panel class with `_rename` attribute.

![image](https://user-images.githubusercontent.com/42288570/170430060-dd566a8e-09ea-4a41-9211-13ee99f830ac.png)
