### PR TITLE
Support datetime bounds 2

### DIFF
--- a/panel/tests/widgets/test_input.py
+++ b/panel/tests/widgets/test_input.py
@@ -61,7 +61,7 @@ def test_date_picker(document, comm):
 def test_datetime_picker(document, comm):
     datetime_picker = DatetimePicker(
         name='DatetimePicker', value=datetime(2018, 9, 2, 1, 5),
-        start=datetime(2018, 9, 1), end=datetime(2018, 9, 10)
+        start=date(2018, 9, 1), end=datetime(2018, 9, 10)
     )
 
     widget = datetime_picker.get_root(document, comm=comm)
@@ -98,7 +98,7 @@ def test_datetime_picker(document, comm):
 def test_datetime_range_picker(document, comm):
     datetime_range_picker = DatetimeRangePicker(
         name='DatetimeRangePicker', value=(datetime(2018, 9, 2, 1, 5), datetime(2018, 9, 2, 1, 6)),
-        start=datetime(2018, 9, 1), end=datetime(2018, 9, 10)
+        start=date(2018, 9, 1), end=datetime(2018, 9, 10)
     )
 
     widget = datetime_range_picker.get_root(document, comm=comm)

--- a/panel/widgets/input.py
+++ b/panel/widgets/input.py
@@ -323,9 +323,19 @@ class _DatetimePickerBase(Widget):
         super().__init__(**params)
         self._update_value_bounds()
 
+    @staticmethod
+    def _convert_to_datetime(v):
+        if isinstance(v, datetime):
+            return v
+        elif isinstance(v, date):
+            return datetime(v.year, v.month, v.day)
+
     @param.depends('start', 'end', watch=True)
     def _update_value_bounds(self):
-        self.param.value.bounds = (self.start, self.end)
+        self.param.value.bounds = (
+            self._convert_to_datetime(self.start),
+            self._convert_to_datetime(self.end)
+        )
         self.param.value._validate(self.value)
 
     def _process_property_change(self, msg):
@@ -338,6 +348,10 @@ class _DatetimePickerBase(Widget):
         msg = super()._process_param_change(msg)
         if 'value' in msg:
             msg['value'] = self._deserialize_value(msg['value'])
+        if 'min_date' in msg:
+            msg['min_date'] = self._convert_to_datetime(msg['min_date'])
+        if 'max_date' in msg:
+            msg['max_date'] = self._convert_to_datetime(msg['max_date'])
         return msg
 
 

--- a/panel/widgets/input.py
+++ b/panel/widgets/input.py
@@ -299,17 +299,13 @@ class _DatetimePickerBase(Widget):
       Enable editing of the seconds in the widget.""")
 
     end = param.Date(default=None, doc="""
-      Inclusive upper bound of the allowed date selection. Note that while
-      the parameter accepts datetimes the time portion of the range
-      is ignored.""")
+      Inclusive upper bound of the allowed date selection.""")
 
     military_time = param.Boolean(default=True, doc="""
       Whether to display time in 24 hour format.""")
 
     start = param.Date(default=None, doc="""
-      Inclusive lower bound of the allowed date selection. Note that while
-      the parameter accepts datetimes the time portion of the range
-      is ignored.""")
+      Inclusive lower bound of the allowed date selection.""")
 
     _source_transforms: ClassVar[Mapping[str, str | None]] = {
         'value': None, 'start': None, 'end': None, 'mode': None
@@ -369,7 +365,6 @@ class DatetimePicker(_DatetimePickerBase):
     def _serialize_value(self, value):
         if isinstance(value, str) and value:
             value = datetime.strptime(value, r'%Y-%m-%d %H:%M:%S')
-
 
         return value
 


### PR DESCRIPTION
I was not completely finished with the original PR #3788 before it got merged.

My original idea was to _only_ support datetime objects for `start`/`end`, but after a night's sleep, I think it is too aggressive. This adds support back for date objects too.

---

The reason why I convert the `min_date`/`max_date` in `_process_param_change` is that if a datestr (and not datetimestr) is passed to `flatpickr` in the bokeh model with the `maxDateHasTime`/`minDateHasTime` set to True, it has some weird behavior. This is shown here where the `end`/`max_date` is a date-object. [StackOverflow issue](https://stackoverflow.com/questions/65369608/unable-to-set-minhour-to-00-in-flatpicker-for-maxdate) about the problem. 

https://user-images.githubusercontent.com/19758978/187371557-ae83f8c3-3ad6-4e18-af51-cfae326d697a.mp4


