### PR TITLE
Make refresh_token available in Auth

### DIFF
--- a/doc/user_guide/Authentication.md
+++ b/doc/user_guide/Authentication.md
@@ -138,6 +138,7 @@ Once a user is authorized with the chosen OAuth provider certain user informatio
 
 * **`pn.state.user`**: A unique name, email or ID that identifies the user.
 * **`pn.state.access_token`**: The access token issued by the OAuth provider to authorize requests to its APIs.
+* **`pn.state.refresh_token`**: The refresh token issued by the OAuth provider to authorize requests to its APIs (if available these are usually longer lived than the `access_token`).
 * **`pn.state.user_info`**: Additional user information provided by the OAuth provider. This may include names, email, APIs to request further user information, IDs and more.
 
 ## Authorization

--- a/doc/user_guide/Overview.md
+++ b/doc/user_guide/Overview.md
@@ -161,6 +161,7 @@ The `pn.config` object allows setting various configuration variables, the confi
 > - `throttled`: Whether sliders and inputs should be throttled until release of mouse.
 
 #### Python and Environment variables
+
 > - `comms` (`PANEL_COMMS`): Whether to render output in Jupyter with the default Jupyter extension or use the `jupyter_bokeh` ipywidget model.
 > - `console_output` (`PANEL_CONSOLE_OUTPUT`): How to log errors and stdout output triggered by callbacks from Javascript in the notebook. Options include `'accumulate'`, `'replace'` and `'disable'`.
 > - `embed` (`PANEL_EMBED`): Whether plot data will be [embedded](./Deploy_and_Export.rst#Embedding).
@@ -175,6 +176,7 @@ The `pn.config` object allows setting various configuration variables, the confi
 
 The `pn.state` object makes various global state available and provides methods to manage that state:
 
+- - `access_token`: The access token issued by the OAuth provider to authorize requests to its APIs.
 > - `busy`: A boolean value to indicate whether a callback is being actively processed.
 > - `cache`: A global cache which can be used to share data between different processes.
 > - `cookies`: HTTP request cookies for the current session.
@@ -189,6 +191,7 @@ The `pn.state` object makes various global state available and provides methods 
 >   * `protocol` (readonly): protocol in window.location e.g. 'http:' or 'https:'
 >   * `port` (readonly): port in window.location e.g. '80'
 > - `headers`: HTTP request headers for the current session.
+> - `refresh_token`: The refresh token issued by the OAuth provider to authorize requests to its APIs (if available these are usually longer lived than the `access_token`).
 > - `session_args`: When running a server session this return the request arguments.
 > - `session_info`: A dictionary tracking information about server sessions:
 >   * `total` (int): The total number of sessions that have been opened

--- a/panel/io/state.py
+++ b/panel/io/state.py
@@ -821,18 +821,25 @@ class _state(param.Parameterized):
     # Public Properties
     #----------------------------------------------------------------
 
-    @property
-    def access_token(self) -> str | None:
+    def _decode_cookie(self, cookie_name):
         from tornado.web import decode_signed_value
 
         from ..config import config
-        access_token = self.cookies.get('access_token')
-        if access_token is None:
+        cookie = self.cookies.get(cookie_name)
+        if cookie is None:
             return None
-        access_token = decode_signed_value(config.cookie_secret, 'access_token', access_token)
+        cookie = decode_signed_value(config.cookie_secret, cookie_name, cookie)
         if self.encryption is None:
-            return access_token.decode('utf-8')
-        return self.encryption.decrypt(access_token).decode('utf-8')
+            return cookie.decode('utf-8')
+        return self.encryption.decrypt(cookie).decode('utf-8')
+
+    @property
+    def access_token(self) -> str | None:
+        return self._decode_cookie('access_token')
+
+    @property
+    def refresh_token(self) -> str | None:
+        return self._decode_cookie('refresh_token')
 
     @property
     def app_url(self) -> str | None:


### PR DESCRIPTION
Exposes the `refresh_token` from an OAuth provider (if available). This is useful in cases where the `authorize_token` expires quickly.

Fixes https://github.com/holoviz/panel/issues/4223