### PR TITLE
Ensure Tabulator internal _index_mapping is updated on stream

### DIFF
--- a/panel/tests/widgets/test_tables.py
+++ b/panel/tests/widgets/test_tables.py
@@ -1883,6 +1883,23 @@ def test_tabulator_pagination_remote_cell_click_event():
                 table._process_event(event)
                 assert values[-1] == (col, (p*2)+row, data[col].iloc[(p*2)+row])
 
+def test_tabulator_pagination_remote_cell_click_event_with_stream():
+    df = makeMixedDataFrame()
+    table = Tabulator(df, pagination='remote', page_size=2)
+
+    values = []
+    table.on_click(lambda e: values.append((e.column, e.row, e.value)))
+
+    data = df.reset_index()
+    for col in data.columns:
+        for p in range(len(df)//2):
+            table.page = p+1
+            for row in range(2):
+                event = CellClickEvent(model=None, column=col, row=row)
+                table._process_event(event)
+                assert values[-1] == (col, (p*2)+row, data[col].iloc[(p*2)+row])
+            table.stream(pd.DataFrame([(5.0, 0, 'foo6', df.D.iloc[-1])], columns=df.columns, index=[5]))
+
 def test_tabulator_cell_click_event_error_duplicate_index():
     df = pd.DataFrame(data={'A': [1, 2]}, index=['a', 'a'])
     table = Tabulator(df, sorters=[{'field': 'A', 'sorter': 'number', 'dir': 'desc'}])


### PR DESCRIPTION
Fixes issues editing newly streamed rows on `Tabulator`