### PR TITLE
Update developer guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 |    |    |
 | --- | --- |
-| Build Status | [![Linux/MacOS Build Status](https://github.com/holoviz/panel/workflows/pytest/badge.svg?query=branch%3Amain)](https://github.com/holoviz/panel/actions/workflows/test.yaml?query=branch%3Amain)
+| Build Status | [![Linux/MacOS Build Status](https://github.com/holoviz/panel/workflows/tests/badge.svg?query=branch%3Amain)](https://github.com/holoviz/panel/actions/workflows/test.yaml?query=branch%3Amain)
 | Coverage | [![codecov](https://codecov.io/gh/holoviz/panel/branch/main/graph/badge.svg)](https://codecov.io/gh/holoviz/panel) |
 | Latest dev release | [![Github tag](https://img.shields.io/github/v/tag/holoviz/panel.svg?label=tag&colorB=11ccbb)](https://github.com/holoviz/panel/tags) [![dev-site](https://img.shields.io/website-up-down-green-red/https/pyviz-dev.github.io/panel.svg?label=dev%20website)](https://pyviz-dev.github.io/panel/) |
 | Latest release | [![Github release](https://img.shields.io/github/release/holoviz/panel.svg?label=tag&colorB=11ccbb)](https://github.com/holoviz/panel/releases) [![PyPI version](https://img.shields.io/pypi/v/panel.svg?colorB=cc77dd)](https://pypi.python.org/pypi/panel) [![panel version](https://img.shields.io/conda/v/pyviz/panel.svg?colorB=4488ff&style=flat)](https://anaconda.org/pyviz/panel) [![conda-forge version](https://img.shields.io/conda/v/conda-forge/panel.svg?label=conda%7Cconda-forge&colorB=4488ff)](https://anaconda.org/conda-forge/panel) [![defaults version](https://img.shields.io/conda/v/anaconda/panel.svg?label=conda%7Cdefaults&style=flat&colorB=4488ff)](https://anaconda.org/anaconda/panel) |

--- a/doc/developer_guide/index.md
+++ b/doc/developer_guide/index.md
@@ -53,10 +53,16 @@ conda activate panel_dev
 To perform an editable install of Panel, including all the dependencies required to run the full unit test suite, run the following:
 
 ```bash
-doit develop_install -c pyviz/label/dev -c conda-forge -c bokeh -o build -o tests -o recommended -o ui
+doit develop_install -c pyviz/label/dev -c conda-forge -c bokeh -o build -o tests -o recommended
 ```
 
 The above command installs Panel's dependencies using conda, then performs a pip editable install of Panel. If it fails, `nodejs>=14.0.0` may be missing from your environment, fix it with `conda install -c conda-forge nodejs` then rerun above command.
+
+If you also want to run the UI tests run the following:
+``` bash
+pip install playwright pytest-playwright
+playwright install chromium
+```
 
 ## Enable the Jupyter extension
 

--- a/doc/developer_guide/index.md
+++ b/doc/developer_guide/index.md
@@ -84,14 +84,14 @@ This will ensure that every time you make a commit linting will automatically be
 
 ## Developing custom models
 
-Panel ships with a number of custom Bokeh models, which have both Python and Javascript components. When developing Panel these custom models have to be compiled. This happens automatically with `pip install -e .` or `python setup.py develop`, however when runnning actively developing you can rebuild the extension with `panel build panel`. The `build` command is just an alias for `bokeh build`; see
+Panel ships with a number of custom Bokeh models, which have both Python and Javascript components. When developing Panel these custom models have to be compiled. This happens automatically with `SETUPTOOLS_ENABLE_FEATURES=legacy-editable pip install -e .` or `python setup.py develop`, however when runnning actively developing you can rebuild the extension with `panel build panel`. The `build` command is just an alias for `bokeh build`; see
 the [Bokeh developer guide](https://docs.bokeh.org/en/latest/docs/dev_guide/setup.html) for more information about developing bokeh models.
 
 Just like any other Javascript (or Typescript) library Panel defines a `package.json` and `package-lock.json` files. When adding, updating or removing a dependency in the package.json file ensure you commit the changes to the `package-lock.json` after running `npm install`.
 
 ## Bundling resources
 
-Panel bundles external resources required for custom models and templates into the `panel/dist` directory. The bundled resources have to be collected whenever they change, so rerun `pip install -e .` or `python setup.py develop` whenever you change one of the following:
+Panel bundles external resources required for custom models and templates into the `panel/dist` directory. The bundled resources have to be collected whenever they change, so rerun `SETUPTOOLS_ENABLE_FEATURES=legacy-editable pip install -e .` or `python setup.py develop` whenever you change one of the following:
 
 * A new model is added with a `__javascript_raw__` declaration or an existing model is updated
 * A new template with a `_resources` declaration is added or an existing template is updated


### PR DESCRIPTION
Spend the better half of an afternoon getting panel to work based on the instructions of the [developer guide](https://panel.holoviz.org/developer_guide/index.html#developing-custom-models). The missing piece was `SETUPTOOLS_ENABLE_FEATURES=legacy-editable` which is what we also do for our test suite:
https://github.com/holoviz/panel/blob/b2a65c64d63e08acbf2acc91ca3ddaa7d7998349/.github/workflows/test.yaml#L46

When I already was in the file, I updated the instructions for running UI test (fixes #4248), which is what we also do in our tests:
https://github.com/pyviz-dev/holoviz_tasks/blob/bbfbd3696cc27ad370735f121898e5d2c154d273/install/action.yaml#L144-L152