### PR TITLE
More specific front-end parameter typing for SpeechToText

### DIFF
--- a/panel/models/speech_to_text.ts
+++ b/panel/models/speech_to_text.ts
@@ -221,7 +221,7 @@ export class SpeechToText extends HTMLBox {
       continuous: [ Boolean,   false ],
       interim_results: [ Boolean,   false ],
       max_alternatives: [ Number,   1 ],
-      service_uri: [String, ],
+      service_uri: [ String, '' ],
       started: [ Boolean,   false ],
       audio_started: [ Boolean,   false ],
       sound_started: [ Boolean,   false ],

--- a/panel/models/speech_to_text.ts
+++ b/panel/models/speech_to_text.ts
@@ -212,12 +212,12 @@ export class SpeechToText extends HTMLBox {
   static init_SpeechToText(): void {
     this.prototype.default_view = SpeechToTextView
 
-    this.define<SpeechToText.Props>(({Array, Boolean, Number, String}) => ({
-      start: [ Boolean, false   ],
-      stop: [ Boolean, false   ],
-      abort: [ Boolean, false   ],
-      grammars: [Array(String), []],
-      lang: [String, ""],
+    this.define<SpeechToText.Props>(({Any, Array, Boolean, Number, String}) => ({
+      start: [ Boolean, false ],
+      stop: [ Boolean, false ],
+      abort: [ Boolean, false ],
+      grammars: [ Array(String), [] ],
+      lang: [ String, '' ],
       continuous: [ Boolean,   false ],
       interim_results: [ Boolean,   false ],
       max_alternatives: [ Number,   1 ],
@@ -226,7 +226,7 @@ export class SpeechToText extends HTMLBox {
       audio_started: [ Boolean,   false ],
       sound_started: [ Boolean,   false ],
       speech_started: [ Boolean,   false ],
-      button_type: [String, 'light'],
+      button_type: [ String, 'light' ],
       button_hide: [ Boolean,   false ],
       button_not_started: [ String,   '' ],
       button_started: [ String,   '' ],

--- a/panel/models/speech_to_text.ts
+++ b/panel/models/speech_to_text.ts
@@ -230,7 +230,7 @@ export class SpeechToText extends HTMLBox {
       button_hide: [ Boolean,   false ],
       button_not_started: [ String,   '' ],
       button_started: [ String,   '' ],
-      results: [ Array(String), []],
+      results: [ Array(Any), [] ],
     }))
   }
 }


### PR DESCRIPTION
Saw the following error working on the branch 1.0 as long as with an error about `results` (didn't catch the error in the log):

> Error rendering Bokeh items: Error: panel.models.speech_to_text.SpeechToText(p1030).service_uri is unset
