### PR TITLE
No warning when ParamFunction is lazy

### DIFF
--- a/panel/param.py
+++ b/panel/param.py
@@ -758,7 +758,7 @@ class ParamMethod(ReplacementPane):
         self._link_object_params()
         if object is not None:
             self._validate_object()
-            self._replace_pane(not self.lazy)
+            self._replace_pane()
 
     @param.depends('object', watch=True)
     def _validate_object(self):

--- a/panel/param.py
+++ b/panel/param.py
@@ -901,7 +901,7 @@ class ParamFunction(ParamMethod):
     def _link_object_params(self):
         deps = getattr(self.object, '_dinfo', {})
         dep_params = list(deps.get('dependencies', [])) + list(deps.get('kw', {}).values())
-        if not dep_params:
+        if not dep_params and not self.lazy:
             fn = getattr(self.object, '__bound_function__', self.object)
             fn_name = getattr(fn, '__name__', repr(self.object))
             self.param.warning(

--- a/panel/tests/test_depends.py
+++ b/panel/tests/test_depends.py
@@ -1,6 +1,7 @@
 import pytest
 
 from panel.depends import bind, param_value_if_widget
+from panel.pane import panel
 from panel.widgets import IntSlider
 
 
@@ -150,3 +151,23 @@ def test_bind_bound_function_to_kwarg():
     widget.value = 3
 
     assert bound_function() == 2
+
+
+def test_bind_bare_emits_warning(caplog):
+
+    def foo():
+        return 'bar'
+
+    from panel.param import ParamFunction
+
+    ParamFunction(foo)
+
+    breakpoint()
+
+    # Emits a Param warning
+    panel(bind(foo))
+
+    log_record = caplog.records[0]
+
+    assert log_record.levelname == 'WARNING'
+    assert "The function 'foo' does not have any dependencies and will never update" in log_record.message

--- a/panel/tests/test_param.py
+++ b/panel/tests/test_param.py
@@ -1335,3 +1335,29 @@ def test_sorted_func():
     assert input1.name=="cba"
     assert input2.name=="acb"
     assert input3.name=="bac"
+
+
+def test_paramfunction_bare_emits_warning(caplog):
+
+    def foo():
+        return 'bar'
+
+    # Emits a Param warning
+    ParamFunction(foo)
+
+    log_record = caplog.records[0]
+
+    assert log_record.levelname == 'WARNING'
+    assert "The function 'foo' does not have any dependencies and will never update" in log_record.message
+
+
+def test_paramfunction_bare_lazy_no_warning(caplog):
+
+    def foo():
+        return 'bar'
+
+    # No warning should be emitted when the ParamFunction is lazy
+    ParamFunction(foo, lazy=True)
+
+    for log_record in caplog.records:
+        assert "The function 'foo' does not have any dependencies and will never update" not in log_record.message


### PR DESCRIPTION
Fixes https://github.com/holoviz/panel/issues/3628

In this PR I've simply skipped emitting a warning when the ParamFunction is lazy. Note that https://github.com/holoviz/panel/commit/3c59d4ddae9830f697455b8d5349fa1a01f970dc is unrelated, it is touching code that is close to what I changed in the PR and that seemed useless given the signature of the method `def _replace_pane(self, *args, force=False)`, whereby `*args` isn't used in the method and would swallow the passed argument I removed.

This change doesn't fix the spurious warning observed in https://github.com/holoviz/hvplot/issues/770. It happens there because of the usage of `pn.panel(self._callback)`

https://github.com/holoviz/hvplot/blob/3f0f4596228f92a8951dc0459ade91e830e62c02/hvplot/interactive.py#L495

Where `self._callback` is a property returning a function decorated with `pn.depends`.

https://github.com/holoviz/hvplot/blob/3f0f4596228f92a8951dc0459ade91e830e62c02/hvplot/interactive.py#L140-L143

`pn.panel()` in this case falls back to the `ParamFunction` pane and as in some cases the `pn.depends` decorator is given an empty list then in those cases it is similar to running `pn.panel(pn.bind(foo))`, for which a warning is expected. To solve that at hvPlot's level I *think* it would be fine to always call `pn.panel` with `lazy=True` in:

https://github.com/holoviz/hvplot/blob/3f0f4596228f92a8951dc0459ade91e830e62c02/hvplot/interactive.py#L495

But I'd need this to be confirmed and tested.

If this warning causes too much trouble, then we may just have to revert it (even if I think it was a nice addition!).