### PR TITLE
Add ability to define async_to_sync_wrapper

### DIFF
--- a/panel/config.py
+++ b/panel/config.py
@@ -98,6 +98,10 @@ class _config(_base_config):
         Whether to set custom Signature which allows tab-completion
         in some IDEs and environments.""")
 
+    async_to_sync_wrapper = param.Callable(default=None, doc="""
+        Wrapper to ensure that calls from an asynchronous context are
+        safe, e.g. required for Django to safely access a database.""")
+
     authorize_callback = param.Callable(default=None, doc="""
         Authorization callback that is invoked when authentication
         is enabled. The callback is given the user information returned
@@ -243,7 +247,8 @@ class _config(_base_config):
         'admin_plugins', 'autoreload', 'comms', 'cookie_secret',
         'nthreads', 'oauth_provider', 'oauth_expiry', 'oauth_key',
         'oauth_secret', 'oauth_jwt_user', 'oauth_redirect_uri',
-        'oauth_encryption_key', 'oauth_extra_params', 'npm_cdn'
+        'oauth_encryption_key', 'oauth_extra_params', 'npm_cdn',
+        'async_to_sync_wrapper'
     ]
 
     _truthy = ['True', 'true', '1', True, 1]

--- a/panel/reactive.py
+++ b/panel/reactive.py
@@ -360,7 +360,7 @@ class Syncable(Renderable):
             with set_curdoc(doc):
                 try:
                     if config.async_to_sync_wrapper:
-                        await config.async_to_sync_wrapper(self._change_event)(doc)
+                        await config.async_to_sync_wrapper(partial(self._change_event, doc))()
                     else:
                         self._change_event(doc)
                 except Exception as e:
@@ -374,7 +374,7 @@ class Syncable(Renderable):
             from .config import config
             try:
                 if config.async_to_sync_wrapper:
-                    await config.async_to_sync_wrapper(self._process_bokeh_event)(event)
+                    await config.async_to_sync_wrapper(partial(self._process_bokeh_event, event))()
                 else:
                     self._process_bokeh_event(doc, event)
             except Exception as e:

--- a/panel/reactive.py
+++ b/panel/reactive.py
@@ -360,7 +360,7 @@ class Syncable(Renderable):
             with set_curdoc(doc):
                 try:
                     if config.async_to_sync_wrapper:
-                        await config.async_to_sync_wrapper(partial(self._change_event, doc))()
+                        await config.async_to_sync_wrapper(self._change_event)(doc)
                     else:
                         self._change_event(doc)
                 except Exception as e:
@@ -374,7 +374,7 @@ class Syncable(Renderable):
             from .config import config
             try:
                 if config.async_to_sync_wrapper:
-                    await config.async_to_sync_wrapper(partial(self._process_bokeh_event, doc, event))()
+                    await config.async_to_sync_wrapper(self._process_bokeh_event)(doc, event)
                 else:
                     self._process_bokeh_event(doc, event)
             except Exception as e:

--- a/panel/reactive.py
+++ b/panel/reactive.py
@@ -374,7 +374,7 @@ class Syncable(Renderable):
             from .config import config
             try:
                 if config.async_to_sync_wrapper:
-                    await config.async_to_sync_wrapper(partial(self._process_bokeh_event, event))()
+                    await config.async_to_sync_wrapper(partial(self._process_bokeh_event, doc, event))()
                 else:
                     self._process_bokeh_event(doc, event)
             except Exception as e:


### PR DESCRIPTION
This is useful for Django (and potentially other frameworks) that do not like executing code from an async context, e.g. for Django you can use this to register `database_async_to_sync` to allow database access in a callback.