### PR TITLE
Ensure Location model reports as idle fixing onload

### DIFF
--- a/panel/models/location.ts
+++ b/panel/models/location.ts
@@ -23,6 +23,9 @@ export class LocationView extends View {
       this.model.hash = window.location.hash
     }
     window.addEventListener('hashchange', this._hash_listener)
+
+    this._has_finished = true
+    this.notify_finished()
   }
 
   connect_signals(): void {


### PR DESCRIPTION
The location model wasn't reporting as idle which meant that the Document never fired the 'documentready' event and onload callbacks were never executed.