### PR TITLE
Move find_imports function

### DIFF
--- a/panel/io/mime_render.py
+++ b/panel/io/mime_render.py
@@ -17,14 +17,86 @@ import ast
 import base64
 import copy
 import io
+import pathlib
+import pkgutil
 import sys
 import traceback
 
 from contextlib import redirect_stderr, redirect_stdout
 from html import escape
-from typing import Any, Dict
+from textwrap import dedent
+from typing import Any, Dict, List
 
 import markdown
+
+#---------------------------------------------------------------------
+# Import API
+#---------------------------------------------------------------------
+
+def _stdlibs():
+    env_dir = str(pathlib.Path(sys.executable).parent.parent)
+    modules = list(sys.builtin_module_names)
+    for m in pkgutil.iter_modules():
+        mpath = getattr(m.module_finder, 'path', '')
+        if mpath.startswith(env_dir) and not 'site-packages' in mpath:
+            modules.append(m.name)
+    return modules
+
+_STDLIBS = _stdlibs()
+_PACKAGE_MAP = {
+    'sklearn': 'scikit-learn',
+    'hvplot': ['holoviews>=1.15.1a1', 'hvplot'],
+    'holoviews': ['holoviews>=1.15.1a1']
+}
+
+def find_imports(code: str) -> List[str]:
+    """
+    Finds the imports in a string of code.
+
+    Parameters
+    ----------
+    code : str
+       the Python code to run.
+
+    Returns
+    -------
+    ``List[str]``
+        A list of module names that are imported in the code.
+
+    Examples
+    --------
+    >>> code = "import numpy as np; import scipy.stats"
+    >>> find_imports(code)
+    ['numpy', 'scipy']
+    """
+    # handle mis-indented input from multi-line strings
+    code = dedent(code)
+
+    mod = ast.parse(code)
+    imports = set()
+    for node in ast.walk(mod):
+        if isinstance(node, ast.Import):
+            for name in node.names:
+                node_name = name.name
+                imports.add(node_name.split(".")[0])
+        elif isinstance(node, ast.ImportFrom):
+            module_name = node.module
+            if module_name is None:
+                continue
+            imports.add(module_name.split(".")[0])
+
+    packages = []
+    for pkg in sorted(imports):
+        pkg = _PACKAGE_MAP.get(pkg, pkg)
+        if pkg in _STDLIBS:
+            continue
+        elif isinstance(pkg, list):
+            packages.extend(pkg)
+        else:
+            packages.append(pkg)
+    if 'bokeh.sampledata' in code and 'pandas' not in packages:
+        packages.append('pandas')
+    return packages
 
 #---------------------------------------------------------------------
 # Execution API


### PR DESCRIPTION
The panel.io.convert module is not importable in pyodide due to the `concurrent.futures` import so we make the `find_imports` functionality available in `panel.io.mime_render`.