### PR TITLE
Add compute_hash in panel.io.__init__ imports

### DIFF
--- a/panel/io/__init__.py
+++ b/panel/io/__init__.py
@@ -4,7 +4,7 @@ model state, and rendering panel objects.
 """
 import sys
 
-from .cache import cache  # noqa
+from .cache import cache, compute_hash  # noqa
 from .callbacks import PeriodicCallback  # noqa
 from .document import init_doc, unlocked, with_lock  # noqa
 from .embed import embed_state  # noqa


### PR DESCRIPTION
The `compute_hash` function is documented as part of the public API but was not imported in panel.io.\_\_init__