### PR TITLE
Fix latest PyScript compatibility in .servable()

### DIFF
--- a/panel/viewable.py
+++ b/panel/viewable.py
@@ -378,8 +378,8 @@ class ServableMixin(object):
             else:
                 self.server_doc(title=title, location=location) # type: ignore
         elif state._is_pyodide:
-            from .io.pyodide import write
-            target = target or getattr(sys.stdout, '_out', None)
+            from .io.pyodide import _get_pyscript_target, write
+            target = target or _get_pyscript_target()
             if target is not None:
                 asyncio.create_task(write(target, self))
         return self


### PR DESCRIPTION
Use helper to get PyScript target to support recent versions of PyScript