### PR TITLE
Undeprecate ReactTemplate and deprecate Viewable.pprint

### DIFF
--- a/doc/background/components/components_overview.md
+++ b/doc/background/components/components_overview.md
@@ -59,11 +59,11 @@ png = pn.panel('https://upload.wikimedia.org/wikipedia/commons/4/47/PNG_transpar
 png
 ```
 
-To see the type of the pane use the ``pprint`` method, which works with any Widget, Pane, or (perhaps most usefully) Panel:
+To see the type of the pane use the `print` function, which works with any Widget, Pane, or (perhaps most usefully) Panel:
 
 
 ```{pyodide}
-png.pprint()
+print(png)
 ```
 
 All Panel objects store the object they are wrapping on the ``object`` parameter.  By setting that parameter, existing views of this object (whether in other notebook cells or on a server instance) will update:

--- a/doc/how_to/components/add_remove.md
+++ b/doc/how_to/components/add_remove.md
@@ -39,9 +39,10 @@ column[4] = pn.widgets.Button(name='Click here')
 column
 ```
 
-Finally, we decide to remove the FloatSlider widget, but we forget its index. We can use `.pprint` to see the index of the components:
+Finally, we decide to remove the FloatSlider widget, but we forget its index. We can use `print` to see the index of the components:
+
 ```{pyodide}
-column.pprint()
+print(column)
 ```
 
 and then `.pop` to remove the FloatSlider:

--- a/doc/how_to/components/pane_type.md
+++ b/doc/how_to/components/pane_type.md
@@ -1,6 +1,6 @@
 # Access Pane Type
 
-To access the type for a given component, use the ``pprint`` method. This can come in handy when a component was created in such a way where the type was not explicitly specified, such as with ``pn.panel`` as described on the [How to construct panes page](construct_panes.md).
+To access the type for a given component, use the `print` function. This can come in handy when a component was created in such a way where the type was not explicitly specified, such as with ``pn.panel`` as described on the [How to construct panes page](construct_panes.md).
 
 ```{pyodide}
 import panel as pn
@@ -8,7 +8,7 @@ pn.extension() # for notebook
 
 example_pane = pn.panel('https://upload.wikimedia.org/wikipedia/commons/b/b1/Loading_icon.gif', width=500)
 
-example_pane.pprint()
+print(example_pane)
 ```
 
 :::{admonition} See Also

--- a/doc/how_to/display/notebook.md
+++ b/doc/how_to/display/notebook.md
@@ -28,10 +28,10 @@ pane = pn.panel('<marquee>Here is some custom HTML</marquee>')
 pane
 ```
 
-To instead see a textual representation of the component, you can use the ``pprint`` method on any Panel object:
+To instead see a textual representation of the component, you can use the `print` function on any Panel object:
 
 ```{pyodide}
-pane.pprint()
+print(pane)
 ```
 
 ### The ``display`` function

--- a/doc/how_to/interact/interact_layout.md
+++ b/doc/how_to/interact/interact_layout.md
@@ -19,7 +19,7 @@ layout
 We can always print the Panel contents to check the indexing:
 
 ```{pyodide}
-layout.pprint()
+print(layout)
 ```
 
 Now, by indexing into this Panel we can lay out the objects precisely how we want:

--- a/panel/template/react/__init__.py
+++ b/panel/template/react/__init__.py
@@ -9,7 +9,6 @@ from ...config import config
 from ...depends import depends
 from ...io.resources import CSS_URLS
 from ...layout import Card, GridSpec
-from ...util.warnings import deprecated
 from ..base import BasicTemplate
 from ..theme import DarkTheme, DefaultTheme
 
@@ -65,7 +64,6 @@ class ReactTemplate(BasicTemplate):
     }
 
     def __init__(self, **params):
-        deprecated('1.0', 'panel.template.ReactTemplate', 'panel.template.FastGridTemplate')
         if 'main' not in params:
             params['main'] = GridSpec(ncols=12, mode='override')
         super().__init__(**params)

--- a/panel/viewable.py
+++ b/panel/viewable.py
@@ -715,6 +715,7 @@ class Viewable(Renderable, Layoutable, ServableMixin):
         """
         Prints a compositional repr of the class.
         """
+        deprecated('1.0', f'{type(self).__name__}.pprint', 'print')
         print(self)
 
     def select(
@@ -752,7 +753,7 @@ class Viewable(Renderable, Layoutable, ServableMixin):
         port: int (optional, default=0)
           Allows specifying a specific port
         """
-        deprecated("1.0", "Viewable.app", "panel.io.notebook.show_server")
+        deprecated('1.0', f'{type(self).__name__}.app', 'panel.io.notebook.show_server')
         return show_server(self, notebook_url, port)
 
     def embed(


### PR DESCRIPTION
I'm not yet sure about template deprecations so I'm leaving it, but `Viewable.pprint` is superfluous and is now to be removed.