### PR TITLE
Simplify determining whether script is executed as application

### DIFF
--- a/doc/api/state.md
+++ b/doc/api/state.md
@@ -36,6 +36,9 @@ The `pn.state` object makes various global state available and provides methods 
 `refresh_token`
 : The refresh token issued by the OAuth provider to authorize requests to its APIs (if available these are usually longer lived than the `access_token`).
 
+`served`
+:Whether we are currently inside a script or notebook that is being served using `panel serve`.
+
 `session_args`
 : When running a server session this return the request arguments.
 

--- a/panel/io/state.py
+++ b/panel/io/state.py
@@ -835,24 +835,16 @@ class _state(param.Parameterized):
 
     @property
     def access_token(self) -> str | None:
+        """
+        Returns the OAuth access_token if enabled.
+        """
         return self._decode_cookie('access_token')
 
     @property
-    def refresh_token(self) -> str | None:
-        return self._decode_cookie('refresh_token')
-
-    @property
-    def in_app(self):
-        """
-        Determines whether we are in an application context.
-        """
-        try:
-            return inspect.stack()[1].frame.f_globals['__name__'].startswith('bokeh_app_')
-        except Exception:
-            return False
-
-    @property
     def app_url(self) -> str | None:
+        """
+        Returns the URL of the app that is currently being executed.
+        """
         if not self.curdoc:
             return
         app_url = self.curdoc.session_context.server_context.application_context.url
@@ -861,6 +853,9 @@ class _state(param.Parameterized):
 
     @property
     def curdoc(self) -> Document | None:
+        """
+        Returns the Document that is currently being executed.
+        """
         try:
             doc = curdoc_locked()
             if doc and doc.session_context or self._is_pyodide:
@@ -872,18 +867,30 @@ class _state(param.Parameterized):
 
     @curdoc.setter
     def curdoc(self, doc: Document) -> None:
+        """
+        Overrides the current Document.
+        """
         self._curdoc.set(doc)
 
     @property
     def cookies(self) -> Dict[str, str]:
+        """
+        Returns the cookies associated with the request that started the session.
+        """
         return self.curdoc.session_context.request.cookies if self.curdoc and self.curdoc.session_context else {}
 
     @property
     def headers(self) -> Dict[str, str | List[str]]:
+        """
+        Returns the header associated with the request that started the session.
+        """
         return self.curdoc.session_context.request.headers if self.curdoc and self.curdoc.session_context else {}
 
     @property
     def loaded(self) -> bool:
+        """
+        Whether the application has been fully loaded.
+        """
         curdoc = self.curdoc
         if curdoc:
             if curdoc in self._loaded:
@@ -918,6 +925,11 @@ class _state(param.Parameterized):
         return loc
 
     @property
+    def log_terminal(self):
+        from .admin import log_terminal
+        return log_terminal
+
+    @property
     def notifications(self) -> NotificationArea | None:
         from ..config import config
         if config.notifications and self.curdoc and self.curdoc not in self._notifications:
@@ -930,12 +942,28 @@ class _state(param.Parameterized):
             return self._notifications.get(self.curdoc) if self.curdoc else None
 
     @property
-    def log_terminal(self):
-        from .admin import log_terminal
-        return log_terminal
+    def refresh_token(self) -> str | None:
+        """
+        Returns the OAuth refresh_token if enabled and available.
+        """
+        return self._decode_cookie('refresh_token')
+
+    @property
+    def served(self):
+        """
+        Whether we are currently inside a script or notebook that is
+        being served using `panel serve`.
+        """
+        try:
+            return inspect.stack()[1].frame.f_globals['__name__'].startswith('bokeh_app_')
+        except Exception:
+            return False
 
     @property
     def session_args(self) -> Dict[str, List[bytes]]:
+        """
+        Returns the request arguments associated with the request that started the session.
+        """
         return self.curdoc.session_context.request.arguments if self.curdoc and self.curdoc.session_context else {}
 
     @property
@@ -954,6 +982,9 @@ class _state(param.Parameterized):
 
     @property
     def user(self) -> str | None:
+        """
+        Returns the OAuth user if enabled.
+        """
         from tornado.web import decode_signed_value
 
         from ..config import config
@@ -964,6 +995,9 @@ class _state(param.Parameterized):
 
     @property
     def user_info(self) -> Dict[str, Any] | None:
+        """
+        Returns the OAuth user information if enabled.
+        """
         from tornado.web import decode_signed_value
 
         from ..config import config

--- a/panel/io/state.py
+++ b/panel/io/state.py
@@ -842,6 +842,16 @@ class _state(param.Parameterized):
         return self._decode_cookie('refresh_token')
 
     @property
+    def in_app(self):
+        """
+        Determines whether we are in an application context.
+        """
+        try:
+            return inspect.stack()[1].frame.f_globals['__name__'].startswith('bokeh_app_')
+        except Exception:
+            return False
+
+    @property
     def app_url(self) -> str | None:
         if not self.curdoc:
             return

--- a/panel/tests/pane/test_alert.py
+++ b/panel/tests/pane/test_alert.py
@@ -61,6 +61,6 @@ def manualtest_all_view():
     return pn.Column(*alerts, margin=50)
 
 
-if __name__.startswith("bokeh"):
+if pn.state.served:
     pn.extension(sizing_mode="stretch_width")
     manualtest_all_view().servable()

--- a/panel/tests/pane/test_echart.py
+++ b/panel/tests/pane/test_echart.py
@@ -57,7 +57,7 @@ def get_pyechart2():
         return pn.pane.ECharts(my_plot, width=500, height=250)
     return pn.Row(pn.Column(bar1, bar2), plot)
 
-if __name__.startswith("bokeh"):
+if pn.state.served:
     # manualtest_echart().servable()
     get_pyechart2().servable()
 if __name__.startswith("__main__"):

--- a/panel/tests/template/fast/test_fast_grid_template.py
+++ b/panel/tests/template/fast/test_fast_grid_template.py
@@ -7,6 +7,7 @@ from bokeh.document import Document
 from holoviews import opts
 
 from panel.config import config
+from panel.io.state import state
 from panel.layout import Column
 from panel.pane import HTML, HoloViews, Markdown
 from panel.param import Param
@@ -19,8 +20,6 @@ ACCENT_COLOR = "#f63366" # "lightblue"
 opts.defaults(opts.Ellipse(line_width=3, color=ACCENT_COLOR))
 
 
-
-
 def test_template_theme_parameter():
     template = FastGridTemplate(title="Fast", theme="dark")
     # Not '#3f3f3f' which is for the Vanilla theme
@@ -29,8 +28,6 @@ def test_template_theme_parameter():
     assert doc.theme._json['attrs']['Figure']['background_fill_color']=="#181818"
 
     assert isinstance(template._get_theme(), FastGridDarkTheme)
-
-
 
 COLLAPSED_ICON = """
 <svg style="stroke: var(--accent-fill-rest);" width="18" height="18" viewBox="0 0 18 18" fill="none" xmlns="http://www.w3.org/2000/svg" slot="collapsed-icon">
@@ -95,7 +92,6 @@ package. You can use it via `pip install awesome-panel-extensions` and
 `from awesome_panel_extensions.frameworks import fast`.
 """ # noqa
 
-
 def _create_hvplot():
     # Generate some data
     cl1 = np.random.normal(loc=2, scale=0.2, size=(200, 200))
@@ -111,17 +107,14 @@ def _create_hvplot():
     plot = clusters * hv.Ellipse(2, 2, 2) * hv.Ellipse(-2, -2, (4, 2))
     return plot
 
-
 def _navigation_menu():
     return HTML(NAVIGATION_HTML)
-
 
 def _sidebar_items():
     return [
         Markdown("## Settings"),
         _navigation_menu(),
     ]
-
 
 def _fast_button_card():
     button = Button(name="Click me", button_type="primary")
@@ -152,7 +145,6 @@ def _fast_button_card():
         sizing_mode="stretch_both",
     )
 
-
 def manualtest_app():
     app = FastGridTemplate(
         title="FastGridTemplate w. Layout Persistence",
@@ -175,6 +167,6 @@ def manualtest_app():
     return app
 
 
-if __name__.startswith("bokeh"):
+if state.served:
     config.sizing_mode = "stretch_width"
     manualtest_app().servable()

--- a/panel/tests/template/fast/test_fast_list_template.py
+++ b/panel/tests/template/fast/test_fast_list_template.py
@@ -57,6 +57,6 @@ def test_accent():
     assert template.header_background==accent
 
 
-if __name__.startswith("bokeh"):
+if pn.state.served:
     pn.extension(sizing_mode="stretch_width")
     manualtest_app().servable()

--- a/panel/tests/template/test_manual.py
+++ b/panel/tests/template/test_manual.py
@@ -202,7 +202,7 @@ def _get_app():
     theme = _get_theme()
     return template_func(template_class=template_class, theme=theme)
 
-if __name__.startswith("bokeh"):
+if pn.state.served:
     pn.extension(sizing_mode="stretch_width")
     _get_app().servable()
     # manualtest_template_with_no_sidebar().servable()

--- a/panel/tests/template/test_vanilla_manual.py
+++ b/panel/tests/template/test_vanilla_manual.py
@@ -123,7 +123,7 @@ Inspect the app and verify that the issues of [Issue 1641]\
     return vanilla
 
 
-if __name__.startswith("bokeh"):
+if pn.state.served:
     pn.extension(sizing_mode="stretch_width")
     manualtest_vanilla_with_sidebar().servable()
     # manualtest_vanilla_with_no_sidebar().servable()

--- a/panel/tests/widgets/test_speech_to_text.py
+++ b/panel/tests/widgets/test_speech_to_text.py
@@ -275,6 +275,6 @@ def manualtest_get_color_app():
     return app
 
 
-if __name__.startswith("bokeh"):
+if pn.state.served:
     pn.extension(sizing_mode="stretch_width")
     manualtest_get_color_app().servable()

--- a/panel/tests/widgets/test_terminal.py
+++ b/panel/tests/widgets/test_terminal.py
@@ -220,5 +220,5 @@ def get_app():
     return template
 
 
-if __name__.startswith("bokeh"):
+if pn.state.served:
     get_app().servable()

--- a/panel/tests/widgets/test_text_to_speech.py
+++ b/panel/tests/widgets/test_text_to_speech.py
@@ -297,6 +297,6 @@ def manualtest_get_app():
     return template
 
 
-if __name__.startswith("bokeh"):
+if pn.state.served:
     pn.extension(sizing_mode="stretch_width")
     manualtest_get_app().servable()

--- a/panel/tests/widgets/test_tqdm.py
+++ b/panel/tests/widgets/test_tqdm.py
@@ -111,6 +111,6 @@ def get_tqdm_app_simple():
         tqdm, button
     )
 
-if __name__.startswith("bokeh"):
+if pn.state.served:
     # get_tqdm_app_simple().servable()
     get_tqdm_app().servable()

--- a/panel/tests/widgets/test_trend_indicator.py
+++ b/panel/tests/widgets/test_trend_indicator.py
@@ -98,5 +98,5 @@ def manualtest_app():
     return app
 
 
-if __name__.startswith("bokeh"):
+if state.served:
     manualtest_app().servable()


### PR DESCRIPTION
It is sometimes useful to write a Panel application in a script and also do some things that have side-effects such as setting `pn.config` options. If you also want this module to be importable without any side-effects you currently have to write something like this:

```python
if __name__.startswith('bokeh_app_'):
    ...
```

This is ugly and weird since it looks like magic and it's a Panel app not a bokeh app. Therefore I think we should provide a helper that makes it easy to determine if we are in a `panel serve` execution context. Therefore I propose introducing `pn.state.served`:

```python
if pn.state.served:
    ...
```

Ping @MarcSkovMadsen since you are the main person I've seen use this pattern. I don't love the `in_app` naming so am very eager to hear suggestions.