### PR TITLE
Fix issues editing a cell when client-side filtering applied

### DIFF
--- a/panel/tests/ui/widgets/test_tabulator.py
+++ b/panel/tests/ui/widgets/test_tabulator.py
@@ -2762,7 +2762,7 @@ def test_tabulator_edit_event_and_header_filters_same_column(page, port):
     editable_cell.fill("Z")
     editable_cell.press('Enter')
 
-    wait_until(lambda: len(values) == 2, page)
+    wait_until(lambda: len(values) == 3, page)
     assert values[-1] == ('values', len(df) - 2, 'B', 'Z')
     assert df.at['idx2', 'values'] == 'Z'
     # current_view should show Y and Z, there's no more B
@@ -2812,7 +2812,7 @@ def test_tabulator_edit_event_and_header_filters_same_column_remote(page, port):
     assert values[0] == ('values', len(df) - 1, 'B', 'X')
     assert df.at['idx5', 'values'] == 'X'
     # The current view should show the edited value
-    assert len(widget.current_view) == 2
+    assert len(widget.current_view) == 4
 
     # In the same column, edit X to Y
     cell = page.locator('text="X"')
@@ -2824,7 +2824,7 @@ def test_tabulator_edit_event_and_header_filters_same_column_remote(page, port):
     wait_until(lambda: len(values) == 2, page)
     assert values[-1] == ('values', len(df) - 1, 'X', 'Y')
     assert df.at['idx5', 'values'] == 'Y'
-    assert len(widget.current_view) == 2
+    assert len(widget.current_view) == 4
 
     # Edit the last B value found in that column, from B to Z
     cell = page.locator('text="B"')
@@ -2833,11 +2833,11 @@ def test_tabulator_edit_event_and_header_filters_same_column_remote(page, port):
     editable_cell.fill("Z")
     editable_cell.press('Enter')
 
-    wait_until(lambda: len(values) == 2, page)
+    wait_until(lambda: len(values) == 3, page)
     assert values[-1] == ('values', len(df) - 2, 'B', 'Z')
     assert df.at['idx4', 'values'] == 'Z'
     # current_view should show Y and Z, there's no more B
-    assert len(widget.current_view) == 2
+    assert len(widget.current_view) == 4
 
 
 @pytest.mark.parametrize('sorter', ['sorter', 'no_sorter'])

--- a/panel/widgets/tables.py
+++ b/panel/widgets/tables.py
@@ -1148,8 +1148,6 @@ class Tabulator(BaseTable):
         super()._cleanup(root)
 
     def _process_event(self, event):
-        if not self._on_click_callbacks and not self._on_edit_callbacks:
-            return
         event_col = self._renamed_cols.get(event.column, event.column)
         if self.pagination in ['remote']:
             nrows = self.page_size

--- a/panel/widgets/tables.py
+++ b/panel/widgets/tables.py
@@ -1257,7 +1257,6 @@ class Tabulator(BaseTable):
         }
         return super()._process_data(data)
 
-
     def _get_data(self):
         if self.pagination != 'remote' or self.value is None:
             return super()._get_data()
@@ -1436,6 +1435,8 @@ class Tabulator(BaseTable):
         self._update_selectable()
 
     def _update_cds(self, *events):
+        if any(event.name == 'filters' for event in events):
+            self._edited_indexes = []
         page_events = ('page', 'page_size', 'sorters', 'filters')
         if self._updating:
             return


### PR DESCRIPTION
When editing a cell and the new value is filtered by the currently set client-side filters we need to keep track of the edited rows to ensure they are not filtered out until the filters are updated and the client-side filtering is recomputed.

Fixes https://github.com/holoviz/panel/issues/3831