### PR TITLE
Handle missing event loop in thread gracefully

### DIFF
--- a/panel/io/document.py
+++ b/panel/io/document.py
@@ -238,7 +238,10 @@ def unlocked() -> Iterator:
                     logger.warning(f"Failed sending message due to following error: {e}")
 
         if state._unblocked(curdoc):
-            asyncio.ensure_future(handle_write_errors())
+            try:
+                asyncio.ensure_future(handle_write_errors())
+            except RuntimeError:
+                curdoc.add_next_tick_callback(handle_write_errors)
         else:
             curdoc.add_next_tick_callback(handle_write_errors)
 


### PR DESCRIPTION
Backs off from using the asyncio event loop directly for handling errors to scheduling it with the curdoc to be executed on the main thread.