### PR TITLE
Silence EMPTY_LAYOUT warnings

### DIFF
--- a/panel/command/serve.py
+++ b/panel/command/serve.py
@@ -19,6 +19,8 @@ from bokeh.application.handlers.document_lifecycle import (
 from bokeh.application.handlers.function import FunctionHandler
 from bokeh.command.subcommands.serve import Serve as _BkServe
 from bokeh.command.util import build_single_handler_applications
+from bokeh.core.validation import silence
+from bokeh.core.validation.warnings import EMPTY_LAYOUT
 from bokeh.server.contexts import ApplicationContext
 from tornado.ioloop import PeriodicCallback
 from tornado.web import StaticFileHandler
@@ -490,3 +492,9 @@ class Serve(_BkServe):
             kwargs['cookie_secret'] = config.cookie_secret
 
         return kwargs
+
+    def invoke(self, args):
+        # Empty layout are valid and the Bokeh warning is silenced as usually
+        # not relevant to Panel users.
+        silence(EMPTY_LAYOUT, True)
+        super().invoke(args)

--- a/panel/io/server.py
+++ b/panel/io/server.py
@@ -41,6 +41,8 @@ from bokeh.application.handlers.code import (
 from bokeh.application.handlers.function import FunctionHandler
 from bokeh.command.util import build_single_handler_application
 from bokeh.core.templates import AUTOLOAD_JS
+from bokeh.core.validation import silence
+from bokeh.core.validation.warnings import EMPTY_LAYOUT
 from bokeh.embed.bundle import Script
 from bokeh.embed.elements import (
     html_page_for_render_items, script_for_render_items,
@@ -682,6 +684,9 @@ def serve(
     kwargs: dict
       Additional keyword arguments to pass to Server instance
     """
+    # Empty layout are valid and the Bokeh warning is silenced as usually
+    # not relevant to Panel users.
+    silence(EMPTY_LAYOUT, True)
     kwargs = dict(kwargs, **dict(
         port=port, address=address, websocket_origin=websocket_origin,
         loop=loop, show=show, start=start, title=title, verbose=verbose,

--- a/panel/tests/test_server.py
+++ b/panel/tests/test_server.py
@@ -1,5 +1,6 @@
 import asyncio
 import datetime as dt
+import logging
 import os
 import pathlib
 import time
@@ -911,3 +912,30 @@ def test_server_exception_handler_async_onload_event(threads, handler, port, req
     time.sleep(0.5)
 
     assert len(exceptions) == 1
+
+
+def test_server_no_warning_empty_layout(port, caplog):
+
+    bk_logger = logging.getLogger('bokeh')
+    old_level = bk_logger.level
+    old_propagate = bk_logger.propagate
+    try:
+        # Test pretty dependent on how Bokeh sets up its logging system
+        bk_logger.propagate = True
+        bk_logger.setLevel(logging.WARNING)
+
+        app = Row()
+
+        serve(app, port=port, threaded=True, show=False)
+
+        # Wait for server to start
+        time.sleep(1)
+        requests.get(f"http://localhost:{port}")
+        time.sleep(1)
+
+        for rec in caplog.records:
+            if rec.levelname == 'WARNING':
+                assert 'EMPTY_LAYOUT' not in rec.message
+    finally:
+        bk_logger.setLevel(old_level)
+        bk_logger.propagate = old_propagate


### PR DESCRIPTION
The `EMPTY_LAYOUT` warning is emitted when an empty layout (e.g. `pn.Row()`) is rendered. Panel use cases are different than Bokeh's ones, Panel is more used to serve interactive apps where it's perfectly valid to render an empty layout that is later populated with some content. In this case this warning is just noise.

The ability to silence specific Bokeh warnings was added to Bokeh a few years ago https://github.com/bokeh/bokeh/pull/8739. This PR is using the `silence` function to silence this warning, for both `panel serve` and `pn.serve()` usages.