### PR TITLE
Support non-vtkPolyData types in vtk synchronizer

### DIFF
--- a/panel/pane/vtk/synchronizable_serializer.py
+++ b/panel/pane/vtk/synchronizable_serializer.py
@@ -1143,9 +1143,7 @@ def mergeToPolydataSerializer(parent, dataObject, dataObjectId, context, depth):
         gf.SetInputData(dataObject)
         gf.Update()
         dataset = gf.GetOutput()
-    elif (dataObject.IsA('vtkUnstructuredGrid') or
-          dataObject.IsA('vtkStructuredGrid') or
-          dataObject.IsA('vtkImageData')):
+    elif not dataObject.IsA('vtkPolyData'):
         gf = vtkGeometryFilter()
         gf.SetInputData(dataObject)
         gf.Update()


### PR DESCRIPTION
I think this is all that is needed to support all non-vtkPolyData types to resolve https://github.com/pyvista/pyvista/issues/3576

I edited this online and did not test/verify. I'm sure there are edge cases but this should generally improve support for more data types

cc @k-a-mendoza