### PR TITLE
Ensure pn.state.execute dispatches immediately if possible

### DIFF
--- a/panel/io/state.py
+++ b/panel/io/state.py
@@ -517,7 +517,7 @@ class _state(param.Parameterized):
         doc = self.curdoc
         if param.parameterized.iscoroutinefunction(cb):
             param.parameterized.async_executor(callback)
-        elif doc and doc.session_context and (schedule == True or (schedule == 'auto' and self._unblocked(doc))):
+        elif doc and doc.session_context and (schedule == True or (schedule == 'auto' and not self._unblocked(doc))):
             doc.add_next_tick_callback(callback)
         else:
             callback()

--- a/panel/widgets/tables.py
+++ b/panel/widgets/tables.py
@@ -1177,13 +1177,13 @@ class Tabulator(BaseTable):
             event.old = self._old_value[event_col].iloc[event.row]
         if event.event_name == 'table-edit':
             for cb in self._on_edit_callbacks:
-                state.execute(partial(cb, event))
+                state.execute(partial(cb, event), schedule=False)
             self._update_style()
         else:
             for cb in self._on_click_callbacks.get(None, []):
-                state.execute(partial(cb, event))
+                state.execute(partial(cb, event), schedule=False)
             for cb in self._on_click_callbacks.get(event_col, []):
-                state.execute(partial(cb, event))
+                state.execute(partial(cb, event), schedule=False)
 
     def _get_theme(self, theme, resources=None):
         from ..io.resources import RESOURCE_MODE


### PR DESCRIPTION
The logic was wrong and pn.state.execute was scheduling stuff on the event loop when we knew the document to be unblocked.

Fixes https://github.com/holoviz/panel/issues/3855