### PR TITLE
Bump minimum Python version supported to 3.7

### DIFF
--- a/examples/user_guide/Pipelines.ipynb
+++ b/examples/user_guide/Pipelines.ipynb
@@ -42,7 +42,7 @@
     "* ``param.output(param.Number)``: Declaring an output with a specific ``Parameter`` or Python type also declares an output with the name of the method but declares that the output will be of a specific type.\n",
     "* ``param.output(c=param.Number)``: Declaring an output using a keyword argument allows overriding the method name as the name of the output and declares the type.\n",
     "\n",
-    "It is also possible to declare multiple outputs, either as keywords (Python >= 3.6 required) or tuples:\n",
+    "It is also possible to declare multiple outputs, either as keywords or tuples:\n",
     "\n",
     "* ``param.output(c=param.Number, d=param.String)`` or\n",
     "* ``param.output(('c', param.Number), ('d', param.String))``\n",

--- a/setup.py
+++ b/setup.py
@@ -231,7 +231,6 @@ setup_args = dict(
         "License :: OSI Approved :: BSD License",
         "Development Status :: 5 - Production/Stable",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
@@ -252,7 +251,7 @@ setup_args = dict(
         "Topic :: Office/Business",
         "Topic :: Office/Business :: Financial",
         "Topic :: Software Development :: Libraries"],
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     entry_points={
         'console_scripts': [
             'panel = panel.command:main'


### PR DESCRIPTION
This is mostly to update the `install_requires` value. No code change has been made to upgrade the code source to use newer features of Python 3.7.