### PR TITLE
Fix serialization of buffer headers in notebook

### DIFF
--- a/panel/io/notebook.py
+++ b/panel/io/notebook.py
@@ -74,7 +74,7 @@ def push(doc: 'Document', comm: 'Comm', binary: bool = True) -> None:
     for buffer in msg.buffers:
         header = json.dumps(buffer.ref)
         payload = buffer.to_bytes()
-        comm.send(json.dumps(header))
+        comm.send(header)
         comm.send(buffers=[payload])
 
 def push_on_root(ref: str):

--- a/panel/pane/plotly.py
+++ b/panel/pane/plotly.py
@@ -5,7 +5,7 @@ bokeh model.
 from __future__ import annotations
 
 from typing import (
-    TYPE_CHECKING, Any, ClassVar, Mapping, Optional,
+    TYPE_CHECKING, Any, ClassVar, List, Mapping, Optional,
 )
 
 import numpy as np

--- a/panel/tests/template/test_base.py
+++ b/panel/tests/template/test_base.py
@@ -1,7 +1,5 @@
 import unittest
 
-from bokeh.document import Document
-
 from panel.config import config
 from panel.io.notifications import NotificationArea
 from panel.io.state import set_curdoc, state
@@ -18,7 +16,7 @@ def test_notification_instantiate_on_config(document):
     session_context = unittest.mock.Mock()
     document._session_context = lambda: session_context
 
-    with set_curdoc(doc):
+    with set_curdoc(document):
         assert state.notifications is tmpl.notifications
 
 
@@ -31,5 +29,5 @@ def test_notification_explicit(document):
     session_context = unittest.mock.Mock()
     document._session_context = lambda: session_context
 
-    with set_curdoc(doc):
+    with set_curdoc(document):
         assert state.notifications is tmpl.notifications


### PR DESCRIPTION
Seemingly buffer headers were json serialized twice causing issues when deserializing them. This did not seem to cause issues for bokeh <3 but does now.