### PR TITLE
Fix prefix handling for admin page

### DIFF
--- a/panel/command/serve.py
+++ b/panel/command/serve.py
@@ -301,13 +301,6 @@ class Serve(_BkServe):
                         state._on_load(None)
                     _cleanup_doc(doc)
 
-        prefix = args.prefix
-        if prefix is None:
-            prefix = ""
-        prefix = prefix.strip("/")
-        if prefix:
-            prefix = "/" + prefix
-
         config.profiler = args.profiler
         if args.admin:
             from ..io.admin import admin_panel
@@ -322,7 +315,6 @@ class Serve(_BkServe):
             for p in per_app_patterns:
                 route = '/admin' + p[0]
                 context = {"application_context": app_ctx}
-                route = prefix + route
                 app_patterns.append((route, p[1], context))
 
             websocket_path = None


### PR DESCRIPTION
The `extra_patterns` argument to the bokeh server is automatically prefixed correctly so we do not have to prefix it manually.  

Fixes https://github.com/holoviz/panel/issues/3793