### PR TITLE
Propagate sizing mode

### DIFF
--- a/examples/reference/panes/HoloViews.ipynb
+++ b/examples/reference/panes/HoloViews.ipynb
@@ -103,7 +103,7 @@
     "\n",
     "hv_panel = pn.panel(dmap)\n",
     "\n",
-    "hv_panel.pprint()"
+    "print(hv_panel)"
    ]
   },
   {

--- a/panel/interact.py
+++ b/panel/interact.py
@@ -17,7 +17,7 @@ from collections.abc import Iterable, Mapping
 from inspect import (
     Parameter, getcallargs, getfullargspec as check_argspec, signature,
 )
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, ClassVar
 
 import param
 
@@ -70,9 +70,11 @@ class interactive(PaneBase):
     manual_update = param.Boolean(default=False, doc="""
         Whether to update manually by clicking on button.""")
 
+    manual_name = param.String(default='Run Interact')
+
     _pane = param.ClassSelector(class_=Viewable)
 
-    manual_name = param.String(default='Run Interact')
+    _rename: ClassVar[Mapping[str, str | None]] = {'_pane': None}
 
     def __init__(self, object, params={}, **kwargs):
         if signature is None:

--- a/panel/interact.py
+++ b/panel/interact.py
@@ -70,6 +70,8 @@ class interactive(PaneBase):
     manual_update = param.Boolean(default=False, doc="""
         Whether to update manually by clicking on button.""")
 
+    _pane = param.ClassSelector(class_=Viewable)
+
     manual_name = param.String(default='Run Interact')
 
     def __init__(self, object, params={}, **kwargs):
@@ -110,6 +112,7 @@ class interactive(PaneBase):
         self.widget_box = Column(*widgets)
         self.layout.objects = [self.widget_box, self._inner_layout]
         self._link_widgets()
+        self._sync_layout()
 
     #----------------------------------------------------------------
     # Model API
@@ -117,6 +120,17 @@ class interactive(PaneBase):
 
     def _get_model(self, doc, root=None, parent=None, comm=None):
         return self._inner_layout._get_model(doc, root, parent, comm)
+
+    @param.depends('_pane', '_pane.sizing_mode', '_pane.width_policy', '_pane.height_policy', watch=True)
+    def _sync_layout(self):
+        if not hasattr(self, '_inner_layout'):
+            return
+        opts = {
+            k: v for k, v in self._pane.param.values().items()
+            if k in ('sizing_mode', 'width_policy', 'height_policy')
+        }
+        self._inner_layout.param.update(opts)
+        self.layout.param.update(opts)
 
     #----------------------------------------------------------------
     # Callback API

--- a/panel/pane/base.py
+++ b/panel/pane/base.py
@@ -152,7 +152,7 @@ class PaneBase(Reactive):
         kwargs = {
             event.name: event.new for event in events
             if event.name in Layoutable.param
-            and event.name not in ('css_classes', 'margin')
+            and event.name not in ('css_classes', 'margin', 'name')
         }
         self.layout.param.update(kwargs)
 

--- a/panel/pane/base.py
+++ b/panel/pane/base.py
@@ -392,7 +392,7 @@ class ReplacementPane(PaneBase):
         self.param.watch(self._update_inner_layout, list(Layoutable.param))
         self._sync_layout()
 
-    @param.depends('_pane.sizing_mode', '_pane.width_policy', '_pane.height_policy', watch=True)
+    @param.depends('_pane', '_pane.sizing_mode', '_pane.width_policy', '_pane.height_policy', watch=True)
     def _sync_layout(self):
         if not hasattr(self, '_inner_layout'):
             return

--- a/panel/pane/base.py
+++ b/panel/pane/base.py
@@ -6,7 +6,8 @@ from __future__ import annotations
 
 from functools import partial
 from typing import (
-    TYPE_CHECKING, Any, Callable, ClassVar, List, Optional, Type, TypeVar,
+    TYPE_CHECKING, Any, Callable, ClassVar, List, Mapping, Optional, Type,
+    TypeVar,
 )
 
 import param
@@ -174,7 +175,7 @@ class PaneBase(Reactive):
     @property
     def _synced_params(self) -> List[str]:
         ignored_params = ['name', 'default_layout', 'loading']+self._rerender_params
-        return [p for p in self.param if p not in ignored_params]
+        return [p for p in self.param if p not in ignored_params and not p.startswith('_')]
 
     def _update_object(
         self, ref: str, doc: 'Document', root: Model, parent: Model, comm: Optional[Comm]
@@ -377,6 +378,8 @@ class ReplacementPane(PaneBase):
     """
 
     _pane = param.ClassSelector(class_=Viewable)
+
+    _rename: ClassVar[Mapping[str, str | None]] = {'_pane': None}
 
     _updates: bool = True
 

--- a/panel/pane/holoviews.py
+++ b/panel/pane/holoviews.py
@@ -189,7 +189,7 @@ class HoloViews(PaneBase):
     def _update_responsive(self):
         from holoviews import HoloMap, Store
         obj = self.object.last if isinstance(self.object, HoloMap) else self.object
-        if obj is None:
+        if obj is None or not Store.renderers:
             return
         backend = self.backend or Store.current_backend
         renderer = self.renderer or Store.renderers[backend]

--- a/panel/pane/plot.py
+++ b/panel/pane/plot.py
@@ -147,7 +147,7 @@ class Bokeh(PaneBase):
                 if p not in self._overrides and p in Layoutable.param and
                 p not in ('css_classes', 'name')
             })
-            self.object.update({
+            self.object.update(**{
                 o: getattr(self, o) for o in self._overrides
             })
         finally:

--- a/panel/pane/plot.py
+++ b/panel/pane/plot.py
@@ -78,6 +78,18 @@ class Bokeh(PaneBase):
 
     _rename: ClassVar[Mapping[str, str | None]] = {'autodispatch': None, 'theme': None}
 
+    def __init__(self, object=None, **params):
+        super().__init__(object, **params)
+        self._syncing_props = False
+        self._overrides = [
+            p for p, v in params.items()
+            if p in Layoutable.param and v != self.param[p].default
+        ]
+
+    def _param_change(self, *events: param.parameterized.Event) -> None:
+        self._track_overrides(*(e for e in events if e.name in Layoutable.param))
+        super()._param_change(*(e for e in events if e.name in self._overrides))
+
     @classmethod
     def applies(cls, obj: Any) -> float | bool | None:
         return isinstance(obj, LayoutDOM)
@@ -112,6 +124,35 @@ class Bokeh(PaneBase):
                     for cb in cbs
                 ]
 
+    def _track_overrides(self, *events):
+        if self._syncing_props:
+            return
+        overrides = list(self._overrides)
+        for e in events:
+            if e.name in overrides and self.param[e.name].default == e.new:
+                overrides.remove(e.name)
+            else:
+                overrides.append(e.name)
+        self._overrides = overrides
+        self._sync_properties()
+
+    @param.depends('object', watch=True)
+    def _sync_properties(self):
+        if self.object is None:
+            return
+        self._syncing_props = True
+        try:
+            self.param.update({
+                p: v for p, v in self.object.properties_with_values().items()
+                if p not in self._overrides and p in Layoutable.param and
+                p not in ('css_classes', 'name')
+            })
+            self.object.update({
+                o: getattr(self, o) for o in self._overrides
+            })
+        finally:
+            self._syncing_props = False
+
     def _get_model(
         self, doc: Document, root: Optional[Model] = None,
         parent: Optional[Model] = None, comm: Optional[Comm] = None
@@ -124,13 +165,6 @@ class Bokeh(PaneBase):
         else:
             model = self.object
 
-        properties = {}
-        for p, value in self.param.values().items():
-            if (p not in Layoutable.param or p == 'name' or
-                value is self.param[p].default):
-                continue
-            properties[p] = value
-        model.update(**properties)
         if comm and self.autodispatch:
             self._wrap_bokeh_callbacks(root, model, doc, comm)
 

--- a/panel/tests/pane/test_base.py
+++ b/panel/tests/pane/test_base.py
@@ -61,8 +61,8 @@ def test_pane_clone(pane):
         pytest.skip("Dependent library could not be imported.")
     clone = p.clone()
 
-    assert ([(k, v) for k, v in sorted(p.param.values().items()) if k != 'name'] ==
-            [(k, v) for k, v in sorted(clone.param.values().items()) if k != 'name'])
+    assert ([(k, v) for k, v in sorted(p.param.values().items()) if k not in ('name', '_pane')] ==
+            [(k, v) for k, v in sorted(clone.param.values().items()) if k not in ('name', '_pane')])
 
 
 @pytest.mark.parametrize('pane', all_panes)

--- a/panel/tests/pane/test_holoviews.py
+++ b/panel/tests/pane/test_holoviews.py
@@ -10,6 +10,12 @@ try:
 except Exception:
     hv = None
 
+try:
+    import holoviews.plotting.plotly as hv_plotly
+except Exception:
+    hv_plotly = None
+plotly_available = pytest.mark.skipif(hv_plotly is None, reason="requires plotly backend")
+
 from bokeh.models import (
     Column as BkColumn, ColumnDataSource, GlyphRenderer, GridBox, Line,
     Row as BkRow, Scatter, Select as BkSelect, Slider as BkSlider,
@@ -19,10 +25,13 @@ from bokeh.plotting import Figure
 
 import panel as pn
 
+from panel.depends import bind
 from panel.layout import Column, FlexBox, Row
-from panel.pane import HoloViews, PaneBase
+from panel.pane import HoloViews, PaneBase, panel
 from panel.tests.util import hv_available, mpl_available
-from panel.widgets import DiscreteSlider, FloatSlider, Select
+from panel.widgets import (
+    Checkbox, DiscreteSlider, FloatSlider, Select,
+)
 
 
 @hv_available
@@ -114,7 +123,6 @@ def test_holoviews_pane_bokeh_renderer(document, comm):
     pane._cleanup(row)
     assert pane._models == {}
 
-
 @pytest.mark.usefixtures("hv_bokeh")
 @hv_available
 def test_holoviews_pane_initialize_empty(document, comm):
@@ -132,6 +140,86 @@ def test_holoviews_pane_initialize_empty(document, comm):
     model = row.children[0]
     assert isinstance(model, Figure)
 
+@pytest.mark.usefixtures("hv_bokeh")
+@hv_available
+def test_holoviews_pane_reflect_responsive(document, comm):
+    curve = hv.Curve([1, 2, 3]).opts(responsive=True)
+    pane = HoloViews(curve)
+
+    # Create pane
+    row = pane.get_root(document, comm=comm)
+
+    assert row.sizing_mode == 'stretch_both'
+    assert pane.sizing_mode == 'stretch_both'
+
+    pane.object = hv.Curve([1, 2, 3])
+
+    assert row.sizing_mode == 'fixed'
+    assert pane.sizing_mode == 'fixed'
+
+@pytest.mark.usefixtures("hv_bokeh")
+@hv_available
+def test_holoviews_pane_reflect_responsive_override(document, comm):
+    curve = hv.Curve([1, 2, 3]).opts(responsive=True)
+    pane = HoloViews(curve, sizing_mode='fixed')
+
+    # Create pane
+    row = pane.get_root(document, comm=comm)
+
+    assert row.sizing_mode == 'fixed'
+    assert pane.sizing_mode == 'fixed'
+
+    # Unset override
+    pane.sizing_mode = None
+
+    row = pane.get_root(document, comm=comm)
+
+    assert row.sizing_mode == 'stretch_both'
+    assert pane.sizing_mode == 'stretch_both'
+
+@pytest.mark.usefixtures("hv_bokeh")
+@hv_available
+def test_holoviews_pane_reflect_responsive_interact_function(document, comm):
+    curve_fn = lambda: hv.Curve([1, 2, 3]).opts(responsive=True)
+    pane = panel(curve_fn)
+
+    # Create pane
+    row = pane.get_root(document, comm=comm)
+
+    assert row.sizing_mode == 'stretch_both'
+
+@pytest.mark.usefixtures("hv_bokeh")
+@hv_available
+def test_holoviews_pane_reflect_responsive_bind_function(document, comm):
+    checkbox = Checkbox(value=True)
+    curve_fn = lambda responsive: hv.Curve([1, 2, 3]).opts(responsive=responsive)
+    pane = panel(bind(curve_fn, responsive=checkbox))
+
+    # Create pane
+    col = pane.get_root(document, comm=comm)
+
+    assert col.sizing_mode == 'stretch_both'
+
+    checkbox.value = False
+
+    assert col.sizing_mode == 'fixed'
+
+@hv_available
+@plotly_available
+def test_holoviews_pane_reflect_responsive_plotly(document, comm):
+    curve = hv.Curve([1, 2, 3]).opts(responsive=True, backend='plotly')
+    pane = HoloViews(curve, backend='plotly')
+
+    # Create pane
+    row = pane.get_root(document, comm=comm)
+
+    assert row.sizing_mode == 'stretch_both'
+    assert pane.sizing_mode == 'stretch_both'
+
+    pane.object = hv.Curve([1, 2, 3])
+
+    assert row.sizing_mode is None
+    assert pane.sizing_mode is None
 
 @hv_available
 def test_holoviews_widgets_from_dynamicmap(document, comm):

--- a/panel/tests/test_interact.py
+++ b/panel/tests/test_interact.py
@@ -233,7 +233,7 @@ def test_interact_replaces_model(document, comm):
     assert new_pane._models[column.ref['id']][0] is new_div
 
     interact_pane._cleanup(column)
-    assert len(interact_pane._callbacks) == 3
+    assert len(interact_pane._callbacks) == 4
 
 
 def test_interact_throttled():


### PR DESCRIPTION
This PR ensures that any dynamic components like `ParamFunction`, `ParamMethod` and `Interactive` reflect the parameters (especially the `sizing_mode`) of the components they are wrapping. It also propagates responsive sizing modes on a HoloViews/Bokeh object to the pane wrapping it ensuring that sizing modes and other options can propagate upwards from a plot all the way to a dynamic pane.

- Fixes https://github.com/holoviz/panel/issues/2774
- Fixes https://github.com/holoviz/panel/issues/4325