### PR TITLE
Ensure futures are correctly awaited when executed on thread

### DIFF
--- a/panel/io/document.py
+++ b/panel/io/document.py
@@ -237,7 +237,10 @@ def unlocked() -> Iterator:
                 except Exception as e:
                     logger.warning(f"Failed sending message due to following error: {e}")
 
-        asyncio.ensure_future(handle_write_errors())
+        if state._unblocked(curdoc):
+            asyncio.ensure_future(handle_write_errors())
+        else:
+            curdoc.add_next_tick_callback(handle_write_errors)
 
         curdoc.callbacks._held_events = remaining_events
     finally:


### PR DESCRIPTION
In certain scenarios we attempted to dispatch futures for processing on a thread without a running event loop. We now check if we are on a thread and if so we use Bokeh's add_next_tick_callback to process them on the main thread.