### PR TITLE
Skip on_load callbacks in liveness check

### DIFF
--- a/panel/io/liveness.py
+++ b/panel/io/liveness.py
@@ -1,7 +1,6 @@
 from tornado import web
 
 from .document import _cleanup_doc
-from .state import set_curdoc, state
 
 
 class LivenessHandler(web.RequestHandler):
@@ -21,8 +20,6 @@ class LivenessHandler(web.RequestHandler):
         app = self.applications[endpoint]
         try:
             doc = app.create_document()
-            with set_curdoc(doc):
-                state._on_load(None)
             _cleanup_doc(doc)
             self.write({endpoint: True})
         except Exception as e:


### PR DESCRIPTION
Liveness checks should not have to execute all callbacks, it's a check to see if the applications renders. Not to a full health check.