### PR TITLE
Pin PyScript version

### DIFF
--- a/panel/io/convert.py
+++ b/panel/io/convert.py
@@ -41,8 +41,8 @@ PY_VERSION = base_version(__version__)
 PANEL_CDN_WHL = f'{CDN_DIST}wheels/panel-{PY_VERSION}-py3-none-any.whl'
 BOKEH_CDN_WHL = f'{CDN_DIST}wheels/bokeh-{BOKEH_VERSION}-py3-none-any.whl'
 PYODIDE_URL = 'https://cdn.jsdelivr.net/pyodide/v0.21.3/full/pyodide.js'
-PYSCRIPT_CSS = '<link rel="stylesheet" href="https://pyscript.net/unstable/pyscript.css" />'
-PYSCRIPT_JS = '<script defer src="https://pyscript.net/unstable/pyscript.js"></script>'
+PYSCRIPT_CSS = '<link rel="stylesheet" href="https://pyscript.net/releases/2022.09.1/pyscript.css" />'
+PYSCRIPT_JS = '<script defer src="https://pyscript.net/releases/2022.09.1/pyscript.js"></script>'
 PYODIDE_JS = f'<script src="{PYODIDE_URL}"></script>'
 
 ICON_DIR = DIST_DIR / 'images'

--- a/panel/tests/ui/io/test_convert.py
+++ b/panel/tests/ui/io/test_convert.py
@@ -46,13 +46,13 @@ def test_pyodide_test_convert_button_app(page, runtime):
     expect(page.locator('body')).to_have_class('bk pn-loading arcs')
     expect(page.locator('body')).to_have_class("", timeout=20000)
 
-    assert page.text_content(".bk.markdown") == '0'
+    assert page.text_content(".bk.bk-clearfix") == '0'
 
     page.click('.bk.bk-btn')
 
     time.sleep(0.1)
 
-    assert page.text_content(".bk.markdown") == '1'
+    assert page.text_content(".bk.bk-clearfix") == '1'
 
 
 @pytest.mark.parametrize('runtime', ['pyodide', 'pyscript'])

--- a/panel/tests/ui/io/test_convert.py
+++ b/panel/tests/ui/io/test_convert.py
@@ -44,7 +44,7 @@ def test_pyodide_test_convert_button_app(page, runtime):
     page.goto(f"file://{str(app_path)[:-3]}.html")
 
     expect(page.locator('body')).to_have_class('bk pn-loading arcs')
-    expect(page.locator('body')).to_have_class("", timeout=20000)
+    expect(page.locator('body')).to_have_class("", timeout=30000)
 
     assert page.text_content(".bk.bk-clearfix") == '0'
 
@@ -64,7 +64,7 @@ def test_pyodide_test_convert_slider_app(page, runtime):
     page.goto(f"file://{str(app_path)[:-3]}.html")
 
     expect(page.locator('body')).to_have_class('bk pn-loading arcs')
-    expect(page.locator('body')).to_have_class("", timeout=20000)
+    expect(page.locator('body')).to_have_class("", timeout=30000)
 
     assert page.text_content(".bk.bk-clearfix") == '0.0'
 

--- a/panel/tests/ui/io/test_convert.py
+++ b/panel/tests/ui/io/test_convert.py
@@ -29,7 +29,7 @@ def write_app(app):
     """
     Writes app to temporary file and returns path.
     """
-    nf = tempfile.NamedTemporaryFile(mode='w', suffix='.py')
+    nf = tempfile.NamedTemporaryFile(mode='w', suffix='.py', delete=False)
     nf.write(app)
     nf.flush()
     return nf

--- a/panel/tests/ui/io/test_convert.py
+++ b/panel/tests/ui/io/test_convert.py
@@ -36,9 +36,6 @@ def write_app(app):
 
 
 @pytest.mark.parametrize('runtime', ['pyodide', 'pyscript'])
-@pytest.mark.xfail(
-    reason='_link_docs mishandling setter id in 0.14.0rc2'
-)
 def test_pyodide_test_convert_button_app(page, runtime):
     nf = write_app(button_app)
     app_path = pathlib.Path(nf.name)


### PR DESCRIPTION
Now that 2022.09.01 is released we pin to it. There's some larger changes coming so we shouldn't pin to unstable or latest.