### PR TITLE
Handle cancelling and empty value edit events on Tabulator

### DIFF
--- a/panel/models/tabulator.ts
+++ b/panel/models/tabulator.ts
@@ -277,6 +277,7 @@ const datetimeEditor = function(cell: any, onRendered: any, success: any, cancel
 export class DataTabulatorView extends PanelHTMLBoxView {
   model: DataTabulator;
   tabulator: any;
+  columns: Map<string, any> = new Map();
   _tabulator_cell_updating: boolean=false
   _updating_page: boolean = true
   _updating_sort: boolean = false
@@ -685,6 +686,7 @@ export class DataTabulatorView extends PanelHTMLBoxView {
   }
 
   getColumns(): any {
+    this.columns = new Map()
     const config_columns: (any[] | undefined) = this.model.configuration?.columns;
     let columns = []
     columns.push({field: '_index', frozen: true})
@@ -735,6 +737,7 @@ export class DataTabulatorView extends PanelHTMLBoxView {
       }
       if (tab_column == null)
         tab_column = {field: column.field}
+      this.columns.set(column.field, tab_column)
       if (tab_column.title == null)
         tab_column.title = column.title
       if (tab_column.width == null && column.width != null && column.width != 0)
@@ -781,6 +784,10 @@ export class DataTabulatorView extends PanelHTMLBoxView {
       else if (ctype === "IntEditor" || ctype === "NumberEditor") {
         tab_column.editor = "number"
         tab_column.editorParams = {step: editor.step}
+	if (ctype === "IntEditor")
+	  tab_column.validator = "integer"
+	else
+	  tab_column.validator = "numeric"
       } else if (ctype === "CheckboxEditor") {
         tab_column.editor = "tickCross"
       } else if (ctype === "DateEditor") {
@@ -829,7 +836,7 @@ export class DataTabulatorView extends PanelHTMLBoxView {
     return columns
   }
 
-  renderEditor(column: any, cell: any, onRendered: any, success: any, error: any): any {
+  renderEditor(column: any, cell: any, onRendered: any, success: any, cancel: any): any {
     const editor = column.editor
     const view = new editor.default_view({column: column, model: editor, parent: this, container: cell._cell.element})
     view.initialize()
@@ -838,14 +845,15 @@ export class DataTabulatorView extends PanelHTMLBoxView {
       view.setValue(cell.getValue())
     })
 
-    view.inputEl.addEventListener('change', () => {
+    view.inputEl.addEventListener('input', () => {
       const value = view.serializeValue()
       const old_value = cell.getValue()
       const validation = view.validate()
+      console.log(validation, view.serializeValue())
       if (!validation.valid)
-        error(validation.msg)
+        cancel(validation.msg)
       if (old_value != null && typeof value != typeof old_value)
-        error("Mismatching type")
+        cancel("Mismatching type")
       else
         success(view.serializeValue())
     });
@@ -1134,8 +1142,14 @@ export class DataTabulatorView extends PanelHTMLBoxView {
 
   cellEdited(cell: any): void {
     const field = cell._cell.column.field;
+    const column_def = this.columns.get(field)
     const index = cell.getData()._index
-    const value = cell._cell.value
+    let value = cell._cell.value
+    if (column_def.validator === 'numeric' && value === '') {
+      value = NaN
+      cell.setValue(value, true)
+      return
+    }
     this._tabulator_cell_updating = true
     comm_settings.debounce = false
     this.model.trigger_event(new TableEditEvent(field, index, true))

--- a/panel/models/tabulator.ts
+++ b/panel/models/tabulator.ts
@@ -1143,10 +1143,9 @@ export class DataTabulatorView extends PanelHTMLBoxView {
     const field = cell._cell.column.field;
     const column_def = this.columns.get(field)
     const index = cell.getData()._index
-    let value = cell._cell.value
+    const value = cell._cell.value
     if (column_def.validator === 'numeric' && value === '') {
-      value = NaN
-      cell.setValue(value, true)
+      cell.setValue(NaN, true)
       return
     }
     this._tabulator_cell_updating = true

--- a/panel/models/tabulator.ts
+++ b/panel/models/tabulator.ts
@@ -849,7 +849,6 @@ export class DataTabulatorView extends PanelHTMLBoxView {
       const value = view.serializeValue()
       const old_value = cell.getValue()
       const validation = view.validate()
-      console.log(validation, view.serializeValue())
       if (!validation.valid)
         cancel(validation.msg)
       if (old_value != null && typeof value != typeof old_value)

--- a/panel/tests/ui/widgets/test_tabulator.py
+++ b/panel/tests/ui/widgets/test_tabulator.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import datetime as dt
 import time
 
+import numpy as np
 import param
 import pytest
 
@@ -19,11 +20,6 @@ except ImportError:
     pytestmark = pytest.mark.skip('playwright not available')
 
 pytestmark = pytest.mark.ui
-
-try:
-    import numpy as np
-except ImportError:
-    pytestmark = pytest.mark.skip('numpy not available')
 
 try:
     import pandas as pd
@@ -1896,6 +1892,54 @@ def test_tabulator_edit_event(page, port, df_mixed):
     wait_until(lambda: len(values) >= 1, page)
     assert values[0] == ('str', 0, 'A', 'AA')
     assert df_mixed.at['idx0', 'str'] == 'AA'
+
+
+def test_tabulator_edit_event_abort(page, port, df_mixed):
+    widget = Tabulator(df_mixed)
+
+    values = []
+    widget.on_edit(lambda e: values.append((e.column, e.row, e.old, e.value)))
+
+    serve(widget, port=port, threaded=True, show=False)
+
+    time.sleep(0.2)
+
+    page.goto(f"http://localhost:{port}")
+
+    cell = page.locator('text="3.14"')
+    cell.click()
+    editable_cell = page.locator('input[type="number"]')
+    editable_cell.fill('0')
+    editable_cell.press('Escape')
+
+    time.sleep(0.2)
+
+    assert not values
+    assert cell.text_content() == '3.14'
+
+
+def test_tabulator_edit_event_empty_to_nan(page, port, df_mixed):
+    widget = Tabulator(df_mixed)
+
+    values = []
+    widget.on_edit(lambda e: values.append((e.column, e.row, e.old, e.value)))
+
+    serve(widget, port=port, threaded=True, show=False)
+
+    time.sleep(0.2)
+
+    page.goto(f"http://localhost:{port}")
+
+    cell = page.locator('text="3.14"')
+    cell.click()
+    editable_cell = page.locator('input[type="number"]')
+    editable_cell.fill('')
+    editable_cell.press('Enter')
+
+    wait_until(lambda: len(values) == 1, page)
+    assert values[0][:-1] == ('float', 0, 3.14)
+    assert np.isnan(values[0][-1])
+    assert cell.text_content() == '-'
 
 
 @pytest.mark.parametrize('pagination', ['remote', 'local'])

--- a/panel/tests/ui/widgets/test_tabulator.py
+++ b/panel/tests/ui/widgets/test_tabulator.py
@@ -1926,7 +1926,7 @@ def test_tabulator_edit_event_empty_to_nan(page, port, df_mixed):
 
     serve(widget, port=port, threaded=True, show=False)
 
-    time.sleep(0.2)
+    time.sleep(0.5)
 
     page.goto(f"http://localhost:{port}")
 
@@ -1939,7 +1939,7 @@ def test_tabulator_edit_event_empty_to_nan(page, port, df_mixed):
     wait_until(lambda: len(values) == 1, page)
     assert values[0][:-1] == ('float', 0, 3.14)
     assert np.isnan(values[0][-1])
-    assert cell.text_content() == '-'
+    assert page.query_selector('text="-"') is not None
 
 
 @pytest.mark.parametrize('pagination', ['remote', 'local'])


### PR DESCRIPTION
- Adds validators on Numeric edit events
- Ensures that cancelling edit event does not clear cell
- Maps an empty cell numeric cell to NaN

Fixes https://github.com/holoviz/panel/issues/3774