### PR TITLE
Clarify usage of the Tabulator range filter

### DIFF
--- a/examples/reference/widgets/Tabulator.ipynb
+++ b/examples/reference/widgets/Tabulator.ipynb
@@ -794,7 +794,7 @@
     "The simplest approach to filtering is to select along a column with a constant or dynamic value. The `.add_filter` method allows passing in constant values, widgets and Param `Parameter`s. If a widget or `Parameter` is provided the table will watch the object for changes in the value and update the data in response. The filtering will depend on the type of the constant or dynamic value:\n",
     "\n",
     "- scalar: Filters by checking for equality\n",
-    "- `tuple`: A tuple will be interpreted as range.\n",
+    "- `tuple`: A tuple will be interpreted as range, the *start* and *end* bounds being both included in the range. Setting one of the bounds to `None` create an open-ended bound.\n",
     "- `list`/`set`: A list or set will be interpreted as a set of discrete scalars and the filter will check if the values in the column match any of the items in the list.\n",
     "\n",
     "As an example we will create a DataFrame with some data of mixed types:"


### PR DESCRIPTION
Explaining that:
- the bounds are inclusive
- `None` can be used to set an open-ended bound