### PR TITLE
IPython display compatibility in pyodide builds

### DIFF
--- a/panel/io/mime_render.py
+++ b/panel/io/mime_render.py
@@ -124,6 +124,16 @@ def _convert_expr(expr: ast.Expr) -> ast.Expression:
     expr.col_offset = 0
     return ast.Expression(expr.value, lineno=0, col_offset = 0)
 
+_OUT_BUFFER = []
+
+def _display(*objs, **kwargs):
+    """
+    IPython.display compatibility wrapper.
+
+    Note: This only handles a single display.
+    """
+    _OUT_BUFFER.extend(list(objs))
+
 def exec_with_return(
     code: str,
     global_context: Dict[str, Any] = None,
@@ -151,6 +161,7 @@ def exec_with_return(
     The return value of the executed code.
     """
     global_context = global_context if global_context else globals()
+    global_context['display'] = _display
     code_ast = ast.parse(code)
 
     init_ast = copy.deepcopy(code_ast)
@@ -173,9 +184,13 @@ def exec_with_return(
                 out = None
             if code.strip().endswith(';'):
                 out = None
+            if _OUT_BUFFER and out is None:
+                out = _OUT_BUFFER[-1]
         except Exception:
             out = None
             traceback.print_exc(file=stderr)
+        finally:
+            _OUT_BUFFER.clear()
     return out
 
 #---------------------------------------------------------------------


### PR DESCRIPTION
Compatibility layer for IPython `display` functionality. Only handles a single `display` output per "cell" and only if the cell does not otherwise return anything, so only a partial fix but should be sufficient for demonstrating `display` in documentation.

Fixes https://github.com/holoviz/panel/issues/4266