### PR TITLE
Tabulator: custom datetime sorter

### DIFF
--- a/panel/tests/ui/widgets/test_tabulator.py
+++ b/panel/tests/ui/widgets/test_tabulator.py
@@ -3208,6 +3208,7 @@ def test_tabulator_sort_algorithm_no_show_index(page, port):
         ('string', [np.nan, '', 'B', 'a', '', np.nan]),
         ('number', [1.0, 1.0, 0.0, 0.0]),
         ('boolean', [True, True, False, False]),
+        ('datetime', [dt.datetime(2019, 1, 1, 1), np.nan, dt.datetime(2019, 12, 1, 1), dt.datetime(2019, 12, 1, 1), np.nan, dt.datetime(2019, 6, 1, 1), np.nan])
     ),
 )
 def test_tabulator_sort_algorithm_by_type(page, port, col, vals):

--- a/panel/tests/widgets/test_tables.py
+++ b/panel/tests/widgets/test_tables.py
@@ -252,7 +252,7 @@ def test_tabulator_multi_index(document, comm):
         {'field': 'A'},
         {'field': 'C'},
         {'field': 'B'},
-        {'field': 'D'}
+        {'field': 'D', 'sorter': 'timestamp'}
     ]
 
     assert np.array_equal(model.source.data['A'], np.array([0., 1., 2., 3., 4.]))
@@ -269,7 +269,7 @@ def test_tabulator_multi_index_remote_pagination(document, comm):
         {'field': 'A'},
         {'field': 'C'},
         {'field': 'B'},
-        {'field': 'D'}
+        {'field': 'D', 'sorter': 'timestamp'}
     ]
 
     assert np.array_equal(model.source.data['A'], np.array([0., 1., 2.]))
@@ -386,7 +386,7 @@ def test_tabulator_config_defaults(document, comm):
         {'field': 'A'},
         {'field': 'B'},
         {'field': 'C'},
-        {'field': 'D'}
+        {'field': 'D', 'sorter': 'timestamp'}
     ]
     assert model.configuration['selectable'] == True
 
@@ -401,7 +401,7 @@ def test_tabulator_config_widths_percent(document, comm):
         {'field': 'A', 'width': '22%'},
         {'field': 'B'},
         {'field': 'C'},
-        {'field': 'D'}
+        {'field': 'D', 'sorter': 'timestamp'}
     ]
     assert model.columns[2].width == 100
 
@@ -416,7 +416,7 @@ def test_tabulator_header_filters_config_boolean(document, comm):
         {'field': 'A', 'headerFilter': True},
         {'field': 'B', 'headerFilter': True},
         {'field': 'C', 'headerFilter': True},
-        {'field': 'D', 'headerFilter': True}
+        {'field': 'D', 'headerFilter': True, 'sorter': 'timestamp'}
     ]
 
 def test_tabulator_header_filters_column_config_list(document, comm):
@@ -430,7 +430,7 @@ def test_tabulator_header_filters_column_config_list(document, comm):
         {'field': 'A'},
         {'field': 'B'},
         {'field': 'C', 'headerFilter': 'list', 'headerFilterParams': {'valuesLookup': True}},
-        {'field': 'D'}
+        {'field': 'D', 'sorter': 'timestamp'}
     ]
     assert model.configuration['selectable'] == True
 
@@ -449,7 +449,7 @@ def test_tabulator_header_filters_column_config_select_autocomplete_backwards_co
         {'field': 'A'},
         {'field': 'B'},
         {'field': 'C', 'headerFilter': 'list', 'headerFilterParams': {'valuesLookup': True}},
-        {'field': 'D', 'headerFilter': 'list', 'headerFilterParams': {'valuesLookup': True}},
+        {'field': 'D', 'headerFilter': 'list', 'headerFilterParams': {'valuesLookup': True}, 'sorter': 'timestamp'},
     ]
     assert model.configuration['selectable'] == True
 
@@ -472,7 +472,7 @@ def test_tabulator_header_filters_column_config_dict(document, comm):
             'headerFilterFunc': '!=',
             'headerFilterPlaceholder': 'Not equal'
         },
-        {'field': 'D'}
+        {'field': 'D', 'sorter': 'timestamp'}
     ]
     assert model.configuration['selectable'] == True
 
@@ -582,7 +582,7 @@ def test_tabulator_groups(document, comm):
         {'title': 'Other',
          'columns': [
             {'field': 'C'},
-            {'field': 'D'}
+            {'field': 'D', 'sorter': 'timestamp'}
         ]}
     ]
 
@@ -615,7 +615,7 @@ def test_tabulator_frozen_cols(document, comm):
         {'field': 'A'},
         {'field': 'B'},
         {'field': 'C'},
-        {'field': 'D'}
+        {'field': 'D', 'sorter': 'timestamp'}
     ]
 
 

--- a/panel/widgets/tables.py
+++ b/panel/widgets/tables.py
@@ -1675,6 +1675,9 @@ class Tabulator(BaseTable):
                 formatter = dict(formatter)
                 col_dict['formatter'] = formatter.pop('type')
                 col_dict['formatterParams'] = formatter
+            dtype = getattr(self.value, column.field).dtype
+            if dtype.kind == 'M':
+                col_dict['sorter'] = 'timestamp'
             editor = self.editors.get(column.field)
             if column.field in self.editors and editor is None:
                 col_dict['editable'] = False

--- a/panel/widgets/tables.py
+++ b/panel/widgets/tables.py
@@ -1675,7 +1675,14 @@ class Tabulator(BaseTable):
                 formatter = dict(formatter)
                 col_dict['formatter'] = formatter.pop('type')
                 col_dict['formatterParams'] = formatter
-            dtype = getattr(self.value, column.field).dtype
+            col_name = self._renamed_cols[column.field]
+            if column.field in self.indexes:
+                if len(self.indexes) == 1:
+                    dtype = self.value.index.dtype
+                else:
+                    dtype = self.value.index.get_level_values(self.indexes.index(column.field)).dtype
+            else:
+                dtype = self.value.dtypes[col_name]
             if dtype.kind == 'M':
                 col_dict['sorter'] = 'timestamp'
             editor = self.editors.get(column.field)


### PR DESCRIPTION
As already pointed out before Tabulator JS defines its own sorters, which can behave differently from `df.sort_values`. The result of these two sorters was different when applied to datetime columns that contain NaN values (this causes issues with the index of edit/click events returned when the sorters aren't aligned on their result...). Datetime cols are actually serialized as UNIX timestamps by Bokeh, and NaN values to `-9223372036854776` (see https://github.com/bokeh/bokeh/issues/10448). Tabulator JS was using its *number* built-in sorter to sorter this kind of column in the end, the NaN values being first when sorting in an ascending way. The default behavior of `df.sort_values` is put NaNs at the end (see https://pandas.pydata.org/docs/reference/api/pandas.Series.sort_values.html#pandas.Series.sort_values). This is where the two sorting algorithms were diverging. Pandas' `df.sort_values` has the `na_position` parameter that can be set to `'first'`, except that it applies to all the columns which I didn't want to do that now, as it affects all the dtypes. Instead this PR adds a custom sorter for datetime objects which always puts the NaNs at the end as `df.sort_values`.