### PR TITLE
Don't skip filtering when the column name is undefined

### DIFF
--- a/panel/tests/ui/widgets/test_tabulator.py
+++ b/panel/tests/ui/widgets/test_tabulator.py
@@ -2831,6 +2831,8 @@ def test_tabulator_edit_event_and_header_filters_same_column_pagination(page, po
     header.fill('B')
     header.press('Enter')
 
+    wait_until(lambda: widget.current_view.equals(df[df['values'] == 'B']))
+
     cell = page.locator('text="B"').first
     cell.click()
     editable_cell = page.locator('input[type="text"]')

--- a/panel/widgets/tables.py
+++ b/panel/widgets/tables.py
@@ -353,7 +353,7 @@ class BaseTable(ReactiveData, Widget):
         """
         filters = []
         for col_name, filt in self._filters:
-            if col_name not in df.columns:
+            if col_name is not None and col_name not in df.columns:
                 continue
             if isinstance(filt, (FunctionType, MethodType)):
                 df = filt(df)


### PR DESCRIPTION
Python filtering from a bound function was broken in Tabulator, surprisingly perhaps no test was able to catch that. This is now fixed and tested.