### PR TITLE
Escaped description of enter key so it shows up in docs

### DIFF
--- a/examples/reference/widgets/TextAreaInput.ipynb
+++ b/examples/reference/widgets/TextAreaInput.ipynb
@@ -24,7 +24,7 @@
     "\n",
     "##### Core\n",
     "\n",
-    "* **``value``** (str): The current value updated when pressing <enter> key.\n",
+    "* **``value``** (str): The current value updated when pressing `<enter>` key.\n",
     "* **``value_input``** (str): The current value updated on every key press.\n",
     "\n",
     "##### Display\n",


### PR DESCRIPTION
Currently the page looks like this which is confusing:

<img width="569" alt="image" src="https://user-images.githubusercontent.com/890576/205663347-5ee3fd54-55fe-498f-b2e0-375811955bc1.png">


With escaping, `<enter>` is dropped, probably cause it looks like the opening of an non-existent HTML tag.