### PR TITLE
Run example notebook tests in parallel

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -133,6 +133,7 @@ _tests = [
     'ipython >=7.0',
     'holoviews',
     'flaky',
+    'pytest-xdist',
 ]
 
 _ui = [

--- a/tox.ini
+++ b/tox.ini
@@ -32,7 +32,7 @@ commands = pytest panel --cov=./panel --cov-report=xml --cov-config=.uicoverager
 [_examples]
 description = Test that default examples run
 deps = .[recommended, tests]
-commands = pytest --nbval-lax examples/user_guide examples/reference examples/gallery --ignore-glob="*VTK.ipynb" --ignore-glob="*VTKVolume.ipynb" --ignore-glob="*IDOM.ipynb" --ignore-glob="*VTKInteractive.ipynb" --ignore-glob="*Components.ipynb" --ignore-glob="*Vega.ipynb" --ignore-glob="*DeckGL.ipynb" --ignore-glob="*dynamic_tabs.ipynb" --ignore-glob="*deck_gl_global_power_plants.ipynb" --ignore-glob="*Terminal.ipynb" --ignore-glob="*GraphViz.ipynb" --ignore-glob="*NetworkX.ipynb"
+commands = pytest -n auto --nbval-lax examples/user_guide examples/reference examples/gallery --ignore-glob="*VTK.ipynb" --ignore-glob="*VTKVolume.ipynb" --ignore-glob="*IDOM.ipynb" --ignore-glob="*VTKInteractive.ipynb" --ignore-glob="*Components.ipynb" --ignore-glob="*Vega.ipynb" --ignore-glob="*DeckGL.ipynb" --ignore-glob="*dynamic_tabs.ipynb" --ignore-glob="*deck_gl_global_power_plants.ipynb" --ignore-glob="*Terminal.ipynb" --ignore-glob="*GraphViz.ipynb" --ignore-glob="*NetworkX.ipynb"
 [_all_recommended]
 description = Run all recommended tests
 deps = .[recommended, tests]

--- a/tox.ini
+++ b/tox.ini
@@ -32,7 +32,7 @@ commands = pytest panel --cov=./panel --cov-report=xml --cov-config=.uicoverager
 [_examples]
 description = Test that default examples run
 deps = .[recommended, tests]
-commands = pytest -n auto --nbval-lax examples/user_guide examples/reference examples/gallery --ignore-glob="*VTK.ipynb" --ignore-glob="*VTKVolume.ipynb" --ignore-glob="*IDOM.ipynb" --ignore-glob="*VTKInteractive.ipynb" --ignore-glob="*Components.ipynb" --ignore-glob="*Vega.ipynb" --ignore-glob="*DeckGL.ipynb" --ignore-glob="*dynamic_tabs.ipynb" --ignore-glob="*deck_gl_global_power_plants.ipynb" --ignore-glob="*Terminal.ipynb" --ignore-glob="*GraphViz.ipynb" --ignore-glob="*NetworkX.ipynb"
+commands = pytest -n auto --dist loadscope --nbval-lax examples/user_guide examples/reference examples/gallery --ignore-glob="*VTK.ipynb" --ignore-glob="*VTKVolume.ipynb" --ignore-glob="*IDOM.ipynb" --ignore-glob="*VTKInteractive.ipynb" --ignore-glob="*Components.ipynb" --ignore-glob="*Vega.ipynb" --ignore-glob="*DeckGL.ipynb" --ignore-glob="*dynamic_tabs.ipynb" --ignore-glob="*deck_gl_global_power_plants.ipynb" --ignore-glob="*Terminal.ipynb" --ignore-glob="*GraphViz.ipynb" --ignore-glob="*NetworkX.ipynb"
 [_all_recommended]
 description = Run all recommended tests
 deps = .[recommended, tests]


### PR DESCRIPTION
Uses pytest-xdist to run example tests in parallel. On my M1 mac this results in a 4x speedup but since GH Action runners have only two cores the best we can hope for is a 2x speedup.