### PR TITLE
Fix FloatInput notebook documentation for `value_throttled`

### DIFF
--- a/examples/reference/widgets/FloatInput.ipynb
+++ b/examples/reference/widgets/FloatInput.ipynb
@@ -26,7 +26,7 @@
     "##### Core\n",
     "\n",
     "* **``value``** (float): The initial value of the spinner\n",
-    "* **``value_throttled``** (float): The initial value of the spinner\n",
+    "* **``value_throttled``** (float): The current value. Updates only on `<enter>` or when the widget looses focus.\n",
     "* **``step``** (float): The step added or subtracted to the current value on each click\n",
     "* **``start``** (float): Optional minimum allowable value\n",
     "* **``end``** (float): Optional maximum allowable value\n",


### PR DESCRIPTION
The doc (https://panel.holoviz.org/reference/widgets/FloatInput.html) mistakenly contained the description for `value` again instead of `value_throttled`.

The description here was copied from `widgets/input.py`.