### PR TITLE
Manage our own CDN

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -62,14 +62,24 @@ jobs:
           echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_API_TOKEN }}" > $HOME/.npmrc
           npm whoami
           npm -v
-      - name: dev deploy
+      - name: Set AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+      - name: Deploy to cdn.holoviz.org
+        run: |
+          pip install awscli
+          python scripts/cdn_upload.py
+      - name: conda dev deploy
         if: (github.event_name == 'push' && (contains(steps.vars.outputs.tag, 'a') || contains(steps.vars.outputs.tag, 'b') || contains(steps.vars.outputs.tag, 'rc')))
         run: |
           doit package_upload --token=${{ secrets.CONDA_UPLOAD_TOKEN }} --label=dev
           python setup.py develop
           cd ./panel
           npm publish --tag dev
-      - name: main deploy
+      - name: conda main deploy
         if: (github.event_name == 'push' && !(contains(steps.vars.outputs.tag, 'a') || contains(steps.vars.outputs.tag, 'b') || contains(steps.vars.outputs.tag, 'rc')))
         run: |
           doit package_upload --token=${{ secrets.CONDA_UPLOAD_TOKEN }} --label=dev --label=main

--- a/panel/compiler.py
+++ b/panel/compiler.py
@@ -142,7 +142,7 @@ def write_bundled_tarball(name, tarball, bundle_dir, module=False):
     tar_obj.close()
 
 
-def bundle_resources():
+def bundle_resources(verbose=False):
     from .config import panel_extension
     from .reactive import ReactiveHTML
     from .template.base import BasicTemplate
@@ -164,6 +164,8 @@ def bundle_resources():
     for name, model in models:
         if not name.startswith('panel.'):
             continue
+        if verbose:
+            print(f'Collecting {name} resources')
         prev_jsfiles = getattr(model, '__javascript_raw__', None)
         prev_jsbundle = getattr(model, '__tarball__', None)
         prev_cls = model
@@ -198,12 +200,16 @@ def bundle_resources():
 
     # Bundle Model dependencies
     for name, jsfiles in js_files.items():
+        if verbose:
+            print(f'Bundling {name} model JS resources')
         if isinstance(jsfiles, dict):
             write_bundled_tarball(name, jsfiles, bundle_dir)
         else:
             write_bundled_files(name, jsfiles, bundle_dir)
 
     for name, cssfiles in css_files.items():
+        if verbose:
+            print(f'Bundling {name} model CSS resources')
         write_bundled_files(name, cssfiles, bundle_dir)
 
     for name, res_files in resource_files.items():
@@ -211,6 +217,8 @@ def bundle_resources():
 
     # Bundle Template resources
     for name, template in param.concrete_descendents(BasicTemplate).items():
+        if verbose:
+            print(f'Bundling {name} resources')
         # Bundle Template._resources
         if template._resources.get('bundle', True):
             write_bundled_files(name, list(template._resources.get('css', {}).values()), bundle_dir, 'css')
@@ -266,6 +274,8 @@ def bundle_resources():
 
     # Bundle Theme classes
     for name, theme in param.concrete_descendents(Theme).items():
+        if verbose:
+            print(f'Bundling {name} theme resources')
         if theme.base_css:
             theme_bundle_dir = bundle_dir / theme.param.base_css.owner.__name__.lower()
             theme_bundle_dir.mkdir(parents=True, exist_ok=True)

--- a/panel/config.py
+++ b/panel/config.py
@@ -192,7 +192,7 @@ class _config(_base_config):
         default='WARNING', objects=['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'],
         doc="Log level of Panel loggers")
 
-    _npm_cdn = param.Selector(default='https://unpkg.com',
+    _npm_cdn = param.Selector(default='https://cdn.jsdelivr.net/npm',
         objects=['https://unpkg.com', 'https://cdn.jsdelivr.net/npm'],  doc="""
         The CDN to load NPM packages from if resources are served from
         CDN. Allows switching between https://unpkg.com and

--- a/panel/io/convert.py
+++ b/panel/io/convert.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import ast
 import dataclasses
-import json
 import os
 import pathlib
 import pkgutil
@@ -30,7 +29,8 @@ from .. import __version__, config
 from ..util import base_version, escape
 from .document import _cleanup_doc
 from .resources import (
-    DIST_DIR, INDEX_TEMPLATE, Resources, _env as _pn_env, bundle_resources,
+    DIST_DIR, INDEX_TEMPLATE, JS_VERSION, Resources, _env as _pn_env,
+    bundle_resources,
 )
 from .state import set_curdoc, state
 
@@ -41,7 +41,6 @@ WEB_WORKER_TEMPLATE = _pn_env.get_template('pyodide_worker.js')
 PANEL_ROOT = pathlib.Path(__file__).parent.parent
 BOKEH_VERSION = '2.4.3'
 PY_VERSION = base_version(__version__)
-JS_VERSION = json.loads((PANEL_ROOT / 'package.json').read_text())['version']
 PANEL_CDN_WHL = f'{config.npm_cdn}/@holoviz/panel@{JS_VERSION}/dist/wheels/panel-{PY_VERSION}-py3-none-any.whl'
 BOKEH_CDN_WHL = f'{config.npm_cdn}/@holoviz/panel@{JS_VERSION}/dist/wheels/bokeh-{BOKEH_VERSION}-py3-none-any.whl'
 PYODIDE_URL = 'https://cdn.jsdelivr.net/pyodide/v0.21.3/full/pyodide.js'


### PR DESCRIPTION
unpkg proved slow and unreliable and jsdelivr, while better, is still not great. So we now have our own CDN hosted on S3 and sped up by CloudFront: https://cdn.holoviz.org