### PR TITLE
Add hard bounds to editable sliders

### DIFF
--- a/examples/reference/widgets/EditableFloatSlider.ipynb
+++ b/examples/reference/widgets/EditableFloatSlider.ipynb
@@ -25,8 +25,10 @@
     "\n",
     "##### Core\n",
     "\n",
-    "* **``start``** (float): The range's lower bound\n",
-    "* **``end``** (float): The range's upper bound\n",
+    "* **``start``** (float): The lower bound for the slider, can be overridden by a lower `value`. \n",
+    "* **``end``** (float): The upper bound for the slider, can be overridden by a higher `value`. \n",
+    "* **``fixed_start``** (float | None): A fixed lower bound for the slider and input, `value` cannot exceed this.\n",
+    "* **``fixed_end``** (float | None): A fixed upper bound for the slider and input, `value` cannot exceed this.\n",
     "* **``step``** (float): The interval between values\n",
     "* **``value``** (float): The selected value as a float type\n",
     "* **``value_throttled``** (float): The selected value as a float type throttled until mouseup\n",
@@ -59,7 +61,23 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The ``FloatSlider`` value is returned as a float and can be accessed and set like any other widget:"
+    "Here the `value` has no bounds and can exceed `end` and go below `start`. If `value` should be fixed to a certain range it can be set with `fixed_start` and `fixed_end`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "float_slider.fixed_start = -3.14"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The `value` of the widget is returned as a float and can be accessed and set like any other widget:"
    ]
   },
   {

--- a/examples/reference/widgets/EditableIntSlider.ipynb
+++ b/examples/reference/widgets/EditableIntSlider.ipynb
@@ -25,8 +25,10 @@
     "\n",
     "##### Core\n",
     "\n",
-    "* **``start``** (int): The range's lower bound\n",
-    "* **``end``** (int): The range's upper bound\n",
+    "* **``start``** (float): The lower bound for the slider, can be overridden by a lower `value`. \n",
+    "* **``end``** (float): The upper bound for the slider, can be overridden by a higher `value`. \n",
+    "* **``fixed_start``** (float | None): A fixed lower bound for the slider and input, `value` cannot exceed this.\n",
+    "* **``fixed_end``** (float | None): A fixed upper bound for the slider and input, `value` cannot exceed this.\n",
     "* **``step``** (int): The interval between values\n",
     "* **``value``** (int): The selected value as an int type\n",
     "* **``value_throttled``** (int): The selected value as a int type throttled until mouseup\n",
@@ -59,7 +61,23 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The ``IntSlider`` value is returned as a integer and can be accessed and set like any other widget:"
+    "Here the `value` has no bounds and can exceed `end` and go below `start`. If `value` should be fixed to a certain range it can be set with `fixed_start` and `fixed_end`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "int_slider.fixed_start = -2"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The `value` of the widget returns a integer and can be accessed and set like any other widget:"
    ]
   },
   {

--- a/examples/reference/widgets/EditableRangeSlider.ipynb
+++ b/examples/reference/widgets/EditableRangeSlider.ipynb
@@ -25,8 +25,10 @@
     "\n",
     "##### Core\n",
     "\n",
-    "* **``start``** (float): The range's lower bound\n",
-    "* **``end``** (float): The range's upper bound\n",
+    "* **``start``** (float): The lower bound for the slider, can be overridden by a lower `value`. \n",
+    "* **``end``** (float): The upper bound for the slider, can be overridden by a higher `value`. \n",
+    "* **``fixed_start``** (float | None): A fixed lower bound for the slider and input, `value` cannot exceed this.\n",
+    "* **``fixed_end``** (float | None): A fixed upper bound for the slider and input, `value` cannot exceed this.\n",
     "* **``step``** (float): The interval between values\n",
     "* **``value``** (tuple): Tuple of upper and lower bounds of selected range\n",
     "* **``value_throttled``** (tuple): Tuple of upper and lower bounds of selected range throttled until mouseup\n",
@@ -61,7 +63,23 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "``RangeSlider.value`` returns a tuple of float values that can be read out and set like other widgets:"
+    "Here the `value` has no bounds and can exceed `end` and go below `start`. If `value` should be fixed to a certain range it can be set with `fixed_start` and `fixed_end`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "range_slider.fixed_start = -1"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The `value` of the widget returns a tuple of float values that can be read out and set like other widgets:"
    ]
   },
   {

--- a/panel/param.py
+++ b/panel/param.py
@@ -456,6 +456,10 @@ class Param(PaneBase):
                         widget_class = LiteralInput
             if hasattr(widget_class, 'step') and getattr(p_obj, 'step', None):
                 kw['step'] = p_obj.step
+            if hasattr(widget_class, 'fixed_start') and getattr(p_obj, 'bounds', None):
+                kw['fixed_start'] = p_obj.bounds[0]
+            if hasattr(widget_class, 'fixed_end') and getattr(p_obj, 'bounds', None):
+                kw['fixed_end'] = p_obj.bounds[1]
 
         kwargs = {k: v for k, v in kw.items() if k in widget_class.param}
 

--- a/panel/tests/test_param.py
+++ b/panel/tests/test_param.py
@@ -1,6 +1,7 @@
 import os
 
 import param
+import pytest
 
 from bokeh.models import (
     AutocompleteInput as BkAutocompleteInput, Button, CheckboxGroup,
@@ -18,8 +19,8 @@ from panel.param import (
 )
 from panel.tests.util import mpl_available, mpl_figure
 from panel.widgets import (
-    AutocompleteInput, DatePicker, DatetimeInput, LiteralInput, NumberInput,
-    RangeSlider,
+    AutocompleteInput, DatePicker, DatetimeInput, EditableFloatSlider,
+    EditableRangeSlider, LiteralInput, NumberInput, RangeSlider,
 )
 
 
@@ -1361,3 +1362,33 @@ def test_paramfunction_bare_lazy_no_warning(caplog):
 
     for log_record in caplog.records:
         assert "The function 'foo' does not have any dependencies and will never update" not in log_record.message
+
+
+def test_param_editablefloatslider_with_bounds():
+    class Test(param.Parameterized):
+        i = param.Number(default=1, softbounds=(1, 5), bounds=(0, 10))
+
+
+    t = Test()
+    w = EditableFloatSlider.from_param(t.param.i)
+
+    msg = "Parameter 'value' must be at least 0, not -1"
+    with pytest.raises(ValueError, match=msg):
+        w.value = -1
+
+    assert w.value == 1
+
+
+def test_param_editablerangeslider_with_bounds():
+    class Test(param.Parameterized):
+        i = param.Range(default=(1, 2), softbounds=(1, 5), bounds=(0, 10))
+
+
+    t = Test()
+    w = EditableRangeSlider.from_param(t.param.i)
+
+    msg = "Range parameter 'value''s lower bound must be in range \[0, 10\]"
+    with pytest.raises(ValueError, match=msg):
+        w.value = (-1, 2)
+
+    assert w.value == (1, 2)

--- a/panel/tests/ui/widgets/test_sliders.py
+++ b/panel/tests/ui/widgets/test_sliders.py
@@ -316,7 +316,7 @@ def test_editablerangeslider_button_start(page, port, widget):
 
 
 def test_editablerangeslider_no_overlap(page, port):
-    widget = EditableRangeSlider(value=(0, 1), step=1)
+    widget = EditableRangeSlider(value=(0, 2), step=1)
 
     serve(widget, port=port, threaded=True, show=False)
     time.sleep(0.2)
@@ -324,11 +324,14 @@ def test_editablerangeslider_no_overlap(page, port):
     page.goto(f"http://localhost:{port}")
 
     up_start = page.locator("button").nth(0)
+    down_start = page.locator("button").nth(1)
     down_end = page.locator("button").nth(3)
 
     up_start.click(click_count=3)
-    wait_until(page, lambda: widget.value == (1, 1))
+    wait_until(page, lambda: widget.value == (2, 2))
 
-    widget.value = (0, 1)
+    down_start.click()
+    wait_until(page, lambda: widget.value == (1, 2))
+
     down_end.click(click_count=3)
-    wait_until(page, lambda: widget.value == (0, 0))
+    wait_until(page, lambda: widget.value == (1, 1))

--- a/panel/tests/ui/widgets/test_sliders.py
+++ b/panel/tests/ui/widgets/test_sliders.py
@@ -10,6 +10,7 @@ except ImportError:
 pytestmark = pytest.mark.ui
 
 from panel.io.server import serve
+from panel.tests.util import wait_until
 from panel.widgets import (
     EditableFloatSlider, EditableIntSlider, EditableRangeSlider,
 )
@@ -57,21 +58,18 @@ def test_editableslider_textinput_end(page, port, widget, val1, val2, val3, func
     text_input = _editable_text_input(page)
 
     text_input.value = val1
-    page.wait_for_timeout(200)
-    assert widget.value == val1
+    wait_until(page, lambda: widget.value == val1)
     assert widget._slider.end == val1
     assert func(text_input.value) == val1
 
     text_input.value = val2
-    page.wait_for_timeout(200)
-    assert widget.value == val2
+    wait_until(page, lambda: widget.value == val2)
     assert widget._slider.end == val1
     assert func(text_input.value) == val2
 
     # Setting fixed end
     widget.fixed_end = val3
-    page.wait_for_timeout(200)
-    assert widget.value == val3
+    wait_until(page, lambda: widget.value == val3)
     assert widget._slider.end == val3
     assert func(text_input.value) == val3
 
@@ -94,21 +92,18 @@ def test_editableslider_textinput_start(page, port, widget, val1, val2, val3, fu
     text_input = _editable_text_input(page)
 
     text_input.value = val1
-    page.wait_for_timeout(200)
-    assert widget.value == val1
+    wait_until(page, lambda: widget.value == val1)
     assert widget._slider.start == val1
     assert func(text_input.value) == val1
 
     text_input.value = val2
-    page.wait_for_timeout(200)
-    assert widget.value == val2
+    wait_until(page, lambda: widget.value == val2)
     assert widget._slider.start == val1
     assert func(text_input.value) == val2
 
     # Setting fixed start
     widget.fixed_start = val3
-    page.wait_for_timeout(200)
-    assert widget.value == val3
+    wait_until(page, lambda: widget.value == val3)
     assert widget._slider.start == val3
     assert func(text_input.value) == val3
 
@@ -135,18 +130,16 @@ def test_editableslider_button_end(page, port, widget):
     down = page.locator("button").nth(1)
 
     up.click()
-    page.wait_for_timeout(200)
+    wait_until(page, lambda: widget.value == default_value + step)
     assert widget.value == default_value + step
     assert widget._slider.end == end
 
     up.click()
-    page.wait_for_timeout(200)
-    assert widget.value == default_value + 2 * step
+    wait_until(page, lambda: widget.value == default_value + 2 * step)
     assert widget._slider.end == end + step
 
     down.click()
-    page.wait_for_timeout(200)
-    assert widget.value == default_value + step
+    wait_until(page, lambda: widget.value == default_value + step)
     assert widget._slider.end == end + step
 
 
@@ -173,18 +166,15 @@ def test_editableslider_button_start(page, port, widget):
     down = page.locator("button").nth(1)
 
     down.click()
-    page.wait_for_timeout(200)
-    assert widget.value == default_value - step
+    wait_until(page, lambda: widget.value == default_value - step)
     assert widget._slider.start == start - step
 
     down.click()
-    page.wait_for_timeout(200)
-    assert widget.value == default_value - 2 * step
+    wait_until(page, lambda: widget.value == default_value - 2 * step)
     assert widget._slider.start == start - 2 * step
 
     up.click()
-    page.wait_for_timeout(200)
-    assert widget.value == default_value - step
+    wait_until(page, lambda: widget.value == default_value - step)
     assert widget._slider.start == start - 2 * step
 
 
@@ -206,21 +196,18 @@ def test_editablerangeslider_textinput_end(page, port, widget, val1, val2, val3,
     text_input = _editable_text_input(page, nth=1)
 
     text_input.value = val1
-    page.wait_for_timeout(200)
-    assert widget.value == (0, val1)
+    wait_until(page, lambda: widget.value == (0, val1))
     assert widget._slider.end == val1
     assert func(text_input.value) == val1
 
     text_input.value = val2
-    page.wait_for_timeout(200)
-    assert widget.value == (0, val2)
+    wait_until(page, lambda: widget.value == (0, val2))
     assert widget._slider.end == val1
     assert func(text_input.value) == val2
 
     # Setting fixed end
     widget.fixed_end = val3
-    page.wait_for_timeout(200)
-    assert widget.value == (0, val3)
+    wait_until(page, lambda: widget.value == (0, val3))
     assert widget._slider.end == val3
     assert func(text_input.value) == val3
 
@@ -243,21 +230,18 @@ def test_editablerangeslider_textinput_start(page, port, widget, val1, val2, val
     text_input = _editable_text_input(page, nth=0)
 
     text_input.value = val1
-    page.wait_for_timeout(200)
-    assert widget.value == (val1, 1)
+    wait_until(page, lambda: widget.value == (val1, 1))
     assert widget._slider.start == val1
     assert func(text_input.value) == val1
 
     text_input.value = val2
-    page.wait_for_timeout(200)
-    assert widget.value == (val2, 1)
+    wait_until(page, lambda: widget.value == (val2, 1))
     assert widget._slider.start == val1
     assert func(text_input.value) == val2
 
     # Setting fixed start
     widget.fixed_start = val3
-    page.wait_for_timeout(200)
-    assert widget.value == (val3, 1)
+    wait_until(page, lambda: widget.value == (val3, 1))
     assert widget._slider.start == val3
     assert func(text_input.value) == val3
 
@@ -284,18 +268,15 @@ def test_editablerangeslider_button_end(page, port, widget):
     down = page.locator("button").nth(3)
 
     up.click()
-    page.wait_for_timeout(200)
-    assert widget.value == (0, default_value[1] + step)
+    wait_until(page, lambda: widget.value == (0, default_value[1] + step))
     assert widget._slider.end == end + step
 
     up.click()
-    page.wait_for_timeout(200)
-    assert widget.value == (0, default_value[1] + 2 * step)
+    wait_until(page, lambda: widget.value == (0, default_value[1] + 2 * step))
     assert widget._slider.end == end + 2 * step
 
     down.click()
-    page.wait_for_timeout(200)
-    assert widget.value == (0, default_value[1] + step)
+    wait_until(page, lambda: widget.value == (0, default_value[1] + step))
     assert widget._slider.end == end + 2 * step
 
 
@@ -322,18 +303,15 @@ def test_editablerangeslider_button_start(page, port, widget):
     down = page.locator("button").nth(1)
 
     down.click()
-    page.wait_for_timeout(200)
-    assert widget.value == (default_value[0] - step, 1)
+    wait_until(page, lambda: widget.value == (default_value[0] - step, 1))
     assert widget._slider.start == start - step
 
     down.click()
-    page.wait_for_timeout(200)
-    assert widget.value == (default_value[0] - 2 * step, 1)
+    wait_until(page, lambda: widget.value == (default_value[0] - 2 * step, 1))
     assert widget._slider.start == start - 2 * step
 
     up.click()
-    page.wait_for_timeout(200)
-    assert widget.value == (default_value[0] - step, 1)
+    wait_until(page, lambda: widget.value == (default_value[0] - step, 1))
     assert widget._slider.start == start - 2 * step
 
 
@@ -349,10 +327,8 @@ def test_editablerangeslider_no_overlap(page, port):
     down_end = page.locator("button").nth(3)
 
     up_start.click(click_count=3)
-    page.wait_for_timeout(200)
-    assert widget.value == (1, 1)
+    wait_until(page, lambda: widget.value == (1, 1))
 
     widget.value = (0, 1)
     down_end.click(click_count=3)
-    page.wait_for_timeout(200)
-    assert widget.value == (0, 0)
+    wait_until(page, lambda: widget.value == (0, 0))

--- a/panel/tests/ui/widgets/test_sliders.py
+++ b/panel/tests/ui/widgets/test_sliders.py
@@ -1,0 +1,187 @@
+import time
+
+import pytest
+
+try:
+    import playwright  # noqa
+except ImportError:
+    pytestmark = pytest.mark.skip('playwright not available')
+
+pytestmark = pytest.mark.ui
+
+from panel.io.server import serve
+from panel.widgets import EditableFloatSlider, EditableIntSlider
+
+
+class _editable_text_input:
+    """
+    This function is added for convenience, as it is pretty
+    cumbersome to find and update the value of Editable text input.
+    """
+
+    def __init__(self, page, nth=0):
+        self.page = page
+        self.text_input = page.locator("[placeholder=\"\\30 \"]").nth(nth)
+
+    @property
+    def value(self):
+        # Needs reload of page to update attribute
+        # Should be reimplemented without the need for update
+        self.page.reload()
+        return self.text_input.get_attribute("value")
+
+    @value.setter
+    def value(self, value):
+        self.text_input.fill(str(value))
+        self.text_input.press("Enter")
+
+
+@pytest.mark.parametrize(
+    "widget,val1,val2,val3,func",
+    [
+       (EditableIntSlider, 25, 24, 20, int),
+       (EditableFloatSlider, 24.5, 24.5, 19.5, float),
+    ]
+)
+def test_editableslider_textinput_end(page, port, widget, val1, val2, val3, func):
+    widget = widget()
+
+    serve(widget, port=port, threaded=True, show=False)
+    time.sleep(0.2)
+
+    page.goto(f"http://localhost:{port}")
+
+    text_input = _editable_text_input(page)
+
+    text_input.value = val1
+    page.wait_for_timeout(200)
+    assert widget.value == val1
+    assert widget._slider.end == val1
+    assert func(text_input.value) == val1
+
+    text_input.value = val2
+    page.wait_for_timeout(200)
+    assert widget.value == val2
+    assert widget._slider.end == val1
+    assert func(text_input.value) == val2
+
+    # Setting fixed end
+    widget.fixed_end = val3
+    page.wait_for_timeout(200)
+    assert widget.value == val3
+    assert widget._slider.end == val3
+    assert func(text_input.value) == val3
+
+
+@pytest.mark.parametrize(
+    "widget,val1,val2,val3,func",
+    [
+       (EditableIntSlider, -25, -24, -20, int),
+       (EditableFloatSlider, -24.5, -24.5, -19.5, float),
+    ]
+)
+def test_editableslider_textinput_start(page, port, widget, val1, val2, val3, func):
+    widget = widget()
+
+    serve(widget, port=port, threaded=True, show=False)
+    time.sleep(0.2)
+
+    page.goto(f"http://localhost:{port}")
+
+    text_input = _editable_text_input(page)
+
+    text_input.value = val1
+    page.wait_for_timeout(200)
+    assert widget.value == val1
+    assert widget._slider.start == val1
+    assert func(text_input.value) == val1
+
+    text_input.value = val2
+    page.wait_for_timeout(200)
+    assert widget.value == val2
+    assert widget._slider.start == val1
+    assert func(text_input.value) == val2
+
+    # Setting fixed start
+    widget.fixed_start = val3
+    page.wait_for_timeout(200)
+    assert widget.value == val3
+    assert widget._slider.start == val3
+    assert func(text_input.value) == val3
+
+@pytest.mark.parametrize(
+    "widget",
+    [
+       EditableIntSlider,
+       EditableFloatSlider
+    ]
+)
+def test_editableslider_button_end(page, port, widget):
+    widget = widget(step=1)
+
+    serve(widget, port=port, threaded=True, show=False)
+    time.sleep(0.2)
+
+    page.goto(f"http://localhost:{port}")
+
+
+    default_value = widget.value
+    step = widget.step
+    end = widget.end
+
+    up = page.locator("button").nth(0)
+    down = page.locator("button").nth(1)
+
+    up.click()
+    page.wait_for_timeout(200)
+    assert widget.value == default_value + step
+    assert widget._slider.end == end
+
+    up.click()
+    page.wait_for_timeout(200)
+    assert widget.value == default_value + 2 * step
+    assert widget._slider.end == end + step
+
+    down.click()
+    page.wait_for_timeout(200)
+    assert widget.value == default_value + step
+    assert widget._slider.end == end + step
+
+
+@pytest.mark.parametrize(
+    "widget",
+    [
+       EditableIntSlider,
+       EditableFloatSlider
+    ]
+)
+def test_editableslider_button_start(page, port, widget):
+    widget = widget(step=1)
+
+    serve(widget, port=port, threaded=True, show=False)
+    time.sleep(0.2)
+
+    page.goto(f"http://localhost:{port}")
+
+
+    default_value = widget.value
+    step = widget.step
+    start = widget.start
+
+    up = page.locator("button").nth(0)
+    down = page.locator("button").nth(1)
+
+    down.click()
+    page.wait_for_timeout(200)
+    assert widget.value == default_value - step
+    assert widget._slider.start == start - step
+
+    down.click()
+    page.wait_for_timeout(200)
+    assert widget.value == default_value - 2 * step
+    assert widget._slider.start == start - 2 * step
+
+    up.click()
+    page.wait_for_timeout(200)
+    assert widget.value == default_value - step
+    assert widget._slider.start == start - 2 * step

--- a/panel/tests/ui/widgets/test_sliders.py
+++ b/panel/tests/ui/widgets/test_sliders.py
@@ -10,7 +10,9 @@ except ImportError:
 pytestmark = pytest.mark.ui
 
 from panel.io.server import serve
-from panel.widgets import EditableFloatSlider, EditableIntSlider
+from panel.widgets import (
+    EditableFloatSlider, EditableIntSlider, EditableRangeSlider,
+)
 
 
 class _editable_text_input:
@@ -40,8 +42,9 @@ class _editable_text_input:
     "widget,val1,val2,val3,func",
     [
        (EditableIntSlider, 25, 24, 20, int),
-       (EditableFloatSlider, 24.5, 24.5, 19.5, float),
-    ]
+       (EditableFloatSlider, 25.5, 24.5, 19.5, float),
+    ],
+    ids=["EditableIntSlider", "EditableFloatSlider"]
 )
 def test_editableslider_textinput_end(page, port, widget, val1, val2, val3, func):
     widget = widget()
@@ -72,13 +75,13 @@ def test_editableslider_textinput_end(page, port, widget, val1, val2, val3, func
     assert widget._slider.end == val3
     assert func(text_input.value) == val3
 
-
 @pytest.mark.parametrize(
     "widget,val1,val2,val3,func",
     [
        (EditableIntSlider, -25, -24, -20, int),
-       (EditableFloatSlider, -24.5, -24.5, -19.5, float),
-    ]
+       (EditableFloatSlider, -25.5, -24.5, -19.5, float),
+    ],
+    ids=["EditableIntSlider", "EditableFloatSlider"]
 )
 def test_editableslider_textinput_start(page, port, widget, val1, val2, val3, func):
     widget = widget()
@@ -113,21 +116,20 @@ def test_editableslider_textinput_start(page, port, widget, val1, val2, val3, fu
     "widget",
     [
        EditableIntSlider,
-       EditableFloatSlider
-    ]
+       EditableFloatSlider,
+    ],
+    ids=["EditableIntSlider", "EditableFloatSlider"]
 )
 def test_editableslider_button_end(page, port, widget):
     widget = widget(step=1)
+    default_value = widget.value
+    step = widget.step
+    end = widget.end
 
     serve(widget, port=port, threaded=True, show=False)
     time.sleep(0.2)
 
     page.goto(f"http://localhost:{port}")
-
-
-    default_value = widget.value
-    step = widget.step
-    end = widget.end
 
     up = page.locator("button").nth(0)
     down = page.locator("button").nth(1)
@@ -153,20 +155,19 @@ def test_editableslider_button_end(page, port, widget):
     [
        EditableIntSlider,
        EditableFloatSlider
-    ]
+    ],
+    ids=["EditableIntSlider", "EditableFloatSlider"]
 )
 def test_editableslider_button_start(page, port, widget):
     widget = widget(step=1)
+    default_value = widget.value
+    step = widget.step
+    start = widget.start
 
     serve(widget, port=port, threaded=True, show=False)
     time.sleep(0.2)
 
     page.goto(f"http://localhost:{port}")
-
-
-    default_value = widget.value
-    step = widget.step
-    start = widget.start
 
     up = page.locator("button").nth(0)
     down = page.locator("button").nth(1)
@@ -185,3 +186,173 @@ def test_editableslider_button_start(page, port, widget):
     page.wait_for_timeout(200)
     assert widget.value == default_value - step
     assert widget._slider.start == start - 2 * step
+
+
+@pytest.mark.parametrize(
+    "widget,val1,val2,val3,func",
+    [
+       (EditableRangeSlider, 25.5, 24.5, 19.5, float),
+    ],
+    ids=["EditableRangeSlider"]
+)
+def test_editablerangeslider_textinput_end(page, port, widget, val1, val2, val3, func):
+    widget = widget()
+
+    serve(widget, port=port, threaded=True, show=False)
+    time.sleep(0.2)
+
+    page.goto(f"http://localhost:{port}")
+
+    text_input = _editable_text_input(page, nth=1)
+
+    text_input.value = val1
+    page.wait_for_timeout(200)
+    assert widget.value == (0, val1)
+    assert widget._slider.end == val1
+    assert func(text_input.value) == val1
+
+    text_input.value = val2
+    page.wait_for_timeout(200)
+    assert widget.value == (0, val2)
+    assert widget._slider.end == val1
+    assert func(text_input.value) == val2
+
+    # Setting fixed end
+    widget.fixed_end = val3
+    page.wait_for_timeout(200)
+    assert widget.value == (0, val3)
+    assert widget._slider.end == val3
+    assert func(text_input.value) == val3
+
+
+@pytest.mark.parametrize(
+    "widget,val1,val2,val3,func",
+    [
+       (EditableRangeSlider, -25.5, -24.5, -19.5, float),
+    ],
+    ids=["EditableRangeSlider"]
+)
+def test_editablerangeslider_textinput_start(page, port, widget, val1, val2, val3, func):
+    widget = widget()
+
+    serve(widget, port=port, threaded=True, show=False)
+    time.sleep(0.2)
+
+    page.goto(f"http://localhost:{port}")
+
+    text_input = _editable_text_input(page, nth=0)
+
+    text_input.value = val1
+    page.wait_for_timeout(200)
+    assert widget.value == (val1, 1)
+    assert widget._slider.start == val1
+    assert func(text_input.value) == val1
+
+    text_input.value = val2
+    page.wait_for_timeout(200)
+    assert widget.value == (val2, 1)
+    assert widget._slider.start == val1
+    assert func(text_input.value) == val2
+
+    # Setting fixed start
+    widget.fixed_start = val3
+    page.wait_for_timeout(200)
+    assert widget.value == (val3, 1)
+    assert widget._slider.start == val3
+    assert func(text_input.value) == val3
+
+
+@pytest.mark.parametrize(
+    "widget",
+    [
+       EditableRangeSlider,
+    ],
+    ids=["EditableRangeSlider"]
+)
+def test_editablerangeslider_button_end(page, port, widget):
+    widget = widget(step=1)
+    default_value = widget.value
+    step = widget.step
+    end = widget.end
+
+    serve(widget, port=port, threaded=True, show=False)
+    time.sleep(0.2)
+
+    page.goto(f"http://localhost:{port}")
+
+    up = page.locator("button").nth(2)
+    down = page.locator("button").nth(3)
+
+    up.click()
+    page.wait_for_timeout(200)
+    assert widget.value == (0, default_value[1] + step)
+    assert widget._slider.end == end + step
+
+    up.click()
+    page.wait_for_timeout(200)
+    assert widget.value == (0, default_value[1] + 2 * step)
+    assert widget._slider.end == end + 2 * step
+
+    down.click()
+    page.wait_for_timeout(200)
+    assert widget.value == (0, default_value[1] + step)
+    assert widget._slider.end == end + 2 * step
+
+
+
+@pytest.mark.parametrize(
+    "widget",
+    [
+       EditableRangeSlider,
+    ],
+    ids=["EditableRangeSlider"]
+)
+def test_editablerangeslider_button_start(page, port, widget):
+    widget = widget(step=1)
+    default_value = widget.value
+    step = widget.step
+    start = widget.start
+
+    serve(widget, port=port, threaded=True, show=False)
+    time.sleep(0.2)
+
+    page.goto(f"http://localhost:{port}")
+
+    up = page.locator("button").nth(0)
+    down = page.locator("button").nth(1)
+
+    down.click()
+    page.wait_for_timeout(200)
+    assert widget.value == (default_value[0] - step, 1)
+    assert widget._slider.start == start - step
+
+    down.click()
+    page.wait_for_timeout(200)
+    assert widget.value == (default_value[0] - 2 * step, 1)
+    assert widget._slider.start == start - 2 * step
+
+    up.click()
+    page.wait_for_timeout(200)
+    assert widget.value == (default_value[0] - step, 1)
+    assert widget._slider.start == start - 2 * step
+
+
+def test_editablerangeslider_no_overlap(page, port):
+    widget = EditableRangeSlider(value=(0, 1), step=1)
+
+    serve(widget, port=port, threaded=True, show=False)
+    time.sleep(0.2)
+
+    page.goto(f"http://localhost:{port}")
+
+    up_start = page.locator("button").nth(0)
+    down_end = page.locator("button").nth(3)
+
+    up_start.click(click_count=3)
+    page.wait_for_timeout(200)
+    assert widget.value == (1, 1)
+
+    widget.value = (0, 1)
+    down_end.click(click_count=3)
+    page.wait_for_timeout(200)
+    assert widget.value == (0, 0)

--- a/panel/tests/widgets/test_slider.py
+++ b/panel/tests/widgets/test_slider.py
@@ -406,15 +406,15 @@ def test_discrete_slider_options_dict(document, comm):
 
 
 @pytest.mark.parametrize(
-    'editableslider,start,end,step,val1,val2,val3',
+    'editableslider,start,end,step,val1,val2,val3,diff1',
     [
-        (EditableFloatSlider, 0.1, 0.5, 0.1, 0.4, 0.2, 0.5),
-        (EditableIntSlider, 1, 5, 1, 4, 2, 5),
+        (EditableFloatSlider, 0.1, 0.5, 0.1, 0.4, 0.2, 0.5, 0.1),
+        (EditableIntSlider, 1, 5, 1, 4, 2, 5, 1),
     ],
     ids=["EditableFloatSlider", "EditableIntSlider"]
 )
 def test_editable_slider(document, comm,
-    editableslider, start, end, step, val1, val2, val3):
+    editableslider, start, end, step, val1, val2, val3, diff1):
 
     slider = editableslider(start=start, end=end, value=val1, name='Slider')
 
@@ -466,16 +466,26 @@ def test_editable_slider(document, comm,
 
     assert static_widget.text == 'New Slider:'
 
+    # Testing update to fixed start
+    slider.fixed_start = slider.value + diff1
+    assert slider._slider.start == slider.fixed_start == slider_widget.start
+    slider.fixed_start = None
+
+    # Testing update to fixed end
+    slider.fixed_end = slider.value - diff1
+    assert slider._slider.end == slider.fixed_end == slider_widget.end
+    slider.fixed_end = None
+
 
 @pytest.mark.parametrize(
-    'editableslider,start,end,step,val1,val2,val3',
+    'editableslider,start,end,step,val1,val2,val3,diff1',
     [
-        (EditableRangeSlider, 0.1, 0.5, 0.1, (0.2, 0.4), (0.2, 0.3), (0.1, 0.5)),
+        (EditableRangeSlider, 0.1, 0.5, 0.1, (0.2, 0.4), (0.2, 0.3), (0.1, 0.5), 0.1),
     ],
     ids=["EditableRangeSlider"]
 )
 def test_editable_rangeslider(document, comm,
-    editableslider, start, end, step, val1, val2, val3):
+    editableslider, start, end, step, val1, val2, val3, diff1):
 
     slider = editableslider(start=start, end=end, value=val1, name='Slider')
 
@@ -524,6 +534,16 @@ def test_editable_rangeslider(document, comm,
     slider.name = 'New Slider'
 
     assert static_widget.text == 'New Slider:'
+
+    # Testing update to fixed start
+    slider.fixed_start = slider.value[0] + diff1
+    assert slider._slider.start == slider.fixed_start == slider_widget.start
+    slider.fixed_start = None
+
+    # Testing update to fixed end
+    slider.fixed_end = slider.value[1] - diff1
+    assert slider._slider.end == slider.fixed_end == slider_widget.end
+    slider.fixed_end = None
 
 
 @pytest.mark.parametrize(

--- a/panel/tests/widgets/test_slider.py
+++ b/panel/tests/widgets/test_slider.py
@@ -10,7 +10,8 @@ from bokeh.models import (
 from panel import config
 from panel.widgets import (
     DateRangeSlider, DateSlider, DiscreteSlider, EditableFloatSlider,
-    EditableIntSlider, EditableRangeSlider, FloatSlider, IntSlider, RangeSlider, StaticText,
+    EditableIntSlider, EditableRangeSlider, FloatSlider, IntSlider,
+    RangeSlider, StaticText,
 )
 
 

--- a/panel/widgets/slider.py
+++ b/panel/widgets/slider.py
@@ -857,6 +857,14 @@ class _EditableContinuousSlider(CompositeWidget):
         self.param.value.bounds = (self.fixed_start, self.fixed_end)
         self.param.value_throttled.bounds = (self.fixed_start, self.fixed_end)
 
+        # First changing _slider and then _value_edit,
+        # because else _value_edit will change the _slider
+        # with the jscallback.
+        if self.fixed_start is not None:
+            self._slider.start = max(self.fixed_start, self.start)
+        if self.fixed_end is not None:
+            self._slider.end = min(self.fixed_end, self.end)
+
         self._value_edit.start = self.fixed_start
         self._value_edit.end = self.fixed_end
 
@@ -1082,6 +1090,14 @@ class EditableRangeSlider(CompositeWidget, _SliderBase):
         self.param.value_throttled.softbounds = (self.start, self.end)
         self.param.value.bounds = (self.fixed_start, self.fixed_end)
         self.param.value_throttled.bounds = (self.fixed_start, self.fixed_end)
+
+        # First changing _slider and then _value_edit,
+        # because else _value_edit will change the _slider
+        # with the jscallback.
+        if self.fixed_start is not None:
+            self._slider.start = max(self.fixed_start, self.start)
+        if self.fixed_end is not None:
+            self._slider.end = min(self.fixed_end, self.end)
 
         self._start_edit.start = self.fixed_start
         self._start_edit.end = self.fixed_end

--- a/panel/widgets/slider.py
+++ b/panel/widgets/slider.py
@@ -955,19 +955,24 @@ class EditableRangeSlider(CompositeWidget, _SliderBase):
         edit = Row(self._label, self._start_edit, sep, self._end_edit,
                    sizing_mode='stretch_width', margin=0)
         self._composite.extend([edit, self._slider])
-        self._slider.jscallback(args={'start': self._start_edit, 'end': self._end_edit}, value="""
-        let [min, max] = cb_obj.value
-        start.value = min
-        end.value = max
-        """)
-        self._start_edit.jscallback(args={'slider': self._slider}, value="""
+        self._start_edit.jscallback(args={'slider': self._slider, 'end': self._end_edit}, value="""
+        // start value always smaller than the end value
+        if (cb_obj.value >= end.value) {
+          cb_obj.value = end.value
+          return
+        }
         if (cb_obj.value < slider.start) {
           slider.start = cb_obj.value
         } else if (cb_obj.value > slider.end) {
           slider.end = cb_obj.value
         }
         """)
-        self._end_edit.jscallback(args={'slider': self._slider}, value="""
+        self._end_edit.jscallback(args={'slider': self._slider ,'start': self._start_edit}, value="""
+        // end value always larger than the start value
+        if (cb_obj.value <= start.value) {
+          cb_obj.value = start.value
+          return
+        }
         if (cb_obj.value < slider.start) {
           slider.start = cb_obj.value
         } else if (cb_obj.value > slider.end) {

--- a/panel/widgets/slider.py
+++ b/panel/widgets/slider.py
@@ -104,12 +104,9 @@ class ContinuousSlider(_SliderBase):
 
     __abstract = True
 
-    _enforce_bounds: ClassVar[bool] = True
-
     def __init__(self, **params):
         if 'value' not in params:
             params['value'] = params.get('start', self.start)
-        self._enforce_bounds = params.pop("_enforce_bounds", self._enforce_bounds)
         super().__init__(**params)
 
     def _get_embed_state(self, root, values=None, max_opts=3):
@@ -145,12 +142,6 @@ class ContinuousSlider(_SliderBase):
         w_model.js_on_change('value', link)
 
         return (dw, w_model, values, lambda x: x.value, 'value', 'cb_obj.value')
-
-    @param.depends("start", "end", watch=True, on_init=True)
-    def _set_value_bounds(self):
-        if self._enforce_bounds:
-            self.param.value.bounds = (self.start, self.end)
-            self.param.value_throttled.bounds = (self.start, self.end)
 
 
 class FloatSlider(ContinuousSlider):
@@ -788,7 +779,7 @@ class _EditableContinuousSlider(CompositeWidget):
         super().__init__(**params)
         self._label = StaticText(margin=0, align='end')
         self._slider = self._slider_widget(
-            value=self.value, margin=(0, 0, 5, 0), sizing_mode='stretch_width', _enforce_bounds=False
+            value=self.value, margin=(0, 0, 5, 0), sizing_mode='stretch_width',
         )
         self._slider.param.watch(self._sync_value, 'value')
         self._slider.param.watch(self._sync_value, 'value_throttled')

--- a/panel/widgets/slider.py
+++ b/panel/widgets/slider.py
@@ -104,9 +104,12 @@ class ContinuousSlider(_SliderBase):
 
     __abstract = True
 
+    _enforce_bounds: ClassVar[bool] = True
+
     def __init__(self, **params):
         if 'value' not in params:
             params['value'] = params.get('start', self.start)
+        self._enforce_bounds = params.pop("_enforce_bounds", self._enforce_bounds)
         super().__init__(**params)
 
     def _get_embed_state(self, root, values=None, max_opts=3):
@@ -142,6 +145,12 @@ class ContinuousSlider(_SliderBase):
         w_model.js_on_change('value', link)
 
         return (dw, w_model, values, lambda x: x.value, 'value', 'cb_obj.value')
+
+    @param.depends("start", "end", watch=True, on_init=True)
+    def _set_value_bounds(self):
+        if self._enforce_bounds:
+            self.param.value.bounds = (self.start, self.end)
+            self.param.value_throttled.bounds = (self.start, self.end)
 
 
 class FloatSlider(ContinuousSlider):
@@ -779,7 +788,7 @@ class _EditableContinuousSlider(CompositeWidget):
         super().__init__(**params)
         self._label = StaticText(margin=0, align='end')
         self._slider = self._slider_widget(
-            value=self.value, margin=(0, 0, 5, 0), sizing_mode='stretch_width'
+            value=self.value, margin=(0, 0, 5, 0), sizing_mode='stretch_width', _enforce_bounds=False
         )
         self._slider.param.watch(self._sync_value, 'value')
         self._slider.param.watch(self._sync_value, 'value_throttled')

--- a/panel/widgets/slider.py
+++ b/panel/widgets/slider.py
@@ -1078,11 +1078,6 @@ class EditableRangeSlider(CompositeWidget, _SliderBase):
 
     @param.depends("start", "end", "fixed_start", "fixed_end", watch=True)
     def _update_bounds(self):
-        self.start = max(self.fixed_start or float('-inf'), min(self.value[0], self.start))
-        self.end = min(self.fixed_end or float('inf'), max(self.value[1], self.end))
-        self.param.trigger("value")
-
-        # with param.edit_constant
         self.param.value.softbounds = (self.start, self.end)
         self.param.value_throttled.softbounds = (self.start, self.end)
         self.param.value.bounds = (self.fixed_start, self.fixed_end)

--- a/panel/widgets/slider.py
+++ b/panel/widgets/slider.py
@@ -935,10 +935,10 @@ class EditableRangeSlider(CompositeWidget, _SliderBase):
 
     end = param.Number(default=1., doc="Upper bound of the range.")
 
-    fixed_start = param.Integer(default=None, doc="""
+    fixed_start = param.Number(default=None, doc="""
         A fixed lower bound for the slider and input.""")
 
-    fixed_end = param.Integer(default=None, doc="""
+    fixed_end = param.Number(default=None, doc="""
         A fixed upper bound for the slider and input.""")
 
     step = param.Number(default=0.1, doc="Slider and number input step.")


### PR DESCRIPTION
Fixes #3637 

The way to set the hard bounds is by using `fixed_start` and `fixed_end`, which are then set on the `value` parameter as bounds and `start` and `end` of the text input widgets. The reason for using two parameters and not one is to mimic how the widget `start` and `end` work.

I tried to set the `bounds` of the `value` parameter of the non-editable sliders to fix the [#2735](https://github.com/holoviz/panel/issues/2735), but it broke a lot of the tests, so I removed it again (for now).

The removal of `self._slider.jscallback` is because it didn't seem to do anything, but maybe it is to avoid multiple synchronizations between the bokeh model and the param class. I will add it back again with a comment if needed.

The last thing is on the `EditableRangeSlider`, I set the start value of the text input always to be smaller than the end value and vice versa.