### PR TITLE
Deprecate ReactTemplate, IDOM pane and Viewable.app

### DIFF
--- a/panel/pane/idom.py
+++ b/panel/pane/idom.py
@@ -15,6 +15,7 @@ from ..io.notebook import push_on_root
 from ..io.resources import DIST_DIR, LOCAL_DIST
 from ..io.state import state
 from ..models import IDOM as _BkIDOM
+from ..util.warnings import deprecated
 from .base import PaneBase
 
 if TYPE_CHECKING:
@@ -73,6 +74,8 @@ class IDOM(PaneBase):
             raise RuntimeError(
                 f"Expected idom>={_IDOM_MIN_VER},<{_IDOM_MAX_VER}, but found {idom_version}"
             )
+        else:
+            deprecated('1.0', 'panel.pane.IDOM', extra='It may be reimplemented as a separate package in future.')
         super().__init__(object, **params)
         self._idom_loop = None
         self._idom_model = {}

--- a/panel/template/react/__init__.py
+++ b/panel/template/react/__init__.py
@@ -9,6 +9,7 @@ from ...config import config
 from ...depends import depends
 from ...io.resources import CSS_URLS
 from ...layout import Card, GridSpec
+from ...util.warnings import deprecated
 from ..base import BasicTemplate
 from ..theme import DarkTheme, DefaultTheme
 
@@ -64,6 +65,8 @@ class ReactTemplate(BasicTemplate):
     }
 
     def __init__(self, **params):
+        deprecated('1.0', 'panel.template.ReactTemplate', 'panel.template.FastGridTemplate')
+        super().__init__(**params)
         if 'main' not in params:
             params['main'] = GridSpec(ncols=12, mode='override')
         super().__init__(**params)

--- a/panel/template/react/__init__.py
+++ b/panel/template/react/__init__.py
@@ -66,7 +66,6 @@ class ReactTemplate(BasicTemplate):
 
     def __init__(self, **params):
         deprecated('1.0', 'panel.template.ReactTemplate', 'panel.template.FastGridTemplate')
-        super().__init__(**params)
         if 'main' not in params:
             params['main'] = GridSpec(ncols=12, mode='override')
         super().__init__(**params)

--- a/panel/template/vanilla/__init__.py
+++ b/panel/template/vanilla/__init__.py
@@ -6,6 +6,7 @@ import pathlib
 import param
 
 from ...layout import Card
+from ...util.warnings import deprecated
 from ..base import BasicTemplate
 from ..theme import DarkTheme, DefaultTheme
 
@@ -25,6 +26,15 @@ class VanillaTemplate(BasicTemplate):
             'margin': (5, 5)
         }
     }
+
+    def __init__(self, **params):
+        extra = (
+            "Use one of 'panel.template.FastListTemplate', "
+            "'panel.template.MaterialTemplate' or 'panel.template.BootstrapTemplate' "
+            "instead."
+        )
+        deprecated('1.0', 'panel.template.VanillaTemplate', extra=extra)
+        super().__init__(**params)
 
     def _apply_root(self, name, model, tags):
         if 'main' in tags:

--- a/panel/template/vanilla/__init__.py
+++ b/panel/template/vanilla/__init__.py
@@ -6,7 +6,6 @@ import pathlib
 import param
 
 from ...layout import Card
-from ...util.warnings import deprecated
 from ..base import BasicTemplate
 from ..theme import DarkTheme, DefaultTheme
 
@@ -26,15 +25,6 @@ class VanillaTemplate(BasicTemplate):
             'margin': (5, 5)
         }
     }
-
-    def __init__(self, **params):
-        extra = (
-            "Use one of 'panel.template.FastListTemplate', "
-            "'panel.template.MaterialTemplate' or 'panel.template.BootstrapTemplate' "
-            "instead."
-        )
-        deprecated('1.0', 'panel.template.VanillaTemplate', extra=extra)
-        super().__init__(**params)
 
     def _apply_root(self, name, model, tags):
         if 'main' in tags:

--- a/panel/viewable.py
+++ b/panel/viewable.py
@@ -43,6 +43,7 @@ from .io.notebook import (
 from .io.save import save
 from .io.state import curdoc_locked, state
 from .util import escape, param_reprs
+from .util.warnings import deprecated
 
 if TYPE_CHECKING:
     from bokeh.model import Model
@@ -751,6 +752,7 @@ class Viewable(Renderable, Layoutable, ServableMixin):
         port: int (optional, default=0)
           Allows specifying a specific port
         """
+        deprecated("1.0", "Viewable.app", "panel.io.notebook.show_server")
         return show_server(self, notebook_url, port)
 
     def embed(


### PR DESCRIPTION
After some discussion I've decided to execute a few deprecations ahead of the 1.0 release. 

For templates I've simply decided that we do not need 5 different ListTemplate implementations and multiple grid template implementations. Deprecating some of these implementations will allow us to better focus on styling existing templates and reduces the maintenance burden.

Here are the deprecations I'm suggesting:

- `IDOM` pane: We only support version 0.24 currently which is very old. Since we do not have a maintainer who could update it and Reacton fills the same niche I've decided to remove it. It may be it could be re-added later in a `panel-idom` package but without anyone requesting support I think the right decision is to remove it.
- `ReactTemplate`: The `ReactTemplate` is overall pretty nice BUT the naming is terrible (it's built on top of a React library but it doesn't actually allow you to use React or anything so really that's an implementation detail. Secondly, the `FastGridTemplate` lets you do the exact same thing but looks prettier.
- `Viewable.app`: The `.app` method allows starting a server in Jupyter and then embedding it as an iframe. This relies on the port being accessible and to specify the `notebook_url`. This is brittle without much benefit at all because you already get interactivity in a notebook without running a server. I've left the function that will let you do the same thing but we don't need a method on all objects to do this.

Please chime in with thoughts and/or objections.  

Ping @MarcSkovMadsen, @jbednar, @maximlt, @Hoxbro 