### PR TITLE
Update the DiscreteSlider slider parameters

### DIFF
--- a/panel/tests/widgets/test_slider.py
+++ b/panel/tests/widgets/test_slider.py
@@ -298,6 +298,36 @@ def test_discrete_slider_single_option(document, comm):
     assert box.children[1].end == 1
 
 
+def test_discrete_slider_disabled(document, comm):
+    # Check that the widget can be disabled on instantiation
+    discrete_slider = DiscreteSlider(name='DiscreteSlider', options=[0, 1], disabled=True)
+
+    box = discrete_slider.get_root(document, comm=comm)
+
+    # Check that the widget
+    assert box.children[0].text == 'DiscreteSlider: <b>0</b>'
+    assert box.children[1].disabled
+    assert box.children[1].start == 0
+    assert box.children[1].end == 1
+
+    # Check that the widget can be enabled after instantiation
+    discrete_slider.disabled = False
+
+    assert box.children[0].text == 'DiscreteSlider: <b>0</b>'
+    assert not box.children[1].disabled
+    assert box.children[1].start == 0
+    assert box.children[1].end == 1
+
+    # Widget can't be disabled if it has 0 or 1 option only.
+    discrete_slider.options = [0]
+    discrete_slider.disabled = True
+
+    assert box.children[0].text == 'DiscreteSlider: <b>0</b>'
+    assert box.children[1].disabled
+    assert box.children[1].start == 0
+    assert box.children[1].end == 1
+
+
 def test_discrete_date_slider(document, comm):
     dates = OrderedDict([('2016-01-0%d' % i, datetime(2016, 1, i)) for i in range(1, 4)])
     discrete_slider = DiscreteSlider(name='DiscreteSlider', value=dates['2016-01-02'],

--- a/panel/widgets/slider.py
+++ b/panel/widgets/slider.py
@@ -431,8 +431,6 @@ class DiscreteSlider(CompositeWidget, _SliderBase):
                 end = len(self.options) - 1
             style['end'] = end
         self._slider.param.update(**style)
-        print(events, style)
-
 
     def _sync_value(self, event):
         """

--- a/panel/widgets/slider.py
+++ b/panel/widgets/slider.py
@@ -347,14 +347,14 @@ class DiscreteSlider(CompositeWidget, _SliderBase):
         else:
             value = values.index(self.value)
             label = labels[value]
-        self.disabled = True if len(values) in (0, 1) else self.disabled
-        end = 1 if self.disabled else len(self.options)-1
+        disabled = True if len(values) in (0, 1) else self.disabled
+        end = 1 if disabled else len(self.options)-1
 
         self._slider = IntSlider(
             start=0, end=end, value=value, tooltips=False,
             show_value=False, margin=(0, 5, 5, 5),
-            _supports_embed=False,
-            **{p: getattr(self, p) for p in self._slider_style_params}
+            _supports_embed=False, disabled=disabled,
+            **{p: getattr(self, p) for p in self._slider_style_params if p != 'disabled'}
         )
         self._update_style()
         js_code = self._text_link.format(


### PR DESCRIPTION
Fixes https://github.com/holoviz/panel/issues/3557

Given that it's a composite widget not all the Slider parameters can or should be updated, hence the short list defined as a class variable. This PR mostly focused on `disabled` to fix the reported issue.