### PR TITLE
Simplify implementation of state.curdoc

### DIFF
--- a/panel/io/jupyter_server_extension.py
+++ b/panel/io/jupyter_server_extension.py
@@ -69,7 +69,7 @@ from ..util import edit_readonly
 from .resources import (
     DIST_DIR, ERROR_TEMPLATE, Resources, _env,
 )
-from .server import _add_task_factory, server_html_page_for_session
+from .server import server_html_page_for_session
 from .state import set_curdoc, state
 
 logger = logging.getLogger(__name__)
@@ -218,10 +218,6 @@ class PanelExecutor(WSHandler):
             app.initialize_document(doc)
 
         loop = tornado.ioloop.IOLoop.current()
-        try:
-            _add_task_factory(loop.asyncio_loop) # type: ignore
-        except Exception:
-            pass
         session = ServerSession(self.session_id, doc, io_loop=loop, token=self.token)
         session_context._set_session(session)
         return session

--- a/panel/io/pyodide.py
+++ b/panel/io/pyodide.py
@@ -290,7 +290,7 @@ def init_doc() -> None:
     doc = Document()
     set_curdoc(doc)
     doc._session_context = lambda: MockSessionContext(document=doc)
-    state._curdoc = doc
+    state.curdoc = doc
 
 async def show(obj: Any, target: str) -> None:
     """

--- a/panel/io/state.py
+++ b/panel/io/state.py
@@ -61,8 +61,10 @@ if TYPE_CHECKING:
 @contextmanager
 def set_curdoc(doc: Document):
     token = state._curdoc.set(doc)
-    yield
-    state._curdoc.reset(token)
+    try:
+        yield
+    finally:
+        state._curdoc.reset(token)
 
 def curdoc_locked() -> Document:
     doc = _curdoc()

--- a/panel/tests/conftest.py
+++ b/panel/tests/conftest.py
@@ -310,10 +310,8 @@ def server_cleanup():
         state.kill_all_servers()
         state._indicators.clear()
         state._locations.clear()
-        state._curdoc = None
         state.cache.clear()
         state._scheduled.clear()
-        state._curdoc_.clear()
         if state._thread_pool is not None:
             state._thread_pool.shutdown(wait=False)
             state._thread_pool = None


### PR DESCRIPTION
So I hadn't realized `contextvars.ContextVar` was available in Python 3.7 when I wrote the state.curdoc management code. This implementation is **much** cleaner.