### PR TITLE
fix windows encoding error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -228,7 +228,7 @@ setup_args = dict(
     name='panel',
     version=get_setup_version("panel"),
     description='A high level app and dashboarding solution for Python.',
-    long_description=open('README.md').read() if os.path.isfile('README.md') else 'Consult README.md',
+    long_description=open('README.md', encoding="utf8").read() if os.path.isfile('README.md') else 'Consult README.md',
     long_description_content_type="text/markdown",
     author="HoloViz",
     author_email="developers@holoviz.org",


### PR DESCRIPTION
This fixes the below issue on windows

```python
$ pip install -e .
Looking in indexes: https://pypi.org/simple, https://masma:****@pkgs.dev.azure.com/dongenergy-p/_packaging/MarketTrading%40Local/pypi/simple/, https://masma:****@pkgs.dev.azure.com/dongenergy-p/_packaging/analytics-workspace/pypi/simple/
Obtaining file:///C:/repos/private/panel
  Installing build dependencies ... done
  WARNING: Missing build requirements in pyproject.toml for file:///C:/repos/private/panel.
  WARNING: The project does not specify a build backend, and pip cannot fall back to setuptools without 'wheel'.
  Checking if build backend supports build_editable ... done
  Getting requirements to build editable ... error
  error: subprocess-exited-with-error

  × Getting requirements to build editable did not run successfully.
  │ exit code: 1
  ╰─> [21 lines of output]
      Traceback (most recent call last):
        File "C:\repos\private\panel\.venv\lib\site-packages\pip\_vendor\pep517\in_process\_in_process.py", line 351, in <module>
          main()
        File "C:\repos\private\panel\.venv\lib\site-packages\pip\_vendor\pep517\in_process\_in_process.py", line 333, in main
          json_out['return_val'] = hook(**hook_input['kwargs'])
        File "C:\repos\private\panel\.venv\lib\site-packages\pip\_vendor\pep517\in_process\_in_process.py", line 132, in get_requires_for_build_editable
          return hook(config_settings)
        File "C:\Users\masma\AppData\Local\Temp\pip-build-env-1u6yu1ex\overlay\Lib\site-packages\setuptools\build_meta.py", line 447, in get_requires_for_build_editable
          return self.get_requires_for_build_wheel(config_settings)
        File "C:\Users\masma\AppData\Local\Temp\pip-build-env-1u6yu1ex\overlay\Lib\site-packages\setuptools\build_meta.py", line 338, in get_requires_for_build_wheel
          return self._get_build_requires(config_settings, requirements=['wheel'])
        File "C:\Users\masma\AppData\Local\Temp\pip-build-env-1u6yu1ex\overlay\Lib\site-packages\setuptools\build_meta.py", line 320, in _get_build_requires
          self.run_setup()
        File "C:\Users\masma\AppData\Local\Temp\pip-build-env-1u6yu1ex\overlay\Lib\site-packages\setuptools\build_meta.py", line 484, in run_setup
          super(_BuildMetaLegacyBackend,
        File "C:\Users\masma\AppData\Local\Temp\pip-build-env-1u6yu1ex\overlay\Lib\site-packages\setuptools\build_meta.py", line 335, in run_setup
          exec(code, locals())
        File "<string>", line 231, in <module>
        File "C:\Program Files (x86)\Microsoft Visual Studio\Shared\Python39_64\lib\encodings\cp1252.py", line 23, in decode
          return codecs.charmap_decode(input,self.errors,decoding_table)[0]
      UnicodeDecodeError: 'charmap' codec can't decode byte 0x90 in position 10143: character maps to <undefined>
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
error: subprocess-exited-with-error

× Getting requirements to build editable did not run successfully.
│ exit code: 1
╰─> See above for output.

note: This error originates from a subprocess, and is likely not a problem with pip.
```

Please note that you should always specify the `encoding` when you `open` a file according to `pylint.