### PR TITLE
Check for jupyter_client before patching event_loop on Windows

### DIFF
--- a/panel/io/server.py
+++ b/panel/io/server.py
@@ -540,7 +540,8 @@ if (
     sys.version_info[:3] >= (3, 8, 0) and
     tornado.version_info >= (6, 1) and
     type(asyncio.get_event_loop_policy()) is asyncio.WindowsSelectorEventLoopPolicy and
-    'jupyter_server' not in sys.modules
+    'jupyter_server' not in sys.modules and
+    'jupyter_client' not in sys.modules
 ):
     asyncio.set_event_loop_policy(asyncio.WindowsProactorEventLoopPolicy())
 

--- a/panel/io/server.py
+++ b/panel/io/server.py
@@ -540,8 +540,9 @@ if (
     sys.version_info[:3] >= (3, 8, 0) and
     tornado.version_info >= (6, 1) and
     type(asyncio.get_event_loop_policy()) is asyncio.WindowsSelectorEventLoopPolicy and
-    'jupyter_server' not in sys.modules and
-    'jupyter_client' not in sys.modules
+    (('jupyter_server' not in sys.modules and
+      'jupyter_client' not in sys.modules) or
+     'pytest' in sys.modules)
 ):
     asyncio.set_event_loop_policy(asyncio.WindowsProactorEventLoopPolicy())
 


### PR DESCRIPTION
Fixes #3627 related to importing panel in the IPython startup folder.