### PR TITLE
IpyLeaflet example: use `add` instead of the deprecated `add_layer`

### DIFF
--- a/examples/reference/panes/IPyWidget.ipynb
+++ b/examples/reference/panes/IPyWidget.ipynb
@@ -157,7 +157,7 @@
     "    bounds=((13, -130), (32, -100))\n",
     ")\n",
     "\n",
-    "m.add_layer(video);\n",
+    "m.add(video);\n",
     "\n",
     "pn.panel(m)"
    ]


### PR DESCRIPTION
Saw this deprecation warning when running this reference notebook.