### PR TITLE
Switch documentation code highlighting to material

### DIFF
--- a/doc/_static/css/custom.css
+++ b/doc/_static/css/custom.css
@@ -78,8 +78,12 @@ div.cell div.cell_input {
     border: none;
 }
 
+.highlight {
+    border-radius: 4px;
+}
+
 html[data-theme="light"] .highlight {
-    background-color: rgb(38 39 48);
+    background-color: #263238;
     color: #f8f8f2;
 }
 
@@ -93,12 +97,16 @@ pre[id^='codecell'] {
 }
 
 button.copybtn {
-    background-color: rgb(38 39 48);
+    background-color: #263238;
 }
 
 button.copybtn:hover {
-    background-color: rgb(38 39 48);
+    background-color: #263238;
     color: #f8f8f2;
+}
+
+.highlight button.copybtn:hover {
+    background: none
 }
 
 .o-tooltip--left:after {

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -54,8 +54,8 @@ html_theme_options = {
     ],
     "navbar_end": ["navbar-icon-links"],
     "google_analytics_id": "UA-154795830-2",
-    "pygment_light_style": "monokai",
-    "pygment_dark_style": "monokai"
+    "pygment_light_style": "material",
+    "pygment_dark_style": "material"
 }
 
 extensions += [


### PR DESCRIPTION
Code highlighting now uses material pygments theme:

<img width="343" alt="Screen Shot 2022-06-20 at 11 53 50" src="https://user-images.githubusercontent.com/1550771/174576494-113e6bcc-86cc-40ce-a7ac-1fa93cf0da8a.png">
