### PR TITLE
Now support step format in date sliders

### DIFF
--- a/examples/reference/widgets/DateRangeSlider.ipynb
+++ b/examples/reference/widgets/DateRangeSlider.ipynb
@@ -43,6 +43,7 @@
     "* **``name``** (str): The title of the widget\n",
     "* **``orientation``** (str): Whether the slider should be displayed in a 'horizontal' or 'vertical' orientation.\n",
     "* **``tooltips``** (boolean): Whether to display tooltips on the slider handle\n",
+    "* **``format``** (str): The datetime format\n",
     "\n",
     "___\n",
     "\n",
@@ -59,6 +60,7 @@
     "    name='Date Range Slider',\n",
     "    start=dt.datetime(2017, 1, 1), end=dt.datetime(2019, 1, 1),\n",
     "    value=(dt.datetime(2017, 1, 1), dt.datetime(2018, 1, 10)),\n",
+    "    step=24*3600*2*1000\n",
     ")\n",
     "\n",
     "date_range_slider"
@@ -97,12 +99,37 @@
    "source": [
     "pn.Row(date_range_slider.controls(jslink=True), date_range_slider)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
    "name": "python",
-   "pygments_lexer": "ipython3"
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.15"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "4d365f0e9de9d09a9d2485a373e55f275bca75bcd720729a96013eba6c0ac0e6"
+   }
   }
  },
  "nbformat": 4,

--- a/examples/reference/widgets/DateSlider.ipynb
+++ b/examples/reference/widgets/DateSlider.ipynb
@@ -31,6 +31,7 @@
     "* **``end``** (date or datetime): The range's upper bound\n",
     "* **``value``** (date or datetime): The selected value as a datetime type\n",
     "* **``value_throttled``** (datetime): The selected value as a datetime type throttled until mouseup\n",
+    "* **``step``** (number): The selected step i the slider in milliseconds\n",
     "\n",
     "##### Display\n",
     "\n",
@@ -40,6 +41,7 @@
     "* **``name``** (str): The title of the widget\n",
     "* **``orientation``** (str): Whether the slider should be displayed in a 'horizontal' or 'vertical' orientation.\n",
     "* **``tooltips``** (boolean): Whether to display tooltips on the slider handle\n",
+    "* **``format``** (string): The datetime's format\n",
     "\n",
     "___"
    ]
@@ -88,12 +90,37 @@
    "source": [
     "pn.Row(date_slider.controls(jslink=True), date_slider)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
    "name": "python",
-   "pygments_lexer": "ipython3"
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.15"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "4d365f0e9de9d09a9d2485a373e55f275bca75bcd720729a96013eba6c0ac0e6"
+   }
   }
  },
  "nbformat": 4,

--- a/panel/widgets/slider.py
+++ b/panel/widgets/slider.py
@@ -250,6 +250,12 @@ class DateSlider(_SliderBase):
     as_datetime = param.Boolean(default=False, doc="""
         Whether to store the date as a datetime.""")
 
+    step = param.Number(default=None, doc="""
+        The step parameter in milliseconds.""")
+
+    format = param.String(default=None, doc="""
+        Datetime format used for parsing and formatting the date.""")
+
     _rename: ClassVar[Mapping[str, str | None]] = {
         'name': 'title', 'as_datetime': None
     }
@@ -661,7 +667,10 @@ class DateRangeSlider(_SliderBase):
         The upper bound.""")
 
     step = param.Number(default=1, doc="""
-        The step size. Default is 1 (day).""")
+        The step size. Default is 1 millisecond.""")
+
+    format = param.String(default=None, doc="""
+        Datetime format used for parsing and formatting the date.""")
 
     _source_transforms: ClassVar[Mapping[str, str | None]] = {
         'value': None, 'value_throttled': None, 'start': None, 'end': None,


### PR DESCRIPTION
Original issues are [2731](https://github.com/holoviz/panel/issues/2731) and [2894](https://github.com/holoviz/panel/issues/2894).

I have not really added tests since the formatting is done in the JS of the bokeh object and I feel like testing must be done on their side rather than ours then. And I kinda do not really like simply testing that if I call `slider=Slider(format=5)` then `slider.format=5` but if needed I can add it.

If needed I can also add some BFSoup checker somewhere to test both steps and format, of course if you have an original example of pr that had to deal with that I will be happy to comply to any specific test format.

On a side note, it looks like the `.controls()` function is oftentimes not displaying the full controls. I would be happy to investigate.

Also if you have a tool that strips the notebooks of the cell metadata updates so that my commits on notebooks are clean I would be very happy.

It is my first ever PR on this project, let me know if there are any specifics to consider when contributing. 

Have a good day