### PR TITLE
Fix plotly eventdata undefined val

### DIFF
--- a/panel/models/plotly.ts
+++ b/panel/models/plotly.ts
@@ -54,8 +54,8 @@ const filterEventData = (gd: any, eventData: any, event: string) => {
             for (let property in fullPoint) {
               const val = fullPoint[property];
               if (fullPoint.hasOwnProperty(property) &&
-                  !Array.isArray(val) && !isPlainObject(val))  {
-
+                  !Array.isArray(val) && !isPlainObject(val) &&
+                  val!==undefined)  {
                 pointData[property] = val;
               }
             }

--- a/panel/models/plotly.ts
+++ b/panel/models/plotly.ts
@@ -55,7 +55,7 @@ const filterEventData = (gd: any, eventData: any, event: string) => {
               const val = fullPoint[property];
               if (fullPoint.hasOwnProperty(property) &&
                   !Array.isArray(val) && !isPlainObject(val) &&
-                  val!==undefined)  {
+                  val !== undefined)  {
                 pointData[property] = val;
               }
             }


### PR DESCRIPTION
Fixes #4354 

## Root Cause

After logging values in the assignments below I could see that for example `this.model.click_data` was assigned a value that contained the key `text` with a value of `undefined`. This caused the error `Uncaught Error: [object Undefined] is not serializable`.

![image](https://user-images.githubusercontent.com/42288570/215309211-28fb4da5-9aaf-420a-af2e-0458051e7d81.png)

## Solution

The solution is to adding further clean up to `filterEventData`.

## The solution works

https://user-images.githubusercontent.com/42288570/215309387-55b8131c-2c39-4186-b3d8-5dac13b2433e.mp4

```python
import pandas as pd
import param as pm
import panel as pn
import plotly.express as px

df = pd.DataFrame({"ticker": ["A", "B", "C"], "value": [1, 2, 3]})


def portfolio_distribution(_=None, data=df):
    """Returns the distribution of the portfolio"""
    portfolio_total = data["value"].sum()

    fig = px.pie(
        data,
        values="value",
        names="ticker",
        hole=0.3,
        title=f"Portfolio Total ${portfolio_total:,.0f}",       
    )
    fig.layout.autosize = True
    return fig


plot = pn.pane.Plotly(
    portfolio_distribution(),
    config={"responsive": True},
    sizing_mode="stretch_both",
)

pn.Column(
    plot.param.hover_data,
    plot.param.click_data,
    plot,
    height=800,
    sizing_mode="stretch_width",
).servable()
```
