### PR TITLE
Standardize parameter mapping APIs

### DIFF
--- a/panel/dist/css/markdown.css
+++ b/panel/dist/css/markdown.css
@@ -80,7 +80,7 @@
 .markdown a { color: -webkit-link }
 .markdown a { color: -moz-hyperlinkText }
 
-.markdown .codehilite {
+:host(.markdown) .codehilite {
     padding: 1rem 1.25rem;
     margin-top: 1rem;
     margin-bottom: 1rem;

--- a/panel/io/location.py
+++ b/panel/io/location.py
@@ -72,10 +72,8 @@ class Location(Syncable):
     ) -> 'Model':
         model = _BkLocation(**self._process_param_change(self._init_params()))
         root = root or model
-        values = self.param.values()
-        properties = list(self._process_param_change(values))
         self._models[root.ref['id']] = (model, parent)
-        self._link_props(model, properties, doc, root, comm)
+        self._link_props(model, self._linked_properties, doc, root, comm)
         return model
 
     def get_root(

--- a/panel/layout/base.py
+++ b/panel/layout/base.py
@@ -72,11 +72,13 @@ class Panel(Reactive):
     # Callback API
     #----------------------------------------------------------------
 
-    def _init_params(self):
-        return {p: v for p, v in self.param.values().items()
-                if v is not None and p != 'objects'}
+    def _init_params(self) -> Dict[str, Any]:
+        return {
+            p: v for p, v in self.param.values().items()
+            if v is not None and p != 'objects'
+        }
 
-    def _get_properties(self):
+    def _get_properties(self) -> Dict[str, Any]:
         return self._process_param_change(self._init_params())
 
     def _update_model(

--- a/panel/layout/base.py
+++ b/panel/layout/base.py
@@ -790,7 +790,7 @@ class WidgetBox(ListPanel):
 
     @param.depends('disabled', 'objects', watch=True)
     def _disable_widgets(self) -> None:
-        from ..widget import Widget
+        from ..widgets import Widget
         for obj in self.select(Widget):
             obj.disabled = self.disabled
 

--- a/panel/layout/base.py
+++ b/panel/layout/base.py
@@ -41,9 +41,6 @@ class Panel(Reactive):
     # Bokeh model used to render this Panel
     _bokeh_model: ClassVar[Type[Model]]
 
-    # Properties that should sync JS -> Python
-    _linked_props: ClassVar[List[str]] = []
-
     # Parameters which require the preprocessors to be re-run
     _preprocess_params: ClassVar[List[str]] = []
 
@@ -155,7 +152,7 @@ class Panel(Reactive):
         objects = self._get_objects(model, [], doc, root, comm)
         model.update(**{self._property_mapping['objects']: objects})
         self._models[root.ref['id']] = (model, parent)
-        self._link_props(model, self._linked_props, doc, root, comm)
+        self._link_props(model, self._linked_properties, doc, root, comm)
         return model
 
     #----------------------------------------------------------------
@@ -678,11 +675,11 @@ class NamedListPanel(NamedListLike, Panel):
     __abstract = True
 
     def _process_param_change(self, params: Dict[str, Any]) -> Dict[str, Any]:
-        scroll = params.pop('scroll', None)
-        css_classes = self.css_classes or []
-        if scroll:
-            params['css_classes'] = css_classes + ['scrollable']
-        elif scroll == False:
+        if 'scroll' in params:
+            scroll = params.pop('scroll')
+            css_classes = list(self.css_classes or [])
+            if scroll:
+                css_classes += ['scrollable']
             params['css_classes'] = css_classes
         return super()._process_param_change(params)
 

--- a/panel/layout/base.py
+++ b/panel/layout/base.py
@@ -777,7 +777,7 @@ class WidgetBox(ListPanel):
     }
 
     _rename: ClassVar[Mapping[str, str | None]] = {
-        'objects': 'children', 'horizontal': None
+        'disabled': None, 'objects': 'children', 'horizontal': None
     }
 
     @property
@@ -786,9 +786,9 @@ class WidgetBox(ListPanel):
 
     @param.depends('disabled', 'objects', watch=True)
     def _disable_widgets(self) -> None:
-        for obj in self:
-            if hasattr(obj, 'disabled'):
-                obj.disabled = self.disabled
+        from ..widget import Widget
+        for obj in self.select(Widget):
+            obj.disabled = self.disabled
 
     def __init__(self, *objects: Any, **params: Any):
         super().__init__(*objects, **params)

--- a/panel/layout/base.py
+++ b/panel/layout/base.py
@@ -84,7 +84,7 @@ class Panel(Reactive):
         root: Model, model: Model, doc: Document, comm: Optional[Comm]
     ) -> None:
         msg = dict(msg)
-        inverse = {v: k for k, v in self._rename.items() if v is not None}
+        inverse = {v: k for k, v in self._property_mapping.items() if v is not None}
         preprocess = any(inverse.get(k, k) in self._preprocess_params for k in msg)
 
         obj_key = self._property_mapping['objects']
@@ -146,12 +146,14 @@ class Panel(Reactive):
     ) -> Model:
         if self._bokeh_model is None:
             raise ValueError(f'{type(self).__name__} did not define a _bokeh_model.')
-        model = self._bokeh_model(**self._get_properties())
+        model = self._bokeh_model()
         if root is None:
             root = model
-        objects = self._get_objects(model, [], doc, root, comm)
-        model.update(**{self._property_mapping['objects']: objects})
         self._models[root.ref['id']] = (model, parent)
+        objects = self._get_objects(model, [], doc, root, comm)
+        properties = self._get_properties()
+        properties[self._property_mapping['objects']] = objects
+        model.update(**properties)
         self._link_props(model, self._linked_properties, doc, root, comm)
         return model
 

--- a/panel/layout/base.py
+++ b/panel/layout/base.py
@@ -621,6 +621,8 @@ class ListPanel(ListLike, Panel):
         Whether to add scrollbars if the content overflows the size
         of the container.""")
 
+    _rename: ClassVar[Mapping[str, str | None]] = {'scroll': None}
+
     _source_transforms: ClassVar[Mapping[str, str | None]] = {'scroll': None}
 
     __abstract = True
@@ -636,6 +638,13 @@ class ListPanel(ListLike, Panel):
         elif 'objects' in params:
             params['objects'] = [panel(pane) for pane in params['objects']]
         super(Panel, self).__init__(**params)
+
+    @property
+    def _linked_properties(self):
+        return tuple(
+            self._property_mapping.get(p, p) for p in self.param
+            if p not in ListPanel.param and self._property_mapping.get(p, p) is not None
+        )
 
     def _process_param_change(self, params: Dict[str, Any]) -> Dict[str, Any]:
         scroll = params.pop('scroll', None)
@@ -707,11 +716,7 @@ class Row(ListPanel):
     >>> pn.Row(some_widget, some_pane, some_python_object)
     """
 
-    col_sizing = param.Parameter()
-
     _bokeh_model: ClassVar[Type[Model]] = BkRow
-
-    _rename: ClassVar[Mapping[str, str | None]] = {'col_sizing': 'cols'}
 
 
 class Column(ListPanel):
@@ -730,11 +735,7 @@ class Column(ListPanel):
     >>> pn.Column(some_widget, some_pane, some_python_object)
     """
 
-    row_sizing = param.Parameter()
-
     _bokeh_model: ClassVar[Type[Model]] = BkColumn
-
-    _rename: ClassVar[Mapping[str, str | None]] = {'row_sizing': 'rows'}
 
 
 class WidgetBox(ListPanel):

--- a/panel/layout/card.py
+++ b/panel/layout/card.py
@@ -72,11 +72,9 @@ class Card(Column):
 
     _bokeh_model: ClassVar[Type[Model]] = BkCard
 
-    _linked_props: ClassVar[List[str]] = ['collapsed']
-
-    _rename: ClassVar[Mapping[str, str | None]] = dict(
-        Column._rename, title=None, header=None, title_css_classes=None
-    )
+    _rename: ClassVar[Mapping[str, str | None]] = {
+        'title': None, 'header': None, 'title_css_classes': None
+    }
 
     _stylesheets: ClassVar[List[str]] = ['css/card.css']
 

--- a/panel/layout/grid.py
+++ b/panel/layout/grid.py
@@ -54,7 +54,9 @@ class GridBox(ListPanel):
 
     _bokeh_model = BkGridBox
 
-    _rename: ClassVar[Mapping[str, str | None]] = {'objects': 'children', 'nrows': None, 'ncols': None}
+    _rename: ClassVar[Mapping[str, str | None]] = {
+        'objects': 'children', 'nrows': None, 'ncols': None
+    }
 
     _source_transforms = {'scroll': None, 'objects': None}
 
@@ -215,7 +217,9 @@ class GridSpec(Panel):
 
     _source_transforms = {'objects': None, 'mode': None}
 
-    _rename: ClassVar[Mapping[str, str | None]] = {'objects': 'children', 'mode': None, 'ncols': None, 'nrows': None}
+    _rename: ClassVar[Mapping[str, str | None]] = {
+        'objects': None, 'mode': None, 'ncols': None, 'nrows': None
+    }
 
     _preprocess_params = ['objects']
 

--- a/panel/layout/grid.py
+++ b/panel/layout/grid.py
@@ -151,15 +151,14 @@ class GridBox(ListPanel):
         return cls._flatten_grid(layout, nrows, ncols)
 
     def _get_model(self, doc, root=None, parent=None, comm=None):
-        model = self._bokeh_model()
+        model = self._bokeh_model(**self._get_properties())
         if root is None:
             root = model
         objects = self._get_objects(model, [], doc, root, comm)
-        properties = self._process_param_change(self._init_params())
-        properties['children'] = self._get_children(objects, self.nrows, self.ncols)
-        model.update(**properties)
+        children = self._get_children(objects, self.nrows, self.ncols)
+        model.update(**{'children': children})
         self._models[root.ref['id']] = (model, parent)
-        self._link_props(model, self._linked_props, doc, root, comm)
+        self._link_props(model, self._linked_properties, doc, root, comm)
         return model
 
     def _update_model(

--- a/panel/layout/gridstack.py
+++ b/panel/layout/gridstack.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from collections import OrderedDict
-from typing import ClassVar, Mapping
 
 import param
 
@@ -131,8 +130,6 @@ class GridStack(ReactiveHTML, GridSpec):
         return {
             'GridStack': cls.__javascript__[0:1],
         }
-
-    _rename: ClassVar[Mapping[str, str | None]] = {}
 
     @classproperty
     def __javascript__(cls):

--- a/panel/layout/tabs.py
+++ b/panel/layout/tabs.py
@@ -67,7 +67,7 @@ class Tabs(NamedListPanel):
     _manual_params: ClassVar[List[str]] = ['closable']
 
     _rename: ClassVar[Mapping[str, str | None]] = {
-        'name': None, 'objects': 'tabs', 'dynamic': None
+        'closable': None, 'dynamic': None, 'name': None, 'objects': 'tabs'
     }
 
     _source_transforms: ClassVar[Mapping[str, str | None]] = {

--- a/panel/layout/tabs.py
+++ b/panel/layout/tabs.py
@@ -62,8 +62,6 @@ class Tabs(NamedListPanel):
     var value = ids;
     """}
 
-    _linked_props: ClassVar[List[str]] = ['active', 'tabs']
-
     _manual_params: ClassVar[List[str]] = ['closable']
 
     _rename: ClassVar[Mapping[str, str | None]] = {

--- a/panel/pane/__init__.py
+++ b/panel/pane/__init__.py
@@ -38,7 +38,7 @@ from .echarts import ECharts  # noqa
 from .equation import LaTeX  # noqa
 from .holoviews import HoloViews, Interactive  # noqa
 from .image import (  # noqa
-    GIF, ICO, JPG, PDF, PNG, SVG,
+    GIF, ICO, JPG, PDF, PNG, SVG, Image,
 )
 from .ipywidget import IPyLeaflet, IPyWidget, Reacton  # noqa
 from .markup import (  # noqa

--- a/panel/pane/__init__.py
+++ b/panel/pane/__init__.py
@@ -2,11 +2,9 @@
 Panel panes renders the Python objects you know and love ❤️
 ===========================================================
 
-Panes may render anything including plots, text,
-images, equations etc.
+Panes may render anything including plots, text, images, equations etc.
 
-For example Panel contains Bokeh, HoloViews,
-Matplotlib and Plotly panes.
+For example Panel contains Bokeh, HoloViews, Matplotlib and Plotly panes.
 
 Check out the Panel gallery of panes
 https://panel.holoviz.org/reference/index.html#panes for inspiration.

--- a/panel/pane/alert.py
+++ b/panel/pane/alert.py
@@ -30,7 +30,7 @@ class Alert(Markdown):
 
     priority: ClassVar[float | bool | None] = 0
 
-    _rename: ClassVar[Mapping[str, str | None]] = dict(Markdown._rename, alert_type=None)
+    _rename: ClassVar[Mapping[str, str | None]] = {'alert_type': None}
 
     _stylesheets = ['css/alerts.css', 'css/variables.css']
 

--- a/panel/pane/alert.py
+++ b/panel/pane/alert.py
@@ -11,7 +11,10 @@ import param
 
 from .markup import Markdown
 
-ALERT_TYPES = ["primary", "secondary", "success", "danger", "warning", "info", "light", "dark"]
+ALERT_TYPES = [
+    "primary", "secondary", "success", "danger",
+    "warning", "info", "light", "dark"
+]
 
 
 class Alert(Markdown):
@@ -46,14 +49,9 @@ class Alert(Markdown):
             params["sizing_mode"] = "stretch_width"
         super().__init__(object, **params)
 
-    @param.depends("alert_type", watch=True, on_init=True)
-    def _set_css_classes(self):
-        css_classes = []
-        if self.css_classes:
-            for class_ in self.css_classes:
-                if class_ != "alert" and not class_.startswith("alert-"):
-                    css_classes.append(class_)
-
-        css_classes.append("alert")
-        css_classes.append(f"alert-{self.alert_type}")
-        self.css_classes = css_classes
+    def _process_param_change(self, params):
+        if 'css_classes' in params or 'alert_type' in params:
+            params['css_classes'] = self.css_classes + [
+                'alert', f'alert-{self.alert_type}'
+            ]
+        return super()._process_param_change(params)

--- a/panel/pane/base.py
+++ b/panel/pane/base.py
@@ -6,8 +6,8 @@ from __future__ import annotations
 
 from functools import partial
 from typing import (
-    TYPE_CHECKING, Any, Callable, ClassVar, List, Mapping, Optional, Type,
-    TypeVar,
+    TYPE_CHECKING, Any, Callable, ClassVar, List, Mapping, Optional, Tuple,
+    Type, TypeVar,
 )
 
 import param
@@ -423,6 +423,8 @@ class ReplacementPane(PaneBase):
     """
 
     _pane = param.ClassSelector(class_=Viewable)
+
+    _linkable_properties: ClassVar[Tuple[str]] = ()
 
     _rename: ClassVar[Mapping[str, str | None]] = {'_pane': None}
 

--- a/panel/pane/base.py
+++ b/panel/pane/base.py
@@ -172,8 +172,15 @@ class PaneBase(Reactive):
     #----------------------------------------------------------------
 
     @property
+    def _linked_properties(self):
+        return tuple(
+            self._property_mapping.get(p, p) for p in self.param
+            if p not in PaneBase.param and self._property_mapping.get(p, p) is not None
+        )
+
+    @property
     def _linkable_params(self) -> List[str]:
-        return [p for p in self._synced_params if self._propert_mapping.get(p, False) is not None]
+        return [p for p in self._synced_params if self._property_mapping.get(p, False) is not None]
 
     @property
     def _synced_params(self) -> List[str]:

--- a/panel/pane/base.py
+++ b/panel/pane/base.py
@@ -173,7 +173,7 @@ class PaneBase(Reactive):
 
     @property
     def _linkable_params(self) -> List[str]:
-        return [p for p in self._synced_params if self._rename.get(p, False) is not None]
+        return [p for p in self._synced_params if self._propert_mapping.get(p, False) is not None]
 
     @property
     def _synced_params(self) -> List[str]:
@@ -391,10 +391,6 @@ class ModelPane(PaneBase):
         self._link_props(model, self._linked_properties, doc, root, comm)
         return model
 
-    @property
-    def _linked_properties(self):
-        return tuple(self._rename.get(p, p) for p in self._linkable_params)
-
     def _update(self, ref: str, model: Model) -> None:
         model.update(**self._get_properties())
 
@@ -402,9 +398,6 @@ class ModelPane(PaneBase):
         params = {p: v for p, v in self.param.values().items() if v is not None}
         params['object'] = self.object
         return params
-
-    def _get_properties(self):
-        return self._process_param_change(self._init_params())
 
     def _transform_object(self, obj):
         return dict(object=obj)

--- a/panel/pane/base.py
+++ b/panel/pane/base.py
@@ -120,6 +120,11 @@ class PaneBase(Reactive):
     # Declares whether Pane supports updates to the Bokeh model
     _updates: ClassVar[bool] = False
 
+    # Mapping from parameter name to bokeh model property name
+    _rename: ClassVar[Mapping[str, str | None]] = {
+        'default_layout': None, 'loading': None
+    }
+
     # List of parameters that trigger a rerender of the Bokeh model
     _rerender_params: ClassVar[List[str]] = ['object']
 
@@ -394,7 +399,9 @@ class ModelPane(PaneBase):
         model.update(**self._get_properties())
 
     def _init_params(self):
-        return self.param.values()
+        params = {p: v for p, v in self.param.values().items() if v is not None}
+        params['object'] = self.object
+        return params
 
     def _get_properties(self):
         return self._process_param_change(self._init_params())

--- a/panel/pane/base.py
+++ b/panel/pane/base.py
@@ -6,8 +6,8 @@ from __future__ import annotations
 
 from functools import partial
 from typing import (
-    TYPE_CHECKING, Any, Callable, ClassVar, List, Mapping, Optional, Tuple,
-    Type, TypeVar,
+    TYPE_CHECKING, Any, Callable, ClassVar, Dict, List, Mapping, Optional,
+    Tuple, Type, TypeVar,
 )
 
 import param
@@ -406,7 +406,7 @@ class ModelPane(PaneBase):
         params['object'] = self.object
         return params
 
-    def _transform_object(self, obj):
+    def _transform_object(self, obj: Any) -> Dict[str, Any]:
         return dict(object=obj)
 
     def _process_param_change(self, params):

--- a/panel/pane/base.py
+++ b/panel/pane/base.py
@@ -36,16 +36,22 @@ if TYPE_CHECKING:
 
 def panel(obj: Any, **kwargs) -> Viewable:
     """
-    Creates a panel from any supplied object by wrapping it in a pane
-    and returning a corresponding Panel.
+    Creates a displayable Panel object given any valid Python object.
 
-    If you provide a "reactive function" as `obj` and set
-    `loading_indicator=True`, then Panel will display a loading indicator
-    when invoking the function.
+    The appropriate Pane to render a specific object is determined by
+    iterating over all defined Pane types and querying it's `.applies`
+    method for a priority value.
 
-    Reference: https://panel.holoviz.org/user_guide/Components.html#panes
+    Any keyword arguments are passed down to the applicable Pane.
 
-    >>> pn.panel(some_python_object, width=500, background="whitesmoke")
+    To lazily render components you may also provide a Python
+    function, with or without bound parameter dependencies and set
+    `defer_load=True`. Setting `loading_indicator=True` will display a
+    loading indicator while the function is being evaluated.
+
+    Reference: https://panel.holoviz.org/background/components/components_overview.html#panes
+
+    >>> pn.panel(some_python_object, width=500)
 
     Arguments
     ---------
@@ -62,7 +68,9 @@ def panel(obj: Any, **kwargs) -> Viewable:
     if isinstance(obj, (Viewable, ServableMixin)):
         return obj
     elif hasattr(obj, '__panel__'):
-        if not isinstance(obj, Viewer) and (isinstance(obj, type) and issubclass(obj, Viewer)):
+        if isinstance(obj, Viewer):
+            return obj._create_view()
+        if isinstance(obj, type) and issubclass(obj, Viewer):
             return panel(obj().__panel__())
         return panel(obj.__panel__())
     if kwargs.get('name', False) is None:

--- a/panel/pane/base.py
+++ b/panel/pane/base.py
@@ -418,7 +418,10 @@ class ModelPane(PaneBase):
         model.update(**self._get_properties())
 
     def _init_params(self):
-        params = {p: v for p, v in self.param.values().items() if v is not None}
+        params = {
+            p: v for p, v in self.param.values().items()
+            if v is not None and p not in ('name', 'default_layout')
+        }
         params['object'] = self.object
         return params
 

--- a/panel/pane/equation.py
+++ b/panel/pane/equation.py
@@ -13,7 +13,7 @@ import param
 from pyviz_comms import JupyterComm
 
 from ..util import lazy_load
-from .markup import DivPaneBase
+from .base import ModelPane
 
 
 def is_sympy_expr(obj):
@@ -25,7 +25,7 @@ def is_sympy_expr(obj):
     return False
 
 
-class LaTeX(DivPaneBase):
+class LaTeX(ModelPane):
     """
     The `LaTeX` pane allows rendering LaTeX equations. It uses either
     `MathJax` or `KaTeX` depending on the defined renderer.
@@ -73,15 +73,13 @@ class LaTeX(DivPaneBase):
         return lazy_load(f'panel.models.{module}', model, isinstance(comm, JupyterComm), root)
 
     def _get_model(self, doc, root=None, parent=None, comm=None):
-        model = self._get_model_type(root, comm)(**self._process_param_change(self._get_properties()))
+        model = self._get_model_type(root, comm)(**self._get_properties())
         if root is None:
             root = model
         self._models[root.ref['id']] = (model, parent)
         return model
 
-    def _get_properties(self):
-        properties = super()._get_properties()
-        obj = self.object
+    def _transform_object(self, obj):
         if obj is None:
             obj = ''
         elif hasattr(obj, '_repr_latex_'):
@@ -89,4 +87,4 @@ class LaTeX(DivPaneBase):
         elif is_sympy_expr(obj):
             import sympy
             obj = r'$'+sympy.latex(obj)+'$'
-        return dict(properties, text=obj)
+        return dict(object=obj)

--- a/panel/pane/equation.py
+++ b/panel/pane/equation.py
@@ -10,9 +10,9 @@ from typing import (
     TYPE_CHECKING, Any, ClassVar, Dict, Mapping, Type,
 )
 
-import param
+import param  # type: ignore
 
-from pyviz_comms import JupyterComm
+from pyviz_comms import Comm, JupyterComm  # type: ignore
 
 from ..util import lazy_load
 from .base import ModelPane
@@ -20,14 +20,12 @@ from .base import ModelPane
 if TYPE_CHECKING:
     from bokeh.document import Document
     from bokeh.model import Model
-    from pyviz_comms import Comm
-
 
 
 def is_sympy_expr(obj: Any) -> bool:
     """Test for sympy.Expr types without usually needing to import sympy"""
     if 'sympy' in sys.modules and 'sympy' in str(type(obj).__class__):
-        import sympy
+        import sympy  # type: ignore
         if isinstance(obj, sympy.Expr):
             return True
     return False
@@ -62,6 +60,8 @@ class LaTeX(ModelPane):
     _rename: ClassVar[Mapping[str, str | None]] = {
         'renderer': None, 'object': 'text'
     }
+
+    _updates: ClassVar[bool] = True
 
     @classmethod
     def applies(cls, obj: Any) -> float | bool | None:

--- a/panel/pane/image.py
+++ b/panel/pane/image.py
@@ -90,8 +90,6 @@ class FileBase(HTMLBasePane):
                     return f.read()
         elif isinstance(obj, bytes):
             return obj
-        elif isinstance(obj, str):
-            return obj.encode('utf-8')
         elif hasattr(obj, 'read'):
             if hasattr(obj, 'seek'):
                 obj.seek(0)
@@ -399,7 +397,9 @@ class SVG(ImageBase):
         width, height = self._imgshape(data)
         if self.encode:
             data = f"<img src='{self._b64(data)}' width={width} height={height}></img>"
-        return dict(width=width, height=height, text=escape(data.decode('utf-8')))
+        if isinstance(data, bytes):
+            data = data.decode('utf-8')
+        return dict(width=width, height=height, text=escape(data))
 
 
 class PDF(FileBase):

--- a/panel/pane/image.py
+++ b/panel/pane/image.py
@@ -17,12 +17,12 @@ import param
 
 from ..models import PDF as _BkPDF
 from ..util import isfile, isurl
-from .markup import DivPaneBase, escape
+from .markup import HTMLBasePane, escape
 
 if TYPE_CHECKING:
     from bokeh.model import Model
 
-class FileBase(DivPaneBase):
+class FileBase(HTMLBasePane):
 
     embed = param.Boolean(default=True, doc="""
         Whether to embed the file as base64.""")

--- a/panel/pane/image.py
+++ b/panel/pane/image.py
@@ -426,7 +426,7 @@ class PDF(FileBase):
 
     _rerender_params: ClassVar[List[str]] = FileBase._rerender_params + ['start_page']
 
-    def _transform_object(self, obj):
+    def _transform_object(self, obj: Any) -> Dict[str, Any]:
         if obj is None:
             return dict(object='<embed></embed>')
         elif self.embed:

--- a/panel/pane/image.py
+++ b/panel/pane/image.py
@@ -10,7 +10,7 @@ import base64
 from io import BytesIO
 from pathlib import PurePath
 from typing import (
-    TYPE_CHECKING, Any, ClassVar, Dict, List, Mapping,
+    TYPE_CHECKING, Any, ClassVar, List, Mapping,
 )
 
 import param
@@ -29,7 +29,7 @@ class FileBase(DivPaneBase):
 
     filetype: ClassVar[str]
 
-    _rename: ClassVar[Dict[str, str | None]] = {'embed': None}
+    _rename: ClassVar[Mapping[str, str | None]] = {'embed': None}
 
     _rerender_params: ClassVar[List[str]] = [
         'embed', 'object', 'styles', 'width', 'height'

--- a/panel/pane/image.py
+++ b/panel/pane/image.py
@@ -10,7 +10,7 @@ import base64
 from io import BytesIO
 from pathlib import PurePath
 from typing import (
-    TYPE_CHECKING, Any, ClassVar, List, Mapping,
+    TYPE_CHECKING, Any, ClassVar, Dict, List, Mapping,
 )
 
 import param
@@ -152,7 +152,7 @@ class ImageBase(FileBase):
         """Calculate and return image width,height"""
         raise NotImplementedError
 
-    def _transform_object(self, obj):
+    def _transform_object(self, obj: Any) -> Dict[str, Any]:
         data = self._data(obj)
         if data is None:
             return dict(object='<img></img>')
@@ -207,7 +207,7 @@ class Image(ImageBase):
                 return applies
         return False
 
-    def _transform_object(self, obj: Any):
+    def _transform_object(self, obj: Any) -> Dict[str, Any]:
         for img_cls in param.concrete_descendents(ImageBase).values():
             if img_cls is not Image and img_cls.applies(obj):
                 return img_cls(obj)._transform_object(obj)
@@ -376,7 +376,7 @@ class SVG(ImageBase):
     def _imgshape(self, data):
         return (self.width, self.height)
 
-    def _transform_object(self, obj):
+    def _transform_object(self, obj: Any) -> Dict[str, Any]:
         if obj is None:
             return dict(object='<img></img>')
         data = self._data(obj)

--- a/panel/pane/image.py
+++ b/panel/pane/image.py
@@ -78,7 +78,7 @@ class FileBase(DivPaneBase):
         if not isinstance(data, bytes):
             data = data.encode('utf-8')
         b64 = base64.b64encode(data).decode("utf-8")
-        return f"data:image/svg+xml;base64,{b64}"
+        return f"data:image/{self.filetype};base64,{b64}"
 
     def _data(self, obj):
         if hasattr(obj, '_repr_{}_'.format(self.filetype)):
@@ -196,6 +196,19 @@ class ImageBase(FileBase):
 
 
 class Image(ImageBase):
+    """
+    The `Image` pane embeds any known image format in a panel if
+    provided a local path, bytes or remote image link.
+
+    :Example:
+
+    >>> Image(
+    ...     'https://panel.holoviz.org/_static/logo_horizontal.png',
+    ...     alt_text='The Panel Logo',
+    ...     link_url='https://panel.holoviz.org/index.html',
+    ...     width=500
+    ... )
+    """
 
     @classmethod
     def applies(cls, obj: Any) -> float | bool | None:

--- a/panel/pane/image.py
+++ b/panel/pane/image.py
@@ -80,7 +80,7 @@ class FileBase(HTMLBasePane):
         b64 = base64.b64encode(data).decode("utf-8")
         return f"data:image/{self.filetype};base64,{b64}"
 
-    def _data(self, obj):
+    def _data(self, obj: Any) -> bytes | None:
         filetype = self.filetype.split('+')[0]
         if hasattr(obj, f'_repr_{filetype}_'):
             return getattr(obj, f'_repr_{filetype}_')()
@@ -90,12 +90,14 @@ class FileBase(HTMLBasePane):
                     return f.read()
         elif isinstance(obj, bytes):
             return obj
+        elif isinstance(obj, str):
+            return obj.encode('utf-8')
         elif hasattr(obj, 'read'):
             if hasattr(obj, 'seek'):
                 obj.seek(0)
             return obj.read()
         elif not isurl(obj, None):
-            return
+            return None
 
         from ..io.state import state
         if state._is_pyodide:
@@ -397,7 +399,7 @@ class SVG(ImageBase):
         width, height = self._imgshape(data)
         if self.encode:
             data = f"<img src='{self._b64(data)}' width={width} height={height}></img>"
-        return dict(width=width, height=height, text=escape(data))
+        return dict(width=width, height=height, text=escape(data.decode('utf-8')))
 
 
 class PDF(FileBase):

--- a/panel/pane/markup.py
+++ b/panel/pane/markup.py
@@ -245,7 +245,7 @@ class DataFrame(HTML):
             html = ''
         return dict(object=escape(html))
 
-    def _init_params(self):
+    def _init_params(self) -> Dict[str, Any]:
         params = HTMLBasePane._init_params(self)
         if self._stream:
             params['object'] = self._object
@@ -436,7 +436,7 @@ class JSON(HTMLBasePane):
             properties['depth'] = -1 if properties['depth'] is None else properties['depth']
         return properties
 
-    def _process_param_change(self, params):
+    def _process_param_change(self, params: Dict[str, Any]) -> Dict[str, Any] :
         params = super()._process_param_change(params)
         if 'depth' in params:
             params['depth'] = None if params['depth'] < 0 else params['depth']

--- a/panel/pane/markup.py
+++ b/panel/pane/markup.py
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
     from pyviz_comms import Comm
 
 
-class DivPaneBase(ModelPane):
+class HTMLBasePane(ModelPane):
     """
     Baseclass for Panes which render HTML inside a Bokeh Div.
     See the documentation for Bokeh Div for more detail about
@@ -47,7 +47,7 @@ class DivPaneBase(ModelPane):
         super().__init__(object=object, **params)
 
 
-class HTML(DivPaneBase):
+class HTML(HTMLBasePane):
     """
     `HTML` panes renders HTML strings and objects with a `_repr_html_` method.
 
@@ -239,20 +239,20 @@ class DataFrame(HTML):
                 html = obj.to_html(table_attributes=f'class="{classes}"')
             else:
                 kwargs = {p: getattr(self, p) for p in self._rerender_params
-                          if p not in DivPaneBase.param and p != '_object'}
+                          if p not in HTMLBasePane.param and p != '_object'}
                 html = obj.to_html(**kwargs)
         else:
             html = ''
         return dict(object=escape(html))
 
     def _init_params(self):
-        params = DivPaneBase._init_params(self)
+        params = HTMLBasePane._init_params(self)
         if self._stream:
             params['object'] = self._object
         return params
 
 
-class Str(DivPaneBase):
+class Str(HTMLBasePane):
     """
     The `Str` pane allows rendering arbitrary text and objects in a panel.
 
@@ -292,7 +292,7 @@ class Str(DivPaneBase):
         return dict(object=escape(text))
 
 
-class Markdown(DivPaneBase):
+class Markdown(HTMLBasePane):
     """
     The `Markdown` pane allows rendering arbitrary markdown strings in a panel.
 
@@ -363,7 +363,7 @@ class Markdown(DivPaneBase):
 
 
 
-class JSON(DivPaneBase):
+class JSON(HTMLBasePane):
     """
     The `JSON` pane allows rendering arbitrary JSON strings, dicts and other
     json serializable objects in a panel.

--- a/panel/pane/markup.py
+++ b/panel/pane/markup.py
@@ -8,7 +8,7 @@ import json
 import textwrap
 
 from typing import (
-    TYPE_CHECKING, Any, ClassVar, List, Mapping, Optional, Type,
+    TYPE_CHECKING, Any, ClassVar, Dict, List, Mapping, Optional, Type,
 )
 
 import param
@@ -82,7 +82,7 @@ class HTML(DivPaneBase):
         else:
             return False
 
-    def _transform_object(self, obj):
+    def _transform_object(self, obj: Any) -> Dict[str, Any]:
         text = '' if obj is None else obj
         if hasattr(text, '_repr_html_'):
             text = text._repr_html_()
@@ -226,7 +226,7 @@ class DataFrame(HTML):
             self._stream.destroy()
             self._stream = None
 
-    def _transform_object(self, obj):
+    def _transform_object(self, obj: Any) -> Dict[str, Any]:
         if hasattr(obj, 'to_frame'):
             obj = obj.to_frame()
 
@@ -284,7 +284,7 @@ class Str(DivPaneBase):
     def applies(cls, obj: Any) -> bool:
         return True
 
-    def _transform_object(self, obj):
+    def _transform_object(self, obj: Any) -> Dict[str, Any]:
         if obj is None or (isinstance(obj, str) and obj == ''):
             text = '<pre> </pre>'
         else:
@@ -343,7 +343,7 @@ class Markdown(DivPaneBase):
         else:
             return False
 
-    def _transform_object(self, obj):
+    def _transform_object(self, obj: Any) -> Dict[str, Any]:
         import markdown
         if obj is None:
             obj = ''
@@ -422,7 +422,7 @@ class JSON(DivPaneBase):
         else:
             return None
 
-    def _transform_object(self, obj):
+    def _transform_object(self, obj: Any) -> Dict[str, Any]:
         try:
             data = json.loads(obj)
         except Exception:

--- a/panel/pane/markup.py
+++ b/panel/pane/markup.py
@@ -8,10 +8,10 @@ import json
 import textwrap
 
 from typing import (
-    TYPE_CHECKING, Any, ClassVar, Dict, List, Mapping, Optional, Type,
+    TYPE_CHECKING, Any, ClassVar, Dict, List, Mapping, Type,
 )
 
-import param
+import param  # type: ignore
 
 from ..models import HTML as _BkHTML, JSON as _BkJSON
 from ..util import escape
@@ -21,7 +21,7 @@ from .base import ModelPane
 if TYPE_CHECKING:
     from bokeh.document import Document
     from bokeh.model import Model
-    from pyviz_comms import Comm
+    from pyviz_comms import Comm  # type: ignore
 
 
 class HTMLBasePane(ModelPane):
@@ -213,8 +213,8 @@ class DataFrame(HTML):
         self._stream.sink(self._set_object)
 
     def _get_model(
-        self, doc: Document, root: Optional[Model] = None,
-        parent: Optional[Model] = None, comm: Optional[Comm] = None
+        self, doc: Document, root: Model | None = None,
+        parent: Model | None = None, comm: Comm | None = None
     ) -> Model:
         model = super()._get_model(doc, root, parent, comm)
         self._setup_stream()
@@ -358,7 +358,7 @@ class Markdown(HTMLBasePane):
 
     def _process_param_change(self, params):
         if 'css_classes' in params:
-            params['css_classes'] = params['css_classes'] + ['markdown']
+            params['css_classes'] = ['markdown'] + params['css_classes']
         return super()._process_param_change(params)
 
 
@@ -430,7 +430,7 @@ class JSON(HTMLBasePane):
         text = json.dumps(data or {}, cls=self.encoder)
         return dict(object=text)
 
-    def _process_property_change(self, properties):
+    def _process_property_change(self, properties: Dict[str, Any]) -> Dict[str, Any]:
         properties = super()._process_property_change(properties)
         if 'depth' in properties:
             properties['depth'] = -1 if properties['depth'] is None else properties['depth']

--- a/panel/pane/markup.py
+++ b/panel/pane/markup.py
@@ -430,6 +430,12 @@ class JSON(DivPaneBase):
         text = json.dumps(data or {}, cls=self.encoder)
         return dict(object=text)
 
+    def _process_property_change(self, properties):
+        properties = super()._process_property_change(properties)
+        if 'depth' in properties:
+            properties['depth'] = -1 if properties['depth'] is None else properties['depth']
+        return properties
+
     def _process_param_change(self, params):
         params = super()._process_param_change(params)
         if 'depth' in params:

--- a/panel/pane/media.py
+++ b/panel/pane/media.py
@@ -8,7 +8,7 @@ import os
 from base64 import b64encode
 from io import BytesIO
 from typing import (
-    Any, ClassVar, List, Mapping,
+    Any, ClassVar, Dict, List, Mapping,
 )
 
 import numpy as np
@@ -85,7 +85,7 @@ class _MediaBase(ModelPane):
             del msg['js_property_callbacks']
         return msg
 
-    def _transform_object(self, obj):
+    def _transform_object(self, obj: Any) -> Dict[str, Any]:
         fmt = self._default_mime
         if obj is None:
             data = b''

--- a/panel/pane/plot.py
+++ b/panel/pane/plot.py
@@ -223,7 +223,9 @@ class Matplotlib(PNG, IPyWidget):
         'high_dpi': None
     }
 
-    _rerender_params = PNG._rerender_params + ['object', 'dpi', 'tight']
+    _rerender_params = PNG._rerender_params + [
+        'interactive', 'object', 'dpi', 'tight', 'high_dpi'
+    ]
 
     @classmethod
     def applies(cls, obj: Any) -> float | bool | None:
@@ -299,9 +301,11 @@ class Matplotlib(PNG, IPyWidget):
             return model
         self.object.set_dpi(self.dpi)
         manager = self._get_widget(self.object)
-        props = self._process_param_change(self._init_params())
-        kwargs = {k: v for k, v in props.items()
-                  if k not in self._rerender_params+['interactive']}
+        props = self._init_params()
+        kwargs = {
+            k: v for k, v in props.items()
+            if k not in self._rerender_params+['loading']
+        }
         kwargs['width'] = self.width
         kwargs['height'] = self.height
         kwargs['sizing_mode'] = self.sizing_mode
@@ -317,7 +321,7 @@ class Matplotlib(PNG, IPyWidget):
     def _update(self, ref: str, model: Model) -> None:
         if not self.interactive:
             self._update_dimensions()
-            model.update(**self._process_param_change(self._get_properties()))
+            model.update(**self._get_properties())
             return
         manager = self._managers[ref]
         if self.object is not manager.canvas.figure:

--- a/panel/pane/plot.py
+++ b/panel/pane/plot.py
@@ -327,9 +327,9 @@ class Matplotlib(PNG, IPyWidget):
             manager.canvas.handle_resize(event)
         manager.canvas.draw_idle()
 
-    def _data(self):
+    def _data(self, obj):
         try:
-            self.object.set_dpi(self.dpi)
+            obj.set_dpi(self.dpi)
         except Exception as ex:
             raise Exception("The Matplotlib backend is not configured. Try adding `matplotlib.use('agg')`") from ex
         b = BytesIO()
@@ -339,7 +339,7 @@ class Matplotlib(PNG, IPyWidget):
         else:
             bbox_inches = None
 
-        self.object.canvas.print_figure(b, bbox_inches=bbox_inches)
+        obj.canvas.print_figure(b, bbox_inches=bbox_inches)
         return b.getvalue()
 
 
@@ -387,25 +387,6 @@ class YT(HTML):
                 hasattr(obj, "plots") and
                 hasattr(obj, "_repr_html_"))
 
-    def _get_properties(self):
-        p = super()._get_properties()
-        if self.object is None:
-            return p
-
-        width = height = 0
-        if self.width  is None or self.height is None:
-            for k,v in self.object.plots.items():
-                if hasattr(v, "_repr_png_"):
-                    img = v._repr_png_()
-                    w,h = PNG._imgshape(img)
-                    height += h
-                    width = max(w, width)
-
-        if self.width  is None: p["width"]  = width
-        if self.height is None: p["height"] = height
-
-        return p
-
 
 class Folium(HTML):
     """
@@ -423,9 +404,8 @@ class Folium(HTML):
         return (getattr(obj, '__module__', '').startswith('folium.') and
                 hasattr(obj, "_repr_html_"))
 
-    def _get_properties(self):
-        properties = super()._get_properties()
-        text = '' if self.object is None else self.object
+    def _transform_object(self, obj):
+        text = '' if obj is None else obj
         if hasattr(text, '_repr_html_'):
             text = text._repr_html_().replace(FOLIUM_BEFORE, FOLIUM_AFTER)
-        return dict(properties, text=escape(text))
+        return dict(object=escape(text))

--- a/panel/pane/plot.py
+++ b/panel/pane/plot.py
@@ -76,7 +76,9 @@ class Bokeh(PaneBase):
 
     priority: ClassVar[float | bool | None] = 0.8
 
-    _rename: ClassVar[Mapping[str, str | None]] = {'autodispatch': None, 'theme': None}
+    _rename: ClassVar[Mapping[str, str | None]] = {
+        'autodispatch': None, 'theme': None
+    }
 
     def __init__(self, object=None, **params):
         super().__init__(object, **params)
@@ -217,7 +219,8 @@ class Matplotlib(PNG, IPyWidget):
         subplots and other artist elements.""")
 
     _rename: ClassVar[Mapping[str, str | None]] = {
-        'object': 'text', 'interactive': None, 'dpi': None,  'tight': None, 'high_dpi': None
+        'object': 'text', 'interactive': None, 'dpi': None,  'tight': None,
+        'high_dpi': None
     }
 
     _rerender_params = PNG._rerender_params + ['object', 'dpi', 'tight']
@@ -356,6 +359,8 @@ class RGGPlot(PNG):
     dpi = param.Integer(default=144, bounds=(1, None))
 
     _rerender_params = PNG._rerender_params + ['object', 'dpi', 'width', 'height']
+
+    _rename: ClassVar[Mapping[str, str | None]] = {'dpi': None}
 
     @classmethod
     def applies(cls, obj: Any) -> float | bool | None:

--- a/panel/pane/plot.py
+++ b/panel/pane/plot.py
@@ -8,7 +8,7 @@ import sys
 from contextlib import contextmanager
 from io import BytesIO
 from typing import (
-    TYPE_CHECKING, Any, ClassVar, Mapping, Optional,
+    TYPE_CHECKING, Any, ClassVar, Dict, Mapping, Optional,
 )
 
 import param
@@ -409,7 +409,7 @@ class Folium(HTML):
         return (getattr(obj, '__module__', '').startswith('folium.') and
                 hasattr(obj, "_repr_html_"))
 
-    def _transform_object(self, obj):
+    def _transform_object(self, obj: Any) -> Dict[str, Any]:
         text = '' if obj is None else obj
         if hasattr(text, '_repr_html_'):
             text = text._repr_html_().replace(FOLIUM_BEFORE, FOLIUM_AFTER)

--- a/panel/pane/plotly.py
+++ b/panel/pane/plotly.py
@@ -286,7 +286,7 @@ class Plotly(PaneBase):
         model = PlotlyPlot(**self._process_param_change(self._init_params()))
         if root is None:
             root = model
-        self._link_props(model, self._linkable_params, doc, root, comm)
+        self._link_props(model, self._linked_properties, doc, root, comm)
         self._models[root.ref['id']] = (model, parent)
         return model
 

--- a/panel/pane/plotly.py
+++ b/panel/pane/plotly.py
@@ -87,7 +87,9 @@ class Plotly(PaneBase):
 
     _updates: ClassVar[bool] = True
 
-    _rename: ClassVar[Mapping[str, str | None]] = {'link_figure': None}
+    _rename: ClassVar[Mapping[str, str | None]] = {
+        'link_figure': None, 'object': None
+    }
 
     @classmethod
     def applies(cls, obj: Any) -> float | bool | None:

--- a/panel/pane/vtk/vtk.py
+++ b/panel/pane/vtk/vtk.py
@@ -460,16 +460,12 @@ class VTKRenderWindowSynchronized(BaseVTKRenderWindow, SyncHelpers):
         )
         scene, arrays, annotations = self._serialize_ren_win(self.object, context)
         self._update_color_mappers()
-        props = self._process_param_change(self._init_params())
+        props = self._get_properties()
         props.update(scene=scene, arrays=arrays, annotations=annotations, color_mappers=self.color_mappers)
         model = VTKSynchronizedPlot(**props)
-
-        if root is None:
-            root = model
-        self._link_props(model,
-                         ['camera', 'color_mappers', 'enable_keybindings', 'one_time_reset',
-                          'orientation_widget'],
-                         doc, root, comm)
+        root = root or model
+        linked = ['camera', 'color_mappers', 'enable_keybindings', 'one_time_reset', 'orientation_widget']
+        self._link_props(model, linked, doc, root, comm)
         self._contexts[model.id] =  context
         self._models[root.ref['id']] = (model, parent)
         return model

--- a/panel/param.py
+++ b/panel/param.py
@@ -17,7 +17,7 @@ from collections.abc import Callable
 from contextlib import contextmanager
 from functools import partial
 from typing import (
-    TYPE_CHECKING, Any, ClassVar, List, Mapping, Optional, Type,
+    TYPE_CHECKING, Any, ClassVar, List, Mapping, Optional, Tuple, Type,
 )
 
 import param
@@ -202,9 +202,11 @@ class Param(PaneBase):
 
     priority: ClassVar[float | bool | None] = 0.1
 
-    _unpack: ClassVar[bool] = True
+    _linkable_properties: ClassVar[Tuple[str]] = ()
 
     _rerender_params: ClassVar[List[str]] = []
+
+    _unpack: ClassVar[bool] = True
 
     def __init__(self, object=None, **params):
         if isinstance(object, param.Parameter):

--- a/panel/reactive.py
+++ b/panel/reactive.py
@@ -497,6 +497,8 @@ class Reactive(Syncable, Viewable):
     the parameters to other objects.
     """
 
+    __abstract = True
+
     #----------------------------------------------------------------
     # Public API
     #----------------------------------------------------------------
@@ -1075,6 +1077,8 @@ class ReactiveData(SyncableData):
     An extension of SyncableData which bi-directionally syncs a data
     parameter between frontend and backend using a ColumnDataSource.
     """
+
+    __abstract = True
 
     def __init__(self, **params):
         super().__init__(**params)
@@ -1689,7 +1693,7 @@ class ReactiveHTML(Reactive, metaclass=ReactiveHTMLMetaclass):
         for children_param in self._parser.children.values():
             if children_param in self._data_model.properties():
                 linked_properties.append(children_param)
-        return linked_properties
+        return tuple(linked_properties)
 
     def _get_model(
         self, doc: Document, root: Optional[Model] = None,

--- a/panel/reactive.py
+++ b/panel/reactive.py
@@ -140,13 +140,13 @@ class Syncable(Renderable):
         return rename
 
     @property
-    def _linked_properties(self):
+    def _linked_properties(self) -> Tuple[str]:
         return tuple(
             self._property_mapping.get(p, p) for p in self.param
             if p not in Viewable.param and self._property_mapping.get(p, p) is not None
         )
 
-    def _get_properties(self):
+    def _get_properties(self) -> Dict[str, Any]:
         return self._process_param_change(self._init_params())
 
     def _process_property_change(self, msg: Dict[str, Any]) -> Dict[str, Any]:

--- a/panel/reactive.py
+++ b/panel/reactive.py
@@ -140,7 +140,7 @@ class Syncable(Renderable):
     def _linked_properties(self):
         return tuple(
             self._property_mapping.get(p, p) for p in self.param
-            if p not in Syncable.param and self._property_mapping.get(p, p) is not None
+            if p not in Viewable.param and self._property_mapping.get(p, p) is not None
         )
 
     def _get_properties(self):

--- a/panel/tests/pane/test_alert.py
+++ b/panel/tests/pane/test_alert.py
@@ -7,33 +7,15 @@ from panel.pane import Alert
 from panel.pane.alert import ALERT_TYPES
 
 
-def test_constructor():
-    """Test that an Alert can be instantiated"""
-    alert = Alert(text="This is some text")
-    # pylint: disable=no-member
-    assert set(alert.css_classes) == {"alert", f"alert-{Alert.param.alert_type.default}"}
-    # pylint: enable=no-member
-
-
 @pytest.mark.parametrize(["alert_type"], [(alert_type,) for alert_type in ALERT_TYPES])
 def test_alert_type_change(alert_type, document, comm):
     """Test that an alert can change alert_type"""
-    alert = Alert(text="This is some text")
+    alert = Alert("This is some text")
 
     model = alert.get_root(document, comm)
 
     alert.alert_type = alert_type
-    assert set(alert.css_classes) == {"alert", f"alert-{alert_type}"}
     assert set(model.css_classes) == {"alert", f"alert-{alert_type}", "markdown"}
-
-
-def test_existing_css_classes():
-    """Test that an alert can change alert_type"""
-    alert = Alert(text="This is some text", css_classes=["important"])
-    assert set(alert.css_classes) == {"alert", f"alert-{Alert.param.alert_type.default}", "important"}
-
-    alert.alert_type="info"
-    assert set(alert.css_classes) == {"alert", "alert-info", "important"}
 
 
 def manualtest_all_view():
@@ -43,7 +25,7 @@ def manualtest_all_view():
         text = f"""\
             This is a **{alert_type}** alert with [an example link](https://panel.holoviz.org/).
             Give it a click if you like."""
-        alert = Alert(object=text, alert_type=alert_type)
+        alert = Alert(text, alert_type=alert_type)
         alert_app = pn.Column(
             alert,
             pn.Param(

--- a/panel/tests/pane/test_image.py
+++ b/panel/tests/pane/test_image.py
@@ -74,7 +74,7 @@ def test_load_from_byteio():
         memory.write(image_file.read())
 
     image_pane = PNG(memory)
-    image_data = image_pane._data()
+    image_data = image_pane._data(memory)
     assert b'PNG' in image_data
 
 def test_load_from_stringio():
@@ -86,7 +86,7 @@ def test_load_from_stringio():
         memory.write(str(image_file.read()))
 
     image_pane = PNG(memory)
-    image_data = image_pane._data()
+    image_data = image_pane._data(memory)
     assert 'PNG' in image_data
 
 def test_loading_a_image_from_url():
@@ -94,7 +94,7 @@ def test_loading_a_image_from_url():
     url = 'https://raw.githubusercontent.com/holoviz/panel/main/doc/_static/logo.png'
 
     image_pane = PNG(url)
-    image_data = image_pane._data()
+    image_data = image_pane._data(url)
     assert b'PNG' in image_data
 
 def test_image_from_bytes():
@@ -103,7 +103,7 @@ def test_image_from_bytes():
         img = f.read()
 
     image_pane = PNG(img)
-    image_data = image_pane._data()
+    image_data = image_pane._data(img)
     assert b'PNG' in image_data
 
 def test_loading_a_image_from_pathlib():
@@ -111,7 +111,7 @@ def test_loading_a_image_from_pathlib():
     filepath = Path(__file__).parent.parent / "test_data" / "logo.png"
 
     image_pane = PNG(filepath)
-    image_data = image_pane._data()
+    image_data = image_pane._data(filepath)
     assert b'PNG' in image_data
 
 def test_image_alt_text(document, comm):

--- a/panel/tests/pane/test_media.py
+++ b/panel/tests/pane/test_media.py
@@ -55,6 +55,7 @@ def test_local_audio(document, comm):
     assert model.value == 'data:audio/mp3;base64,/+MYxAAAAANIAAAAAExBTUUzLjk4LjIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' # noqa
 
 
+@scipy_available
 def test_numpy_audio(document, comm):
     sps = 8000 # Samples per second
     duration = 0.01 # Duration in seconds

--- a/panel/tests/test_docs.py
+++ b/panel/tests/test_docs.py
@@ -57,7 +57,7 @@ def test_widgets_are_in_reference_gallery():
 
 @ref_available
 def test_panes_are_in_reference_gallery():
-    exceptions = {"PaneBase", "YT", "RGGPlot", "Interactive", "ICO", "IPyLeaflet"}
+    exceptions = {"PaneBase", "YT", "RGGPlot", "Interactive", "ICO", "Image", "IPyLeaflet"}
     docs = {f.with_suffix("").name for f in (REF_PATH / "panes").iterdir()}
 
     def is_panel_pane(attr):

--- a/panel/tests/test_interact.py
+++ b/panel/tests/test_interact.py
@@ -233,7 +233,7 @@ def test_interact_replaces_model(document, comm):
     assert new_pane._models[column.ref['id']][0] is new_div
 
     interact_pane._cleanup(column)
-    assert len(interact_pane._callbacks) == 4
+    assert len(interact_pane._callbacks) == 5
 
 
 def test_interact_throttled():

--- a/panel/tests/test_reactive.py
+++ b/panel/tests/test_reactive.py
@@ -523,7 +523,7 @@ def test_reactive_html_scripts_linked_properties_assignment_operator():
 
                 _scripts = {'render': f'test.onclick = () => {{ data.clicks{sep}{operator}= 1 }}'}
 
-            assert TestScripts()._linked_properties() == ['clicks']
+            assert TestScripts()._linked_properties == ('clicks',)
 
 
 def test_reactive_html_templated_literal_add_loop_id_and_for_loop_var():

--- a/panel/tests/test_viewable.py
+++ b/panel/tests/test_viewable.py
@@ -4,6 +4,7 @@ import pytest
 from panel import config
 from panel.interact import interactive
 from panel.pane import Markdown, Str, panel
+from panel.param import ParamMethod
 from panel.viewable import Viewable, Viewer
 
 from .util import bokeh3_failing_all, jb_available
@@ -12,6 +13,20 @@ all_viewables = [w for w in param.concrete_descendents(Viewable).values()
                if not w.__name__.startswith('_') and
                not issubclass(w, interactive)]
 
+class TestViewer(Viewer):
+    value = param.String()
+
+    def __panel__(self):
+        return self.value
+
+class TestViewerWithDeps(Viewer):
+    value = param.String()
+
+    @param.depends('value')
+    def __panel__(self):
+        return self.value
+
+
 @bokeh3_failing_all
 @jb_available
 def test_viewable_ipywidget():
@@ -19,7 +34,6 @@ def test_viewable_ipywidget():
     with config.set(comms='ipywidgets'):
         data, metadata = pane._repr_mimebundle_()
     assert 'application/vnd.jupyter.widget-view+json' in data
-
 
 @pytest.mark.parametrize('viewable', all_viewables)
 def test_viewable_signature(viewable):
@@ -30,7 +44,6 @@ def test_viewable_signature(viewable):
         assert parameters['params'] == Parameter('params', Parameter.VAR_KEYWORD, annotation='Any')
     except Exception:
         assert parameters['params'] == Parameter('params', Parameter.VAR_KEYWORD)
-
 
 def test_Viewer_not_initialized():
     class Test(Viewer):
@@ -45,16 +58,35 @@ def test_Viewer_not_initialized():
     assert test.object == "# Test"
 
 def test_viewer_wraps_panel():
-    class TestViewer(Viewer):
-        value = param.String()
-
-        def __panel__(self):
-            return self.value
-
     tv = TestViewer(value="hello")
 
-    assert isinstance(tv._create_view(), Markdown)
+    view = tv._create_view()
+    assert isinstance(view, Markdown)
+    assert view.object == "hello"
 
+def test_viewer_wraps_panel_with_deps(document, comm):
+    tv = TestViewerWithDeps(value="hello")
+
+    view = tv._create_view()
+
+    view.get_root(document, comm)
+
+    assert isinstance(view, ParamMethod)
+    assert view._pane.object == "hello"
+
+    tv.value = "goodbye"
+
+    assert view._pane.object == "goodbye"
+
+def test_viewer_with_deps_resolved_by_panel_func(document, comm):
+    tv = TestViewerWithDeps(value="hello")
+
+    view = panel(tv)
+
+    view.get_root(document, comm)
+
+    assert isinstance(view, ParamMethod)
+    assert view._pane.object == "hello"
 
 def test_non_viewer_class():
     # This test checks that a class with __panel__ (other than Viewer)

--- a/panel/tests/util.py
+++ b/panel/tests/util.py
@@ -59,6 +59,7 @@ except Exception:
     jupyter_bokeh = None
 jb_available = pytest.mark.skipif(jupyter_bokeh is None, reason="requires jupyter_bokeh")
 
+from panel.pane.alert import Alert
 from panel.pane.markup import Markdown
 
 
@@ -82,8 +83,11 @@ def check_layoutable_properties(layoutable, model):
     assert model.styles["background"] == '#ffffff'
 
     layoutable.css_classes = ['custom_class']
-    if isinstance(layoutable, Markdown):
-        assert model.css_classes == ['custom_class', 'markdown']
+    if isinstance(layoutable, Alert):
+        print(model.css_classes)
+        assert model.css_classes == ['markdown', 'custom_class', 'alert', 'alert-primary']
+    elif isinstance(layoutable, Markdown):
+        assert model.css_classes == ['markdown', 'custom_class']
     else:
         assert model.css_classes == ['custom_class']
 

--- a/panel/viewable.py
+++ b/panel/viewable.py
@@ -76,7 +76,7 @@ class Layoutable(param.Parameterized):
     background = param.Parameter(default=None, doc="""
         Background color of the component.""")
 
-    css_classes = param.List(default=None, doc="""
+    css_classes = param.List(default=[], doc="""
         CSS classes to apply to the layout.""")
 
     width = param.Integer(default=None, bounds=(0, None), doc="""

--- a/panel/widgets/base.py
+++ b/panel/widgets/base.py
@@ -108,19 +108,13 @@ class Widget(Reactive):
         self, doc: Document, root: Optional[Model] = None,
         parent: Optional[Model] = None, comm: Optional[Comm] = None
     ) -> Model:
-        model = self._widget_type(**self._process_param_change(self._init_params()))
+        model = self._widget_type(**self._get_properties())
         if root is None:
             root = model
         # Link parameters and bokeh model
-        values = self.param.values()
-        properties = self._filter_properties(list(self._process_param_change(values)))
         self._models[root.ref['id']] = (model, parent)
-        self._link_props(model, properties, doc, root, comm)
+        self._link_props(model, self._linked_properties, doc, root, comm)
         return model
-
-    def _filter_properties(self, properties: List[str]) -> List[str]:
-        ignored = list(Layoutable.param)+['loading']
-        return [p for p in properties if p not in ignored]
 
     def _get_embed_state(
         self, root: 'Model', values: Optional[List[Any]] = None, max_opts: int = 3

--- a/panel/widgets/base.py
+++ b/panel/widgets/base.py
@@ -157,6 +157,8 @@ class CompositeWidget(Widget):
 
     _composite_type: ClassVar[Type[ListPanel]] = Row
 
+    _linked_properties: ClassVar[Tuple[str]] = ()
+
     __abstract = True
 
     def __init__(self, **params):

--- a/panel/widgets/indicators.py
+++ b/panel/widgets/indicators.py
@@ -67,8 +67,11 @@ class Indicator(Widget):
 
     __abstract = True
 
-    def _filter_properties(self, properties):
-        "Indicators are solely display units so we do not need to sync properties."
+    @property
+    def _linked_properties(self, properties):
+        """
+        Indicators are solely display units so we do not need to sync properties.
+        """
         return []
 
 

--- a/panel/widgets/indicators.py
+++ b/panel/widgets/indicators.py
@@ -63,6 +63,8 @@ class Indicator(Widget):
         'fixed', 'stretch_width', 'stretch_height', 'stretch_both',
         'scale_width', 'scale_height', 'scale_both', None])
 
+    _rename: ClassVar[Mapping[str, str | None]] = {'name': None}
+
     __abstract = True
 
     def _filter_properties(self, properties):
@@ -111,8 +113,6 @@ class BooleanStatus(BooleanIndicator):
     value = param.Boolean(default=False, doc="""
         Whether the indicator is active or not.""")
 
-    _rename: ClassVar[Mapping[str, str | None]] = {}
-
     _source_transforms: ClassVar[Mapping[str, str | None]] = {'value': None, 'color': None}
 
     _stylesheets: ClassVar[List[str]] = [
@@ -160,8 +160,6 @@ class LoadingSpinner(BooleanIndicator):
 
     value = param.Boolean(default=False, doc="""
         Whether the indicator is active or not.""")
-
-    _rename: ClassVar[Mapping[str, str | None]] = {}
 
     _source_transforms: ClassVar[Mapping[str, str | None]] = {'value': None, 'color': None, 'bgcolor': None}
 
@@ -226,8 +224,6 @@ class Progress(ValueIndicator):
 
     width = param.Integer(default=300)
 
-    _rename: ClassVar[Mapping[str, str | None]] = {'name': None}
-
     _stylesheets: ClassVar[List[str]] = ['css/variables.css', 'css/progress.css']
 
     _widget_type: ClassVar[Type[Model]] = _BkProgress
@@ -274,7 +270,7 @@ class Number(ValueIndicator):
     title_size = param.String(default='18pt', doc="""
         The size of the title given by the name.""")
 
-    _rename: ClassVar[Mapping[str, str | None]] = {}
+    _rename: ClassVar[Mapping[str, str | None]] = {'name': 'name'}
 
     _source_transforms: ClassVar[Mapping[str, str | None]] = {
         'value': None, 'colors': None, 'default_color': None,
@@ -785,7 +781,9 @@ class LinearGauge(ValueIndicator):
     _rerender_params = ['horizontal']
 
     _rename: ClassVar[Mapping[str, str | None]] = {
-        'background': 'background_fill_color', 'show_boundaries': None,
+        'background': 'background_fill_color',
+        'name': 'name',
+        'show_boundaries': None,
         'default_color': None
     }
 
@@ -1046,7 +1044,9 @@ class Trend(SyncableData, Indicator):
 
     _manual_params: ClassVar[List[str]] = ['data']
 
-    _rename: ClassVar[Mapping[str, str | None]] = {'data': None, 'selection': None}
+    _rename: ClassVar[Mapping[str, str | None]] = {
+        'data': None, 'name': 'name', 'selection': None
+    }
 
     _widget_type: ClassVar[Type[Model]] = _BkTrendIndicator
 
@@ -1190,7 +1190,7 @@ class Tqdm(Indicator):
     _layouts: ClassVar[Dict[Type[Panel], str]] = {Row: 'row', Column: 'column'}
 
     _rename: ClassVar[Mapping[str, str | None]] = {
-        'value': None, 'min': None, 'max': None, 'text': None
+        'value': None, 'min': None, 'max': None, 'text': None, 'name': 'name'
     }
 
     def __init__(self, **params):

--- a/panel/widgets/indicators.py
+++ b/panel/widgets/indicators.py
@@ -63,16 +63,11 @@ class Indicator(Widget):
         'fixed', 'stretch_width', 'stretch_height', 'stretch_both',
         'scale_width', 'scale_height', 'scale_both', None])
 
+    _linked_properties: ClassVar[Tuple[str]] = ()
+
     _rename: ClassVar[Mapping[str, str | None]] = {'name': None}
 
     __abstract = True
-
-    @property
-    def _linked_properties(self) -> Tuple[str]:
-        """
-        Indicators are solely display units so we do not need to sync properties.
-        """
-        return ()
 
 
 class BooleanIndicator(Indicator):

--- a/panel/widgets/indicators.py
+++ b/panel/widgets/indicators.py
@@ -23,7 +23,7 @@ import sys
 
 from math import pi
 from typing import (
-    TYPE_CHECKING, ClassVar, Dict, List, Mapping, Optional, Type,
+    TYPE_CHECKING, ClassVar, Dict, List, Mapping, Optional, Tuple, Type,
 )
 
 import numpy as np
@@ -68,11 +68,11 @@ class Indicator(Widget):
     __abstract = True
 
     @property
-    def _linked_properties(self, properties):
+    def _linked_properties(self) -> Tuple[str]:
         """
         Indicators are solely display units so we do not need to sync properties.
         """
-        return []
+        return ()
 
 
 class BooleanIndicator(Indicator):

--- a/panel/widgets/input.py
+++ b/panel/widgets/input.py
@@ -160,7 +160,7 @@ class FileInput(Widget):
 
     value = param.Parameter(default=None)
 
-    _rename: ClassVar[Mapping[str, str | None]] = {'name': None, 'filename': None}
+    _rename: ClassVar[Mapping[str, str | None]] = {'filename': None, 'name': None}
 
     _source_transforms: ClassVar[Mapping[str, str | None]] = {
         'value': "'data:' + source.mime_type + ';base64,' + value"
@@ -299,7 +299,7 @@ class DatePicker(Widget):
     _source_transforms: ClassVar[Mapping[str, str | None]] = {}
 
     _rename: ClassVar[Mapping[str, str | None]] = {
-        'start': 'min_date', 'end': 'max_date', 'name': 'title'
+        'start': 'min_date', 'end': 'max_date'
     }
 
     _widget_type: ClassVar[Type[Model]] = _BkDatePicker
@@ -343,7 +343,7 @@ class _DatetimePickerBase(Widget):
     }
 
     _rename: ClassVar[Mapping[str, str | None]] = {
-        'start': 'min_date', 'end': 'max_date', 'name': 'title'
+        'start': 'min_date', 'end': 'max_date'
     }
 
     _widget_type: ClassVar[Type[Model]] = _bkDatetimePicker
@@ -482,7 +482,7 @@ class ColorPicker(Widget):
 
     _widget_type: ClassVar[Type[Model]] = _BkColorPicker
 
-    _rename: ClassVar[Mapping[str, str | None]] = {'value': 'color', 'name': 'title'}
+    _rename: ClassVar[Mapping[str, str | None]] = {'value': 'color'}
 
 
 class _NumericInputBase(Widget):
@@ -505,7 +505,7 @@ class _NumericInputBase(Widget):
     end = param.Parameter(default=None, allow_None=True, doc="""
         Optional maximum allowable value.""")
 
-    _rename: ClassVar[Mapping[str, str | None]] = {'name': 'title', 'start': 'low', 'end': 'high'}
+    _rename: ClassVar[Mapping[str, str | None]] = {'start': 'low', 'end': 'high'}
 
     _widget_type: ClassVar[Type[Model]] = _BkNumericInput
 
@@ -692,7 +692,7 @@ class LiteralInput(Widget):
     value = param.Parameter(default=None)
 
     _rename: ClassVar[Mapping[str, str | None]] = {
-        'name': 'title', 'type': None, 'serializer': None
+        'type': None, 'serializer': None
     }
 
     _source_transforms: ClassVar[Mapping[str, str | None]] = {
@@ -798,7 +798,7 @@ class ArrayInput(LiteralInput):
         restriction helps avoid overwhelming the browser and lets
         other widgets remain usable.""")
 
-    _rename: ClassVar[Mapping[str, str | None]] = dict(LiteralInput._rename, max_array_size=None)
+    _rename: ClassVar[Mapping[str, str | None]] = {'max_array_size': None}
 
     _source_transforms: ClassVar[Mapping[str, str | None]] = {'value': None}
 
@@ -876,8 +876,8 @@ class DatetimeInput(LiteralInput):
     }
 
     _rename: ClassVar[Mapping[str, str | None]] = {
-        'format': None, 'type': None, 'name': 'title', 'start': None,
-        'end': None, 'serializer': None
+        'format': None, 'type': None, 'start': None, 'end': None,
+        'serializer': None
     }
 
     def __init__(self, **params):
@@ -1062,6 +1062,8 @@ class Switch(_BooleanWidget):
     >>> Switch(name='Works with the tools you know and love', value=True)
     """
 
-    _rename: ClassVar[Mapping[str, str | None]] = {'value': 'active', 'name': None}
+    _rename: ClassVar[Mapping[str, str | None]] = {
+        'name': None, 'value': 'active'
+    }
 
     _widget_type: ClassVar[Type[Model]] = _BkSwitch

--- a/panel/widgets/input.py
+++ b/panel/widgets/input.py
@@ -160,7 +160,9 @@ class FileInput(Widget):
 
     value = param.Parameter(default=None)
 
-    _rename: ClassVar[Mapping[str, str | None]] = {'filename': None, 'name': None}
+    _rename: ClassVar[Mapping[str, str | None]] = {
+        'filename': None, 'name': None
+    }
 
     _source_transforms: ClassVar[Mapping[str, str | None]] = {
         'value': "'data:' + source.mime_type + ';base64,' + value"
@@ -176,9 +178,10 @@ class FileInput(Widget):
             msg.pop('mime_type')
         return msg
 
-    def _filter_properties(self, properties):
-        properties = super()._filter_properties(properties)
-        return properties + ['value', 'mime_type', 'filename']
+    @property
+    def _linked_properties(self):
+        properties = super().linked_properties
+        return properties + ['filename']
 
     def _process_property_change(self, msg):
         msg = super()._process_property_change(msg)

--- a/panel/widgets/input.py
+++ b/panel/widgets/input.py
@@ -699,6 +699,7 @@ class LiteralInput(Widget):
     }
 
     _source_transforms: ClassVar[Mapping[str, str | None]] = {
+        'serializer': None,
         'value': """JSON.parse(value.replace(/'/g, '"'))"""
     }
 
@@ -801,9 +802,13 @@ class ArrayInput(LiteralInput):
         restriction helps avoid overwhelming the browser and lets
         other widgets remain usable.""")
 
-    _rename: ClassVar[Mapping[str, str | None]] = {'max_array_size': None}
+    _rename: ClassVar[Mapping[str, str | None]] = {
+        'max_array_size': None
+    }
 
-    _source_transforms: ClassVar[Mapping[str, str | None]] = {'value': None}
+    _source_transforms: ClassVar[Mapping[str, str | None]] = {
+        'serializer': None, 'type': None, 'value': None
+    }
 
     def __init__(self, **params):
         super().__init__(**params)

--- a/panel/widgets/input.py
+++ b/panel/widgets/input.py
@@ -180,8 +180,8 @@ class FileInput(Widget):
 
     @property
     def _linked_properties(self):
-        properties = super().linked_properties
-        return properties + ['filename']
+        properties = super()._linked_properties
+        return properties + ('filename',)
 
     def _process_property_change(self, msg):
         msg = super()._process_property_change(msg)

--- a/panel/widgets/misc.py
+++ b/panel/widgets/misc.py
@@ -136,7 +136,7 @@ class FileDownload(Widget):
     }
 
     _rename: ClassVar[Mapping[str, str | None]] = {
-        'callback': None, 'file': None, '_clicks': 'clicks', 'name': 'title'
+        'callback': None, 'file': None, '_clicks': 'clicks'
     }
 
     _widget_type: ClassVar[Type[Model]] = _BkFileDownload
@@ -291,7 +291,9 @@ class JSONEditor(Widget):
     value = param.Parameter(default={}, doc="""
         JSON data to be edited.""")
 
-    _rename: ClassVar[Mapping[str, str | None]] = {'value': 'data'}
+    _rename: ClassVar[Mapping[str, str | None]] = {
+        'name': None, 'value': 'data'
+    }
 
     def _get_model(self, doc, root=None, parent=None, comm=None):
         if self._widget_type is None:

--- a/panel/widgets/select.py
+++ b/panel/widgets/select.py
@@ -316,6 +316,8 @@ class _MultiSelectBase(SingleSelectBase):
 
     _supports_embed: ClassVar[bool] = False
 
+    __abstract = True
+
     def _process_param_change(self, msg):
         msg = super(SingleSelectBase, self)._process_param_change(msg)
         labels, values = self.labels, self.values

--- a/panel/widgets/select.py
+++ b/panel/widgets/select.py
@@ -246,7 +246,7 @@ class Select(SingleSelectBase):
                 ' `groups` parameter, use `options` instead.'
             )
 
-    def _process_param_change(self, msg):
+    def _process_param_change(self, msg: Dict[str, Any]) -> Dict[str, Any]:
         groups_provided = 'groups' in msg
         msg = super()._process_param_change(msg)
         if groups_provided or 'options' in msg and self.groups:

--- a/panel/widgets/select.py
+++ b/panel/widgets/select.py
@@ -9,7 +9,7 @@ import re
 
 from collections import OrderedDict
 from typing import (
-    TYPE_CHECKING, ClassVar, Mapping, Type,
+    TYPE_CHECKING, Any, ClassVar, Dict, Mapping, Type,
 )
 
 import param

--- a/panel/widgets/select.py
+++ b/panel/widgets/select.py
@@ -234,7 +234,6 @@ class Select(SingleSelectBase):
                 'as it is one of the disabled options.'
             )
 
-
     def _validate_options_groups(self, *events):
         if self.options and self.groups:
             raise ValueError(
@@ -248,11 +247,10 @@ class Select(SingleSelectBase):
             )
 
     def _process_param_change(self, msg):
+        groups_provided = 'groups' in msg
         msg = super()._process_param_change(msg)
-        if msg.get('size') == 1:
-            msg.pop('size')
-        groups = msg.pop('groups', None)
-        if groups is not None:
+        if groups_provided or 'options' in msg and self.groups:
+            groups = self.groups
             if (all(isinstance(values, dict) for values in groups.values()) is False
                and  all(isinstance(values, list) for values in groups.values()) is False):
                 raise ValueError(

--- a/panel/widgets/select.py
+++ b/panel/widgets/select.py
@@ -173,6 +173,10 @@ class Select(SingleSelectBase):
         If set to 1 displays options as dropdown otherwise displays
         scrollable area.""")
 
+    _rename: ClassVar[Mapping[str, str | None]] = {
+        'groups': None, 'size': None
+    }
+
     _source_transforms: ClassVar[Mapping[str, str | None]] = {
         'size': None, 'groups': None
     }

--- a/panel/widgets/speech_to_text.py
+++ b/panel/widgets/speech_to_text.py
@@ -394,10 +394,7 @@ class SpeechToText(Widget):
         browser.""")
 
     _rename: ClassVar[Mapping[str, str | None]] = {
-        'grammars': None,
-        '_grammars': 'grammars',
-        'name': None,
-        'value': None,
+        'grammars': None, '_grammars': 'grammars', 'name': None, 'value': None,
     }
 
     _widget_type: ClassVar[Type[Model]] = _BkSpeechToText

--- a/panel/widgets/speech_to_text.py
+++ b/panel/widgets/speech_to_text.py
@@ -394,9 +394,10 @@ class SpeechToText(Widget):
         browser.""")
 
     _rename: ClassVar[Mapping[str, str | None]] = {
-        "value": None,
-        "grammars": None,
-        "_grammars": "grammars",
+        'grammars': None,
+        '_grammars': 'grammars',
+        'name': None,
+        'value': None,
     }
 
     _widget_type: ClassVar[Type[Model]] = _BkSpeechToText
@@ -411,7 +412,7 @@ class SpeechToText(Widget):
         # multiple actions
         return f"SpeechToText(name='{self.name}')"
 
-    @param.depends("grammars", watch=True)
+    @param.depends('grammars', watch=True)
     def _update_grammars(self):
         with param.edit_constant(self):
             if self.grammars:
@@ -419,14 +420,14 @@ class SpeechToText(Widget):
             else:
                 self._grammars = []
 
-    @param.depends("results", watch=True)
+    @param.depends('results', watch=True)
     def _update_results(self):
         # pylint: disable=unsubscriptable-object
         with param.edit_constant(self):
-            if self.results and "alternatives" in self.results[-1]:
-                self.value = (self.results[-1]["alternatives"][0]["transcript"]).lstrip()
+            if self.results and 'alternatives' in self.results[-1]:
+                self.value = (self.results[-1]['alternatives'][0]['transcript']).lstrip()
             else:
-                self.value = ""
+                self.value = ''
 
     @property
     def results_deserialized(self):
@@ -443,16 +444,16 @@ class SpeechToText(Widget):
         Convenience method for ease of use
         """
         if not self.results:
-            return "No results"
-        html = "<div class='pn-speech-recognition-result'>"
+            return 'No results'
+        html = '<div class="pn-speech-recognition-result">'
         total = len(self.results) - 1
         for index, result in enumerate(reversed(self.results_deserialized)):
             if len(self.results) > 1:
-                html += f"<h3>Result {total-index}</h3>"
-            html += f"<span>Is Final: {result.is_final}</span><br/>"
+                html += f'<h3>Result {total-index}</h3>'
+            html += f'<span>Is Final: {result.is_final}</span><br/>'
             for index2, alternative in enumerate(result.alternatives):
                 if len(result.alternatives) > 1:
-                    html += f"<h4>Alternative {index2}</h4>"
+                    html += f'<h4>Alternative {index2}</h4>'
                 html += f"""
                 <span>Confidence: {alternative.confidence:.2f}</span>
                 </br>
@@ -460,5 +461,5 @@ class SpeechToText(Widget):
                   <strong>{alternative.transcript}</strong>
                 </p>
                 """
-        html += "</div>"
+        html += '</div>'
         return html

--- a/panel/widgets/terminal.py
+++ b/panel/widgets/terminal.py
@@ -256,16 +256,12 @@ class Terminal(Widget):
     _output = param.String(default="")
 
     _rename: ClassVar[Mapping[str, str | None]] = {
-        "clear": None,
-        "name": None,
-        "output": None,
-        "_output": "output",
-        "write_to_console": None,
-        "value": None
+        'clear': None, 'name': None, 'output': None, '_output': 'output',
+        'value': None, 'write_to_console': None,
     }
 
     def __init__(self, output=None, **params):
-        params['_output'] = output = output or ""
+        params['_output'] = output = output or ''
         params['clear'] = self._clear
         super().__init__(output=output, **params)
         self._subprocess = None
@@ -275,13 +271,13 @@ class Terminal(Widget):
         if isinstance(__s, str):
             cleaned = __s
         elif isinstance(__s, bytes):
-            cleaned = __s.decode("utf8")
+            cleaned = __s.decode('utf8')
         else:
             cleaned = str(__s)
 
         if self._output == cleaned:
             # Hack to support writing the same string multiple times in a row
-            self._output = ""
+            self._output = ''
 
         self._output = cleaned
         self.output += cleaned
@@ -301,22 +297,22 @@ class Terminal(Widget):
         with edit_readonly(self):
             self.value = event.key
             with param.discard_events(self):
-                self.value = ""
+                self.value = ''
 
     def _clear(self, *events):
         """
         Clears all output on the terminal.
         """
-        self.output = ""
+        self.output = ''
         self._clears += 1
 
-    @param.depends("_output", watch=True)
+    @param.depends('_output', watch=True)
     def _write(self):
         if self.write_to_console:
             sys.__stdout__.write(self._output)
 
     def __repr__(self, depth=None):
-        return f"Terminal(id={id(self)})"
+        return f'Terminal(id={id(self)})'
 
     @property
     def subprocess(self):

--- a/panel/widgets/terminal.py
+++ b/panel/widgets/terminal.py
@@ -257,6 +257,7 @@ class Terminal(Widget):
 
     _rename: ClassVar[Mapping[str, str | None]] = {
         "clear": None,
+        "name": None,
         "output": None,
         "_output": "output",
         "write_to_console": None,

--- a/panel/widgets/text_to_speech.py
+++ b/panel/widgets/text_to_speech.py
@@ -226,6 +226,7 @@ class TextToSpeech(Utterance, Widget):
     _rename: ClassVar[Mapping[str, str | None]] = {
         "auto_speak": None,
         "lang": None,
+        'name': None,
         "pitch": None,
         "rate": None,
         "speak": None,

--- a/panel/widgets/text_to_speech.py
+++ b/panel/widgets/text_to_speech.py
@@ -224,17 +224,9 @@ class TextToSpeech(Utterance, Widget):
     _voices = param.List()
 
     _rename: ClassVar[Mapping[str, str | None]] = {
-        "auto_speak": None,
-        "lang": None,
-        'name': None,
-        "pitch": None,
-        "rate": None,
-        "speak": None,
-        "value": None,
-        "voice": None,
-        "voices": None,
-        "volume": None,
-        "_voices": "voices",
+        'auto_speak': None, 'lang': None, 'name': None, 'pitch': None,
+        'rate': None, 'speak': None, 'value': None, 'voice': None,
+        'voices': None, 'volume': None, '_voices': 'voices',
     }
 
     _widget_type: ClassVar[Type[Model]] = _BkTextToSpeech
@@ -246,7 +238,7 @@ class TextToSpeech(Utterance, Widget):
             msg['speak'] = self.to_dict()
         return msg
 
-    @param.depends("_voices", watch=True)
+    @param.depends('_voices', watch=True)
     def _update_voices(self):
         voices = []
         for _voice in self._voices:  # pylint: disable=not-an-iterable
@@ -258,7 +250,7 @@ class TextToSpeech(Utterance, Widget):
     def __repr__(self, depth=None):
         # We need to do this because otherwise a error is raised when used in notebook
         # due to infinite recursion
-        return f"TextToSpeech(name={self.name})"
+        return f'TextToSpeech(name={self.name!r})'
 
     def __str__(self):
-        return f"TextToSpeech(name={self.name})"
+        return f'TextToSpeech(name={self.name!r})'

--- a/panel/widgets/texteditor.py
+++ b/panel/widgets/texteditor.py
@@ -48,7 +48,9 @@ class TextEditor(Widget):
 
     value = param.String(doc="State of the current text in the editor")
 
-    _rename: ClassVar[Mapping[str, str | None]] = {"value": "text"}
+    _rename: ClassVar[Mapping[str, str | None]] = {
+        'name': 'name', 'value': 'text'
+    }
 
     def _get_model(
         self, doc: Document, root: Optional[Model] = None,


### PR DESCRIPTION
Over time we accumulated a bunch of workaround for mapping parameters to properties. Specifically we had the `_rename` dictionary used for mapping from parameter to property names, then we had various `_init_params` and `_get_properties` methods used to provide parameters to initialize and update properties on the underlying bokeh model. This PR attempts to rationalize this a bit:

- `_rename` consistently used to declare parameter mapping (i.e. avoid manual workarounds for this)
- Bokeh models are now always initialized by calling `_get_properties` which itself calls `_init_params` and then transforms those parameters with `_process_param_change`, ensuring that as much logic for mapping from Panel parameters to Bokeh properties is encapsulated in this method.
- Introduce a `ModelPane` baseclass for panes that very simply map to an underlying bokeh model and apply some transformations to parameters.