### PR TITLE
Wrong example signature

### DIFF
--- a/examples/user_guide/Custom_Components.ipynb
+++ b/examples/user_guide/Custom_Components.ipynb
@@ -178,7 +178,7 @@
     "    _dom_events = {'input': ['change']}\n",
     "```\n",
     "\n",
-    "Once subscribed the class may also define a method following the `_{node-id}_{event}` naming convention which will fire when the DOM event triggers, e.g. we could define a `__custom_id_change` method. Any such callback will be given a `DOMEvent` object as the first and only argument. The `DOMEvent` contains information about the event on the `.data` attribute and declares the type of event on the `.type` attribute."
+    "Once subscribed the class may also define a method following the `_{node-id}_{event}` naming convention which will fire when the DOM event triggers, e.g. we could define a `_custom_id_change` method. Any such callback will be given a `DOMEvent` object as the first and only argument. The `DOMEvent` contains information about the event on the `.data` attribute and declares the type of event on the `.type` attribute."
    ]
   },
   {


### PR DESCRIPTION
Callback should follow the `_{node-id}_{event}`, but example uses a double underscore (which is not working)