### PR TITLE
Ensure updates to Tabulator formatter or editor updates model

### DIFF
--- a/panel/models/tabulator.ts
+++ b/panel/models/tabulator.ts
@@ -292,7 +292,12 @@ export class DataTabulatorView extends PanelHTMLBoxView {
 
     const p = this.model.properties
     const {configuration, layout, columns, theme, groupby} = p;
-    this.on_change([configuration, layout, columns, groupby], debounce(() => this.invalidate_render(), 20, false))
+    this.on_change([configuration, layout, groupby], debounce(() => this.invalidate_render(), 20, false))
+
+    this.on_change([columns], () => {
+      this.tabulator.setColumns(this.getColumns())
+      this.setHidden()
+    })
 
     this.on_change([theme], () => this.setCSS())
 

--- a/panel/tests/widgets/test_tables.py
+++ b/panel/tests/widgets/test_tables.py
@@ -1936,6 +1936,32 @@ def test_tabulator_styling_empty_dataframe():
         }
     }
 
+def test_tabulator_editor_property_change(dataframe, document, comm):
+    editor = SelectEditor(options=['A', 'B', 'C'])
+    table = Tabulator(dataframe, editors={'str': editor})
+    model = table.get_root(document, comm)
+
+    model_editor = model.columns[-1].editor
+    assert isinstance(model_editor, SelectEditor) is not editor
+    assert isinstance(model_editor, SelectEditor)
+    assert model_editor.options == editor.options
+
+    editor.options = ['D', 'E']
+    model_editor = model.columns[-1].editor
+    assert model_editor.options == editor.options
+
+def test_tabulator_formatter_update(dataframe, document, comm):
+    formatter = NumberFormatter(format='0.0000')
+    table = Tabulator(dataframe, formatters={'float': formatter})
+    model = table.get_root(document, comm)
+    model_formatter = model.columns[2].formatter
+    assert model_formatter is not formatter
+    assert isinstance(model_formatter, NumberFormatter)
+    assert model_formatter.format == formatter.format
+
+    formatter.format = '0.0'
+    model_formatter = model.columns[2].formatter
+    assert model_formatter.format == formatter.format
 
 def test_tabulator_pandas_import():
     # Checks for: https://github.com/holoviz/panel/issues/4102


### PR DESCRIPTION
When providing `CellEditor` and `CellFormatter` objects to `Tabulator` updating the properties on these objects would not have any effect.