### PR TITLE
Ensures global notification object can be used inside notebook callbacks

### DIFF
--- a/panel/io/state.py
+++ b/panel/io/state.py
@@ -948,11 +948,11 @@ class _state(param.Parameterized):
     @property
     def notifications(self) -> NotificationArea | None:
         from ..config import config
-        if config.notifications and self.curdoc and self.curdoc not in self._notifications:
+        if config.notifications and self.curdoc and self.curdoc.session_context and self.curdoc not in self._notifications:
             from .notifications import NotificationArea
             self._notifications[self.curdoc] = notifications = NotificationArea()
             return notifications
-        elif self.curdoc is None:
+        elif self.curdoc is None or self.curdoc.session_context is None:
             return self._notification
         else:
             return self._notifications.get(self.curdoc) if self.curdoc else None

--- a/panel/tests/template/test_base.py
+++ b/panel/tests/template/test_base.py
@@ -1,3 +1,5 @@
+import unittest
+
 from panel.config import config
 from panel.io.notifications import NotificationArea
 from panel.io.state import set_curdoc, state
@@ -11,6 +13,8 @@ def test_notification_instantiate_on_config():
     assert isinstance(tmpl.notifications, NotificationArea)
 
     doc = tmpl.server_doc()
+    session_context = unittest.mock.Mock()
+    doc._session_context = lambda: session_context
 
     with set_curdoc(doc):
         assert state.notifications is tmpl.notifications
@@ -22,6 +26,8 @@ def test_notification_explicit():
     assert isinstance(tmpl.notifications, NotificationArea)
 
     doc = tmpl.server_doc()
+    session_context = unittest.mock.Mock()
+    doc._session_context = lambda: session_context
 
     with set_curdoc(doc):
         assert state.notifications is tmpl.notifications


### PR DESCRIPTION
Fixes https://github.com/holoviz/panel/issues/4230