### PR TITLE
Fix branch-1.0 tests after rebase

### DIFF
--- a/examples/reference/widgets/Switch.ipynb
+++ b/examples/reference/widgets/Switch.ipynb
@@ -1,0 +1,91 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import panel as pn\n",
+    "pn.extension()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The ``Switch`` widget allows toggling a single condition between ``True``/``False`` states by ticking a switch. This widget is interchangeable with the ``Toggle`` widget.\n",
+    "\n",
+    "For more information about listening to widget events and laying out widgets refer to the [widgets user guide](../../user_guide/Widgets.ipynb). Alternatively you can learn how to build GUIs by declaring parameters independently of any specific widgets in the [param user guide](../../user_guide/Param.ipynb). To express interactivity entirely using Javascript without the need for a Python server take a look at the [links user guide](../../user_guide/Param.ipynb).\n",
+    "\n",
+    "#### Parameters:\n",
+    "\n",
+    "For layout and styling related parameters see the [customization user guide](../../user_guide/Customization.ipynb).\n",
+    "\n",
+    "##### Core\n",
+    "\n",
+    "* **``value``** (boolean): Whether the switch is on or off\n",
+    "\n",
+    "##### Display\n",
+    "\n",
+    "* **``disabled``** (boolean): Whether the widget is editable\n",
+    "* **``name``** (str): The title of the widget\n",
+    "\n",
+    "___"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "switch = pn.widgets.Switch(name='Switch')\n",
+    "\n",
+    "switch"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "``Switch.value`` parameter is either True or False depending on whether the switch is ticked."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "switch.value"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Controls\n",
+    "\n",
+    "The `Switch` widget exposes a number of options which can be changed from both Python and Javascript. Try out the effect of these parameters interactively:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pn.Row(switch.controls(jslink=True), switch)"
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/panel/tests/io/test_embed.py
+++ b/panel/tests/io/test_embed.py
@@ -34,7 +34,7 @@ def test_embed_param_jslink(document, comm):
     cb1, cb2 = (cb1, cb2) if select._models[ref][0] is cb1.args['target'] else (cb2, cb1)
     assert cb1.code == """
     var value = source['active'];
-    value = value.indexOf(0) >= 0;
+    value = value;
     value = value;
     try {
       var property = target.properties['disabled'];
@@ -53,7 +53,7 @@ def test_embed_param_jslink(document, comm):
     assert cb2.code == """
     var value = source['disabled'];
     value = value;
-    value = value ? [0] : [];
+    value = value;
     try {
       var property = target.properties['active'];
       if (property !== undefined) { property.validate(value); }
@@ -303,7 +303,7 @@ def test_embed_checkbox_str_link(document, comm):
         model = panel.get_root(document, comm)
     embed_state(panel, model, document)
     _, state = document.roots
-    assert set(state.state) == {'false', 'true'}
+    assert set(state.state) == {False, True}
     for k, v in state.state.items():
         content = json.loads(v['content'])
         assert 'events' in content
@@ -313,7 +313,7 @@ def test_embed_checkbox_str_link(document, comm):
         assert event['kind'] == 'ModelChanged'
         assert event['attr'] == 'text'
         assert event['model'] == model.children[1].ref
-        assert event['new'] == '&lt;pre&gt;%s&lt;/pre&gt;' % k.title()
+        assert event['new'] == f'&lt;pre&gt;{k}&lt;/pre&gt;'
 
 
 def test_embed_checkbox_str_jslink(document, comm):
@@ -334,7 +334,7 @@ def test_embed_checkbox_str_jslink(document, comm):
     cb1, cb2 = (cb1, cb2) if checkbox._models[ref][0] is cb1.args['source'] else (cb2, cb1)
     assert cb1.code == """
     var value = source['active'];
-    value = value.indexOf(0) >= 0;
+    value = value;
     value = JSON.stringify(value).replace(/,/g, ", ").replace(/:/g, ": ");
     try {
       var property = target.properties['text'];
@@ -353,7 +353,7 @@ def test_embed_checkbox_str_jslink(document, comm):
     assert cb2.code == """
     var value = source['text'];
     value = value;
-    value = value ? [0] : [];
+    value = value;
     try {
       var property = target.properties['active'];
       if (property !== undefined) { property.validate(value); }

--- a/panel/tests/test_param.py
+++ b/panel/tests/test_param.py
@@ -4,7 +4,7 @@ import param
 import pytest
 
 from bokeh.models import (
-    AutocompleteInput as BkAutocompleteInput, Button, CheckboxGroup,
+    AutocompleteInput as BkAutocompleteInput, Button, Checkbox,
     Column as BkColumn, Div, MultiSelect, RangeSlider as BkRangeSlider,
     Row as BkRow, Select, Slider, Tabs as BkTabs, TextInput,
     TextInput as BkTextInput, Toggle,
@@ -200,14 +200,14 @@ def test_boolean_param(document, comm):
     model = test_pane.get_root(document, comm=comm)
 
     checkbox = model.children[1]
-    assert isinstance(checkbox, CheckboxGroup)
-    assert checkbox.labels == ['A']
-    assert checkbox.active == []
+    assert isinstance(checkbox, Checkbox)
+    assert checkbox.label == 'A'
+    assert checkbox.active == False
     assert checkbox.disabled == False
 
     # Check changing param value updates widget
     test.a = True
-    assert checkbox.active == [0]
+    assert checkbox.active == True
 
     # Check changing param attribute updates widget
     a_param = test.param['a']
@@ -218,7 +218,7 @@ def test_boolean_param(document, comm):
     test_pane._cleanup(model)
     a_param.constant = False
     test.a = False
-    assert checkbox.active == [0]
+    assert checkbox.active == True
     assert checkbox.disabled == True
 
 
@@ -440,7 +440,7 @@ def test_explicit_params(document, comm):
     model = test_pane.get_root(document, comm=comm)
 
     assert len(model.children) == 2
-    assert isinstance(model.children[1], CheckboxGroup)
+    assert isinstance(model.children[1], Checkbox)
 
 
 def test_param_precedence(document, comm):

--- a/panel/tests/test_reactive.py
+++ b/panel/tests/test_reactive.py
@@ -123,7 +123,7 @@ def test_text_input_controls():
     assert len(controls) == 2
     wb1, wb2 = controls
     assert isinstance(wb1, WidgetBox)
-    assert len(wb1) == 6
+    assert len(wb1) == 7
     name, disabled, *(ws) = wb1
 
     assert isinstance(name, StaticText)
@@ -143,6 +143,10 @@ def test_text_input_controls():
             assert w.value == "Test placeholder..."
         elif w.name == 'Max length':
             assert isinstance(w, IntInput)
+        elif w.name == 'Description':
+            assert isinstance(w, TextInput)
+            text_input.description = "Test description..."
+            assert w.value == "Test description..."
         else:
             not_checked.append(w)
 

--- a/panel/tests/util.py
+++ b/panel/tests/util.py
@@ -13,14 +13,15 @@ from panel.io.server import serve
 
 # Ignore tests which are not yet working with Bokeh 3.
 # Will begin to fail again when the first rc is released.
+pnv = Version(pn.__version__)
 bokeh3_failing = pytest.mark.xfail(
-    not Version(pn.__version__).is_prerelease,
+    not (pnv.major == 1 and pnv.is_prerelease),
     reason="Bokeh 3: Not working yet"
 )
 # These tests passes when running alone
 # but will fail when running with all the other tests
 bokeh3_failing_all = pytest.mark.skipif(
-    not Version(pn.__version__).is_prerelease,
+    not (pnv.major == 1 and pnv.is_prerelease),
     reason="Bokeh 3: Not working when running all tests"
 )
 

--- a/panel/tests/widgets/test_input.py
+++ b/panel/tests/widgets/test_input.py
@@ -21,15 +21,15 @@ def test_checkbox(document, comm):
     widget = checkbox.get_root(document, comm=comm)
 
     assert isinstance(widget, checkbox._widget_type)
-    assert widget.labels == ['Checkbox']
-    assert widget.active == [0]
+    assert widget.label == 'Checkbox'
+    assert widget.active == True
 
-    widget.active = []
-    checkbox._process_events({'active': []})
+    widget.active = False
+    checkbox._process_events({'active': False})
     assert checkbox.value == False
 
     checkbox.value = True
-    assert widget.active == [0]
+    assert widget.active == True
 
 
 def test_date_picker(document, comm):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = [
     "param >=1.9.0",
     "pyct >=0.4.4",
     "setuptools >=42",
-    "bokeh >=3.0.0",
+    "bokeh >=3.0,<3.1",
     "pyviz_comms >=0.6.0",
     "requests",
     "bleach",

--- a/setup.py
+++ b/setup.py
@@ -103,7 +103,7 @@ except Exception:
 ########## dependencies ##########
 
 install_requires = [
-    'bokeh >=3.0.0',
+    'bokeh >=3.0,<3.1',
     'param >=1.12.0',
     'pyviz_comms >=0.7.4',
     'markdown',
@@ -210,7 +210,7 @@ extras_require['build'] = [
     'param >=1.9.2',
     'pyct >=0.4.4',
     'setuptools >=42',
-    'bokeh >=2.4.3,<2.5',
+    'bokeh >=3.0,<3.1',
     'pyviz_comms >=0.6.0',
     'bleach',
     'tqdm',


### PR DESCRIPTION
Mostly small fixes. 

Most of the fixes are related to changes made in #4130, where `panel.widgets.Checkbox` was switched from using `bokeh.models.CheckboxGroup` to `bokeh.models.Checkbox` as the `_widget_type`.
