### PR TITLE
Update expand icon on expanded change

### DIFF
--- a/panel/models/tabulator.ts
+++ b/panel/models/tabulator.ts
@@ -256,9 +256,20 @@ export class DataTabulatorView extends PanelHTMLBoxView {
     this.connect(p.children.change, () => this.renderChildren())
 
     this.connect(p.expanded.change, () => {
+      // The first cell is the cell of the frozen _index column.
       for (const row of this.tabulator.rowManager.getRows()) {
-        if (row.cells.length > 0)
+        if (row.cells.length > 0) {
           row.cells[0].layoutElement()
+        }
+      }
+      // Make sure the expand icon is changed when expanded is
+      // changed from Python.
+      for (const row of this.tabulator.rowManager.getRows()) {
+        if (row.cells.length > 0) {
+          const index = row.data._index
+          const icon = this.model.expanded.indexOf(index) < 0 ? "►" : "▼"
+          row.cells[1].element.innerText = icon
+        }
       }
     })
 
@@ -630,7 +641,7 @@ export class DataTabulatorView extends PanelHTMLBoxView {
 
   _expand_render(cell: any): string {
     const index = cell._cell.row.data._index
-    const icon = this.model.expanded.indexOf(index) < 0 ? "\u25ba" : "\u25bc"
+    const icon = this.model.expanded.indexOf(index) < 0 ? "►" : "▼"
     return "<i>" + icon + "</i>"
   }
 
@@ -650,8 +661,6 @@ export class DataTabulatorView extends PanelHTMLBoxView {
       }
     }
     this.model.expanded = expanded
-    const icon = expanded.indexOf(index) < 0 ? "\u25ba" : "\u25bc"
-    cell._cell.element.innerText = icon
     if (expanded.indexOf(index) < 0)
       return
     let ready = true

--- a/panel/models/tabulator.ts
+++ b/panel/models/tabulator.ts
@@ -258,9 +258,8 @@ export class DataTabulatorView extends PanelHTMLBoxView {
     this.connect(p.expanded.change, () => {
       // The first cell is the cell of the frozen _index column.
       for (const row of this.tabulator.rowManager.getRows()) {
-        if (row.cells.length > 0) {
+        if (row.cells.length > 0)
           row.cells[0].layoutElement()
-        }
       }
       // Make sure the expand icon is changed when expanded is
       // changed from Python.

--- a/panel/tests/ui/widgets/test_tabulator.py
+++ b/panel/tests/ui/widgets/test_tabulator.py
@@ -1589,7 +1589,6 @@ def test_tabulator_row_content_expand_from_python_init(page, port, df_mixed):
     assert openables.count() == len(df_mixed) - len(widget.expanded)
 
 
-@pytest.mark.xfail(reason='See https://github.com/holoviz/panel/issues/3646')
 def test_tabulator_row_content_expand_from_python_after(page, port, df_mixed):
     widget = Tabulator(df_mixed, row_content=lambda i: f"{i['str']}-row-content")
 


### PR DESCRIPTION
Fixes https://github.com/holoviz/panel/issues/3646

By going through the rows when `expanded` is changed and resetting the expand icon for each row.