### PR TITLE
add callback to allow level change in debugger

### DIFF
--- a/panel/widgets/debugger.py
+++ b/panel/widgets/debugger.py
@@ -263,6 +263,7 @@ class Debugger(Card):
             logger.addHandler(stream_handler)
 
         self.terminal = terminal
+        self.stream_handler = stream_handler
 
         #callbacks for header
         self.param.watch(self.update_log_counts,'_number_of_errors')
@@ -320,8 +321,4 @@ class Debugger(Card):
 
     @param.depends("level", watch=True)
     def _update_level(self):
-        stream_handler = logging.StreamHandler(self.terminal)
-        stream_handler.setLevel(self.level)
-        for logger_name in self.logger_names:
-            logger = logging.getLogger(logger_name)
-            logger.addHandler(stream_handler)
+        self.stream_handler.setLevel(self.level)

--- a/panel/widgets/debugger.py
+++ b/panel/widgets/debugger.py
@@ -313,7 +313,15 @@ class Debugger(Card):
 
         self.title = ', '.join(title)
 
-    def acknowledge_errors(self,event):
+    def acknowledge_errors(self, event):
         self._number_of_errors = 0
         self._number_of_warnings = 0
         self._number_of_infos = 0
+
+    @param.depends("level", watch=True)
+    def _update_level(self):
+        stream_handler = logging.StreamHandler(self.terminal)
+        stream_handler.setLevel(self.level)
+        for logger_name in self.logger_names:
+            logger = logging.getLogger(logger_name)
+            logger.addHandler(stream_handler)


### PR DESCRIPTION
The current debugger widget does not update the logging level once it is instantiated.
For example, the console created with the following code will always have its logging level set at given value:

```python
import panel as pn
import param
import logging

pn.extension('terminal')

console = pn.widgets.Debugger(
            name="Console",
            level=logging.INFO,
            sizing_mode="stretch_width",
            logger_names=["panel", "imars3d"],
        )

console.level = logging.DEBUG   # <- this does not have any impact on the console widget due to missing callbacks
```

This PR adds a callback function that retrieve the stream and set the new log level for all tracking loggers.

