### PR TITLE
Improve the Tabulator reference page

### DIFF
--- a/examples/reference/widgets/Tabulator.ipynb
+++ b/examples/reference/widgets/Tabulator.ipynb
@@ -250,11 +250,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Column layouts\n",
+    "## Column layouts\n",
     "\n",
     "By default the DataFrame widget will adjust the sizes of both the columns and the table based on the contents, reflecting the default value of the parameter: `layout=\"fit_data_table\"`. Alternative modes allow manually specifying the widths of the columns, giving each column equal widths, or adjusting just the size of the columns.\n",
     "\n",
-    "#### Manual column widths\n",
+    "### Manual column widths\n",
     "\n",
     "To manually adjust column widths provide explicit `widths` for each of the columns:"
    ]
@@ -306,7 +306,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### Autosize columns\n",
+    "### Autosize columns\n",
     "\n",
     "To automatically adjust the columns dependending on their content set `layout='fit_data'`:"
    ]
@@ -372,7 +372,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### Equal size\n",
+    "### Equal size\n",
     "\n",
     "The simplest option is simply to allocate each column equal amount of size:"
    ]
@@ -806,8 +806,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "mixed_df = pd._testing.makeMixedDataFrame()\n",
-    "filter_table = pn.widgets.Tabulator(mixed_df)\n",
+    "filter_table = pn.widgets.Tabulator(pd._testing.makeMixedDataFrame())\n",
     "filter_table"
    ]
   },

--- a/examples/reference/widgets/Tabulator.ipynb
+++ b/examples/reference/widgets/Tabulator.ipynb
@@ -11,6 +11,7 @@
     "import pandas as pd\n",
     "import panel as pn\n",
     "\n",
+    "np.random.seed(7)\n",
     "pn.extension('tabulator', css_files=[pn.io.resources.CSS_URLS['font-awesome']])"
    ]
   },
@@ -18,7 +19,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The ``Tabulator`` widget allows displaying and editing a pandas DataFrame. The `Tabulator` is a largely backward compatible replacement for the [`DataFrame`](./DataFrame.ipynb) widget and will eventually replace it. It is built on the [Tabulator](http://tabulator.info/) library, which provides for a wide range of features.\n",
+    "The ``Tabulator`` widget allows displaying and editing a pandas DataFrame. The `Tabulator` is a largely backward compatible replacement for the [`DataFrame`](./DataFrame.ipynb) widget and will eventually replace it. It is built on the **version 4.9** of the [Tabulator](http://tabulator.info/) library, which provides for a wide range of features.\n",
     "\n",
     "For more information about listening to widget events and laying out widgets refer to the [widgets user guide](../../user_guide/Widgets.ipynb). Alternatively you can learn how to build GUIs by declaring parameters independently of any specific widgets in the [param user guide](../../user_guide/Param.ipynb). To express interactivity entirely using Javascript without the need for a Python server take a look at the [links user guide](../../user_guide/Param.ipynb).\n",
     "\n",
@@ -30,25 +31,24 @@
     "\n",
     "* **``aggregators``** (``dict``): A dictionary mapping from index name to an aggregator to be used for `hierarchical` multi-indexes (valid aggregators include 'min', 'max', 'mean' and 'sum'). If separate aggregators for different columns are required the dictionary may be nested as `{index_name: {column_name: aggregator}}`\n",
     "* **``buttons``** (``dict``): A dictionary of buttons to add to the table mapping from column name to the HTML contents of the button cell, e.g. `{'print': '<i class=\"fa fa-print\"></i>'}`. Buttons are added after all data columns.\n",
-    "* **``configuration``** (``dict``): A dictionary mapping used to specify tabulator options not explicitly exposed by panel.\n",
-    "* **``editors``** (``dict``):  A dictionary mapping from column name to a bokeh `CellEditor` instance or tabulator editor specification.\n",
+    "* **``configuration``** (``dict``): A dictionary mapping used to specify *Tabulator* options not explicitly exposed by Panel.\n",
+    "* **``editors``** (``dict``):  A dictionary mapping from column name to a bokeh `CellEditor` instance or *Tabulator* editor specification.\n",
     "* **``embed_content``** (``boolean``): Whether to embed the `row_content` or to dynamically fetch it when a row is expanded.\n",
     "* **``expanded``** (``list``): The currently expanded rows as a list of integer indexes.\n",
     "* **``filters``** (``list``): A list of client-side filter definitions that are applied to the table.\n",
-    "* **``formatters``** (``dict``): A dictionary mapping from column name to a bokeh `CellFormatter` instance or tabulator formatter specification.\n",
+    "* **``formatters``** (``dict``): A dictionary mapping from column name to a bokeh `CellFormatter` instance or *Tabulator* formatter specification.\n",
+    "* **``frozen_columns``** (`list`): List of columns to freeze, preventing them from scrolling out of frame. Column can be specified by name or index.\n",
+    "* **``frozen_rows``**: (`list`): List of rows to freeze, preventing them from scrolling out of frame. Rows can be specified by positive or negative index.\n",
     "* **``groupby``** (`list`): Groups rows in the table by one or more columns.\n",
     "* **``header_align``** (``dict`` or ``str``): A mapping from column name to header alignment or a fixed header alignment, which should be one of `'left'`, `'center'`, `'right'`.\n",
     "* **``header_filters``** (``boolean``/``dict``): A boolean enabling filters in the column headers or a dictionary providing filter definitions for specific columns.\n",
-    "* **``hierarchical``** (boolean, default=False): Whether to render multi-indexes as hierarchical index (note hierarchical must be enabled during instantiation and cannot be modified later)\n",
     "* **``hidden_columns``** (`list`): List of columns to hide.\n",
+    "* **``hierarchical``** (boolean, default=False): Whether to render multi-indexes as hierarchical index (note hierarchical must be enabled during instantiation and cannot be modified later)\n",
     "* **``layout``** (``str``, `default='fit_data_table'`): Describes the column layout mode with one of the following options `'fit_columns'`, `'fit_data'`, `'fit_data_stretch'`, `'fit_data_fill'`, `'fit_data_table'`. \n",
-    "* **``frozen_columns``** (`list`): List of columns to freeze, preventing them from scrolling out of frame. Column can be specified by name or index.\n",
-    "* **``frozen_rows``**: (`list`): List of rows to freeze, preventing them from scrolling out of frame. Rows can be specified by positive or negative index.\n",
     "* **``page``** (``int``, `default=1`): Current page, if pagination is enabled.\n",
     "* **``page_size``** (``int``, `default=20`): Number of rows on each page, if pagination is enabled.\n",
     "* **``pagination``** (`str`, `default=None`):  Set to `'local` or `'remote'` to enable pagination; by default pagination is disabled with the value set to `None`.\n",
-    "* **``row_content``** (``callable``): A function that receives the expanded row as input and should return a Panel object to render into the expanded region below the row.\n",
-    "* **``row_height``** (``int``, `default=30`):  The height of each table row.\n",
+    "* **``row_content``** (``callable``): A function that receives the expanded row (``pandas.Series``) as input and should return a Panel object to render into the expanded region below the row.\n",
     "* **``selection``** (``list``): The currently selected rows as a list of integer indexes.\n",
     "* **``selectable``** (`boolean` or `str` or `int`, `default=True`): Defines the selection mode:\n",
     "  * `True`\n",
@@ -65,7 +65,7 @@
     "      The maximum number of selectable rows.\n",
     "* **``selectable_rows``** (`callable`): A function that should return a list of integer indexes given a DataFrame indicating which rows may be selected.\n",
     "* **``show_index``** (``boolean``, `default=True`): Whether to show the index column.\n",
-    "* **``sorters``** (list): A lisst of sorter definitions mapping where each item should declare the column to sort on and the direction to sort, e.g. `[{'field': 'column_name', 'dir': 'asc'}, {'field': 'another_column', 'dir': 'desc'}]`.\n",
+    "* **``sorters``** (``list``): A list of sorter definitions mapping where each item should declare the column to sort on and the direction to sort, e.g. `[{'field': 'column_name', 'dir': 'asc'}, {'field': 'another_column', 'dir': 'desc'}]`.\n",
     "* **``text_align``** (``dict`` or ``str``): A mapping from column name to alignment or a fixed column alignment, which should be one of `'left'`, `'center'`, `'right'`.\n",
     "* **`theme`** (``str``, `default='simple'`): The CSS theme to apply (note that changing the theme will restyle all tables on the page), which should be one of `'default'`, `'site'`, `'simple'`, `'midnight'`, `'modern'`, `'bootstrap'`, `'bootstrap4'`, `'materialize'`, `'bulma'`, `'semantic-ui'`, or `'fast'`.\n",
     "* **``titles``** (``dict``): A mapping from column name to a title to override the name with.\n",
@@ -75,7 +75,6 @@
     "##### Display\n",
     "\n",
     "* **``disabled``** (``boolean``): Whether the cells are editable\n",
-    "* **``name``** (``str``): The title of the widget\n",
     "\n",
     "##### Properties\n",
     "\n",
@@ -85,7 +84,7 @@
     "##### Callbacks\n",
     "\n",
     "* **``on_click``**: Allows registering callbacks which are given `CellClickEvent` objects containing the `column`, `row` and `value` of the clicked cell.\n",
-    "* **``on_edit``**: Allows registering callbacks which are given `TableEditEvent` objects containing the `column`, `row`, `value` and `old` value.\n",
+    "* **``on_edit``**: Allows registering callbacks which are given `TableEditEvent` objects containing the `column`, `row`, `value` and `old` value of the edited cell.\n",
     "\n",
     "___"
    ]
@@ -94,7 +93,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The ``Tabulator`` widget renders a DataFrame using an interactive grid, which allows directly editing the contents of the dataframe in place, with any changes being synced with Python. The `Tabulator` will usually determine the appropriate formatter appropriately based on the type of the data:"
+    "The `Tabulator` widget renders a DataFrame using an interactive grid, which allows directly editing the contents of the DataFrame in place, with any changes being synced with Python. The `Tabulator` will usually determine the appropriate formatter appropriately based on the type of the data:"
    ]
   },
   {
@@ -122,7 +121,7 @@
    "source": [
     "## Formatters\n",
     "\n",
-    "By default the widget will pick bokeh ``CellFormatter`` and ``CellEditor`` types appropriate to the dtype of the column. These may be overriden by explicit dictionaries mapping from the column name to the editor or formatter instance. For example below we create a ``SelectEditor`` instance to pick from four options in the ``str`` column and a ``NumberFormatter`` to customize the formatting of the float values:"
+    "By default the widget will pick Bokeh ``CellFormatter`` and ``CellEditor`` types appropriate to the dtype of the column. These may be overriden by explicit dictionaries mapping from the column name to the editor or formatter instance. For example below we create a ``NumberFormatter`` to customize the formatting of the numers in the ``float`` column and a ``BooleanFormatter`` instance to display the values in the ``bool`` column with tick crosses:"
    ]
   },
   {
@@ -154,7 +153,7 @@
     "* [StringFormatter](https://docs.bokeh.org/en/latest/docs/reference/models/widgets.tables.html#bokeh.models.widgets.tables.StringFormatter)\n",
     "* [ScientificFormatter](https://docs.bokeh.org/en/latest/docs/reference/models/widgets.tables.html#bokeh.models.widgets.tables.ScientificFormatter)\n",
     "\n",
-    "However in addition to the formatters exposed by Bokeh it is also possible to provide valid formatters built into the Tabulator library. These may be defined either as a string or as a dictionary declaring the 'type' and other arguments, which are passed to Tabulator as the `formatterParams`:"
+    "However in addition to the formatters exposed by Bokeh it is also possible to provide valid formatters built into the *Tabulator* library. These may be defined either as a string or as a dictionary declaring the `type` and other arguments, which are passed to *Tabulator* as the `formatterParams`:"
    ]
   },
   {
@@ -175,11 +174,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The list of valid Tabulator formatters can be found in the [Tabulator documentation](http://tabulator.info/docs/4.9/format#format-builtin).\n",
+    "The list of valid *Tabulator* formatters can be found in the [Tabulator documentation](http://tabulator.info/docs/4.9/format#format-builtin).\n",
     "\n",
-    "## Editors\n",
+    "## Editors/Editing\n",
     "\n",
-    "Just like the formatters, the `Tabulator` will natively understand the Bokeh `Editor` types. However, in the background it will replace most of them with equivalent editors natively supported by the tabulator library:"
+    "Just like the formatters, the `Tabulator` will natively understand the Bokeh `Editor` types. However, in the background it will replace most of them with equivalent editors natively supported by the *Tabulator* library:"
    ]
   },
   {
@@ -203,7 +202,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Therefore it is often preferable to use one of the [Tabulator editors](http://tabulator.info/docs/5.0/edit#edit) directly. Setting the editor of a column to `None` makes that column non-editable. Note that in addition to the standard Tabulator editors the Tabulator widget also supports `'date'` and `'datetime'` editors:"
+    "Therefore it is often preferable to use one of the [*Tabulator* editors](http://tabulator.info/docs/4.9/edit#edit) directly. Setting the editor of a column to `None` makes that column non-editable. Note that in addition to the standard *Tabulator* editors the `Tabulator` widget also supports `'date'` and `'datetime'` editors:"
    ]
   },
   {
@@ -212,9 +211,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from bokeh.models.widgets.tables import CheckboxEditor, NumberEditor, SelectEditor\n",
-    "\n",
-    "bokeh_editors = {\n",
+    "tabulator_editors = {\n",
     "    'int': None,\n",
     "    'float': {'type': 'number', 'max': 10, 'step': 0.1},\n",
     "    'bool': {'type': 'tickCross', 'tristate': True, 'indeterminateValue': None},\n",
@@ -223,7 +220,7 @@
     "    'datetime': 'datetime'\n",
     "}\n",
     "\n",
-    "edit_table = pn.widgets.Tabulator(df, editors=bokeh_editors)\n",
+    "edit_table = pn.widgets.Tabulator(df, editors=tabulator_editors)\n",
     "\n",
     "edit_table"
    ]
@@ -236,7 +233,8 @@
     "\n",
     "- `column`: Name of the edited column\n",
     "- `row`: Integer index of the edited row\n",
-    "- `value`: The updated value"
+    "- `old`: Old cell value\n",
+    "- `value`: New cell value"
    ]
   },
   {
@@ -245,7 +243,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "edit_table.on_edit(lambda e: print(e.column, e.row, e.value))"
+    "edit_table.on_edit(lambda e: print(e.column, e.row, e.old, e.value))"
    ]
   },
   {
@@ -267,7 +265,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "custom_df = pd._testing.makeMixedDataFrame()\n",
+    "custom_df = pd._testing.makeMixedDataFrame().iloc[:3, :]\n",
     "\n",
     "pn.widgets.Tabulator(custom_df, widths={'index': 70, 'A': 50, 'B': 50, 'C': 70, 'D': 130})"
    ]
@@ -403,7 +401,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "pn.widgets.Tabulator(df, header_align='center', text_align={'str': 'right', 'bool': 'center'}, widths=200)"
+    "pn.widgets.Tabulator(df.iloc[:, :2], header_align='center', text_align={'int': 'center', 'float': 'left'}, widths=150)"
    ]
   },
   {
@@ -412,7 +410,7 @@
    "source": [
     "## Styling\n",
     "\n",
-    "The ability to style the contents of a table based on its content and other considerations is very important. Thankfully pandas provides a powerful [styling API](https://pandas.pydata.org/pandas-docs/stable/user_guide/style.html), which can be used in conjunction with the `Tabulator` widget. Specifically the `Tabulator` widget exposes a `.style` attribute just like a `pandas.DataFrame` which lets the user apply custom styling using methods like `.apply` and `.applymap`. For a detailed guide to styling see the [Pandas documentation](https://pandas.pydata.org/pandas-docs/stable/user_guide/style.html).\n",
+    "The ability to style the contents of a table based on its content and other considerations is very important. Thankfully `pandas` provides a powerful [styling API](https://pandas.pydata.org/pandas-docs/stable/user_guide/style.html), which can be used in conjunction with the `Tabulator` widget. Specifically the `Tabulator` widget exposes a `.style` attribute just like a `pandas.DataFrame` which lets the user apply custom styling using methods like `.apply` and `.applymap`. For a detailed guide to styling see the [Pandas documentation](https://pandas.pydata.org/pandas-docs/stable/user_guide/style.html).\n",
     "\n",
     "Here we will demonstrate with a simple example, starting with a basic table:"
    ]
@@ -423,7 +421,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "style_df = pd.DataFrame(np.random.randn(10, 5), columns=list('ABCDE'))\n",
+    "style_df = pd.DataFrame(np.random.randn(4, 5), columns=list('ABCDE'))\n",
     "styled = pn.widgets.Tabulator(style_df)"
    ]
   },
@@ -467,7 +465,7 @@
    "source": [
     "## Theming\n",
     "\n",
-    "The Tabulator library ships with a number of themes, which are defined as CSS stylesheets. For that reason changing the theme on one table will affect all Tables on the page and it will usually be preferable to see the theme once at the class level like this:\n",
+    "The Tabulator library ships with a number of themes, which are defined as CSS stylesheets. For that reason changing the theme on one table will affect all tables on the page and it will usually be preferable to see the theme once at the class level like this:\n",
     "\n",
     "```python\n",
     "pn.widgets.Tabulator.theme = 'default'\n",
@@ -491,7 +489,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Selection\n",
+    "## Selection/Click\n",
     "\n",
     "The `selection` parameter controls which rows in the table are selected and can be set from Python and updated by selecting rows on the frontend:"
    ]
@@ -502,9 +500,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sel_df = pd.DataFrame(np.random.randn(10, 5), columns=list('ABCDE'))\n",
+    "sel_df = pd.DataFrame(np.random.randn(3, 5), columns=list('ABCDE'))\n",
     "\n",
-    "select_table = pn.widgets.Tabulator(sel_df, selection=[0, 3, 7])\n",
+    "select_table = pn.widgets.Tabulator(sel_df, selection=[0, 2])\n",
     "select_table"
    ]
   },
@@ -521,7 +519,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "select_table.selection = [1, 4, 9]\n",
+    "select_table.selection = [1]\n",
     "\n",
     "select_table.selected_dataframe"
    ]
@@ -546,14 +544,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "pn.widgets.Tabulator(sel_df, selection=[0, 3, 7], selectable='checkbox')"
+    "pn.widgets.Tabulator(sel_df, selection=[0, 2], selectable='checkbox')"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Additionally we can also disable selection for specific rows by providing a `selectable_rows` function. The function must accept a DataFrame and return a list of integer indexes indicating which rows are selectable, e.g. here we disable selection for every second row:"
+    "Additionally we can also disable selection for specific rows by providing a `selectable_rows` function. The function must accept a `DataFrame` and return a list of integer indexes indicating which rows are selectable, e.g. here we disable selection for every second row:"
    ]
   },
   {
@@ -562,7 +560,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "pn.widgets.Tabulator(sel_df, selectable_rows=lambda df: list(range(0, len(df), 2)))"
+    "select_table = pn.widgets.Tabulator(sel_df, selectable_rows=lambda df: list(range(0, len(df), 2)))\n",
+    "select_table"
    ]
   },
   {
@@ -579,7 +578,7 @@
    "outputs": [],
    "source": [
     "def click(event):\n",
-    "    print(f'Clicked cell in {event.column} column, row {event.row}')\n",
+    "    print(f'Clicked cell in {event.column!r} column, row {event.row!r} with value {event.value!r}')\n",
     "\n",
     "select_table.on_click(click) \n",
     "# Optionally we can also limit the callback to a specific column\n",
@@ -605,7 +604,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "wide_df = pd._testing.makeCustomDataframe(10, 10, r_idx_names=['index'])\n",
+    "wide_df = pd._testing.makeCustomDataframe(3, 10, r_idx_names=['index'])\n",
     "\n",
     "pn.widgets.Tabulator(wide_df, frozen_columns=['index'], width=400)"
    ]
@@ -625,11 +624,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "date_df = pd._testing.makeTimeDataFrame().iloc[:10]\n",
+    "date_df = pd._testing.makeTimeDataFrame().iloc[:5, :2]\n",
     "agg_df = pd.concat([date_df, date_df.median().to_frame('Median').T, date_df.mean().to_frame('Mean').T])\n",
     "agg_df.index= agg_df.index.map(str)\n",
     "\n",
-    "pn.widgets.Tabulator(agg_df, frozen_rows=[-2, -1], width=400)"
+    "pn.widgets.Tabulator(agg_df, frozen_rows=[-2, -1], height=200)"
    ]
   },
   {
@@ -638,7 +637,7 @@
    "source": [
     "## Row contents\n",
     "\n",
-    "A table can only display so much information without becoming difficult to scan. We may want to render additional information to a table row to provide additional context. To make this possible you can provide a `row_content` function which is given the table row as an argument and should return a panel object that will be rendered into an expanding region below the row. By default the contents are fetched dynamically whenever a row is expanded, however using the `embed_content` parameter we can embed all the content.\n",
+    "A table can only display so much information without becoming difficult to scan. We may want to render additional information to a table row to provide additional context. To make this possible you can provide a `row_content` function which is given the table row as an argument (a `pandas.Series` object) and should return a panel object that will be rendered into an expanding region below the row. By default the contents are fetched dynamically whenever a row is expanded, however using the `embed_content` parameter we can embed all the content.\n",
     "\n",
     "Below we create a periodic table of elements where the Wikipedia page for each element will be rendered into the expanded region:"
    ]
@@ -654,12 +653,12 @@
     "periodic_df = elements[['atomic number', 'name', 'atomic mass', 'metal', 'year discovered']].set_index('atomic number')\n",
     "\n",
     "content_fn = lambda row: pn.pane.HTML(\n",
-    "    f'<iframe src=\"http://en.wikipedia.org/wiki/{row[\"name\"]}?printable=yes\" width=\"100%\" height=\"300px\"></iframe>',\n",
+    "    f'<iframe src=\"http://en.wikipedia.org/wiki/{row[\"name\"]}?printable=yes\" width=\"100%\" height=\"200px\"></iframe>',\n",
     "    sizing_mode='stretch_width'\n",
     ")\n",
     "\n",
     "periodic_table = pn.widgets.Tabulator(\n",
-    "    periodic_df, height=500, layout='fit_columns', sizing_mode='stretch_width',\n",
+    "    periodic_df, height=350, layout='fit_columns', sizing_mode='stretch_width',\n",
     "    row_content=content_fn, embed_content=True\n",
     ")\n",
     "\n",
@@ -670,7 +669,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The currently expanded rows can be accessed (and set) on the `expanded` parameter:"
+    "The currently expanded rows can be accessed and set on the `expanded` parameter:"
    ]
   },
   {
@@ -697,7 +696,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "pn.widgets.Tabulator(date_df, groups={'Group 1': ['A', 'B'], 'Group 2': ['C', 'D']})"
+    "pn.widgets.Tabulator(date_df.iloc[:3], groups={'Group 1': ['A', 'B'], 'Group 2': ['C', 'D']})"
    ]
   },
   {
@@ -741,7 +740,7 @@
     "\n",
     "pop_df = population_data[population_data.Year == 2020].set_index(['Location', 'AgeGrp', 'Sex'])[['Value']]\n",
     "\n",
-    "pn.widgets.Tabulator(value=pop_df, hierarchical=True, aggregators={'Sex': 'sum', 'AgeGrp': 'sum'}, height=400)"
+    "pn.widgets.Tabulator(value=pop_df, hierarchical=True, aggregators={'Sex': 'sum', 'AgeGrp': 'sum'}, height=200)"
    ]
   },
   {
@@ -750,7 +749,7 @@
    "source": [
     "## Pagination\n",
     "\n",
-    "When working with large tables it is generally not advisible to display the whole table at once. In these scenarios we can enable either 'local' or 'remote' pagination, which will render only a single page of data at the same time. In the case of 'remote' pagination only the currently viewed data is actually transferred from the backend server to the frontend and new data is fetched dynamically when we switch the page or filter and sort the data. Note that Panel will automatically enable `'local'` pagination for tables larger than 200 rows and enable `'remote'` pagination for tables larger than 10,000 rows. This protection may be overridden by explicitly setting the `pagination` parameter.\n",
+    "When working with large tables it is generally not advisible to display the whole table at once. In these scenarios we can enable either `'local'` or `'remote'` pagination, which will render only a single page of data at the same time. In the case of `'remote'` pagination only the currently viewed data is actually transferred from the backend server to the frontend and new data is fetched dynamically when we switch the page or filter and sort the data. Note that Panel will automatically enable `'local'` pagination for tables larger than 200 rows and enable `'remote'` pagination for tables larger than 10 000 rows. This protection may be overridden by explicitly setting the `pagination` parameter.\n",
     "\n",
     "The pagination setting may be enabled by setting `pagination='remote'` or `pagination='local'` and the size of each page can be set using the `page_size` option:"
    ]
@@ -761,18 +760,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "large_df = pd._testing.makeCustomDataframe(100_000, 5)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%%time\n",
-    "paginated_table = pn.widgets.Tabulator(large_df, pagination='remote', page_size=10)\n",
-    "paginated_table"
+    "large_df = pd._testing.makeCustomDataframe(100000, 5)\n",
+    "pn.widgets.Tabulator(large_df, pagination='remote', page_size=3)"
    ]
   },
   {
@@ -788,18 +777,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "medium_df = pd._testing.makeCustomDataframe(10_000, 5)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%%time\n",
-    "paginated_table = pn.widgets.Tabulator(large_df, pagination='local', page_size=10)\n",
-    "paginated_table"
+    "medium_df = pd._testing.makeCustomDataframe(1000, 5)\n",
+    "pn.widgets.Tabulator(medium_df, pagination='local', page_size=3)"
    ]
   },
   {
@@ -812,7 +791,7 @@
     "\n",
     "#### Constant and Widget filters\n",
     "\n",
-    "The simplest approach to filtering is to select along a column with a constant or dynamic value. The `.add_filter` method allows passing in constant values, widgets and parameters. If a widget or parameter is provided the table will watch the object for changes in the value and update the data in response. The filtering will depend on the type of the constant or dynamic value:\n",
+    "The simplest approach to filtering is to select along a column with a constant or dynamic value. The `.add_filter` method allows passing in constant values, widgets and Param `Parameter`s. If a widget or `Parameter` is provided the table will watch the object for changes in the value and update the data in response. The filtering will depend on the type of the constant or dynamic value:\n",
     "\n",
     "- scalar: Filters by checking for equality\n",
     "- `tuple`: A tuple will be interpreted as range.\n",
@@ -905,7 +884,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "After filtering you can inspect the current view with the `current_view` property:"
+    "After filtering (and sorting) you can inspect the current view with the `current_view` property:"
    ]
   },
   {
@@ -914,6 +893,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "select.value = ['foo1', 'foo2']\n",
     "filter_table.current_view"
    ]
   },
@@ -942,18 +922,17 @@
     "from bokeh.sampledata.movies_data import movie_path\n",
     "\n",
     "con = sqlite3.Connection(movie_path)\n",
-    "\n",
     "movies_df = pd.read_sql('SELECT Title, Year, Genre, Director, Writer, imdbRating from omdb', con)\n",
     "movies_df = movies_df[~movies_df.Director.isna()]\n",
     "\n",
-    "movies_table = pn.widgets.Tabulator(movies_df, pagination='remote', layout='fit_columns', width=800)"
+    "movies_table = pn.widgets.Tabulator(movies_df, pagination='remote', page_size=4)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "By using the `pn.bind` function, which binds widget and parameter values to a function, complex filtering can be achieved. E.g. here we will add a filter function that uses tests whether the string or regex is contained in the 'Director' column of a listing of thousands of movies:"
+    "By using the `pn.bind` function, which binds widget and `Parameter` values to a function, complex filtering can be achieved. E.g. here we will add a filter function that tests whether the string or regex is contained in the 'Director' column of a listing of thousands of movies:"
    ]
   },
   {
@@ -980,7 +959,7 @@
    "source": [
     "### Client-side filtering\n",
     "\n",
-    "In addition to the Python API the Tabulator widget also offers a client-side filtering API, which can be exposed through `header_filters` or by manually adding filters to the rendered Bokeh model. The API for declaring header filters is almost identical to the API for defining [Editors](#Editors). The `header_filters` can either be enabled by setting it to `True` or by manually supplying filter types for each column. The types of filters supports all the same options as the editors, in fact if you do not declare explicit `header_filters` the tabulator will simply use the defined `editors` to determine the correct filter type:"
+    "In addition to the Python API the `Tabulator` widget also offers a client-side filtering API, which can be exposed through `header_filters` or by manually setting filters in the rendered table. The API for declaring header filters is almost identical to the API for defining [Editors](#Editors). The `header_filters` can either be enabled by setting it to `True` or by manually supplying filter types for each column. The types of filters supports all the same options as the editors, in fact if you do not declare explicit `header_filters` the `Tabulator` widget will simply use the defined `editors` to determine the correct filter type:"
    ]
   },
   {
@@ -989,7 +968,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "bokeh_editors = {\n",
+    "tabulator_editors = {\n",
     "    'float': {'type': 'number', 'max': 10, 'step': 0.1},\n",
     "    'bool': {'type': 'tickCross', 'tristate': True, 'indeterminateValue': None},\n",
     "    'str': {'type': 'autocomplete', 'values': True}\n",
@@ -997,9 +976,8 @@
     "\n",
     "header_filter_table = pn.widgets.Tabulator(\n",
     "    df[['float', 'bool', 'str']], height=140, width=400, layout='fit_columns',\n",
-    "    editors=bokeh_editors, header_filters=True\n",
+    "    editors=tabulator_editors, header_filters=True\n",
     ")\n",
-    "\n",
     "header_filter_table"
    ]
   },
@@ -1029,7 +1007,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "For all supported filtering types see the [Tabulator Filtering documentation](http://tabulator.info/docs/4.9/filter).\n",
+    "For all supported filtering types see the [*Tabulator* Filtering documentation](http://tabulator.info/docs/4.9/filter).\n",
     "\n",
     "If we want to change the filter type for the `header_filters` we can do so in the definition by supplying a dictionary indexed by the column names and then either providing a dictionary which may define the `'type'`, a comparison `'func'`, a `'placeholder'` and any additional keywords supported by the particular filter type."
    ]
@@ -1050,7 +1028,7 @@
     "}\n",
     "\n",
     "filter_table = pn.widgets.Tabulator(\n",
-    "    movies_df, pagination='remote', layout='fit_columns', page_size=10, sizing_mode='stretch_width',\n",
+    "    movies_df, pagination='remote', layout='fit_columns', page_size=4, sizing_mode='stretch_width',\n",
     "    header_filters=movie_filters\n",
     ")\n",
     "filter_table"
@@ -1062,7 +1040,7 @@
    "source": [
     "## Downloading\n",
     "\n",
-    "The `Tabulator` also supports triggering a download of the data as a CSV or JSON file dependending on the filename. The download can be triggered with the `.download()` method, which optionally accepts the filename as the first argument.\n",
+    "The `Tabulator` widget also supports triggering a download of the data as a CSV or JSON file dependending on the filename. The download can be triggered with the `.download()` method, which optionally accepts the filename as the first argument.\n",
     "\n",
     "To trigger the download client-side (i.e. without involving the server) you can use the `.download_menu` method which creates a `TextInput` and `Button` widget, which allow setting the filename and triggering the download respectively:"
    ]
@@ -1073,7 +1051,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "download_df = pd.DataFrame(np.random.randn(10, 5), columns=list('ABCDE'))\n",
+    "download_df = pd.DataFrame(np.random.randn(4, 5), columns=list('ABCDE'))\n",
     "\n",
     "download_table = pn.widgets.Tabulator(download_df)\n",
     "\n",
@@ -1139,7 +1117,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "stream_df = pd.DataFrame(np.random.randn(10, 5), columns=list('ABCDE'))\n",
+    "stream_df = pd.DataFrame(np.random.randn(5, 5), columns=list('ABCDE'))\n",
     "\n",
     "stream_table = pn.widgets.Tabulator(stream_df, layout='fit_columns', width=450, height=400)\n",
     "stream_table"
@@ -1159,10 +1137,10 @@
    "outputs": [],
    "source": [
     "def stream_data(follow=True):\n",
-    "    stream_df = pd.DataFrame(np.random.randn(10, 5), columns=list('ABCDE'))\n",
+    "    stream_df = pd.DataFrame(np.random.randn(5, 5), columns=list('ABCDE'))\n",
     "    stream_table.stream(stream_df, follow=follow)\n",
     "\n",
-    "pn.state.add_periodic_callback(stream_data, period=1000, count=5)"
+    "pn.state.add_periodic_callback(stream_data, period=1000, count=5);"
    ]
   },
   {
@@ -1216,7 +1194,7 @@
     "}\n",
     "```\n",
     "    \n",
-    "As an example, below we will patch the 'bool' and 'int' columns. On the `'bool'` column we will replace the 0th and 2nd row and on the `'int'` column we replace the first two rows:"
+    "As an example, below we will patch the `'bool'` and `'int'` columns. On the `'bool'` column we will replace the 0th and 2nd row and on the `'int'` column we replace the first two rows:"
    ]
   },
   {
@@ -1262,20 +1240,18 @@
     "    'date': [dt.date(2019, 1, 1), dt.date(2020, 1, 1), dt.date(2020, 1, 10)]\n",
     "}, index=[1, 2, 3])\n",
     "\n",
-    "df_widget = pn.widgets.Tabulator(df, configuration={'columnDefaults': {\n",
-    "    'resizable': False,\n",
-    "    'headerSort': True\n",
-    "}})\n",
-    "\n",
-    "df_widget.servable()"
+    "pn.widgets.Tabulator(df, configuration={\n",
+    "    'resizableColumns': False,\n",
+    "    'headerSort': False\n",
+    "})"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "These and other available tabulator options are listed at http://tabulator.info/docs/4.9/options.  \n",
-    "Obviously not all options will work though, especially any settable callbacks and options which are set by the internal panel tabulator module (for example the `columns` option).\n",
+    "These and other available *Tabulator* options are listed at http://tabulator.info/docs/4.9/options.  \n",
+    "Obviously not all options will work though, especially any settable callbacks and options which are set by the internal Panel tabulator module (for example the `columns` option).\n",
     "Additionally it should be noted that the configuration parameter is not responsive so it can only be set at instantiation time."
    ]
   }


### PR DESCRIPTION
This PR:
* fixes some small issues in the documentation, such as wrong name for the editors
* makes most of the tables smaller in height, the reference page is very long so that can only help
* makes some other minor enhancements
