### PR TITLE
Bump jsoneditor package

### DIFF
--- a/panel/models/json_editor.py
+++ b/panel/models/json_editor.py
@@ -40,15 +40,15 @@ class JSONEditor(HTMLBox):
     templates = List(Any)
 
     __javascript_raw__ = [
-        'https://cdn.jsdelivr.net/npm/jsoneditor@9.1.9/dist/jsoneditor.min.js'
+        'https://cdn.jsdelivr.net/npm/jsoneditor@9.5.6/dist/jsoneditor.min.js'
     ]
 
     __css_raw__ = [
-        'https://cdn.jsdelivr.net/npm/jsoneditor@9.1.9/dist/jsoneditor.min.css'
+        'https://cdn.jsdelivr.net/npm/jsoneditor@9.5.6/dist/jsoneditor.min.css'
     ]
 
     __resources__ = [
-        'https://cdn.jsdelivr.net/npm/jsoneditor@9.1.9/dist/img/jsoneditor-icons.svg'
+        'https://cdn.jsdelivr.net/npm/jsoneditor@9.5.6/dist/img/jsoneditor-icons.svg'
     ]
 
     @classproperty
@@ -65,7 +65,7 @@ class JSONEditor(HTMLBox):
 
     __js_require__ = {
         'paths': {
-            'jsoneditor': "//cdn.jsdelivr.net/npm/jsoneditor@9.1.9/dist/jsoneditor.min"
+            'jsoneditor': "//cdn.jsdelivr.net/npm/jsoneditor@9.5.6/dist/jsoneditor.min"
         },
         'exports': {'jsoneditor': 'JSONEditor'},
         'shim': {


### PR DESCRIPTION
This PR aims to update the jsoneditor package.

The current jsoneditor version (9.1.9) has the following [CVE-2021-3822](https://nvd.nist.gov/vuln/detail/CVE-2021-3822#vulnCurrentDescriptionTitle). Here is a [POC](https://huntr.dev/bounties/1e3ed803-b7ed-42f1-a4ea-c4c75da9de73/). It was fixed in the 9.5.6 version.

@philippjfr