### PR TITLE
Do not dispatch events if hold value is set

### DIFF
--- a/panel/io/document.py
+++ b/panel/io/document.py
@@ -192,18 +192,18 @@ def unlocked() -> Iterator:
     curdoc = state.curdoc
     session_context = getattr(curdoc, 'session_context', None)
     session = getattr(session_context, 'session', None)
-    if (curdoc is None or session_context is None or session is None):
+    if curdoc is None or session_context is None or session is None:
         yield
         return
+    elif curdoc.callbacks.hold_value:
+        yield
+        monkeypatch_events(curdoc.callbacks._held_events)
+        return
+
     from tornado.websocket import WebSocketClosedError, WebSocketHandler
     connections = session._subscribed_connections
 
-    hold = curdoc.callbacks.hold_value
-    if hold:
-        old_events = list(curdoc.callbacks._held_events)
-    else:
-        old_events = []
-        curdoc.hold()
+    curdoc.hold()
     try:
         yield
 
@@ -218,7 +218,7 @@ def unlocked() -> Iterator:
         monkeypatch_events(events)
         remaining_events, futures = [], []
         for event in events:
-            if not isinstance(event, ModelChangedEvent) or event in old_events or locked:
+            if not isinstance(event, ModelChangedEvent) or locked:
                 remaining_events.append(event)
                 continue
             for conn in connections:
@@ -247,8 +247,6 @@ def unlocked() -> Iterator:
 
         curdoc.callbacks._held_events = remaining_events
     finally:
-        if hold:
-            return
         try:
             curdoc.unhold()
         except RuntimeError:

--- a/panel/tests/io/test_document.py
+++ b/panel/tests/io/test_document.py
@@ -1,0 +1,29 @@
+import time
+
+import requests
+
+from panel.io.document import unlocked
+from panel.io.server import serve
+from panel.io.state import set_curdoc
+from panel.widgets import IntSlider
+
+
+def test_document_hold(port):
+    slider = IntSlider()
+
+    serve(slider, port=port, threaded=True, show=False)
+
+    # Wait for server to start
+    time.sleep(1)
+
+    requests.get(f"http://localhost:{port}/")
+
+    doc, model = list(slider._documents.items())[0]
+
+    doc.hold()
+
+    with set_curdoc(doc):
+        with unlocked():
+            model.value = 3
+
+    assert doc.callbacks._held_events


### PR DESCRIPTION
Not sure what the thinking here was but we should not be dispatching events if the Document has been set to hold. Holding is a powerful way to batch events and we should not stop users from taking advantage of it.