### PR TITLE
Change Pane to panel

### DIFF
--- a/panel/pane/base.py
+++ b/panel/pane/base.py
@@ -386,7 +386,7 @@ class ReplacementPane(PaneBase):
         self._kwargs =  {p: params.pop(p) for p in list(params)
                          if p not in self.param}
         super().__init__(object, **params)
-        self._pane = Pane(None)
+        self._pane = panel(None)
         self._internal = True
         self._inner_layout = Row(self._pane, **{k: v for k, v in params.items() if k in Row.param})
         self.param.watch(self._update_inner_layout, list(Layoutable.param))

--- a/panel/tests/pane/test_vega.py
+++ b/panel/tests/pane/test_vega.py
@@ -13,8 +13,10 @@ altair_available = pytest.mark.skipif(alt is None, reason="requires altair")
 
 import numpy as np
 
+import panel as pn
+
 from panel.models.vega import VegaPlot
-from panel.pane import Pane, PaneBase, Vega
+from panel.pane import PaneBase, Vega
 
 blank_schema = {'$schema': ''}
 
@@ -137,7 +139,7 @@ def test_get_vega_pane_type_from_dict():
 
 
 def test_vega_pane(document, comm):
-    pane = Pane(vega_example)
+    pane = pn.panel(vega_example)
 
     # Create pane
     model = pane.get_root(document, comm=comm)
@@ -164,7 +166,7 @@ def test_vega_pane(document, comm):
 
 
 def test_vega_geometry_data(document, comm):
-    pane = Pane(gdf_example)
+    pane = pn.panel(gdf_example)
 
     # Create pane
     model = pane.get_root(document, comm=comm)
@@ -175,7 +177,7 @@ def test_vega_geometry_data(document, comm):
 
 
 def test_vega_pane_inline(document, comm):
-    pane = Pane(vega_inline_example)
+    pane = pn.panel(vega_inline_example)
 
     # Create pane
     model = pane.get_root(document, comm=comm)
@@ -209,7 +211,7 @@ def test_get_vega_pane_type_from_altair():
 
 @altair_available
 def test_altair_pane(document, comm):
-    pane = Pane(altair_example())
+    pane = pn.panel(altair_example())
 
     # Create pane
     model = pane.get_root(document, comm=comm)


### PR DESCRIPTION
Fixes #3673

Following the warning message of replacing `panel.Pane` with `panel.panel`.

Found that test_vega also used `Pane` so I replaced them too.