### PR TITLE
Fixes a memory leak in holoviews Pane.

### DIFF
--- a/panel/pane/holoviews.py
+++ b/panel/pane/holoviews.py
@@ -31,6 +31,7 @@ from .plotly import Plotly
 if TYPE_CHECKING:
     from bokeh.document import Document
     from bokeh.model import Model
+    from bokeh.server.contexts import BokehSessionContext
     from pyviz_comms import Comm
 
 
@@ -353,6 +354,11 @@ class HoloViews(PaneBase):
             if old_pane:
                 old_pane._cleanup(root)
         super()._cleanup(root)
+
+    def _server_destroy(self, session_context: 'BokehSessionContext') -> None:
+        with param.discard_events(self):
+            self.object = None
+        return super()._server_destroy(session_context)
 
     #----------------------------------------------------------------
     # Public API


### PR DESCRIPTION
Fixes #4096

Fixes a memory leak by setting `self.object` to None before destroying it in the Holoviews pane. I'm not completely sure this fixes the problem at the root, but at least it stops it. 

This would give the following memory usage with `panel serve 4096.py --admin --unused-session-lifetime 100 --check-unused-sessions 500` and reloading it 10 times and closing the tab:
``` python
import hvplot.xarray  # noqa
import panel as pn
import xarray as xr


def get_plot():
    with xr.tutorial.open_dataset("air_temperature") as ds:
        air = ds.air
    plot = air.hvplot.line("time")
    return plot


pn.pane.HoloViews(get_plot()).servable()

```

| Before | After |
| --------- | ------- |
|![image](https://user-images.githubusercontent.com/19758978/201672029-37d6c9a9-d5cd-4647-aae7-3f27fb0d4a68.png) |![image](https://user-images.githubusercontent.com/19758978/201671845-72a43221-3696-466e-8368-31f9b0180714.png) |


