### PR TITLE
Ensure HoloViews pane can handle Plot objects

### DIFF
--- a/panel/pane/holoviews.py
+++ b/panel/pane/holoviews.py
@@ -321,7 +321,7 @@ class HoloViews(PaneBase):
                 'height': None
             }
         elif backend == 'plotly':
-            if state.get('config').get('responsive'):
+            if state.get('config', {}).get('responsive'):
                 sizing_mode = 'stretch_both'
             else:
                 sizing_mode = None


### PR DESCRIPTION
The `HoloViews` pane is meant to be able to handle `holoviews.plotting.plot.Plot` types.