### PR TITLE
Convert terminal bold with HTML bold

### DIFF
--- a/panel/io/server.py
+++ b/panel/io/server.py
@@ -516,11 +516,12 @@ def modify_document(self, doc: 'Document'):
             else:
                 doc._modules.remove(module)
             bokeh.application.handlers.code_runner.handle_exception = handle_exception
-            tb = html.escape(traceback.format_exc())
+            tb = html.escape(traceback.format_exc()).replace('\033[1m', '<b>').replace('\033[0m', '</b>')
 
             # Serve error
+            e_msg = str(e).replace('\033[1m', '<b>').replace('\033[0m', '</b>')
             HTML(
-                f'<b>{type(e).__name__}</b>: {e}</br><pre style="overflow-y: scroll">{tb}</pre>',
+                f'<b>{type(e).__name__}</b>: {e_msg}</br><pre style="overflow-y: scroll">{tb}</pre>',
                 css_classes=['alert', 'alert-danger'], sizing_mode='stretch_width'
             ).servable()
 


### PR DESCRIPTION
This converts terminal bold with HTML bold. This is related to the work in holoviz/lumen#312.

![image](https://user-images.githubusercontent.com/19758978/188421757-2dce7223-2386-4082-b7c6-1dc8378a9f51.png)
