### PR TITLE
add cache to all

### DIFF
--- a/panel/__init__.py
+++ b/panel/__init__.py
@@ -84,6 +84,7 @@ __all__ = (
     "Template",
     "WidgetBox",
     "bind",
+    "cache",
     "config",
     "depends",
     "extension",


### PR DESCRIPTION
My linter was complaining about non-existent `cache`.

```bash
E1101: Module 'panel' has no 'cache' member (no-member)
```