### PR TITLE
Better estimation of value for editable sliders with fixed_start / fixed_end

### DIFF
--- a/panel/tests/widgets/test_slider.py
+++ b/panel/tests/widgets/test_slider.py
@@ -607,7 +607,7 @@ def test_editable_rangeslider_bounds(
 @pytest.mark.parametrize(
     "editableslider,fixed_start,fixed_end",
     [
-        (EditableFloatSlider, 0.05, 0.10),
+        (EditableFloatSlider, 5, 10),
         (EditableIntSlider, 5, 10),
     ],
 )
@@ -621,24 +621,97 @@ def test_editable_slider_fixed_novalue(editableslider, fixed_start, fixed_end):
     assert slider.value == fixed_start
 
     slider = editableslider(fixed_end=fixed_end)
-    assert slider.value == fixed_end
+    assert slider.value == fixed_end - 1
 
 
 def test_editable_rangeslider_fixed_novalue():
-    fixed_start, fixed_end, step = 0.05, 0.10, 0.01
+    fixed_start, fixed_end, step = 5, 10, 0.01
     slider = EditableRangeSlider(
         fixed_start=fixed_start, fixed_end=fixed_end,
     )
     assert slider.value == (fixed_start, fixed_end)
 
     slider = EditableRangeSlider(fixed_start=fixed_start)
-    assert slider.value == (fixed_start, fixed_start + 0.1)
+    assert slider.value == (fixed_start, fixed_start + 1)
 
     slider = EditableRangeSlider(fixed_start=fixed_start, step=step)
     assert slider.value == (fixed_start, fixed_start + step)
 
     slider = EditableRangeSlider(fixed_end=fixed_end)
-    assert slider.value == (fixed_end - 0.1, fixed_end)
+    assert slider.value == (fixed_end - 1, fixed_end)
 
     slider = EditableRangeSlider(fixed_end=fixed_end, step=step)
     assert slider.value == (fixed_end - step, fixed_end)
+
+@pytest.mark.parametrize(
+    "editableslider",
+    [EditableFloatSlider, EditableIntSlider, EditableRangeSlider],
+)
+def test_editable_fixed_nosoftbounds_fixed_start_end(editableslider):
+    start, end = 8, 9
+    fixed_start, fixed_end = 5, 10
+
+    slider = editableslider(
+        fixed_start=fixed_start, fixed_end=fixed_end,
+    )
+    assert slider.start == fixed_start
+    assert slider.end == fixed_end
+
+    slider = editableslider(
+        fixed_start=fixed_start, fixed_end=fixed_end,
+        start=start, end=end,
+    )
+    assert slider.start == start
+    assert slider.end == end
+
+
+@pytest.mark.parametrize(
+    "editableslider",
+    [EditableFloatSlider, EditableIntSlider, EditableRangeSlider],
+)
+def test_editable_fixed_nosoftbounds_fixed_start(editableslider):
+    start, _ = 8, 9
+    fixed_start, _ = 5, 10
+    step = 2
+
+    slider = editableslider(fixed_start=fixed_start)
+    assert slider.start == fixed_start
+    assert slider.end == fixed_start + 1
+
+    slider = editableslider(fixed_start=fixed_start, step=step)
+    assert slider.start == fixed_start
+    assert slider.end == fixed_start + step
+
+    slider = editableslider(fixed_start=fixed_start, start=start)
+    assert slider.start == start
+    assert slider.end == start + 1
+
+    slider = editableslider(fixed_start=fixed_start, start=start, step=step)
+    assert slider.start == start
+    assert slider.end == start + step
+
+
+
+@pytest.mark.parametrize(
+    "editableslider",
+    [EditableFloatSlider, EditableIntSlider, EditableRangeSlider],
+)
+def test_editable_fixed_nosoftbounds_fixed_end(editableslider):
+    _, end = 8, 9
+    _, fixed_end = 5, 10
+    step = 2
+    slider = editableslider(fixed_end=fixed_end)
+    assert slider.start == fixed_end - 1
+    assert slider.end == fixed_end
+
+    slider = editableslider(fixed_end=fixed_end, step=step)
+    assert slider.start == fixed_end - step
+    assert slider.end == fixed_end
+
+    slider = editableslider(fixed_end=fixed_end, end=end)
+    assert slider.start == end - 1
+    assert slider.end == end
+
+    slider = editableslider(fixed_end=fixed_end, end=end, step=step)
+    assert slider.start == end - step
+    assert slider.end == end

--- a/panel/tests/widgets/test_slider.py
+++ b/panel/tests/widgets/test_slider.py
@@ -602,3 +602,43 @@ def test_editable_rangeslider_bounds(
         slider.value = val_update
     except Exception:
         assert fail_update
+
+
+@pytest.mark.parametrize(
+    "editableslider,fixed_start,fixed_end",
+    [
+        (EditableFloatSlider, 0.05, 0.10),
+        (EditableIntSlider, 5, 10),
+    ],
+)
+def test_editable_slider_fixed_novalue(editableslider, fixed_start, fixed_end):
+    slider = editableslider(
+        fixed_start=fixed_start, fixed_end=fixed_end,
+    )
+    assert slider.value == fixed_start
+
+    slider = editableslider(fixed_start=fixed_start)
+    assert slider.value == fixed_start
+
+    slider = editableslider(fixed_end=fixed_end)
+    assert slider.value == fixed_end
+
+
+def test_editable_rangeslider_fixed_novalue():
+    fixed_start, fixed_end, step = 0.05, 0.10, 0.01
+    slider = EditableRangeSlider(
+        fixed_start=fixed_start, fixed_end=fixed_end,
+    )
+    assert slider.value == (fixed_start, fixed_end)
+
+    slider = EditableRangeSlider(fixed_start=fixed_start)
+    assert slider.value == (fixed_start, fixed_start + 0.1)
+
+    slider = EditableRangeSlider(fixed_start=fixed_start, step=step)
+    assert slider.value == (fixed_start, fixed_start + step)
+
+    slider = EditableRangeSlider(fixed_end=fixed_end)
+    assert slider.value == (fixed_end - 0.1, fixed_end)
+
+    slider = EditableRangeSlider(fixed_end=fixed_end, step=step)
+    assert slider.value == (fixed_end - step, fixed_end)

--- a/panel/widgets/slider.py
+++ b/panel/widgets/slider.py
@@ -787,6 +787,11 @@ class _EditableContinuousSlider(CompositeWidget):
     def __init__(self, **params):
         if not 'width' in params and not 'sizing_mode' in params:
             params['width'] = 300
+        if "value" not in params and "fixed_start" in params:
+            params["value"] = params["fixed_start"]
+        if "value" not in params and "fixed_end" in params:
+            params["value"] = params["fixed_end"]
+
         super().__init__(**params)
         self._label = StaticText(margin=0, align='end')
         self._slider = self._slider_widget(
@@ -977,6 +982,15 @@ class EditableRangeSlider(CompositeWidget, _SliderBase):
     def __init__(self, **params):
         if not 'width' in params and not 'sizing_mode' in params:
             params['width'] = 300
+        if "value" not in params and "fixed_start" in params:
+            start = params["fixed_start"]
+            end = params.get("fixed_end", start + params.get("step", 0.1))
+            params["value"] = (start, end)
+        if "value" not in params and "fixed_end" in params:
+            end = params["fixed_end"]
+            start = params.get("fixed_start", end - params.get("step", 0.1))
+            params["value"] = (start, end)
+
         super().__init__(**params)
         self._label = StaticText(margin=0, align='end')
         self._slider = RangeSlider(margin=(0, 0, 5, 0), show_value=False)

--- a/panel/widgets/slider.py
+++ b/panel/widgets/slider.py
@@ -787,11 +787,7 @@ class _EditableContinuousSlider(CompositeWidget):
     def __init__(self, **params):
         if not 'width' in params and not 'sizing_mode' in params:
             params['width'] = 300
-        if "value" not in params and "fixed_start" in params:
-            params["value"] = params["fixed_start"]
-        if "value" not in params and "fixed_end" in params:
-            params["value"] = params["fixed_end"]
-
+        self._validate_init_bounds(params)
         super().__init__(**params)
         self._label = StaticText(margin=0, align='end')
         self._slider = self._slider_widget(
@@ -820,6 +816,38 @@ class _EditableContinuousSlider(CompositeWidget):
         self._update_slider()
         self._update_value()
         self._update_bounds()
+
+    def _validate_init_bounds(self, params):
+        """
+        This updates the default value, start and end
+        if outside the fixed_start and fixed_end
+        """
+        start, end = None, None
+        if "start" not in params:
+            if "fixed_start" in params:
+                start = params["fixed_start"]
+            elif "end" in params:
+                start = params.get("end") - params.get("step", 1)
+            elif "fixed_end" in params:
+                start = params.get("fixed_end") - params.get("step", 1)
+
+        if "end" not in params:
+            if "fixed_end" in params:
+                end = params["fixed_end"]
+            elif "start" in params:
+                end = params["start"] + params.get("step", 1)
+            elif "fixed_start" in params:
+                end = params["fixed_start"] + params.get("step", 1)
+
+        if start is not None:
+            params["start"] = start
+        if end is not None:
+            params["end"] = end
+
+        if "value" not in params and "start" in params:
+            params["value"] = params["start"]
+        if "value" not in params and "end" in params:
+            params["value"] = params["end"]
 
     @param.depends('width', 'height', 'sizing_mode', watch=True)
     def _update_layout(self):
@@ -982,15 +1010,7 @@ class EditableRangeSlider(CompositeWidget, _SliderBase):
     def __init__(self, **params):
         if not 'width' in params and not 'sizing_mode' in params:
             params['width'] = 300
-        if "value" not in params and "fixed_start" in params:
-            start = params["fixed_start"]
-            end = params.get("fixed_end", start + params.get("step", 0.1))
-            params["value"] = (start, end)
-        if "value" not in params and "fixed_end" in params:
-            end = params["fixed_end"]
-            start = params.get("fixed_start", end - params.get("step", 0.1))
-            params["value"] = (start, end)
-
+        self._validate_init_bounds(params)
         super().__init__(**params)
         self._label = StaticText(margin=0, align='end')
         self._slider = RangeSlider(margin=(0, 0, 5, 0), show_value=False)
@@ -1039,6 +1059,42 @@ class EditableRangeSlider(CompositeWidget, _SliderBase):
         self._update_slider()
         self._update_value()
         self._update_bounds()
+
+    def _validate_init_bounds(self, params):
+        """
+        This updates the default value, start and end
+        if outside the fixed_start and fixed_end
+        """
+        start, end = None, None
+        if "start" not in params:
+            if "fixed_start" in params:
+                start = params["fixed_start"]
+            elif "end" in params:
+                start = params.get("end") - params.get("step", 1)
+            elif "fixed_end" in params:
+                start = params.get("fixed_end") - params.get("step", 1)
+
+        if "end" not in params:
+            if "fixed_end" in params:
+                end = params["fixed_end"]
+            elif "start" in params:
+                end = params["start"] + params.get("step", 1)
+            elif "fixed_start" in params:
+                end = params["fixed_start"] + params.get("step", 1)
+
+        if start is not None:
+            params["start"] = start
+        if end is not None:
+            params["end"] = end
+
+        if "value" not in params and "start" in params:
+            start = params["start"]
+            end = params.get("end", start + params.get("step", 1))
+            params["value"] = (start, end)
+        if "value" not in params and "end" in params:
+            end = params["end"]
+            start = params.get("start", end - params.get("step", 1))
+            params["value"] = (start, end)
 
     @param.depends('editable', watch=True)
     def _update_editable(self):


### PR DESCRIPTION
Before this PR, the value will always be set to `0` or `(0,1)` even if the value was outside the hard bounds of `fixed_start` / `fixed_end`.  