### PR TITLE
fix: require wheel for setup

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,5 +8,6 @@ requires = [
     "requests",
     "bleach",
     "packaging",
-    "tqdm >=4.48.0"
+    "tqdm >=4.48.0",
+    "wheel"
 ]


### PR DESCRIPTION
Small fix that gets rid of some of the warnings when installing from this branch.