### PR TITLE
RGGPlot: rename the method that gets the image data

### DIFF
--- a/panel/pane/plot.py
+++ b/panel/pane/plot.py
@@ -361,7 +361,7 @@ class RGGPlot(PNG):
     def applies(cls, obj: Any) -> float | bool | None:
         return type(obj).__name__ == 'GGPlot' and hasattr(obj, 'r_repr')
 
-    def _img(self):
+    def _data(self):
         from rpy2 import robjects
         from rpy2.robjects.lib import grdevices
         with grdevices.render_to_bytesio(grdevices.png,


### PR DESCRIPTION
This PR renames the RGGPlot `_img` method to `_data`. This pane being untested this slipped through some (old?) refactoring. The pane being undocumented too, nobody complained about it because presumably nobody's really using it :)
