### PR TITLE
Update `page` Parameter when pagination is 'local'

### DIFF
--- a/panel/models/tabulator.ts
+++ b/panel/models/tabulator.ts
@@ -542,6 +542,13 @@ export class DataTabulatorView extends PanelHTMLBoxView {
       pagination: this.model.pagination,
       paginationSize: this.model.page_size,
       paginationInitialPage: 1,
+      pageLoaded: function(pageno: number) {
+        if (that.model.pagination === 'local' && that.model.page !== pageno) {
+          that._updating_page = true
+          that.model.page = pageno
+          that._updating_page = false
+        }
+      },
       tableBuilding: function() { that.tableInit(that, this) },
       renderComplete: () => this.renderComplete(),
       rowSelectionChanged: (data: any, rows: any) => this.rowSelectionChanged(data, rows),

--- a/panel/tests/ui/widgets/test_tabulator.py
+++ b/panel/tests/ui/widgets/test_tabulator.py
@@ -1815,13 +1815,8 @@ def test_tabulator_edit_event(page, port, df_mixed):
     assert values[0] == ('str', 0, 'A', 'AA')
     assert df_mixed.at['idx0', 'str'] == 'AA'
 
-@pytest.mark.parametrize(
-    'pagination',
-    [
-        'remote',
-        pytest.param('local', marks=pytest.mark.xfail(reason='See https://github.com/holoviz/panel/issues/3647')),
-    ],
-)
+
+@pytest.mark.parametrize('pagination', ['remote', 'local',])
 def test_tabulator_pagination(page, port, df_mixed, pagination):
     page_size = 2
     widget = Tabulator(df_mixed, pagination=pagination, page_size=page_size)


### PR DESCRIPTION
Fixes https://github.com/holoviz/panel/issues/3647

By setting up the `pageLoaded` callback that is triggered on page change by Tabulator JS, and within which the `page` model attribute is set when `pagination` is `'local'`. By the way this check is there to be explicit as I didn't see the callback being triggered when `pagination` is `'remote'`.