### PR TITLE
Plotly pane UI tests: plot rendered

### DIFF
--- a/panel/tests/ui/pane/test_plotly.py
+++ b/panel/tests/ui/pane/test_plotly.py
@@ -1,0 +1,99 @@
+import time
+
+import pytest
+
+try:
+    import plotly
+    import plotly.graph_objs as go
+    import plotly.io as pio
+    pio.templates.default = None
+except Exception:
+    plotly = None
+plotly_available = pytest.mark.skipif(plotly is None, reason="requires plotly")
+
+import numpy as np
+
+from panel.io.server import serve
+from panel.pane import Plotly
+
+try:
+    from playwright.sync_api import expect
+except ImportError:
+    pytestmark = pytest.mark.skip('playwright not available')
+
+pytestmark = pytest.mark.ui
+
+
+@pytest.fixture
+def plotly_2d_plot():
+    trace = go.Scatter(x=[0, 1], y=[2, 3], uid='Test')
+    plot_2d = Plotly({'data': [trace], 'layout': {'width': 350}})
+    return plot_2d
+
+
+@pytest.fixture
+def plotly_3d_plot():
+    xx = np.linspace(-3.5, 3.5, 100)
+    yy = np.linspace(-3.5, 3.5, 100)
+    x, y = np.meshgrid(xx, yy)
+    z = np.exp(-(x - 1) ** 2 - y ** 2) - (x ** 3 + y ** 4 - x / 5) * np.exp(-(x ** 2 + y ** 2))
+
+    surface = go.Surface(z=z)
+    title = 'Plotly 3D Plot'
+    layout = go.Layout(
+        title=title,
+        autosize=False,
+        width=500,
+        height=500,
+        margin=dict(t=50, b=50, r=50, l=50)
+    )
+    fig = dict(data=[surface], layout=layout)
+    plot_3d = Plotly(fig)
+
+    return plot_3d, title
+
+
+@plotly_available
+def test_plotly_2d_plot(page, port, plotly_2d_plot):
+    serve(plotly_2d_plot, port=port, threaded=True, show=False)
+    time.sleep(0.2)
+    page.goto(f"http://localhost:{port}")
+
+    # main pane
+    plotly_plot = page.locator('.js-plotly-plot .plot-container.plotly')
+    expect(plotly_plot).to_have_count(1)
+
+    # x y axes
+    xaxis = page.locator('g.xaxislayer-above')
+    yaxis = page.locator('g.yaxislayer-above')
+    expect(xaxis).to_have_count(1)
+    expect(yaxis).to_have_count(1)
+
+    # mode bar
+    modebar = page.locator('.modebar-container')
+    expect(modebar).to_have_count(1)
+
+    hover = page.locator('.hoverlayer')
+    expect(hover).to_have_count(1)
+
+
+@plotly_available
+def test_plotly_3d_plot(page, port, plotly_3d_plot):
+    plot_3d, title = plotly_3d_plot
+    serve(plot_3d, port=port, threaded=True, show=False)
+    time.sleep(0.2)
+    page.goto(f"http://localhost:{port}")
+
+    # main pane
+    plotly_plot = page.locator('.js-plotly-plot .plot-container.plotly')
+    expect(plotly_plot).to_have_count(1)
+    expect(plotly_plot).to_contain_text(title, use_inner_text=True)
+
+    plot_title = page.locator('.g-gtitle')
+    expect(plot_title).to_have_count(1)
+
+    color_bar = page.locator('.colorbar')
+    expect(color_bar).to_have_count(1)
+
+    modebar = page.locator('.modebar-container')
+    expect(modebar).to_have_count(1)

--- a/panel/tests/ui/pane/test_plotly.py
+++ b/panel/tests/ui/pane/test_plotly.py
@@ -110,9 +110,10 @@ def _test_plotly_click_data(page, port, plotly_3d_plot):
     time.sleep(0.2)
     page.goto(f"http://localhost:{port}")
 
-    plot = page.locator('.js-plotly-plot')
-    plot.click()
+    plot = page.locator('.js-plotly-plot .plot-container.plotly .gl-container #scene')
     plot_bbox = plot.bounding_box()
+
+    # TODO: clicking on plot updates data in Python
     print('plot_bbox', plot_bbox)
     for i in range(0, plot_bbox['width'], 20):
         for j in range(0, plot_bbox['height'], 20):

--- a/panel/tests/ui/pane/test_plotly.py
+++ b/panel/tests/ui/pane/test_plotly.py
@@ -48,7 +48,7 @@ def plotly_3d_plot():
         margin=dict(t=50, b=50, r=50, l=50)
     )
     fig = dict(data=[surface], layout=layout)
-    plot_3d = Plotly(fig)
+    plot_3d = Plotly(fig, width=500, height=500)
 
     return plot_3d, title
 
@@ -92,8 +92,30 @@ def test_plotly_3d_plot(page, port, plotly_3d_plot):
     plot_title = page.locator('.g-gtitle')
     expect(plot_title).to_have_count(1)
 
+    # actual plot
+    plot = page.locator('.js-plotly-plot .plot-container.plotly .gl-container #scene')
+    expect(plot).to_have_count(1)
+
     color_bar = page.locator('.colorbar')
     expect(color_bar).to_have_count(1)
 
     modebar = page.locator('.modebar-container')
     expect(modebar).to_have_count(1)
+
+
+@plotly_available
+def _test_plotly_click_data(page, port, plotly_3d_plot):
+    plot_3d, title = plotly_3d_plot
+    serve(plot_3d, port=port, threaded=True, show=False)
+    time.sleep(0.2)
+    page.goto(f"http://localhost:{port}")
+
+    plot = page.locator('.js-plotly-plot')
+    plot.click()
+    plot_bbox = plot.bounding_box()
+    print('plot_bbox', plot_bbox)
+    for i in range(0, plot_bbox['width'], 20):
+        for j in range(0, plot_bbox['height'], 20):
+            page.mouse.click(plot_bbox['x'] + i, plot_bbox['y'] + j)
+            page.wait_for_timeout(500)
+            print(i, j, plot_3d.click_data)


### PR DESCRIPTION
Test if plot is rendered when creating a `panel.pane.Plotly` object. 

We also want to test if the data in Python reflects the actions from the UI. For example, to check if `click_data` is updated when clicking on a plot. In order to do so, at least we'll need to know if the position we click contains some data or not. I found the `locator.bounding_box()` and `page.mouse.click()` quite helpful but haven't been able to do what I want. At the moment, clicking on an arbitrary pixel within a plot's bounding box always returns None. 