### PR TITLE
Ensure PWA can be built without index page

### DIFF
--- a/panel/dist/images/icon-vector.svg
+++ b/panel/dist/images/icon-vector.svg
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   width="512"
+   height="512"
+   viewBox="0 0 479.99998 480"
+   id="svg6730"
+   version="1.1">
+  <defs
+     id="defs6732" />
+  <metadata
+     id="metadata6735">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1"
+     transform="translate(-96.532079,-196.27443)">
+    <g
+       id="g5614"
+       transform="matrix(4.2434061,0,0,4.2391313,5947.9389,-4631.1062)">
+      <rect
+         y="1138.7665"
+         x="-1378.941"
+         height="113.23074"
+         width="113.11668"
+         id="rect4136-8-8-1"
+         style="opacity:1;fill:#00aa44;fill-opacity:1;stroke:none;stroke-width:4;stroke-miterlimit:1;stroke-dasharray:none" />
+      <g
+         id="g5603">
+        <g
+           id="g5591">
+          <rect
+             y="1165.5731"
+             x="-1361.4104"
+             height="8"
+             width="78.055412"
+             id="rect4327-3-71"
+             style="opacity:1;fill:#eeeeee;fill-opacity:1;stroke:none;stroke-width:4;stroke-miterlimit:1;stroke-dasharray:none" />
+          <circle
+             r="9"
+             cy="1169.5731"
+             cx="-1341.4192"
+             id="path4355-79-2"
+             style="opacity:1;fill:#eeeeee;fill-opacity:1;stroke:none;stroke-width:4;stroke-miterlimit:1;stroke-dasharray:none" />
+        </g>
+        <g
+           id="g5595">
+          <rect
+             y="1191.3817"
+             x="-1361.4104"
+             height="8"
+             width="78.055412"
+             id="rect4327-5-1-0"
+             style="opacity:1;fill:#eeeeee;fill-opacity:1;stroke:none;stroke-width:4;stroke-miterlimit:1;stroke-dasharray:none" />
+          <circle
+             r="9"
+             cy="1195.3817"
+             cx="-1305.4111"
+             id="path4355-7-3-7"
+             style="opacity:1;fill:#eeeeee;fill-opacity:1;stroke:none;stroke-width:4;stroke-miterlimit:1;stroke-dasharray:none" />
+        </g>
+        <g
+           id="g5599">
+          <rect
+             y="1217.1904"
+             x="-1361.4104"
+             height="8"
+             width="78.055412"
+             id="rect4327-54-6-2"
+             style="opacity:1;fill:#eeeeee;fill-opacity:1;stroke:none;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none" />
+          <circle
+             r="9"
+             cy="1221.1904"
+             cx="-1341.4274"
+             id="path4355-3-9-8"
+             style="opacity:1;fill:#eeeeee;fill-opacity:1;stroke:none;stroke-width:4;stroke-miterlimit:1;stroke-dasharray:none" />
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/panel/io/convert.py
+++ b/panel/io/convert.py
@@ -433,15 +433,12 @@ def convert_apps(
                 if result is not None:
                     name, filename = result
                     files[name] = filename
-    if not build_index or len(files) == 1:
-        return
-
-    # Write index
-    index = make_index(files, manifest=build_pwa, title=title)
-    with open(dest_path / 'index.html', 'w') as f:
-        f.write(index)
-    if verbose:
-        print('Successfully wrote index.html.')
+    if build_index and len(files) >= 1:
+        index = make_index(files, manifest=build_pwa, title=title)
+        with open(dest_path / 'index.html', 'w') as f:
+            f.write(index)
+        if verbose:
+            print('Successfully wrote index.html.')
 
     if not build_pwa:
         return


### PR DESCRIPTION
Previously enabling `--pwa` but no `--index` in `panel convert` would still skip writing the service worker and manifest.