### PR TITLE
fix bug in link callback when object._models is empty

### DIFF
--- a/panel/links.py
+++ b/panel/links.py
@@ -384,7 +384,7 @@ class CallbackGenerator(object):
                     model_spec = None
                 model = obj.handles[handle_spec]
         elif isinstance(obj, Viewable):
-            model, _ = obj._models[root_model.ref['id']]
+            model, _ = obj._models.get(root_model.ref['id'], (None, None))
         elif isinstance(obj, BkModel):
             model = obj
         elif isinstance(obj, param.Parameterized):


### PR DESCRIPTION
I've been getting this error with the latest dev releases of panel:

```
2022-09-27 22:51:39,410 - tornado.application - ERROR - Exception in callback functools.partial(<bound method IOLoop._discard_future_result of <tornado.platform.asyncio.AsyncIOMainLoop object at 0x1fe23e170>>, <Task finished name='Task-259' coro=<ServerSession.with_document_locked() done, defined at /Users/rditlsc9/miniconda/envs/tethys4-ce/lib/python3.10/site-packages/bokeh/server/session.py:78> exception=KeyError('1003')>)
Traceback (most recent call last):
  File "/Users/rditlsc9/miniconda/envs/tethys4-ce/lib/python3.10/site-packages/tornado/ioloop.py", line 741, in _run_callback
    ret = callback()
  File "/Users/rditlsc9/miniconda/envs/tethys4-ce/lib/python3.10/site-packages/tornado/ioloop.py", line 765, in _discard_future_result
    future.result()
  File "/Users/rditlsc9/miniconda/envs/tethys4-ce/lib/python3.10/site-packages/bokeh/server/session.py", line 95, in _needs_document_lock_wrapper
    result = func(self, *args, **kwargs)
  File "/Users/rditlsc9/miniconda/envs/tethys4-ce/lib/python3.10/site-packages/bokeh/server/session.py", line 229, in with_document_locked
    return func(*args, **kwargs)
  File "/Users/rditlsc9/miniconda/envs/tethys4-ce/lib/python3.10/site-packages/bokeh/document/callbacks.py", line 450, in wrapper
    return invoke_with_curdoc(doc, invoke)
  File "/Users/rditlsc9/miniconda/envs/tethys4-ce/lib/python3.10/site-packages/bokeh/document/callbacks.py", line 408, in invoke_with_curdoc
    return f()
  File "/Users/rditlsc9/miniconda/envs/tethys4-ce/lib/python3.10/site-packages/bokeh/document/callbacks.py", line 449, in invoke
    return f(*args, **kwargs)
  File "/Users/rditlsc9/miniconda/envs/tethys4-ce/lib/python3.10/site-packages/bokeh/document/callbacks.py", line 179, in remove_then_invoke
    return callback()
  File "/Users/rditlsc9/miniconda/envs/tethys4-ce/lib/python3.10/site-packages/panel/pane/base.py", line 230, in _update_object
    state._views[ref][0]._preprocess(root)
  File "/Users/rditlsc9/miniconda/envs/tethys4-ce/lib/python3.10/site-packages/panel/viewable.py", line 496, in _preprocess
    hook(self, root)
  File "/Users/rditlsc9/miniconda/envs/tethys4-ce/lib/python3.10/site-packages/panel/links.py", line 247, in _process_callbacks
    cb(root_model, link, src, tgt, arg_overrides=overrides)
  File "/Users/rditlsc9/miniconda/envs/tethys4-ce/lib/python3.10/site-packages/panel/links.py", line 342, in __init__
    self._init_callback(root_model, link, source, src_spec, target, tgt_spec, code)
  File "/Users/rditlsc9/miniconda/envs/tethys4-ce/lib/python3.10/site-packages/panel/links.py", line 429, in _init_callback
    arg_model = self._resolve_model(root_model, v, None)
  File "/Users/rditlsc9/miniconda/envs/tethys4-ce/lib/python3.10/site-packages/panel/links.py", line 387, in _resolve_model
    model, _ = obj._models[root_model.ref['id']]
KeyError: '1003'
```

I've haven't isolated a simple case to reproduce yet, but it seems to be when I'm hiding/re-rendering panes after clicking a button. 

This minor change fixes the issue.