### PR TITLE
Tabulator: ignore case when sorting strings

### DIFF
--- a/panel/tests/ui/widgets/test_tabulator.py
+++ b/panel/tests/ui/widgets/test_tabulator.py
@@ -3109,6 +3109,7 @@ def test_tabulator_sort_algorithm(page, port):
     wait_until(page, lambda: len(values) == 2)
     assert values[1] == (target_col, target_index, target_val)
 
+
 def test_tabulator_sort_algorithm_no_show_index(page, port):
     df = pd.DataFrame({
         'vals': [
@@ -3180,3 +3181,32 @@ def test_tabulator_sort_algorithm_no_show_index(page, port):
 
     wait_until(page, lambda: len(values) == 2)
     assert values[1] == (target_col, target_index, target_val)
+
+
+@pytest.mark.parametrize(
+    ('col', 'vals'),
+    (
+        ('string', [np.nan, '', 'B', 'a', '', np.nan]),
+        ('number', [1.0, 1.0, 0.0, 0.0]),
+        ('boolean', [True, True, False, False]),
+    ),
+)
+def test_tabulator_sort_algorithm_by_type(page, port, col, vals):
+    df = pd.DataFrame({
+        col: vals,
+    })
+
+    widget = Tabulator(df, sorters=[{'field': col, 'dir': 'asc'}])
+
+    serve(widget, port=port, threaded=True, show=False)
+
+    time.sleep(0.2)
+
+    page.goto(f"http://localhost:{port}")
+
+    client_index = [int(i) for i in tabulator_column_values(page, 'index')]
+
+    wait_until(
+        page,
+        lambda: client_index == list(widget.current_view.index)
+    )

--- a/panel/widgets/tables.py
+++ b/panel/widgets/tables.py
@@ -311,7 +311,7 @@ class BaseTable(ReactiveData, Widget):
         def tabulator_sorter(col):
             # Tabulator JS defines its own sorting algorithm:
             # - strings's case isn't taken into account
-            if col.dtype.kind not in 'SUO': 
+            if col.dtype.kind not in 'SUO':
                 return col
             try:
                 return col.str.lower()

--- a/panel/widgets/tables.py
+++ b/panel/widgets/tables.py
@@ -311,7 +311,7 @@ class BaseTable(ReactiveData, Widget):
         def tabulator_sorter(col):
             # Tabulator JS defines its own sorting algorithm:
             # - strings's case isn't taken into account
-            if col.dtype != 'O':
+            if col.dtype.kind not in 'SUO': 
                 return col
             try:
                 return col.str.lower()

--- a/panel/widgets/tables.py
+++ b/panel/widgets/tables.py
@@ -308,7 +308,18 @@ class BaseTable(ReactiveData, Widget):
         else:
             rename = False
 
-        df_sorted = df.sort_values(fields, ascending=ascending, kind='mergesort')
+        def tabulator_sorter(col):
+            # Tabulator JS defines its own sorting algorithm:
+            # - strings's case isn't taken into account
+            if col.dtype != 'O':
+                return col
+            try:
+                return col.str.lower()
+            except Exception:
+                return col
+
+        df_sorted = df.sort_values(fields, ascending=ascending, kind='mergesort',
+                                  key=tabulator_sorter)
 
         # Revert temporary changes to DataFrames
         if rename:


### PR DESCRIPTION
Tabulator JS implements its own sorting algorithms which for the string type ignores the case, while `df.sort_values` does and is used internally to mirror what happens on the client side. This PR adds a key function to `sort_values` so that strings are temporally lower-cased to sort them.