### PR TITLE
Implement ability to reuse session for initial render

### DIFF
--- a/panel/command/serve.py
+++ b/panel/command/serve.py
@@ -209,6 +209,10 @@ class Serve(_BkServe):
             help    = "The endpoint for the liveness API.",
             default = "liveness"
         )),
+        ('--reuse-sessions', dict(
+            action  = 'store_true',
+            help    = "Whether to reuse sessions when serving the initial request."
+        )),
     )
 
     # Supported file extensions
@@ -277,6 +281,7 @@ class Serve(_BkServe):
             raise ValueError("rest-provider %r not recognized." % args.rest_provider)
 
         config.autoreload = args.autoreload
+        config.reuse_sessions = args.reuse_sessions
 
         if config.autoreload:
             for f in files:

--- a/panel/command/serve.py
+++ b/panel/command/serve.py
@@ -211,7 +211,7 @@ class Serve(_BkServe):
         )),
         ('--reuse-sessions', dict(
             action  = 'store_true',
-            help    = "Whether to reuse sessions when serving the initial request."
+            help    = "Whether to reuse sessions when serving the initial request.",
         )),
     )
 

--- a/panel/config.py
+++ b/panel/config.py
@@ -156,7 +156,13 @@ class _config(_base_config):
         the initial page render. Note that if the initial page differs
         between sessions, e.g. because it uses query parameters to modify
         the rendered content, then this option will result in the wrong
-        content being rendered.""")
+        content being rendered. Define a session_key_func to ensure that
+        reused sessions are only reused when appropriate.""")
+
+    session_key_func = param.Callable(default=None, doc="""
+        Used in conjunction with the reuse_sessions option, the
+        session_key_func is given a tornado.httputil.HTTPServerRequest
+        and should return a key that uniquely captures a session.""")
 
     safe_embed = param.Boolean(default=False, doc="""
         Ensure all bokeh property changes trigger events which are

--- a/panel/config.py
+++ b/panel/config.py
@@ -151,6 +151,13 @@ class _config(_base_config):
         'pyinstrument', 'snakeviz', 'memray'], doc="""
         The profiler engine to enable.""")
 
+    reuse_sessions = param.Boolean(default=False, doc="""
+        Whether to reuse a session for the initial request to speed up
+        the initial page render. Note that if the initial page differs
+        between sessions, e.g. because it uses query parameters to modify
+        the rendered content, then this option will result in the wrong
+        content being rendered.""")
+
     safe_embed = param.Boolean(default=False, doc="""
         Ensure all bokeh property changes trigger events which are
         embedded. Useful when only partial updates are made in an

--- a/panel/io/server.py
+++ b/panel/io/server.py
@@ -359,7 +359,7 @@ class DocHandler(BkDocHandler, SessionPrefixHandler):
         from ..config import config
         path = self.request.path
         session = None
-        if path in self._session_key_funcs:
+        if config.reuse_sessions and path in self._session_key_funcs:
             key = self._session_key_funcs[path](self.request)
             session = state._sessions.get(key)
         if session is None:

--- a/panel/io/server.py
+++ b/panel/io/server.py
@@ -359,6 +359,7 @@ class DocHandler(BkDocHandler, SessionPrefixHandler):
             session = await super().get_session()
             if config.reuse_sessions:
                 state._sessions[self.request.uri] = session
+                session.block_expiration()
         return session
 
     @authenticated

--- a/panel/io/server.py
+++ b/panel/io/server.py
@@ -197,7 +197,10 @@ state.on_session_created(_initialize_session_info)
 #---------------------------------------------------------------------
 
 def server_html_page_for_session(
-    session: 'ServerSession', resources: 'Resources', title: str, token: str,
+    session: 'ServerSession',
+    resources: 'Resources',
+    title: str,
+    token: str | None = None,
     template: str | Template = BASE_TEMPLATE,
     template_variables: Optional[Dict[str, Any]] = None,
 ) -> str:
@@ -217,7 +220,7 @@ def server_html_page_for_session(
         patch_model_css(root, dist_url=dist_url)
 
     render_item = RenderItem(
-        token = token,
+        token = token or session.token,
         roots = session.document.roots,
         use_for_title = False,
     )
@@ -319,7 +322,6 @@ class Application(BkApplication):
                 template.server_doc(title=template.title, location=True, doc=doc)
 
 bokeh.command.util.Application = Application # type: ignore
-
 
 class SessionPrefixHandler:
 

--- a/panel/io/state.py
+++ b/panel/io/state.py
@@ -734,6 +734,7 @@ class _state(param.Parameterized):
         if self._thread_pool is not None:
             self._thread_pool.shutdown(wait=False)
             self._thread_pool = None
+        self._sessions.clear()
 
     def schedule_task(
         self, name: str, callback: Callable[[], None], at: Tat =None,

--- a/panel/io/state.py
+++ b/panel/io/state.py
@@ -207,6 +207,9 @@ class _state(param.Parameterized):
     # Locks
     _cache_locks: ClassVar[Dict[str, threading.Lock]] = {'main': threading.Lock()}
 
+    # Sessions
+    _sessions = {}
+
     def __repr__(self) -> str:
         server_info = []
         for server, panel, docs in self._servers.values():

--- a/panel/tests/conftest.py
+++ b/panel/tests/conftest.py
@@ -360,6 +360,16 @@ def threads():
         config.nthreads = None
 
 @pytest.fixture
+def reuse_sessions():
+    config.reuse_sessions = True
+    try:
+        yield
+    finally:
+        config.reuse_sessions = False
+        config.session_key_func = None
+        state._sessions.clear()
+
+@pytest.fixture
 def nothreads():
     yield
 

--- a/panel/tests/test_server.py
+++ b/panel/tests/test_server.py
@@ -457,6 +457,65 @@ def test_server_schedule_at_callable(port):
     server.stop()
 
 @pytest.mark.xdist_group(name="server")
+def test_server_reuse_sessions(port):
+    def app(counts=[0]):
+        config.reuse_sessions = True
+        content = f'# Count {counts[0]}'
+        counts[0] += 1
+        return content
+
+    serve(app, port=port, threaded=True, show=False)
+
+    # Wait for server to start
+    time.sleep(1)
+
+    r1 = requests.get(f"http://localhost:{port}/")
+    r2 = requests.get(f"http://localhost:{port}/")
+
+    assert len(state._sessions) == 1
+    assert '/' in state._sessions
+
+    session = state._sessions['/']
+
+    assert session.token in r1.content.decode('utf-8')
+    assert session.token not in r2.content.decode('utf-8')
+
+
+@pytest.mark.xdist_group(name="server")
+def test_server_reuse_sessions_with_session_key_func(port):
+    def app(counts=[0]):
+        config.param.update(
+            reuse_sessions=True,
+            session_key_func = lambda r: (r.path, r.arguments.get('arg', [''])[0])
+        )
+        if 'arg' in state.session_args:
+            title = state.session_args['arg'][0].decode('utf-8')
+        else:
+            title = 'Empty'
+        content = f"# Count {counts[0]}"
+        tmpl = BootstrapTemplate(title=title)
+        tmpl.main.append(content)
+        counts[0] += 1
+        return tmpl
+
+    serve(app, port=port, threaded=True, show=False)
+
+    # Wait for server to start
+    time.sleep(1)
+
+    r1 = requests.get(f"http://localhost:{port}/?arg=foo")
+    r2 = requests.get(f"http://localhost:{port}/?arg=bar")
+
+    assert len(state._sessions) == 2
+    assert ('/', b'foo') in state._sessions
+    assert ('/', b'bar') in state._sessions
+
+    session1, session2 = state._sessions.values()
+    assert session1.token in r1.content.decode('utf-8')
+    assert session2.token in r2.content.decode('utf-8')
+
+
+@pytest.mark.xdist_group(name="server")
 def test_show_server_info(html_server_session, markdown_server_session):
     *_, html_port = html_server_session
     *_, markdown_port = markdown_server_session

--- a/panel/tests/test_server.py
+++ b/panel/tests/test_server.py
@@ -457,9 +457,8 @@ def test_server_schedule_at_callable(port):
     server.stop()
 
 @pytest.mark.xdist_group(name="server")
-def test_server_reuse_sessions(port):
+def test_server_reuse_sessions(port, reuse_sessions):
     def app(counts=[0]):
-        config.reuse_sessions = True
         content = f'# Count {counts[0]}'
         counts[0] += 1
         return content
@@ -482,12 +481,9 @@ def test_server_reuse_sessions(port):
 
 
 @pytest.mark.xdist_group(name="server")
-def test_server_reuse_sessions_with_session_key_func(port):
+def test_server_reuse_sessions_with_session_key_func(port, reuse_sessions):
+    config.session_key_func = lambda r: (r.path, r.arguments.get('arg', [''])[0])
     def app(counts=[0]):
-        config.param.update(
-            reuse_sessions=True,
-            session_key_func = lambda r: (r.path, r.arguments.get('arg', [''])[0])
-        )
         if 'arg' in state.session_args:
             title = state.session_args['arg'][0].decode('utf-8')
         else:

--- a/panel/tests/ui/io/test_server.py
+++ b/panel/tests/ui/io/test_server.py
@@ -1,0 +1,57 @@
+import time
+
+import pytest
+
+pytestmark = pytest.mark.ui
+
+from panel import config, state
+from panel.io.server import serve
+from panel.template import BootstrapTemplate
+
+
+def test_server_reuse_sessions(page, port):
+    def app(counts=[0]):
+        config.reuse_sessions = True
+        content = f'# Count {counts[0]}'
+        counts[0] += 1
+        return content
+
+    serve(app, port=port, threaded=True, show=False)
+
+    time.sleep(0.2)
+
+    page.goto(f"http://localhost:{port}")
+
+    assert page.text_content(".bk.markdown") == 'Count 0'
+
+    page.goto(f"http://localhost:{port}")
+
+    assert page.text_content(".bk.markdown") == 'Count 1'
+
+
+def test_server_reuse_sessions_with_session_key_func(page, port):
+    def app(counts=[0]):
+        config.param.update(
+            reuse_sessions=True,
+            session_key_func = lambda r: (r.path, r.arguments.get('arg', [''])[0])
+        )
+        title = state.session_args.get('arg', [b''])[0].decode('utf-8')
+        content = f"# Count {counts[0]}"
+        tmpl = BootstrapTemplate(title=title)
+        tmpl.main.append(content)
+        counts[0] += 1
+        return tmpl
+
+    serve(app, port=port, threaded=True, show=False)
+
+    time.sleep(0.2)
+
+    page.goto(f"http://localhost:{port}/?arg=foo")
+
+    assert page.text_content("title") == 'foo'
+    assert page.text_content(".bk.markdown") == 'Count 0'
+
+    page.goto(f"http://localhost:{port}/?arg=bar")
+
+    assert page.text_content("title") == 'bar'
+    assert page.text_content(".bk.markdown") == 'Count 1'

--- a/panel/tests/ui/io/test_server.py
+++ b/panel/tests/ui/io/test_server.py
@@ -9,9 +9,8 @@ from panel.io.server import serve
 from panel.template import BootstrapTemplate
 
 
-def test_server_reuse_sessions(page, port):
+def test_server_reuse_sessions(page, port, reuse_sessions):
     def app(counts=[0]):
-        config.reuse_sessions = True
         content = f'# Count {counts[0]}'
         counts[0] += 1
         return content
@@ -29,12 +28,9 @@ def test_server_reuse_sessions(page, port):
     assert page.text_content(".bk.markdown") == 'Count 1'
 
 
-def test_server_reuse_sessions_with_session_key_func(page, port):
+def test_server_reuse_sessions_with_session_key_func(page, port, reuse_sessions):
+    config.session_key_func = lambda r: (r.path, r.arguments.get('arg', [''])[0])
     def app(counts=[0]):
-        config.param.update(
-            reuse_sessions=True,
-            session_key_func = lambda r: (r.path, r.arguments.get('arg', [''])[0])
-        )
         title = state.session_args.get('arg', [b''])[0].decode('utf-8')
         content = f"# Count {counts[0]}"
         tmpl = BootstrapTemplate(title=title)

--- a/panel/tests/ui/io/test_server.py
+++ b/panel/tests/ui/io/test_server.py
@@ -21,11 +21,11 @@ def test_server_reuse_sessions(page, port, reuse_sessions):
 
     page.goto(f"http://localhost:{port}")
 
-    assert page.text_content(".bk.markdown") == 'Count 0'
+    assert page.text_content(".markdown h1") == 'Count 0'
 
     page.goto(f"http://localhost:{port}")
 
-    assert page.text_content(".bk.markdown") == 'Count 1'
+    assert page.text_content(".markdown h1") == 'Count 1'
 
 
 def test_server_reuse_sessions_with_session_key_func(page, port, reuse_sessions):
@@ -45,9 +45,9 @@ def test_server_reuse_sessions_with_session_key_func(page, port, reuse_sessions)
     page.goto(f"http://localhost:{port}/?arg=foo")
 
     assert page.text_content("title") == 'foo'
-    assert page.text_content(".bk.markdown") == 'Count 0'
+    assert page.text_content(".markdown h1") == 'Count 0'
 
     page.goto(f"http://localhost:{port}/?arg=bar")
 
     assert page.text_content("title") == 'bar'
-    assert page.text_content(".bk.markdown") == 'Count 1'
+    assert page.text_content(".markdown h1") == 'Count 1'


### PR DESCRIPTION
This is an experiment to see if we can improve the speed of handling the initial request. The basic idea behind this is that in most cases the initial page served to the user is identical, i.e. the template does not differ between sessions. As long as that holds true we can simply cache the first session for each endpoint and reuse that to render the template served to the user. In the background we can then still create a session for each user which the rendered template connects to.

The way this works is that we simply modify the `token` which tells the frontend which session it should connect to. So the steps are:

1. User visits application
2. The `DocHandler` uses a cached session to render the template
3. We swap out the `session_id` in the token so that the frontend does not re-connect to the existing session
4. When the frontend establishes the Websocket connection a new session is created

This will significantly reduce time to first render but also comes with some caveats and drawbacks:

- Even though the initial render is faster establishing the websocket connection will be slower because we have simply postponed when the session is created
- This will not work if the initial page render is dependent on some state, e.g. a query parameter determines the theme or a header/cookie is used to render the user into the header.