### PR TITLE
Disable

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,3 +26,5 @@ repos:
     hooks:
       - id: isort
         name: isort (python)
+ci:
+  autofix_prs: false


### PR DESCRIPTION
Enabled the CI which automatically pushes fixes by default. This PR disables this but you can still trigger it by commenting:

```
pre-commit.ci run
```