### PR TITLE
Extra cleanup for 1.0

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2018-2020, HoloViz team (holoviz.org).
+Copyright (c) 2018, HoloViz team (holoviz.org).
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/panel/pane/perspective.py
+++ b/panel/pane/perspective.py
@@ -329,12 +329,6 @@ class Perspective(PaneBase, ReactiveData):
 
     _updates: ClassVar[bool] = True
 
-    _deprecations = {
-        'computed_columns': 'expressions',
-        'column_pivots': 'split_by',
-        'row_pivots': 'group_by'
-    }
-
     @classmethod
     def applies(cls, object):
         if isinstance(object, dict) and all(isinstance(v, (list, np.ndarray)) for v in object.values()):

--- a/setup.py
+++ b/setup.py
@@ -259,7 +259,6 @@ setup_args = dict(
         "License :: OSI Approved :: BSD License",
         "Development Status :: 5 - Production/Stable",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
@@ -280,7 +279,7 @@ setup_args = dict(
         "Topic :: Office/Business",
         "Topic :: Office/Business :: Financial",
         "Topic :: Software Development :: Libraries"],
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     entry_points={
         'console_scripts': [
             'panel = panel.command:main'

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@
 
 [tox]
 #          python version             test group                  extra envs  extra commands
-envlist = {py37,py38,py39,py310,py311}-{flakes,unit,ui,unit_deploy,examples,all_recommended,deprecations}-{default}-{dev,pkg}
+envlist = {py38,py39,py310,py311}-{flakes,unit,ui,unit_deploy,examples,all_recommended,deprecations}-{default}-{dev,pkg}
 build = wheel
 
 [_flakes]


### PR DESCRIPTION
I forgot to remove `_deprecations` in #4300

Removing Python 3.7 as Bokeh 3.0 only supports Python 3.8 and up.

Remove the current year from the license. I can see the `doc/conf.py` use 2019 as the starting year, so what is the correct starting year?
