### PR TITLE
Docs build: bump the install action

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -37,7 +37,7 @@ jobs:
       DISPLAY: ":99.0"
       PANEL_IPYWIDGET: 1
     steps:
-      - uses: pyviz-dev/holoviz_tasks/install@v0.1a9
+      - uses: pyviz-dev/holoviz_tasks/install@v0.1a10
         with:
           name: doc_build
           python-version: "3.9"


### PR DESCRIPTION
To a new version that forces `git fetch` to avoid:

>  ! [rejected]          v0.14.3rc2            -> v0.14.3rc2  (would clobber existing tag)
