### PR TITLE
Properly describe where the .type attribute of DOMEvent is found

### DIFF
--- a/examples/user_guide/Custom_Components.ipynb
+++ b/examples/user_guide/Custom_Components.ipynb
@@ -178,7 +178,9 @@
     "    _dom_events = {'input': ['change']}\n",
     "```\n",
     "\n",
-    "Once subscribed the class may also define a method following the `_{node-id}_{event}` naming convention which will fire when the DOM event triggers, e.g. we could define a `__custom_id_change` method. Any such callback will be given a `DOMEvent` object as the first and only argument. The `DOMEvent` contains information about the event on the `.data` attribute and declares the type of event on the `.type` attribute."
+    "Once subscribed the class may also define a method following the `_{node-id}_{event}` naming convention which will fire when the DOM event triggers, e.g. we could define a `__custom_id_change` method. Any such callback will be given a `DOMEvent` object as the first and only argument.\n",
+    "\n",
+    "The `DOMEvent` contains information about the event on the `.data` attribute, like declaring the type of event on `.data.type`."
    ]
   },
   {


### PR DESCRIPTION
Documentation is currently wrong, as there's no `.type` attribute on DOMEvent, but it's `.data.type`