### PR TITLE
Ipywidget comm breaks when a new ipywidget is rendered

### DIFF
--- a/panel/pane/ipywidget.py
+++ b/panel/pane/ipywidget.py
@@ -63,7 +63,6 @@ class IPyWidget(PaneBase):
                 widgets = (obj._active_widgets if hasattr(obj, '_active_widgets') else obj.widgets).values()
                 for w in widgets:
                     w.comm.kernel = kernel
-                    w.comm.open()
 
         model = IPyWidget(widget=obj, **kwargs)
         return model

--- a/panel/pane/ipywidget.py
+++ b/panel/pane/ipywidget.py
@@ -63,6 +63,8 @@ class IPyWidget(PaneBase):
                 widgets = (obj._active_widgets if hasattr(obj, '_active_widgets') else obj.widgets).values()
                 for w in widgets:
                     w.comm.kernel = kernel
+                    if w.comm._closed:
+                        w.comm.open()
 
         model = IPyWidget(widget=obj, **kwargs)
         return model


### PR DESCRIPTION
Fixes https://github.com/holoviz/panel/issues/4088

This commit drops explicitly calling ipywidget.comm.open() as it causes a protocol version mismatch issue - reproducer in the referenced issue. When opening a new comm, as per the [docs](https://github.com/jupyter-widgets/ipywidgets/blob/7.6.x/packages/schema/messages.md#instantiating-a-widget-object-1), we need to pass data and meta data. So the w.comm.open() call should be something like:

```python
metadata = {"version": "2.0.0"}
data = {"state": w.get_state()}
w.comm.open(data=data, metadata=metadata)
```

This seems to fix the error but the widgets still do not update. This is because when we create a new comm, ipywidgets seems to create a new model [reference](https://github.com/jupyter-widgets/ipywidgets/blob/74774dae5becb9f4781c3438a5fece1f8ca60415/packages/base-manager/src/manager-base.ts#L252). In my understanding, we need not explicitly open a comm to the frontend as the kernel will automatically reconstruct an existing comm. If for some reason we do want to open a comm, then ipywidgets bokeh needs to be updated so that the view uses the correct model.