### PR TITLE
Align dependency pins

### DIFF
--- a/dodo.py
+++ b/dodo.py
@@ -10,7 +10,7 @@ def task_pip_on_conda():
     """Experimental: provide pip build env via conda"""
     return {'actions':[
         # some ecosystem=pip build tools must be installed with conda when using conda...
-        'conda install -y pip twine wheel',
+        'conda install -y pip twine wheel "rfc3986>=1.4.0"',
         # ..and some are only available via conda-forge
         'conda install -y -c conda-forge tox "virtualenv<=20.4.7"',
     ]}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = [
     "pyct >=0.4.4",
     "setuptools >=42",
     "bokeh >=2.4.3,<2.5.0",
-    "pyviz_comms >=0.6.0",
+    "pyviz_comms >=0.7.4",
     "requests",
     "bleach",
     "packaging",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = [
     "param >=1.9.2",
     "pyct >=0.4.4",
     "setuptools >=42",
-    "bokeh >=2.4.0,<2.5.0",
+    "bokeh >=2.4.3,<2.5.0",
     "pyviz_comms >=0.6.0",
     "requests",
     "bleach",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-    "param >=1.9.0",
+    "param >=1.9.2",
     "pyct >=0.4.4",
     "setuptools >=42",
     "bokeh >=2.4.0,<2.5.0",

--- a/setup.py
+++ b/setup.py
@@ -213,12 +213,12 @@ extras_require['build'] = [
     'param >=1.9.2',
     'pyct >=0.4.4',
     'setuptools >=42',
-    'bokeh >=2.4.3,<2.5',
-    'pyviz_comms >=0.6.0',
+    'bokeh >=2.4.3,<2.5.0',
+    'pyviz_comms >=0.7.4',
+    'requests',
+    'packaging',
     'bleach',
-    'tqdm',
-    'twine',
-    'rfc3986>=1.4.0'
+    'tqdm >=4.48.0',
 ]
 
 setup_args = dict(

--- a/setup.py
+++ b/setup.py
@@ -111,7 +111,7 @@ install_requires = [
     'tqdm >=4.48.0',
     'pyct >=0.4.4',
     'bleach',
-    'setuptools',
+    'setuptools >=42',
     'typing_extensions'
 ]
 


### PR DESCRIPTION
While updating the [conda-forge recipe](https://github.com/conda-forge/panel-feedstock/pull/53) for the 0.14.1 release I noticed a mismatch between the pins. This PR aligns them across setup.py, pyproject.toml and conda-forge recipe/meta.yaml.