### PR TITLE
django_url_configuration

### DIFF
--- a/panel/io/django.py
+++ b/panel/io/django.py
@@ -65,8 +65,11 @@ async def autoload_handle(self, body):
         else:
             server_url = None
 
+        absolute = server_url not in absolute_url
         resources = self.resources(server_url)
-        js = autoload_js_script(session.document, resources, session.token, element_id, app_path, absolute_url)
+        js = autoload_js_script(
+            session.document, resources, session.token, element_id, app_path, absolute_url, absolute=absolute
+        )
 
     headers = [
         (b"Access-Control-Allow-Headers", b"*"),

--- a/panel/io/server.py
+++ b/panel/io/server.py
@@ -196,8 +196,8 @@ def server_html_page_for_session(
     return html_page_for_render_items(bundle, {}, [render_item], title,
         template=template, template_variables=template_variables)
 
-def autoload_js_script(doc, resources, token, element_id, app_path, absolute_url):
-    resources = Resources.from_bokeh(resources)
+def autoload_js_script(doc, resources, token, element_id, app_path, absolute_url, absolute=False):
+    resources = Resources.from_bokeh(resources, absolute=absolute)
     bundle = bundle_resources(doc.roots, resources)
 
     render_items = [RenderItem(token=token, elementid=element_id, use_for_title=False)]


### PR DESCRIPTION
handle django configuration where domain name is not included in url passed to server document.

Passing in a URL without the domain (i.e.):

```python

script = server_document(request.get_full_path())
```

instead of:

```python
script = server_document(request.build_absolute_uri())
```

Is required when serving behind a reverse web proxy that terminates HTTPS requests. Otherwise you will get a `Mixed Content type` error and `autoload.js` will not be served.
