### PR TITLE
Don't raise TypeError for a class containing  `__panel__` and not Viewer

### DIFF
--- a/panel/pane/base.py
+++ b/panel/pane/base.py
@@ -76,7 +76,7 @@ def panel(obj: Any, **kwargs) -> Viewable:
     if isinstance(obj, (Viewable, ServableMixin)):
         return obj
     elif hasattr(obj, '__panel__'):
-        if not isinstance(obj, Viewer) and issubclass(obj, Viewer):
+        if not isinstance(obj, Viewer) and (isinstance(obj, type) and issubclass(obj, Viewer)):
             return panel(obj().__panel__())
         return panel(obj.__panel__())
     if kwargs.get('name', False) is None:

--- a/panel/tests/test_viewable.py
+++ b/panel/tests/test_viewable.py
@@ -53,3 +53,14 @@ def test_viewer_wraps_panel():
     tv = TestViewer(value="hello")
 
     assert isinstance(tv._create_view(), Markdown)
+
+
+def test_non_viewer_class():
+    # This test checks that a class with __panel__ (other than Viewer)
+    # does not raise a TypeError: issubclass() arg 1 must be a class
+
+    class Example:
+        def __panel__(self):
+            return 42
+
+    panel(Example())


### PR DESCRIPTION
Don't raise TypeError for a class containing  `__panel__` and not `pn.viewable.Viewer`  by checking if the class is an instance of type before checking if it is a subclass. 

Before:
![image](https://user-images.githubusercontent.com/19758978/205596688-c9e4804e-5795-44af-b616-1dbcda551222.png)
