### PR TITLE
Add ability to defer load until after page is rendered

### DIFF
--- a/doc/user_guide/Overview.md
+++ b/doc/user_guide/Overview.md
@@ -148,6 +148,7 @@ The `pn.config` object allows setting various configuration variables, the confi
 > - `js_files`: External JS files to load. Dictionary should map from exported name to the URL of the JS file.
 > - `loading_spinner`: The style of the global loading indicator, e.g. 'arcs', 'bars', 'dots', 'petals'.
 > - `loading_color`: The color of the global loading indicator as a hex color, e.g. #6a6a6a
+> - `defer_load`: Whether reactive function evaluation is deferred until the page is rendered.
 > - `nthreads`: If set will start a `ThreadPoolExecutor` to dispatch events to for concurrent execution on separate cores. By default no thread pool is launched, while setting nthreads=0 launches `min(32, os.cpu_count() + 4)` threads.
 > - `raw_css`: List of raw CSS strings to add to load.
 > - `reuse_sessions`: Whether to reuse a session for the initial request to speed up the initial page render. Note that if the initial page differs between sessions, e.g. because it uses query parameters to modify the rendered content, then this option will result in the wrong content being rendered. See the [Performance and Debugging guide](Performance_and_Debugging.rst#Reuse-sessions) for more information.

--- a/examples/user_guide/Session_State_and_Callbacks.ipynb
+++ b/examples/user_guide/Session_State_and_Callbacks.ipynb
@@ -197,6 +197,25 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "Alternatively we may also use the `defer_load` option to wait to evaluate a function until the page is loaded. This will render a placeholder and display the global `config.loading_spinner`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def render_on_load():\n",
+    "    return pn.widgets.Select(options=['A', 'B', 'C'])\n",
+    "\n",
+    "pn.Row(pn.panel(render_on_load, defer_load=True))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "#### pn.state.on_session_destroyed\n",
     "\n",
     "In many cases it is useful to define on_session_destroyed callbacks to perform any custom cleanup that is required, e.g,  dispose  a database engine, or when a user is logged out. These callbacks can be registered with `pn.state.on_session_destroyed(callback)`"

--- a/panel/config.py
+++ b/panel/config.py
@@ -112,6 +112,9 @@ class _config(_base_config):
     autoreload = param.Boolean(default=False, doc="""
         Whether to autoreload server when script changes.""")
 
+    defer_load = param.Boolean(default=False, doc="""
+        Whether to defer load of rendered functions.""")
+
     load_entry_points = param.Boolean(default=True, doc="""
         Load entry points from external packages.""")
 

--- a/panel/io/server.py
+++ b/panel/io/server.py
@@ -275,7 +275,8 @@ class Application(BkApplication):
         super().initialize_document(doc)
         if doc in state._templates and doc not in state._templates[doc]._documents:
             template = state._templates[doc]
-            template.server_doc(title=template.title, location=True, doc=doc)
+            with set_curdoc(doc):
+                template.server_doc(title=template.title, location=True, doc=doc)
 
 bokeh.command.util.Application = Application # type: ignore
 

--- a/panel/param.py
+++ b/panel/param.py
@@ -820,7 +820,7 @@ class ParamMethod(ReplacementPane):
     def _replace_pane(self, *args, force=False):
         deferred = self.defer_load and not state.loaded
         if not self._inner_layout.loading:
-            self._inner_layout.loading = self.loading_indicator or deferred
+            self._inner_layout.loading = bool(self.loading_indicator or deferred)
         self._evaled |= force or not (self.lazy or deferred)
         if not self._evaled:
             return

--- a/panel/param.py
+++ b/panel/param.py
@@ -775,7 +775,8 @@ class ParamMethod(ReplacementPane):
         self._link_object_params()
         if object is not None:
             self._validate_object()
-            self._replace_pane()
+            if not self.defer_load:
+                self._replace_pane()
 
     @param.depends('object', watch=True)
     def _validate_object(self):

--- a/panel/param.py
+++ b/panel/param.py
@@ -23,6 +23,7 @@ import param
 from packaging.version import Version
 from param.parameterized import classlist, discard_events
 
+from .config import config
 from .io import init_doc, state
 from .layout import (
     Column, Panel, Row, Spacer, Tabs,
@@ -752,6 +753,10 @@ class ParamMethod(ReplacementPane):
     return any object which itself can be rendered as a Pane.
     """
 
+    defer_load = param.Boolean(default=None, doc="""
+        Whether to defer load until after the page is rendered.
+        Can be set as parameter or by setting panel.config.defer_load.""")
+
     lazy = param.Boolean(default=False, doc="""
         Whether to lazily evaluate the contents of the object
         only when it is required for rendering.""")
@@ -760,8 +765,10 @@ class ParamMethod(ReplacementPane):
         Whether to show loading indicator while pane is updating.""")
 
     def __init__(self, object=None, **params):
+        if self.param.defer_load.default is None and config.defer_load:
+            params['defer_load'] = config.defer_load
         super().__init__(object, **params)
-        self._evaled = not self.lazy
+        self._evaled = not (self.lazy or self.defer_load)
         self._link_object_params()
         if object is not None:
             self._validate_object()
@@ -807,20 +814,22 @@ class ParamMethod(ReplacementPane):
             self._inner_layout.loading = False
 
     def _replace_pane(self, *args, force=False):
-        self._evaled = bool(self._models) or force or not self.lazy
-        if self._evaled:
-            self._inner_layout.loading = self.loading_indicator
-            try:
-                if self.object is None:
-                    new_object = Spacer()
-                else:
-                    new_object = self.eval(self.object)
-                if inspect.isawaitable(new_object):
-                    param.parameterized.async_executor(partial(self._eval_async, new_object))
-                    return
-                self._update_inner(new_object)
-            finally:
-                self._inner_layout.loading = False
+        deferred = self.defer_load and not state.loaded
+        self._inner_layout.loading = self.loading_indicator or deferred
+        self._evaled |= force or not self.lazy and not deferred
+        if not self._evaled:
+            return
+        try:
+            if self.object is None:
+                new_object = Spacer()
+            else:
+                new_object = self.eval(self.object)
+            if inspect.isawaitable(new_object):
+                param.parameterized.async_executor(partial(self._eval_async, new_object))
+                return
+            self._update_inner(new_object)
+        finally:
+            self._inner_layout.loading = False
 
     def _update_pane(self, *events):
         callbacks = []
@@ -881,7 +890,10 @@ class ParamMethod(ReplacementPane):
         parent: Optional[Model] = None, comm: Optional[Comm] = None
     ) -> Model:
         if not self._evaled:
-            self._replace_pane(force=True)
+            if self.defer_load and not state.loaded:
+                state.onload(partial(self._replace_pane, force=True))
+            else:
+                self._replace_pane(force=True)
         return super()._get_model(doc, root, parent, comm)
 
     #----------------------------------------------------------------
@@ -905,10 +917,13 @@ class ParamFunction(ParamMethod):
 
     priority: ClassVar[float | bool | None] = 0.6
 
+    # Whether applies requires full set of keywords
+    _applies_kw: ClassVar[bool] = True
+
     def _link_object_params(self):
         deps = getattr(self.object, '_dinfo', {})
         dep_params = list(deps.get('dependencies', [])) + list(deps.get('kw', {}).values())
-        if not dep_params and not self.lazy:
+        if not dep_params and not self.lazy and not self.defer_load:
             fn = getattr(self.object, '__bound_function__', self.object)
             fn_name = getattr(fn, '__name__', repr(self.object))
             self.param.warning(
@@ -939,9 +954,11 @@ class ParamFunction(ParamMethod):
     #----------------------------------------------------------------
 
     @classmethod
-    def applies(cls, obj: Any) -> float | bool | None:
+    def applies(cls, obj: Any, **kwargs) -> float | bool | None:
         if isinstance(obj, types.FunctionType):
             if hasattr(obj, '_dinfo'):
+                return True
+            if 'defer_load' in kwargs or (cls.param.defer_load.default is None and config.defer_load):
                 return True
             return None
         return False

--- a/panel/param.py
+++ b/panel/param.py
@@ -776,7 +776,6 @@ class ParamMethod(ReplacementPane):
         if object is not None:
             self._validate_object()
             self._replace_pane()
-        self._inner_layout.loading = self.defer_load and not state.loaded
 
     @param.depends('object', watch=True)
     def _validate_object(self):

--- a/panel/tests/conftest.py
+++ b/panel/tests/conftest.py
@@ -312,6 +312,7 @@ def server_cleanup():
         state._locations.clear()
         state._templates.clear()
         state._views.clear()
+        state._loaded.clear()
         state.cache.clear()
         state._scheduled.clear()
         if state._thread_pool is not None:

--- a/panel/tests/ui/test_param.py
+++ b/panel/tests/ui/test_param.py
@@ -1,0 +1,29 @@
+import time
+
+import pytest
+
+pytestmark = pytest.mark.ui
+
+from panel.io.server import serve
+from panel.pane import panel
+
+
+def test_param_defer_load(page, port):
+    def defer_load():
+        time.sleep(0.5)
+        return 'I render after load!'
+
+    component = panel(defer_load, defer_load=True)
+
+    serve(component, port=port, threaded=True, show=False)
+
+    time.sleep(0.2)
+
+    page.goto(f"http://localhost:{port}")
+
+    assert page.locator(".bk.pn-loading")
+    assert page.locator('.bk.markdown').count() == 0
+
+    time.sleep(0.5)
+
+    assert page.text_content('.bk.markdown') == 'I render after load!'


### PR DESCRIPTION
Makes it possible to defer the loading of components until after the page is rendered. Can be used explicitly with `ParamMethod` and `ParamFunction` (or via `panel()`) OR by setting `config.defer_load`.  

```python
import time
start = time.time()

import pandas as pd
import panel as pn
import hvplot.pandas

pn.extension(
    sizing_mode='stretch_width', template='fast', defer_load=True,
    loading_spinner='arc', loading_color='blue'
)

def duration():
    return time.time()-start

def big_load():
    time.sleep(2)
    return pd.DataFrame({"x": [1,2,3], "y": [1,2,3]})

def big_plot():
    time.sleep(2)
    return pd.DataFrame({"x": [1,2,3], "y": [1,2,3]}).hvplot()

pn.Column(big_load, big_plot, duration).servable()
```

![defer_load](https://user-images.githubusercontent.com/1550771/192138670-3019bf59-cccc-462c-b451-50206aa0cdc5.gif)

- [x] Fixes #3881 
- [x] Add docs