### PR TITLE
Added add_periodic_callback coroutine typing

### DIFF
--- a/panel/io/state.py
+++ b/panel/io/state.py
@@ -18,8 +18,8 @@ from collections.abc import Iterator
 from contextlib import contextmanager
 from functools import partial
 from typing import (
-    TYPE_CHECKING, Any, Callable, ClassVar, Dict, Iterator as TIterator, List,
-    Optional, Tuple, Union, Coroutine,
+    TYPE_CHECKING, Any, Callable, ClassVar, Coroutine, Dict,
+    Iterator as TIterator, List, Optional, Tuple, Union,
 )
 from urllib.parse import urljoin
 from weakref import WeakKeyDictionary

--- a/panel/io/state.py
+++ b/panel/io/state.py
@@ -19,7 +19,7 @@ from contextlib import contextmanager
 from functools import partial
 from typing import (
     TYPE_CHECKING, Any, Callable, ClassVar, Dict, Iterator as TIterator, List,
-    Optional, Tuple, Union,
+    Optional, Tuple, Union, Coroutine,
 )
 from urllib.parse import urljoin
 from weakref import WeakKeyDictionary
@@ -379,8 +379,9 @@ class _state(param.Parameterized):
         return ret
 
     def add_periodic_callback(
-        self, callback: Callable[[], None], period: int=500,
-        count: Optional[int] = None, timeout: int = None, start: bool=True
+        self, callback: Callable[[], None] | Coroutine[Any, Any, None],
+        period: int=500, count: Optional[int] = None, timeout: int = None,
+        start: bool=True
     ) -> PeriodicCallback:
         """
         Schedules a periodic callback to be run at an interval set by


### PR DESCRIPTION
The `add_periodic_callback` method only had the `Callable` type hint while it also supports asyncio functions. This adds that type hint so `pyright` won't complain anymore :)