### PR TITLE
Improve docstring and type annotation of as_cached

### DIFF
--- a/panel/io/state.py
+++ b/panel/io/state.py
@@ -19,7 +19,7 @@ from contextlib import contextmanager
 from functools import partial
 from typing import (
     TYPE_CHECKING, Any, Callable, ClassVar, Coroutine, Dict,
-    Iterator as TIterator, List, Optional, Tuple, Union,
+    Iterator as TIterator, List, Optional, Tuple, TypeVar, Union, 
 )
 from urllib.parse import urljoin
 from weakref import WeakKeyDictionary
@@ -51,6 +51,8 @@ if TYPE_CHECKING:
     from .location import Location
     from .notifications import NotificationArea
     from .server import StoppableThread
+
+    T = TypeVar("T")
 
 
 @contextmanager
@@ -333,7 +335,7 @@ class _state(param.Parameterized):
     # Public Methods
     #----------------------------------------------------------------
 
-    def as_cached(self, key: str, fn: Callable[[], None], ttl: int = None, **kwargs) -> None:
+    def as_cached(self, key: str, fn: Callable[[], T], ttl: int = None, **kwargs) -> T:
         """
         Caches the return value of a function, memoizing on the given
         key and supplied keyword arguments.

--- a/panel/io/state.py
+++ b/panel/io/state.py
@@ -340,6 +340,11 @@ class _state(param.Parameterized):
 
         Note: Keyword arguments must be hashable.
 
+        Example:
+
+        >>> import seaborn as sns
+        >>> planets = pn.state.as_cached("seaborn-planets", sns.load_dataset, name='planets')
+
         Arguments
         ---------
         key: (str)

--- a/panel/io/state.py
+++ b/panel/io/state.py
@@ -19,7 +19,7 @@ from contextlib import contextmanager
 from functools import partial
 from typing import (
     TYPE_CHECKING, Any, Callable, ClassVar, Coroutine, Dict,
-    Iterator as TIterator, List, Optional, Tuple, TypeVar, Union, 
+    Iterator as TIterator, List, Optional, Tuple, TypeVar, Union,
 )
 from urllib.parse import urljoin
 from weakref import WeakKeyDictionary

--- a/panel/io/state.py
+++ b/panel/io/state.py
@@ -344,8 +344,10 @@ class _state(param.Parameterized):
 
         Example:
 
-        >>> import seaborn as sns
-        >>> planets = pn.state.as_cached("seaborn-planets", sns.load_dataset, name='planets')
+        >>> def load_dataset(name):
+        >>>     # some slow operation that uses name to load a dataset....
+        >>>     return dataset
+        >>> penguins = pn.state.as_cached('dataset-penguins', load_dataset, name='penguins')
 
         Arguments
         ---------


### PR DESCRIPTION
I'm trying to help a user on discourse. I wanted to use `as_cached` for the first time. 

Its just much faster (for me) to look at an example before I study the more systematic documentation. So I added an example.

I added a better type annotation than return type `None` as described here https://stackoverflow.com/questions/62153257/specify-type-annotation-for-python-function-returning-type-of-argument

## Comments

- Why did you pick the name `as_cached`. Its not a term I know from elsewhere. It does not give me associations to anything I already know and love which would have been helpful 😄 .