### PR TITLE
Improve robustness of tests

### DIFF
--- a/panel/tests/io/test_reload.py
+++ b/panel/tests/io/test_reload.py
@@ -11,7 +11,7 @@ from panel.io.state import state
 def test_record_modules_not_stdlib():
     with record_modules():
         import audioop  # noqa
-    assert (_modules == set() or _modules == set('audioop'))
+    assert ((_modules == set()) or (_modules == set('audioop')))
     _modules.clear()
 
 def test_check_file():

--- a/panel/tests/test_reactive.py
+++ b/panel/tests/test_reactive.py
@@ -466,17 +466,17 @@ def test_reactive_html_templated_children_add_loop_id_and_for_loop_var():
     assert model.looped == ['option']
 
 
-@pytest.mark.parametrize('operator', ['', '+', '-', '*', '\\', '%', '**', '>>', '<<', '>>>', '&', '^', '&&', '||', '??'])
+def test_reactive_html_scripts_linked_properties_assignment_operator():
 
-@pytest.mark.parametrize('sep', [' ', ''])
-def test_reactive_html_scripts_linked_properties_assignment_operator(operator, sep):
+    for operator in ['', '+', '-', '*', '\\', '%', '**', '>>', '<<', '>>>', '&', '^', '&&', '||', '??']:
+        for sep in [' ', '']:
 
-    class TestScripts(ReactiveHTML):
+            class TestScripts(ReactiveHTML):
 
-        clicks = param.Integer()
+                clicks = param.Integer()
 
-        _template = "<div id='test'></div>"
+                _template = "<div id='test'></div>"
 
-        _scripts = {'render': f'test.onclick = () => {{ data.clicks{sep}{operator}= 1 }}'}
+                _scripts = {'render': f'test.onclick = () => {{ data.clicks{sep}{operator}= 1 }}'}
 
-    assert TestScripts()._linked_properties() == ['clicks']
+            assert TestScripts()._linked_properties() == ['clicks']


### PR DESCRIPTION
- Remove `parametrize` that was increasing memory
- Fix `test_record_modules_not_stdlib` test