### PR TITLE
Refactor util and add util.warnings

### DIFF
--- a/panel/entry_points.py
+++ b/panel/entry_points.py
@@ -28,9 +28,9 @@ except ImportError:
     try:
         import pkg_resources
     except ImportError:
-        import warnings
+        from .util.warnings import warn
 
-        warnings.warn(
+        warn(
             "Under Python <= 3.7, Panel requires either the importlib_metadata "
             "or setuptools package in order to load plugins via entrypoints.",
         )

--- a/panel/io/server.py
+++ b/panel/io/server.py
@@ -16,7 +16,6 @@ import sys
 import threading
 import traceback
 import uuid
-import warnings
 import weakref
 
 from collections import OrderedDict
@@ -66,6 +65,7 @@ from tornado.wsgi import WSGIContainer
 # Internal imports
 from ..config import config
 from ..util import edit_readonly, fullpath
+from ..util.warnings import warn
 from .document import init_doc, unlocked, with_lock  # noqa
 from .logging import (
     LOG_SESSION_CREATED, LOG_SESSION_DESTROYED, LOG_SESSION_LAUNCHING,
@@ -967,7 +967,7 @@ def get_server(
         except RuntimeError:
             pass
         except TypeError:
-            warnings.warn(
+            warn(
                 "IOLoop couldn't be started. Ensure it is started by "
                 "process invoking the panel.io.server.serve."
             )

--- a/panel/links.py
+++ b/panel/links.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 import difflib
 import sys
-import warnings
 import weakref
 
 from typing import (
@@ -20,6 +19,7 @@ from bokeh.models import CustomJS, LayoutDOM, Model as BkModel
 from .io.datamodel import create_linked_datamodel
 from .models import ReactiveHTML
 from .reactive import Reactive
+from .util.warnings import warn
 from .viewable import Viewable
 
 if TYPE_CHECKING:
@@ -499,7 +499,7 @@ class CallbackGenerator(object):
                 if self.error:
                     raise ValueError(msg)
                 else:
-                    warnings.warn(msg)
+                    warn(msg)
             tgt_model.js_on_change(ch, tgt_cb)
         for ev in events:
             tgt_model.js_on_event(ev, tgt_cb)

--- a/panel/pane/base.py
+++ b/panel/pane/base.py
@@ -4,8 +4,6 @@ objects to a visual representation expressed as a bokeh model.
 """
 from __future__ import annotations
 
-import warnings
-
 from functools import partial
 from typing import (
     TYPE_CHECKING, Any, Callable, ClassVar, List, Optional, Type, TypeVar,
@@ -25,6 +23,7 @@ from ..links import Link
 from ..models import ReactiveHTML as _BkReactiveHTML
 from ..reactive import Reactive
 from ..util import param_reprs
+from ..util.warnings import deprecated
 from ..viewable import (
     Layoutable, ServableMixin, Viewable, Viewer,
 )
@@ -39,10 +38,7 @@ def Pane(obj: Any, **kwargs) -> 'PaneBase':
     """
     Converts any object to a Pane if a matching Pane class exists.
     """
-    warnings.warn(
-        'panel.Pane(...) is deprecated, use panel.panel(...) instead.',
-        DeprecationWarning
-    )
+    deprecated("1.0", "panel.Pane", "panel.panel")
     if isinstance(obj, Viewable):
         return obj
     return PaneBase.get_pane_type(obj, **kwargs)(obj, **kwargs)

--- a/panel/pane/perspective.py
+++ b/panel/pane/perspective.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import datetime as dt
 import sys
-import warnings
 
 from enum import Enum
 from typing import (
@@ -17,6 +16,7 @@ from pyviz_comms import JupyterComm
 
 from ..reactive import ReactiveData
 from ..util import lazy_load
+from ..util.warnings import deprecated
 from ..viewable import Viewable
 from .base import PaneBase
 
@@ -389,10 +389,7 @@ class Perspective(PaneBase, ReactiveData):
         updates = {}
         for event in events:
             renamed = self._deprecations[event.name]
-            warnings.warn(
-                f'The {event.name!r} parameter is deprecated use {renamed!r} parameter instead.',
-                DeprecationWarning
-            )
+            deprecated("1.0", event.name, renamed)
             updates[renamed] = event.new
         self.param.update(**updates)
 

--- a/panel/tests/layout/test_accordion.py
+++ b/panel/tests/layout/test_accordion.py
@@ -2,9 +2,10 @@ import pytest
 
 from bokeh.models import Column as BkColumn, Div
 
+import panel as pn
+
 from panel.layout import Accordion
 from panel.models import Card
-from panel.pane import Pane
 
 
 @pytest.fixture
@@ -57,8 +58,8 @@ def test_accordion_constructor(document, comm):
 
 def test_accordion_implicit_constructor(document, comm):
     div1, div2 = Div(), Div()
-    p1 = Pane(div1, name='Div1')
-    p2 = Pane(div2, name='Div2')
+    p1 = pn.panel(div1, name='Div1')
+    p2 = pn.panel(div2, name='Div2')
     accordion = Accordion(p1, p2)
 
     model = accordion.get_root(document, comm=comm)
@@ -76,8 +77,8 @@ def test_accordion_implicit_constructor(document, comm):
 
 def test_accordion_constructor_with_named_objects(document, comm):
     div1, div2 = Div(), Div()
-    p1 = Pane(div1, name='Div1')
-    p2 = Pane(div2, name='Div2')
+    p1 = pn.panel(div1, name='Div1')
+    p2 = pn.panel(div2, name='Div2')
     accordion = Accordion(('Tab1', p1), ('Tab2', p2))
 
     model = accordion.get_root(document, comm=comm)

--- a/panel/tests/layout/test_tabs.py
+++ b/panel/tests/layout/test_tabs.py
@@ -4,8 +4,9 @@ from bokeh.models import (
     Div, Panel as BkPanel, Spacer as BkSpacer, Tabs as BkTabs,
 )
 
+import panel as pn
+
 from panel.layout import Tabs
-from panel.pane import Pane
 
 
 @pytest.fixture
@@ -58,8 +59,8 @@ def test_tabs_constructor(document, comm):
 
 def test_tabs_implicit_constructor(document, comm):
     div1, div2 = Div(), Div()
-    p1 = Pane(div1, name='Div1')
-    p2 = Pane(div2, name='Div2')
+    p1 = pn.panel(div1, name='Div1')
+    p2 = pn.panel(div2, name='Div2')
     tabs = Tabs(p1, p2)
 
     model = tabs.get_root(document, comm=comm)
@@ -77,8 +78,8 @@ def test_tabs_implicit_constructor(document, comm):
 
 def test_tabs_constructor_with_named_objects(document, comm):
     div1, div2 = Div(), Div()
-    p1 = Pane(div1, name='Div1')
-    p2 = Pane(div2, name='Div2')
+    p1 = pn.panel(div1, name='Div1')
+    p2 = pn.panel(div2, name='Div2')
     tabs = Tabs(('Tab1', p1), ('Tab2', p2))
 
     model = tabs.get_root(document, comm=comm)
@@ -185,14 +186,14 @@ def test_tabs_radd_list(document, comm):
 
 def test_tabs_set_panes(document, comm):
     div1, div2 = Div(), Div()
-    p1 = Pane(div1, name='Div1')
-    p2 = Pane(div2, name='Div2')
+    p1 = pn.panel(div1, name='Div1')
+    p2 = pn.panel(div2, name='Div2')
     tabs = Tabs(p1, p2)
 
     model = tabs.get_root(document, comm=comm)
 
     div3 = Div()
-    p3 = Pane(div3, name='Div3')
+    p3 = pn.panel(div3, name='Div3')
     tabs.objects = [p1, p2, p3]
 
     assert isinstance(model, BkTabs)
@@ -210,8 +211,8 @@ def test_tabs_set_panes(document, comm):
 
 def test_tabs_reverse(document, comm):
     div1, div2 = Div(), Div()
-    p1 = Pane(div1, name='Div1')
-    p2 = Pane(div2, name='Div2')
+    p1 = pn.panel(div1, name='Div1')
+    p2 = pn.panel(div2, name='Div2')
     tabs = Tabs(p1, p2)
 
     model = tabs.get_root(document, comm=comm)
@@ -303,7 +304,7 @@ def test_tabs_append_uses_object_name(document, comm, tabs):
     tab1_before, tab2_before = model.tabs
 
     div3 = Div()
-    p3 = Pane(div3, name='Div3')
+    p3 = pn.panel(div3, name='Div3')
     tabs.append(p3)
 
     tab1, tab2, tab3 = model.tabs
@@ -334,7 +335,7 @@ def test_tabs_append_with_tuple_and_named_contents(document, comm, tabs):
     tab1_before, tab2_before = model.tabs
 
     div3 = Div()
-    p3 = Pane(div3, name='Div3')
+    p3 = pn.panel(div3, name='Div3')
     tabs.append(('Tab3', p3))
 
     tab1, tab2, tab3 = model.tabs
@@ -381,7 +382,7 @@ def test_tabs_extend_uses_object_name(document, comm, tabs):
     tab1_before, tab2_before = model.tabs
 
     div3, div4 = Div(), Div()
-    p3, p4 = Pane(div3, name='Div3'), Pane(div4, name='Div4')
+    p3, p4 = pn.panel(div3, name='Div3'), pn.panel(div4, name='Div4')
     tabs.extend([p4, p3])
 
     tab1, tab2, tab3, tab4 = model.tabs
@@ -416,7 +417,7 @@ def test_tabs_extend_with_tuple_and_named_contents(document, comm, tabs):
     tab1_before, tab2_before = model.tabs
 
     div3, div4 = Div(), Div()
-    p3, p4 = Pane(div3, name='Div3'), Pane(div4, name='Div4')
+    p3, p4 = pn.panel(div3, name='Div3'), pn.panel(div4, name='Div4')
     tabs.extend([('Tab4', p4), ('Tab3', p3)])
 
     tab1, tab2, tab3, tab4 = model.tabs
@@ -450,7 +451,7 @@ def test_tabs_insert_uses_object_name(document, comm, tabs):
     tab1_before, tab2_before = model.tabs
 
     div3 = Div()
-    p3 = Pane(div3, name='Div3')
+    p3 = pn.panel(div3, name='Div3')
     tabs.insert(1, p3)
 
     tab1, tab2, tab3 = model.tabs
@@ -480,7 +481,7 @@ def test_tabs_insert_with_tuple_and_named_contents(document, comm, tabs):
     tab1_before, tab2_before = model.tabs
 
     div3 = Div()
-    p3 = Pane(div3, name='Div3')
+    p3 = pn.panel(div3, name='Div3')
     tabs.insert(1, ('Tab3', p3))
     tab1, tab2, tab3 = model.tabs
 
@@ -513,7 +514,7 @@ def test_tabs_setitem(document, comm):
 def test_tabs_clone():
     div1 = Div()
     div2 = Div()
-    tabs = Tabs(Pane(div1), Pane(div2))
+    tabs = Tabs(pn.panel(div1), pn.panel(div2))
     clone = tabs.clone()
 
     assert ([(k, v) for k, v in tabs.param.values().items() if k != 'name'] ==

--- a/panel/tests/pane/test_base.py
+++ b/panel/tests/pane/test_base.py
@@ -1,11 +1,13 @@
 import param
 import pytest
 
+import panel as pn
+
 from panel.interact import interactive
 from panel.layout import Row
 from panel.links import CallbackGenerator
 from panel.pane import (
-    IDOM, Bokeh, HoloViews, Interactive, IPyWidget, Pane, PaneBase, Vega,
+    IDOM, Bokeh, HoloViews, Interactive, IPyWidget, PaneBase, Vega,
 )
 from panel.param import ParamMethod
 from panel.tests.util import check_layoutable_properties
@@ -19,7 +21,7 @@ all_panes = [w for w in param.concrete_descendents(PaneBase).values()
 
 
 def test_pane_repr(document, comm):
-    pane = Pane('Some text', width=400)
+    pane = pn.panel('Some text', width=400)
     assert repr(pane) == 'Markdown(str, width=400)'
 
 

--- a/panel/tests/pane/test_holoviews.py
+++ b/panel/tests/pane/test_holoviews.py
@@ -17,8 +17,10 @@ from bokeh.models import (
 )
 from bokeh.plotting import Figure
 
+import panel as pn
+
 from panel.layout import Column, FlexBox, Row
-from panel.pane import HoloViews, Pane, PaneBase
+from panel.pane import HoloViews, PaneBase
 from panel.tests.util import hv_available, mpl_available
 from panel.widgets import DiscreteSlider, FloatSlider, Select
 
@@ -34,7 +36,7 @@ def test_get_holoviews_pane_type():
 @hv_available
 def test_holoviews_pane_mpl_renderer(document, comm):
     curve = hv.Curve([1, 2, 3])
-    pane = Pane(curve)
+    pane = pn.panel(curve)
 
     # Create pane
     row = pane.get_root(document, comm=comm)
@@ -61,7 +63,7 @@ def test_holoviews_pane_mpl_renderer(document, comm):
 @hv_available
 def test_holoviews_pane_switch_backend(document, comm):
     curve = hv.Curve([1, 2, 3])
-    pane = Pane(curve)
+    pane = pn.panel(curve)
 
     # Create pane
     row = pane.get_root(document, comm=comm)
@@ -85,7 +87,7 @@ def test_holoviews_pane_switch_backend(document, comm):
 @hv_available
 def test_holoviews_pane_bokeh_renderer(document, comm):
     curve = hv.Curve([1, 2, 3])
-    pane = Pane(curve)
+    pane = pn.panel(curve)
 
     # Create pane
     row = pane.get_root(document, comm=comm)
@@ -512,7 +514,7 @@ def test_holoviews_link_across_panes(document, comm):
 
     RangeToolLink(c1, c2)
 
-    layout = Row(Pane(c1, backend='bokeh'), Pane(c2, backend='bokeh'))
+    layout = Row(pn.panel(c1, backend='bokeh'), pn.panel(c2, backend='bokeh'))
     row = layout.get_root(document, comm=comm)
 
     assert len(row.children) == 2
@@ -536,7 +538,7 @@ def test_holoviews_link_after_adding_item(document, comm):
 
     RangeToolLink(c1, c2)
 
-    layout = Row(Pane(c1, backend='bokeh'))
+    layout = Row(pn.panel(c1, backend='bokeh'))
     row = layout.get_root(document, comm=comm)
 
     assert len(row.children) == 1
@@ -546,7 +548,7 @@ def test_holoviews_link_after_adding_item(document, comm):
     range_tool = row.select_one({'type': RangeTool})
     assert range_tool is None
 
-    layout.append(Pane(c2, backend='bokeh'))
+    layout.append(pn.panel(c2, backend='bokeh'))
     _, p2 = row.children
     assert isinstance(p2, Figure)
     range_tool = row.select_one({'type': RangeTool})
@@ -564,7 +566,7 @@ def test_holoviews_link_within_pane(document, comm):
 
     RangeToolLink(c1, c2)
 
-    pane = Pane(Pane(hv.Layout([c1, c2]), backend='bokeh'))
+    pane = pn.panel(pn.panel(hv.Layout([c1, c2]), backend='bokeh'))
     column = pane.get_root(document, comm=comm)
 
     assert len(column.children) == 1
@@ -588,7 +590,7 @@ def test_holoviews_link_within_pane(document, comm):
 def test_holoviews_property_override(document, comm):
     c1 = hv.Curve([])
 
-    pane = Pane(c1, backend='bokeh', background='red',
+    pane = pn.panel(c1, backend='bokeh', background='red',
                 css_classes=['test_class'])
     model = pane.get_root(document, comm=comm)
 

--- a/panel/tests/pane/test_markup.py
+++ b/panel/tests/pane/test_markup.py
@@ -3,8 +3,10 @@ import json
 
 import numpy as np
 
+import panel as pn
+
 from panel.pane import (
-    HTML, JSON, DataFrame, Markdown, Pane, PaneBase, Str,
+    HTML, JSON, DataFrame, Markdown, PaneBase, Str,
 )
 from panel.tests.util import pd_available, streamz_available
 
@@ -50,7 +52,7 @@ def test_get_streamz_seriess_pane_type():
 
 
 def test_markdown_pane(document, comm):
-    pane = Pane("**Markdown**")
+    pane = pn.panel("**Markdown**")
 
     # Create pane
     model = pane.get_root(document, comm=comm)
@@ -67,7 +69,7 @@ def test_markdown_pane(document, comm):
     assert pane._models == {}
 
 def test_markdown_pane_dedent(document, comm):
-    pane = Pane("    ABC")
+    pane = pn.panel("    ABC")
 
     # Create pane
     model = pane.get_root(document, comm=comm)
@@ -79,7 +81,7 @@ def test_markdown_pane_dedent(document, comm):
 
 
 def test_markdown_pane_extensions(document, comm):
-    pane = Pane("""
+    pane = pn.panel("""
     ```python
     None
     ```

--- a/panel/tests/pane/test_plot.py
+++ b/panel/tests/pane/test_plot.py
@@ -1,8 +1,8 @@
 from bokeh.models import Div, Row as BkRow
 
-from panel.pane import (
-    Bokeh, Matplotlib, Pane, PaneBase,
-)
+import panel as pn
+
+from panel.pane import Bokeh, Matplotlib, PaneBase
 from panel.tests.util import mpl_available, mpl_figure
 
 
@@ -13,7 +13,7 @@ def test_get_bokeh_pane_type():
 
 def test_bokeh_pane(document, comm):
     div = Div()
-    pane = Pane(div)
+    pane = pn.panel(div)
 
     # Create pane
     row = pane.get_root(document, comm=comm)
@@ -42,7 +42,7 @@ def test_get_matplotlib_pane_type():
 
 @mpl_available
 def test_matplotlib_pane(document, comm):
-    pane = Pane(mpl_figure())
+    pane = pn.panel(mpl_figure())
 
     # Create pane
     model = pane.get_root(document, comm=comm)

--- a/panel/tests/test_param.py
+++ b/panel/tests/test_param.py
@@ -13,7 +13,7 @@ from bokeh.models import (
 from panel.io.state import set_curdoc, state
 from panel.layout import Row, Tabs
 from panel.pane import (
-    HTML, Bokeh, Matplotlib, Pane, PaneBase, Str, panel,
+    HTML, Bokeh, Matplotlib, PaneBase, Str, panel,
 )
 from panel.param import (
     JSONInit, Param, ParamFunction, ParamMethod,
@@ -23,6 +23,10 @@ from panel.widgets import (
     AutocompleteInput, DatePicker, DatetimeInput, EditableFloatSlider,
     EditableRangeSlider, LiteralInput, NumberInput, RangeSlider,
 )
+
+
+def Pane(obj, **kwargs):
+    return PaneBase.get_pane_type(obj, **kwargs)(obj, **kwargs)
 
 
 def test_instantiate_from_class():

--- a/panel/util/__init__.py
+++ b/panel/util/__init__.py
@@ -21,9 +21,7 @@ from datetime import datetime
 from functools import partial
 from html import escape  # noqa
 from importlib import import_module
-from typing import (
-    Any, AnyStr, Dict, Iterator, List, Union,
-)
+from typing import Any, AnyStr, Iterator
 
 import bokeh
 import numpy as np
@@ -76,7 +74,7 @@ def param_name(name: str) -> str:
     return name[:name.index(match[0])] if match else name
 
 
-def recursive_parameterized(parameterized: param.Parameterized, objects=None) -> List[param.Parameterized]:
+def recursive_parameterized(parameterized: param.Parameterized, objects=None) -> list[param.Parameterized]:
     """
     Recursively searches a Parameterized object for other Parmeterized
     objects.
@@ -151,7 +149,7 @@ def param_reprs(parameterized, skip=None):
         elif isinstance(v, dict) and v == {}: continue
         elif (skip and p in skip) or (p == 'name' and v.startswith(cls)): continue
         else: v = abbreviated_repr(v)
-        param_reprs.append('%s=%s' % (p, v))
+        param_reprs.append(f'{p}={v}')
     return param_reprs
 
 
@@ -199,13 +197,13 @@ def datetime_as_utctimestamp(value):
     return value.replace(tzinfo=dt.timezone.utc).timestamp() * 1000
 
 
-def parse_query(query: str) -> Dict[str, Any]:
+def parse_query(query: str) -> dict[str, Any]:
     """
     Parses a url query string, e.g. ?a=1&b=2.1&c=string, converting
     numeric strings to int or float types.
     """
     query_dict = dict(urlparse.parse_qsl(query[1:]))
-    parsed_query: Dict[str, Any] = {}
+    parsed_query: dict[str, Any] = {}
     for k, v in query_dict.items():
         if v.isdigit():
             parsed_query[k] = int(v)
@@ -243,7 +241,7 @@ def base64url_decode(input):
     return base64.urlsafe_b64decode(input)
 
 
-class classproperty(object):
+class classproperty:
 
     def __init__(self, f):
         self.f = f
@@ -356,7 +354,7 @@ def parse_timedelta(time_str: str) -> dt.timedelta | None:
     return dt.timedelta(**time_params)
 
 
-def fullpath(path: Union[AnyStr, os.PathLike]) -> Union[AnyStr, os.PathLike]:
+def fullpath(path: AnyStr | os.PathLike) -> AnyStr | os.PathLike:
     """Expanduser and then abspath for a given path
     """
     return os.path.abspath(os.path.expanduser(path))

--- a/panel/util/__init__.py
+++ b/panel/util/__init__.py
@@ -22,7 +22,7 @@ from functools import partial
 from html import escape  # noqa
 from importlib import import_module
 from typing import (
-    Any, AnyStr, Dict, Iterable, Iterator, List, Optional, Union,
+    Any, AnyStr, Dict, Iterator, List, Union,
 )
 
 import bokeh
@@ -32,44 +32,15 @@ import param
 from bokeh.model import Model
 from packaging.version import Version
 
-datetime_types = (np.datetime64, dt.datetime, dt.date)
+from .checks import (  # noqa
+    datetime_types, is_dataframe, is_holoviews, is_number, is_parameterized,
+    is_series, isdatetime, isfile, isIn, isurl,
+)
 
 bokeh_version = Version(bokeh.__version__)
 
 
 PARAM_NAME_PATTERN = re.compile(r'^.*\d{5}$')
-
-
-def isfile(path: str) -> bool:
-    """Safe version of os.path.isfile robust to path length issues on Windows"""
-    try:
-        return os.path.isfile(path)
-    except ValueError: # path too long for Windows
-        return False
-
-
-def isurl(obj: Any, formats: Optional[Iterable[str]] = None) -> bool:
-    if not isinstance(obj, str):
-        return False
-    lower_string = obj.lower().split('?')[0].split('#')[0]
-    return (
-        lower_string.startswith('http://')
-        or lower_string.startswith('https://')
-    ) and (formats is None or any(lower_string.endswith('.'+fmt) for fmt in formats))
-
-
-def is_dataframe(obj) -> bool:
-    if 'pandas' not in sys.modules:
-        return False
-    import pandas as pd
-    return isinstance(obj, pd.DataFrame)
-
-
-def is_series(obj) -> bool:
-    if 'pandas' not in sys.modules:
-        return False
-    import pandas as pd
-    return isinstance(obj, pd.Series)
 
 
 def hashable(x):
@@ -79,22 +50,6 @@ def hashable(x):
         return tuple([(k,v) for k,v in x.items()])
     else:
         return x
-
-
-def isIn(obj, objs):
-    """
-    Checks if the object is in the list of objects safely.
-    """
-    for o in objs:
-        if o is obj:
-            return True
-        try:
-            if o == obj:
-                return True
-        except Exception:
-            pass
-    return False
-
 
 def indexOf(obj, objs):
     """
@@ -219,39 +174,6 @@ def get_method_owner(meth):
         return meth.__self__
 
 
-def is_parameterized(obj) -> bool:
-    """
-    Whether an object is a Parameterized class or instance.
-    """
-    return (isinstance(obj, param.Parameterized) or
-            (isinstance(obj, type) and issubclass(obj, param.Parameterized)))
-
-def is_holoviews(obj: Any) -> bool:
-    """
-    Whether the object is a HoloViews type that can be rendered.
-    """
-    if 'holoviews' not in sys.modules:
-        return False
-    from holoviews.core.dimension import Dimensioned
-    from holoviews.plotting import Plot
-    return isinstance(obj, (Dimensioned, Plot))
-
-def isdatetime(value) -> bool:
-    """
-    Whether the array or scalar is recognized datetime type.
-    """
-    if is_series(value) and len(value):
-        return isinstance(value.iloc[0], datetime_types)
-    elif isinstance(value, np.ndarray):
-        return (
-            value.dtype.kind == "M" or
-            (value.dtype.kind == "O" and len(value) != 0 and
-             isinstance(value[0], datetime_types))
-        )
-    elif isinstance(value, list):
-        return all(isinstance(d, datetime_types) for d in value)
-    else:
-        return isinstance(value, datetime_types)
 
 def value_as_datetime(value):
     """
@@ -275,14 +197,6 @@ def datetime_as_utctimestamp(value):
     Converts a datetime to a UTC timestamp used by Bokeh interally.
     """
     return value.replace(tzinfo=dt.timezone.utc).timestamp() * 1000
-
-
-def is_number(s: Any) -> bool:
-    try:
-        float(s)
-        return True
-    except ValueError:
-        return False
 
 
 def parse_query(query: str) -> Dict[str, Any]:
@@ -387,7 +301,7 @@ def lazy_load(module, model, notebook=False, root=None):
             f'\n\npn.extension(\'{ext}\')\n'
         )
     elif root is not None:
-        from .io.state import state
+        from ..io.state import state
         ext = module.split('.')[-1]
         if root.ref['id'] in state._views:
             param.main.param.warning(

--- a/panel/util/checks.py
+++ b/panel/util/checks.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import datetime as dt
+import os
+import sys
+
+from typing import Any, Iterable
+
+import numpy as np
+import param
+
+__all__ = (
+    "datetime_types",
+    "is_dataframe",
+    "is_holoviews",
+    "is_number",
+    "is_parameterized",
+    "is_series",
+    "isdatetime",
+    "isfile",
+    "isIn",
+    "isurl",
+)
+
+
+datetime_types = (np.datetime64, dt.datetime, dt.date)
+
+
+def isfile(path: str) -> bool:
+    """Safe version of os.path.isfile robust to path length issues on Windows"""
+    try:
+        return os.path.isfile(path)
+    except ValueError: # path too long for Windows
+        return False
+
+
+def isurl(obj: Any, formats: Iterable[str] | None = None) -> bool:
+    if not isinstance(obj, str):
+        return False
+    lower_string = obj.lower().split('?')[0].split('#')[0]
+    return (
+        lower_string.startswith('http://')
+        or lower_string.startswith('https://')
+    ) and (formats is None or any(lower_string.endswith('.'+fmt) for fmt in formats))
+
+
+def is_dataframe(obj) -> bool:
+    if 'pandas' not in sys.modules:
+        return False
+    import pandas as pd
+    return isinstance(obj, pd.DataFrame)
+
+
+def is_series(obj) -> bool:
+    if 'pandas' not in sys.modules:
+        return False
+    import pandas as pd
+    return isinstance(obj, pd.Series)
+
+
+def isIn(obj, objs):
+    """
+    Checks if the object is in the list of objects safely.
+    """
+    for o in objs:
+        if o is obj:
+            return True
+        try:
+            if o == obj:
+                return True
+        except Exception:
+            pass
+    return False
+
+
+def is_parameterized(obj) -> bool:
+    """
+    Whether an object is a Parameterized class or instance.
+    """
+    return (isinstance(obj, param.Parameterized) or
+            (isinstance(obj, type) and issubclass(obj, param.Parameterized)))
+
+
+def is_holoviews(obj: Any) -> bool:
+    """
+    Whether the object is a HoloViews type that can be rendered.
+    """
+    if 'holoviews' not in sys.modules:
+        return False
+    from holoviews.core.dimension import Dimensioned
+    from holoviews.plotting import Plot
+    return isinstance(obj, (Dimensioned, Plot))
+
+
+def isdatetime(value) -> bool:
+    """
+    Whether the array or scalar is recognized datetime type.
+    """
+    if is_series(value) and len(value):
+        return isinstance(value.iloc[0], datetime_types)
+    elif isinstance(value, np.ndarray):
+        return (
+            value.dtype.kind == "M" or
+            (value.dtype.kind == "O" and len(value) != 0 and
+             isinstance(value[0], datetime_types))
+        )
+    elif isinstance(value, list):
+        return all(isinstance(d, datetime_types) for d in value)
+    else:
+        return isinstance(value, datetime_types)
+
+
+def is_number(s: Any) -> bool:
+    try:
+        float(s)
+        return True
+    except ValueError:
+        return False

--- a/panel/util/warnings.py
+++ b/panel/util/warnings.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import inspect
+import os
+import warnings
+
+import param
+
+from packaging.version import Version
+
+__all__ = (
+    "deprecated",
+    "find_stack_level",
+    "PanelDeprecationWarning",
+    "PanelUserWarning",
+    "warn",
+)
+
+
+def warn(
+    message: str, category: type[Warning] | None = None, stacklevel: int | None = None
+) -> None:
+    if stacklevel is None:
+        stacklevel = find_stack_level()
+
+    warnings.warn(message, category, stacklevel=stacklevel)
+
+
+def find_stack_level() -> int:
+    """
+    Find the first place in the stack that is not inside Panel and Param.
+    Inspired by: pandas.util._exceptions.find_stack_level
+    """
+
+    import panel as pn
+
+    pkg_dir = os.path.dirname(pn.__file__)
+    test_dir = os.path.join(pkg_dir, "tests")
+    param_dir = os.path.dirname(param.__file__)
+
+    frame = inspect.currentframe()
+    stacklevel = 1
+    while frame:
+        fname = inspect.getfile(frame)
+        if (
+            fname.startswith(pkg_dir) or fname.startswith(param_dir)
+        ) and not fname.startswith(test_dir):
+            frame = frame.f_back
+            stacklevel += 1
+        else:
+            break
+
+    return stacklevel
+
+
+def deprecated(
+    remove_version: Version | str,
+    old: str,
+    new: str | None = None,
+    extra: str | None = None,
+) -> None:
+
+    import panel as pn
+
+    current_version = Version(pn.__version__)
+
+    if isinstance(remove_version, str):
+        remove_version = Version(remove_version)
+
+    if remove_version < current_version:
+        # This is most for developers to secure that the removal actually find place
+        raise ValueError(
+            f"{old!r} should have been removed in {remove_version}, current version {current_version}"
+        )
+
+    message = f"{old!r} is deprecated and will be removed in version {remove_version}."
+
+    if new:
+        message = f"{message[:-1]}, use {new!r} instead."
+
+    if extra:
+        message += " " + extra.strip()
+
+    warn(message, PanelDeprecationWarning)
+
+
+class PanelDeprecationWarning(DeprecationWarning):
+    """A Panel-specific ``DeprecationWarning`` subclass.
+    Used to selectively filter Panel deprecations for unconditional display.
+    """
+
+
+class PanelUserWarning(UserWarning):
+    """A Panel-specific ``UserWarning`` subclass.
+    Used to selectively filter Panel warnings for unconditional display.
+    """
+
+
+warnings.simplefilter("always", PanelDeprecationWarning)
+warnings.simplefilter("always", PanelUserWarning)

--- a/panel/util/warnings.py
+++ b/panel/util/warnings.py
@@ -39,7 +39,7 @@ def find_stack_level() -> int:
     param_dir = os.path.dirname(param.__file__)
 
     frame = inspect.currentframe()
-    stacklevel = 1
+    stacklevel = 0
     while frame:
         fname = inspect.getfile(frame)
         if (
@@ -68,9 +68,9 @@ def deprecated(
         remove_version = Version(remove_version)
 
     if remove_version < current_version:
-        # This is most for developers to secure that the removal actually find place
+        # This error is mainly for developers to remove the deprecated.
         raise ValueError(
-            f"{old!r} should have been removed in {remove_version}, current version {current_version}"
+            f"{old!r} should have been removed in {remove_version}, current version {current_version}."
         )
 
     message = f"{old!r} is deprecated and will be removed in version {remove_version}."


### PR DESCRIPTION
At first, this PR was meant only to give a visible warning to users when running `pn.Pane`.

I wanted to add a `find_stack_level` and the logical place to have it was in `util.py`, but I felt like it would pollute the file. So I moved it to `util/__init__.py`  and split the checks into `util/checks.py`, and then imported them back into the `__ini__.py`. This should make it backward-compatible. And because I already was in these files, I made some small refactoring mostly related to type hints. 

Finally, I created a `util/warnings.py` and created a `deprecated` function, which needs a version when the function is removed from Panel. I have added an error for when this version is exceeded by Panel itself.  

Some questions:
- I would like to change all the check functions to start with `is_XXX`. But for now, I haven't done it. 
- Should I add a `deprecated` to other things, here I'm mainly thinking about `pn.pane.VTK`.