### PR TITLE
Remove extra space from site_title

### DIFF
--- a/panel/template/bootstrap/bootstrap.html
+++ b/panel/template/bootstrap/bootstrap.html
@@ -55,7 +55,7 @@
     <div class="app-header">
       {% if app_logo %}<a class="navbar-brand app-logo" href="{{ site_url }}"><img src="{{ app_logo }}" class="app-logo"></a>{% endif %}
       {% if site_title %}<a class="title" href="{{ site_url }}" >&nbsp;{{ site_title }}</a>{% endif %}
-      {% if site_title and app_title%}<span class="title">&nbsp;-</span>{% endif %}
+      {% if site_title and app_title%}<span class="title">-</span>{% endif %}
       {% if app_title %}<a class="title" href="" >&nbsp;{{ app_title }}</a>{% endif %}
     </div>
     <div id="header-items">

--- a/panel/template/fast/grid/fast_grid_template.html
+++ b/panel/template/fast/grid/fast_grid_template.html
@@ -205,7 +205,7 @@
     <div class="app-header">
       {% if app_logo %}<a class="navbar-brand app-logo" href="{{ site_url }}"><img src="{{ app_logo }}" class="app-logo"></a>{% endif %}
       {% if site_title %}<a class="title" href="{{ site_url }}" >&nbsp;{{ site_title }}</a>{% endif %}
-      {% if site_title and app_title%}<span class="title">&nbsp;-</span>{% endif %}
+      {% if site_title and app_title%}<span class="title">-</span>{% endif %}
       {% if app_title %}<a class="title" href="" >{{ app_title }}</a>{% endif %}
     </div>
     <div id="header-items">

--- a/panel/template/golden/golden.html
+++ b/panel/template/golden/golden.html
@@ -43,8 +43,8 @@
     <div class="app-header">
       {% if app_logo %}<a href="{{ site_url }}"><img src="{{ app_logo }}" class="app-logo"></a>{% endif %}
       {% if site_title %}<a class="title" href="{{ site_url }}" >{{ site_title }}</a>{% endif %}
-      {% if site_title and app_title%}<span class="title">&nbsp;-&nbsp;</span>{% endif %}
-      {% if app_title %}<a class="title" href="" >{{ app_title }}</a>{% endif %}
+      {% if site_title and app_title%}<span class="title">-</span>{% endif %}
+      {% if app_title %}<a class="title" href="">{{ app_title }}</a>{% endif %}
     </div>
 	<section class="header-contents">
 	  {% for doc in docs %}

--- a/panel/template/material/material.html
+++ b/panel/template/material/material.html
@@ -61,7 +61,7 @@
         <span class="mdc-top-app-bar__title app-header">
           {% if app_logo %}<a href="{{ site_url }}"><img src="{{ app_logo }}" class="app-logo"></a>{% endif %}
           {% if site_title %}<a class="title" href="{{ site_url }}" >&nbsp;{{ site_title }}</a>{% endif %}
-          {% if site_title and app_title%}<span class="title">&nbsp;-</span>{% endif %}
+          {% if site_title and app_title%}<span class="title">-</span>{% endif %}
           {% if app_title %}<a class="title" href="" >&nbsp;{{ app_title }}</a>{% endif %}
         </span>
         <div id="header-items">

--- a/panel/template/react/react.html
+++ b/panel/template/react/react.html
@@ -55,7 +55,7 @@
     <div class="app-header">
       {% if app_logo %}<a class="navbar-brand app-logo" href="{{ site_url }}"><img src="{{ app_logo }}" class="app-logo"></a>{% endif %}
       {% if site_title %}<a class="title" href="{{ site_url }}" >&nbsp;{{ site_title }}</a>{% endif %}
-      {% if site_title and app_title%}<span class="title">&nbsp;-</span>{% endif %}
+      {% if site_title and app_title%}<span class="title">-</span>{% endif %}
       {% if app_title %}<a class="title" href="" >&nbsp;{{ app_title }}</a>{% endif %}
     </div>
     <div id="header-items">

--- a/panel/template/vanilla/vanilla.html
+++ b/panel/template/vanilla/vanilla.html
@@ -55,7 +55,7 @@
 	  <div class="app-header">
       {% if app_logo %}<a href="{{ site_url }}"><img src="{{ app_logo }}" class="app-logo"></a>{% endif %}
       {% if site_title %}<a class="title" href="{{ site_url }}" >&nbsp;{{ site_title }}</a>{% endif %}
-      {% if site_title and app_title%}<span class="title">&nbsp;-</span>{% endif %}
+      {% if site_title and app_title%}<span class="title">-</span>{% endif %}
       {% if app_title %}<a class="title" href="" >&nbsp;{{ app_title }}</a>{% endif %}
     </div>
     <div id="header-items">


### PR DESCRIPTION
Got annoyed by the extra space:

<img width="566" alt="Screen Shot 2022-10-04 at 17 34 41" src="https://user-images.githubusercontent.com/1550771/193862763-4b22bffa-7492-431c-ba58-c8be217841f9.png">

<img width="555" alt="Screen Shot 2022-10-04 at 17 34 58" src="https://user-images.githubusercontent.com/1550771/193862824-ff5216fa-4d76-4a97-9561-f6d1a81637f5.png">
