### PR TITLE
Add option to specify name of extension for JSONEditor

### DIFF
--- a/panel/util.py
+++ b/panel/util.py
@@ -371,15 +371,15 @@ def edit_readonly(parameterized: param.Parameterized) -> Iterator:
             p.constant = constant
 
 
-def lazy_load(module, model, notebook=False, root=None):
+def lazy_load(module, model, notebook=False, root=None, ext=None):
     if module in sys.modules:
         model_cls = getattr(sys.modules[module], model)
         if model not in Model.model_class_reverse_map:
             Model.model_class_reverse_map[model] = model_cls
         return model_cls
 
+    ext = ext or module.split('.')[-1]
     if notebook:
-        ext = module.split('.')[-1]
         param.main.param.warning(
             f'{model} was not imported on instantiation and may not '
             'render in a notebook. Restart the notebook kernel and '
@@ -388,7 +388,6 @@ def lazy_load(module, model, notebook=False, root=None):
         )
     elif root is not None:
         from .io.state import state
-        ext = module.split('.')[-1]
         if root.ref['id'] in state._views:
             param.main.param.warning(
                 f'{model} was not imported on instantiation may not '

--- a/panel/widgets/misc.py
+++ b/panel/widgets/misc.py
@@ -297,7 +297,7 @@ class JSONEditor(Widget):
     def _get_model(self, doc, root=None, parent=None, comm=None):
         if self._widget_type is None:
             self._widget_type = lazy_load(
-                'panel.models.json_editor', 'JSONEditor', isinstance(comm, JupyterComm)
+                'panel.models.json_editor', 'JSONEditor', isinstance(comm, JupyterComm), ext="jsoneditor"
             )
         model = super()._get_model(doc, root, parent, comm)
         return model


### PR DESCRIPTION
I noticed to use JSONEditor `pn.extension(`jsoneditor`) is needed, which is not what is specified in the warning. 

This PR can be closed if there is a more elegant way to do it and still be backward compatible. Thinking about it, maybe it is just to rename `panel.models.json_editor` to `panel.models.jsoneditor`.  

![ Screenshot 2022-09-26 22 23 44](https://user-images.githubusercontent.com/19758978/192373452-561ebe22-68c5-4fa4-bef4-19713fb5c24f.png)

![ Screenshot 2022-09-26 22 24 12](https://user-images.githubusercontent.com/19758978/192373461-e6befd34-882e-47c9-a3fc-03e1eb8da6eb.png)

![ Screenshot 2022-09-26 22 24 31](https://user-images.githubusercontent.com/19758978/192373464-0b5802ff-6868-4590-a6f1-9813ea35bf3a.png)

