### PR TITLE
Improve support for requests in pyodide

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -153,7 +153,7 @@ else:
     bokeh_req = f'{CDN_DIST}wheels/bokeh-{BOKEH_VERSION}-py3-none-any.whl'
 
 nbsite_pyodide_conf = {
-    'requirements': [bokeh_req, panel_req, 'pandas', 'holoviews>=1.15.1']
+    'requirements': [bokeh_req, panel_req, 'pandas', 'pyodide-http', 'holoviews>=1.15.1']
 }
 
 templates_path = [

--- a/doc/user_guide/Running_in_Webassembly.md
+++ b/doc/user_guide/Running_in_Webassembly.md
@@ -30,7 +30,8 @@ The ``panel convert`` command has the following options:
       --index               Whether to create an index if multiple files are served.
       --pwa                 Whether to add files to allow serving the application as a Progressive Web App.
       --requirements        List of Python requirements to add to the converted file. By default it will automatically try to infer dependencies based on your imports and Panel will automatically be included.
-	  -- watch              Watches files for changes and rebuilds them when they are updated.
+      --watch               Watches files for changes and rebuilds them when they are updated.
+      --disable-http-patch  Disables patching of http requests using pyodide-http library.
 
 ### Example
 
@@ -130,6 +131,12 @@ Once generated, you can inspect the `site.webmanifest` file and modify it to you
 ```{note}
 If you decide to enable the `--pwa` ensure that you also provide a unique `--title`. Otherwise the browser caches storing your apps dependencies will end up overwriting each other.
 ```
+
+### Handling HTTP requests
+
+By default Panel 0.14.1 will install the [pyodide-http](https://github.com/koenvo/pyodide-http) library which patches `urllib3` and `requests` making it possible to use them within the pyodide process. To disable this behavior use the `--disable-http-patch` CLI option.
+
+Note that making HTTP requests when converting to the `pyodide` or `pyscript` target will block the main browser thread and result in a poor user experience. Therefore we strongly recommend converting to `pyodide-worker` if your app is making synchronous HTTP requests.
 
 ## Installing Panel in the browser
 

--- a/panel/command/convert.py
+++ b/panel/command/convert.py
@@ -56,6 +56,10 @@ class Convert(Subcommand):
             nargs   = '+',
             help    = "Explicit requirements to add to the converted file or a single requirements.txt file. By default requirements are inferred from the code."
         )),
+        ('--disable-http-patch', dict(
+            action  = 'store_false',
+            help    = "Whether to disable patching http requests using the pyodide-http library."
+        )),
         ('--watch', dict(
             action  = 'store_true',
             help    = "Watch the files"
@@ -95,7 +99,8 @@ class Convert(Subcommand):
                 convert_apps(
                     files, dest_path=args.out, runtime=runtime, requirements=requirements,
                     prerender=not args.skip_embed, build_index=index, build_pwa=args.pwa,
-                    title=args.title, max_workers=args.num_procs, verbose=True
+                    title=args.title, max_workers=args.num_procs,
+                    http_patch=not args.disable_http_patch, verbose=True
                 )
             except KeyboardInterrupt:
                 print("Aborted while building docs.")

--- a/panel/io/convert.py
+++ b/panel/io/convert.py
@@ -232,7 +232,7 @@ def script_to_html(
     else:
         panel_req = f'panel=={panel_version}'
         bokeh_req = f'bokeh=={BOKEH_VERSION}'
-    reqs = [bokeh_req, panel_req] + [
+    reqs = [bokeh_req, panel_req, 'pyodide-http'] + [
         req for req in requirements if req not in ('panel', 'bokeh')
     ]
 

--- a/panel/io/pyodide.py
+++ b/panel/io/pyodide.py
@@ -61,7 +61,7 @@ if 'pandas' in sys.modules and pyodide_http is None:
         return args, kwargs
 
     # Patch pandas.read_csv
-    _read_csv_original = pandas._read_csv
+    _read_csv_original = pandas.read_csv
     @functools.wraps(pandas.read_csv)
     def _read_csv(*args, **kwargs):
         args, kwargs = _read_file(*args, **kwargs)
@@ -69,7 +69,7 @@ if 'pandas' in sys.modules and pyodide_http is None:
     pandas.read_csv = _read_csv
 
     # Patch pandas.read_json
-    _read_json_original = pandas._read_json
+    _read_json_original = pandas.read_json
     @functools.wraps(pandas.read_json)
     def _read_json(*args, **kwargs):
         args, kwargs = _read_file(*args, **kwargs)

--- a/panel/pane/image.py
+++ b/panel/pane/image.py
@@ -81,10 +81,14 @@ class FileBase(DivPaneBase):
         if isurl(self.object, None):
             from ..io.state import state
             if state._is_pyodide:
-                from pyodide.http import pyfetch
-                async def replace_content():
-                    self.object = await (await pyfetch(self.object)).bytes()
-                asyncio.create_task(replace_content())
+                from ..io.pyodide import _IN_WORKER, fetch_binary
+                if _IN_WORKER:
+                    return fetch_binary(self.object).read()
+                else:
+                    from pyodide.http import pyfetch
+                    async def replace_content():
+                        self.object = await (await pyfetch(self.object)).bytes()
+                    asyncio.create_task(replace_content())
             else:
                 import requests
                 r = requests.request(url=self.object, method='GET')

--- a/panel/tests/ui/io/test_convert.py
+++ b/panel/tests/ui/io/test_convert.py
@@ -60,6 +60,24 @@ button.on_click(on_click)
 pn.Row(button, tabulator).servable();
 """
 
+csv_app = """
+import pandas as pd
+import panel as pn
+
+df = pd.read_csv('https://raw.githubusercontent.com/holoviz/panel/master/examples/assets/occupancy.csv')
+tabulator = pn.widgets.Tabulator(df)
+
+tabulator.servable()
+"""
+
+png_app = """
+import panel as pn
+
+png = pn.pane.PNG('https://upload.wikimedia.org/wikipedia/commons/4/47/PNG_transparency_demonstration_1.png', width=200)
+
+png.servable()
+"""
+
 def write_app(app):
     """
     Writes app to temporary file and returns path.
@@ -112,11 +130,13 @@ def launch_app():
             os.remove(f)
 
 
-@pytest.mark.parametrize('runtime', ['pyodide', 'pyscript', 'pyodide-worker'])
-def test_pyodide_test_convert_button_app(page, runtime, launch_app):
-    app_path = launch_app(button_app)
+def wait_for_app(launch_app, app, page, runtime, **kwargs):
+    app_path = launch_app(app)
 
-    convert_apps([app_path], app_path.parent, runtime=runtime, build_pwa=False, build_index=False, prerender=False, panel_version='local')
+    convert_apps(
+        [app_path], app_path.parent, runtime=runtime, build_pwa=False,
+        prerender=False, panel_version='local', **kwargs
+    )
 
     msgs = []
     page.on("console", lambda msg: msgs.append(msg))
@@ -125,7 +145,13 @@ def test_pyodide_test_convert_button_app(page, runtime, launch_app):
 
     cls = f'bk pn-loading {config.loading_spinner}'
     expect(page.locator('body')).to_have_class(cls)
-    expect(page.locator('body')).not_to_have_class(cls, timeout=60 * 1000)
+    expect(page.locator('body')).not_to_have_class(cls, timeout=90 * 1000)
+
+    return msgs
+
+@pytest.mark.parametrize('runtime', ['pyodide', 'pyscript', 'pyodide-worker'])
+def test_pyodide_test_convert_button_app(page, runtime, launch_app):
+    msgs = wait_for_app(launch_app, button_app, page, runtime)
 
     expect(page.locator(".bk.bk-clearfix")).to_have_text('0')
 
@@ -137,18 +163,7 @@ def test_pyodide_test_convert_button_app(page, runtime, launch_app):
 
 @pytest.mark.parametrize('runtime', ['pyodide', 'pyscript', 'pyodide-worker'])
 def test_pyodide_test_convert_slider_app(page, runtime, launch_app):
-    app_path = launch_app(slider_app)
-
-    convert_apps([app_path], app_path.parent, runtime=runtime, build_pwa=False, build_index=False, prerender=False, panel_version='local')
-
-    msgs = []
-    page.on("console", lambda msg: msgs.append(msg))
-
-    page.goto(f"http://localhost:8123/{app_path.name[:-3]}.html")
-
-    cls = f'bk pn-loading {config.loading_spinner}'
-    expect(page.locator('body')).to_have_class(cls)
-    expect(page.locator('body')).not_to_have_class(cls, timeout=60 * 1000)
+    msgs = wait_for_app(launch_app, slider_app, page, runtime)
 
     expect(page.locator(".bk.bk-clearfix")).to_have_text('0.0')
 
@@ -159,23 +174,40 @@ def test_pyodide_test_convert_slider_app(page, runtime, launch_app):
 
     assert [msg for msg in msgs if msg.type == 'error' and 'favicon' not in msg.location['url']] == []
 
-@pytest.mark.parametrize('runtime', ['pyodide', 'pyscript', 'pyodide-worker'])
+@pytest.mark.parametrize('runtime', ['pyodide', 'pyodide-worker'])
 def test_pyodide_test_convert_tabulator_app(page, runtime, launch_app):
-    app_path = launch_app(tabulator_app)
-
-    convert_apps([app_path], app_path.parent, runtime=runtime, build_pwa=False, build_index=False, prerender=False, panel_version='local')
-
-    msgs = []
-    page.on("console", lambda msg: msgs.append(msg))
-
-    page.goto(f"http://localhost:8123/{app_path.name[:-3]}.html")
-
-    cls = f'bk pn-loading {config.loading_spinner}'
-    expect(page.locator('body')).to_have_class(cls)
-    expect(page.locator('body')).not_to_have_class(cls, timeout=60 * 1000)
+    msgs = wait_for_app(launch_app, tabulator_app, page, runtime)
 
     page.click('.bk.bk-btn')
 
     time.sleep(1)
+
+    assert [msg for msg in msgs if msg.type == 'error' and 'favicon' not in msg.location['url']] == []
+
+@pytest.mark.parametrize(
+    'runtime, http_patch', [
+        ('pyodide', False),
+        ('pyodide', True)
+        ('pyodide-worker', False),
+        ('pyodide-worker', True)
+    ]
+)
+def test_pyodide_test_convert_csv_app(page, runtime, http_patch, launch_app):
+    msgs = wait_for_app(launch_app, csv_app, page, runtime, http_patch=http_patch)
+
+    titles = page.locator('.tabulator-col-title').all_text_contents()
+
+    import pdb
+    pdb.set_trace()
+
+    assert titles[1:] == ['index', 'date', 'Temperature', 'Humidity', 'Light', 'CO2', 'HumidityRatio', 'Occupancy']
+
+    assert [msg for msg in msgs if msg.type == 'error' and 'favicon' not in msg.location['url']] == []
+
+@pytest.mark.parametrize('runtime', ['pyodide', 'pyodide-worker'])
+def test_pyodide_test_convert_png_app(page, runtime, launch_app):
+    msgs = wait_for_app(launch_app, png_app, page, runtime)
+
+    assert page.locator('img').count() == 1
 
     assert [msg for msg in msgs if msg.type == 'error' and 'favicon' not in msg.location['url']] == []

--- a/panel/tests/ui/io/test_convert.py
+++ b/panel/tests/ui/io/test_convert.py
@@ -197,9 +197,6 @@ def test_pyodide_test_convert_csv_app(page, runtime, http_patch, launch_app):
 
     titles = page.locator('.tabulator-col-title').all_text_contents()
 
-    import pdb
-    pdb.set_trace()
-
     assert titles[1:] == ['index', 'date', 'Temperature', 'Humidity', 'Light', 'CO2', 'HumidityRatio', 'Occupancy']
 
     assert [msg for msg in msgs if msg.type == 'error' and 'favicon' not in msg.location['url']] == []

--- a/panel/tests/ui/io/test_convert.py
+++ b/panel/tests/ui/io/test_convert.py
@@ -187,7 +187,7 @@ def test_pyodide_test_convert_tabulator_app(page, runtime, launch_app):
 @pytest.mark.parametrize(
     'runtime, http_patch', [
         ('pyodide', False),
-        ('pyodide', True)
+        ('pyodide', True),
         ('pyodide-worker', False),
         ('pyodide-worker', True)
     ]


### PR DESCRIPTION
- Adds [`pyodide-http`](https://github.com/koenvo/pyodide-http) as a dependency for converted pyodide apps ensuring that `requests` and `urllib3` work (even for binary files if using the `pyodide-worker` target)
- Additionally we also patch `pd.read_parquet` and enable synchronous queries on the `Image` pane. 