### PR TITLE
Ensure ReactiveHTML inline callbacks on looped nodes return correct node

### DIFF
--- a/panel/models/reactive_html.ts
+++ b/panel/models/reactive_html.ts
@@ -409,7 +409,17 @@ export class ReactiveHTMLView extends PanelHTMLBoxView {
         } else {
           definition = `
           const ${method} = (event) => {
-            view._send_event("${elname}", "${cb}", event)
+            let elname = "${elname}"
+            if (RegExp("\{\{.*loop\.index.*\}\}").test(elname)) {
+              const pattern = RegExp(elname.replace(/\{\{(.+?)\}\}/g, String.fromCharCode(92) + "d+"))
+              for (const p of event.path) {
+                if (pattern.exec(p.id) != null) {
+                  elname = p.id.split("-").slice(null, -1).join("-")
+                  break
+                }
+              }
+            }
+            view._send_event(elname, "${cb}", event)
           }
           `
         }

--- a/panel/reactive.py
+++ b/panel/reactive.py
@@ -1673,8 +1673,12 @@ class ReactiveHTML(Reactive, metaclass=ReactiveHTMLMetaclass):
         event_type = event.data['type']
         star_cbs = self._event_callbacks.get('*', {})
         node_cbs = self._event_callbacks.get(event.node, {})
+
+        def match(node, pattern):
+            return re.findall(re.sub(r'\{\{.*loop.index.*\}\}', r'\\d+', pattern), node)
+
         inline_cbs = {attr: [getattr(self, p)] for node, attr, p in self._inline_callbacks
-                      if node == event.node}
+                      if node == event.node or match(event.node, node)}
         event_cbs = (
             node_cbs.get(event_type, []) + node_cbs.get('*', []) +
             star_cbs.get(event_type, []) + star_cbs.get('*', []) +


### PR DESCRIPTION
Ensures that in example like below the onclick event returns a DOMEvent with the `node` set to the runtime value (`list-item-0`) rather than the template value: `list-item-{{ loop.index0 }}`:

```
class Test(pn.reactive.ReactiveHTML):
    
    a = param.List()
    
    _template = """
    <div id="list">
    {% for item in a %}
      <div id="list-item-{{ loop.index0 }}" onclick=${_call}>${item}</div>
    {% endfor %}
    </div>"""
    
    def _call(self, event):
        print(event.node)
```
