### PR TITLE
Tabulator: re-introduce headerSort in the docs

### DIFF
--- a/examples/reference/widgets/Tabulator.ipynb
+++ b/examples/reference/widgets/Tabulator.ipynb
@@ -1243,7 +1243,9 @@
     "pn.widgets.Tabulator(df, configuration={\n",
     "    'clipboard': True,\n",
     "    'rowHeight': 50,\n",
-    "    'headerSortElement': None\n",
+    "    'columnDefaults': {\n",
+    "        'headerSort': False,\n",
+    "    },\n",
     "})"
    ]
   },

--- a/examples/reference/widgets/Tabulator.ipynb
+++ b/examples/reference/widgets/Tabulator.ipynb
@@ -1223,7 +1223,7 @@
     "Panel does not expose all options available from Tabulator, if a desired option is not natively supported, it can be set via the `configuration` argument.  \n",
     "This dictionary can be seen as a base dictionary which the tabulator object fills and passes to the Tabulator javascript-library.\n",
     "\n",
-    "As an example, we can enable `clipboard` functionality and set the `rowHeight` options."
+    "As an example, we can enable `clipboard` functionality and set the `rowHeight` options. `columnDefaults` takes a dictionary used to configure the columns specifically, in this example we disable header sorting with `headerSort`."
    ]
   },
   {


### PR DESCRIPTION
Documenting `columnDefaults` seems relevant.

```python
pn.widgets.Tabulator(df, configuration={
    'clipboard': True,
    'rowHeight': 50,
    'columnDefaults': {
        'headerSort': False,
    },
})
```