### PR TITLE
Remove direct usage of `background` in the docs in favor of `styles`

### DIFF
--- a/doc/background/components/components_overview.md
+++ b/doc/background/components/components_overview.md
@@ -202,8 +202,8 @@ fig.scatter([0, 1, 2, 3, 4, 5, 6, 7, 8, 9], [0, 1, 2, 3, 2, 1, 0, -1, -2, -3])
 
 gspec = pn.GridSpec(sizing_mode='stretch_both', max_height=800)
 
-gspec[0, :3] = pn.Spacer(background='#FF0000')
-gspec[1:3, 0] = pn.Spacer(background='#0000FF')
+gspec[0, :3] = pn.Spacer(styles=dict(background='#FF0000'))
+gspec[1:3, 0] = pn.Spacer(styles=dict(background='#0000FF'))
 gspec[1:3, 1:3] = fig
 gspec[3:5, 0] = hv.Curve([1, 2, 3])
 gspec[3:5, 1] = 'https://upload.wikimedia.org/wikipedia/commons/4/47/PNG_transparency_demonstration_1.png'

--- a/doc/how_to/components/add_remove.md
+++ b/doc/how_to/components/add_remove.md
@@ -96,8 +96,8 @@ First, declare a ``GridSpec`` and add red and blue blocks. The red block goes in
 ```{pyodide}
 gridspec = pn.GridSpec(sizing_mode='stretch_both', max_height=400)
 
-gridspec[0, :3] = pn.Spacer(background='#FF0000')
-gridspec[1:3, 0] = pn.Spacer(background='#0000FF')
+gridspec[0, :3] = pn.Spacer(styles=(background='#FF0000'))
+gridspec[1:3, 0] = pn.Spacer(styles=(background='#0000FF'))
 
 gridspec
 ```

--- a/doc/how_to/components/add_remove.md
+++ b/doc/how_to/components/add_remove.md
@@ -96,8 +96,8 @@ First, declare a ``GridSpec`` and add red and blue blocks. The red block goes in
 ```{pyodide}
 gridspec = pn.GridSpec(sizing_mode='stretch_both', max_height=400)
 
-gridspec[0, :3] = pn.Spacer(styles=(background='#FF0000'))
-gridspec[1:3, 0] = pn.Spacer(styles=(background='#0000FF'))
+gridspec[0, :3] = pn.Spacer(styles=dict(background='#FF0000'))
+gridspec[1:3, 0] = pn.Spacer(styles=dict(background='#0000FF'))
 
 gridspec
 ```

--- a/doc/how_to/components/align.md
+++ b/doc/how_to/components/align.md
@@ -12,7 +12,7 @@ pn.extension() # for notebook
 button = pn.widgets.Button(name='Test', height=100)
 slider = pn.widgets.IntSlider(align='center')
 
-pn.Row(button, slider, background='lightgrey')
+pn.Row(button, slider, styles=dict(background='lightgrey'))
 ```
 
 Now, let's look at aligning components in a grid with an instance of passing in `(horizontal, vertical)`:

--- a/doc/how_to/components/change_background.md
+++ b/doc/how_to/components/change_background.md
@@ -1,20 +1,25 @@
 # Change Background
 
-Many components have a `background` argument that can take a color either as a hex string or color name. See the list of available color names for modern browsers in the [bokeh docs](https://docs.bokeh.org/en/latest/docs/reference/colors.html#bokeh-colors-groups).
+Panel components have a `styles` parameter that takes a dictionary of CSS styles to apply to the component. To customize the background you can set the [background](https://developer.mozilla.org/en-US/docs/Web/CSS/background) property  with a CSS [color](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value), or really any value that is accepted by the `background` property.
 
-First, define a simple HTML pane, set the width and height, and then change the background color to '#f307eb'.
+First, define a simple HTML pane with a default *skyblue* color. Set the width and height to make it visible.
 
 ```{pyodide}
 import panel as pn
 pn.extension() # for notebook
 
-block1 = pn.pane.HTML(width=100, height=100)
-block1.background='#f307eb'
-block1
+block = pn.pane.HTML(width=100, height=100, styles=dict(background='skyblue'))
+block
 ```
 
-Now, create another block with the color of 'mediumseagreen':
+Now, update the background to *crimson* by re-setting the `styles` parameter.
 
 ```{pyodide}
-pn.pane.HTML(background='mediumseagreen', width=200, height=100)
+block.styles = dict(background='crimson')
+```
+
+Let's be more creative and set a CSS radial-gradient background, radiating from *crimson* in the center to *skyblue*.
+
+```{pyodide}
+block.styles = dict(background='radial-gradient(crimson, skyblue)')
 ```

--- a/doc/how_to/components/load_icon.md
+++ b/doc/how_to/components/load_icon.md
@@ -28,7 +28,7 @@ Next, let's display a simple component and set `loading=True`:
 
 ```{pyodide}
 
-pn.pane.HTML(background='#00aa41', width=100, height=100, loading=True)
+pn.pane.HTML(styles=dict(background='#00aa41'), width=100, height=100, loading=True)
 
 ```
 

--- a/doc/how_to/components/size.md
+++ b/doc/how_to/components/size.md
@@ -19,10 +19,12 @@ Let's create a simple example that fixes the height or width of several componen
 import panel as pn
 pn.extension() # for notebook
 
+styles = dict(background='#f0f0f0')
+
 pn.Row(
-    pn.pane.Markdown('ABCDE', background='#f0f0f0', width=75, height=100),
-    pn.widgets.FloatSlider(width=200, background='#f0f0f0'),
-    pn.pane.PNG('https://upload.wikimedia.org/wikipedia/commons/4/47/PNG_transparency_demonstration_1.png', width=300, background='#f0f0f0'),
+    pn.pane.Markdown('ABCDE', styles=styles, width=75, height=100),
+    pn.widgets.FloatSlider(width=200, styles=styles),
+    pn.pane.PNG('https://upload.wikimedia.org/wikipedia/commons/4/47/PNG_transparency_demonstration_1.png', width=300, styles=styles),
 )
 ```
 
@@ -40,7 +42,7 @@ Most panel objects support reactive sizing which adjusts depending on the size o
 
 ```{pyodide}
 pn.Row(
-    pn.pane.Str(background='#f0f0f0', height=100, sizing_mode='stretch_width'),
+    pn.pane.Str(styles=styles, height=100, sizing_mode='stretch_width'),
     width_policy='max', height=200
 )
 ```
@@ -49,7 +51,7 @@ pn.Row(
 
 ```{pyodide}
 pn.Column(
-    pn.pane.Str(background='#f0f0f0', sizing_mode='stretch_height', width=200),
+    pn.pane.Str(styles=styles, sizing_mode='stretch_height', width=200),
     height=200
 )
 ```
@@ -58,7 +60,7 @@ pn.Column(
 
 ```{pyodide}
 pn.Column(
-    pn.pane.Str(background='#f0f0f0', sizing_mode='stretch_both'),
+    pn.pane.Str(styles=styles, sizing_mode='stretch_both'),
     height=200, width_policy='max'
 )
 ```
@@ -71,5 +73,5 @@ pn.Column(
 ```{pyodide}
 pn.Column(
     pn.pane.PNG('https://upload.wikimedia.org/wikipedia/commons/4/47/PNG_transparency_demonstration_1.png', sizing_mode='scale_both'),
-    height=400, width=500, background='#f0f0f0')
+    height=400, width=500, styles=styles)
 ```

--- a/doc/how_to/components/spacing.md
+++ b/doc/how_to/components/spacing.md
@@ -28,10 +28,12 @@ For example, let's create three buttons and customize their margin. To make it e
 import panel as pn
 pn.extension() # for notebook
 
+styles = dict(background='#f0f0f0')
+
 pn.Row(
-    pn.Column(pn.widgets.Button(name='B1', width=100, margin=25), background='#f0f0f0'),
-    pn.Column(pn.widgets.Button(name='B2', width=100, margin=(40, 50)), background='#f0f0f0'),
-    pn.Column(pn.widgets.Button(name='B3', width=100, margin=(25, 50, 75, 100)), background='#f0f0f0'))
+    pn.Column(pn.widgets.Button(name='B1', width=100, margin=25), styles=styles),
+    pn.Column(pn.widgets.Button(name='B2', width=100, margin=(40, 50)), styles=styles),
+    pn.Column(pn.widgets.Button(name='B3', width=100, margin=(25, 50, 75, 100)), styles=styles))
 
 ```
 

--- a/doc/how_to/components/visibility.md
+++ b/doc/how_to/components/visibility.md
@@ -9,9 +9,9 @@ Let's create three simple components with different colors. We'll set the visibi
 import panel as pn
 pn.extension() # for notebook
 
-a = pn.pane.HTML(width=60, height=60, background='green')
-b = pn.pane.HTML(width=60, height=60, background='blue', visible=False)
-c = pn.pane.HTML(width=60, height=60, background='red')
+a = pn.pane.HTML(width=60, height=60, styles=dict(background='green'))
+b = pn.pane.HTML(width=60, height=60, styles=dict(background='blue'), visible=False)
+c = pn.pane.HTML(width=60, height=60, styles=dict(background='red'))
 
 layout = pn.Row(a, b, c)
 layout

--- a/doc/how_to/interact/interact_basics.md
+++ b/doc/how_to/interact/interact_basics.md
@@ -30,7 +30,7 @@ We can also explicitly pass a widget as one of the values:
 
 ```{pyodide}
 def create_block(c):
-    return pn.pane.HTML(width=100, height=100, background=c)
+    return pn.pane.HTML(width=100, height=100, styles=dict(background=c))
 
 color_widget = pn.widgets.ColorPicker(name='Color', value='#4f4fdf')
 

--- a/examples/gallery/dynamic/dynamic_timeseries_image_analysis.ipynb
+++ b/examples/gallery/dynamic/dynamic_timeseries_image_analysis.ipynb
@@ -135,7 +135,7 @@
     "    pn.Spacer(),\n",
     "    pn.pane.PNG(\"http://holoviews.org/_static/logo.png\", height=50, sizing_mode=\"fixed\", align=\"center\"),\n",
     "    pn.pane.PNG(\"https://panel.holoviz.org/_static/logo_horizontal.png\", height=50, sizing_mode=\"fixed\", align=\"center\"),\n",
-    "    background=\"black\",\n",
+    "    styles=dict(background=\"black\"),\n",
     ")\n",
     "app_bar"
    ]

--- a/examples/gallery/simple/color_speech_recognition.ipynb
+++ b/examples/gallery/simple/color_speech_recognition.ipynb
@@ -111,10 +111,10 @@
     "def update_result_panel(results_last):\n",
     "    results_last = results_last.lower()\n",
     "    if results_last in colors:\n",
-    "        app.background = results_last\n",
+    "        app.styles = dict(background=results_last)\n",
     "        result_panel.object = \"Result received: \" + results_last\n",
     "    else:\n",
-    "        app.background = \"white\"\n",
+    "        app.styles = dict(background=\"white\")\n",
     "        result_panel.object = \"Result received: \" + results_last + \" (Not recognized)\""
    ]
   },
@@ -158,9 +158,20 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "panel1-dev38",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
    "name": "python",
-   "pygments_lexer": "ipython3"
+   "pygments_lexer": "ipython3",
+   "version": "3.8.15 | packaged by conda-forge | (default, Nov 22 2022, 08:53:40) \n[Clang 14.0.6 ]"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "637aba8a4ffbb9450b122f53cf75848b7ecdd01e6ffecfed3c9a1724c6e0e4f9"
+   }
   }
  },
  "nbformat": 4,

--- a/examples/gallery/simple/color_speech_recognition.ipynb
+++ b/examples/gallery/simple/color_speech_recognition.ipynb
@@ -158,20 +158,9 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "panel1-dev38",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
    "name": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.8.15 | packaged by conda-forge | (default, Nov 22 2022, 08:53:40) \n[Clang 14.0.6 ]"
-  },
-  "vscode": {
-   "interpreter": {
-    "hash": "637aba8a4ffbb9450b122f53cf75848b7ecdd01e6ffecfed3c9a1724c6e0e4f9"
-   }
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/examples/gallery/styles/MatplotlibStyle.ipynb
+++ b/examples/gallery/styles/MatplotlibStyle.ipynb
@@ -253,20 +253,9 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "panel1-dev38",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
    "name": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.8.15 | packaged by conda-forge | (default, Nov 22 2022, 08:53:40) \n[Clang 14.0.6 ]"
-  },
-  "vscode": {
-   "interpreter": {
-    "hash": "637aba8a4ffbb9450b122f53cf75848b7ecdd01e6ffecfed3c9a1724c6e0e4f9"
-   }
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/examples/gallery/styles/MatplotlibStyle.ipynb
+++ b/examples/gallery/styles/MatplotlibStyle.ipynb
@@ -113,7 +113,10 @@
    "outputs": [],
    "source": [
     "accent_color, color = get_nice_accent_color()\n",
-    "pn.pane.Markdown(f\"# Color: {accent_color}\", background=accent_color, height=70, margin=0, style={\"color\": color, \"padding\": \"10px\"})"
+    "pn.pane.Markdown(\n",
+    "    f\"# Color: {accent_color}\", height=70, margin=0,\n",
+    "    styles={\"color\": color, \"background\": accent_color, \"padding\": \"10px\"},\n",
+    ")"
    ]
   },
   {
@@ -250,9 +253,20 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "panel1-dev38",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
    "name": "python",
-   "pygments_lexer": "ipython3"
+   "pygments_lexer": "ipython3",
+   "version": "3.8.15 | packaged by conda-forge | (default, Nov 22 2022, 08:53:40) \n[Clang 14.0.6 ]"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "637aba8a4ffbb9450b122f53cf75848b7ecdd01e6ffecfed3c9a1724c6e0e4f9"
+   }
   }
  },
  "nbformat": 4,

--- a/examples/gallery/styles/PlotlyStyle.ipynb
+++ b/examples/gallery/styles/PlotlyStyle.ipynb
@@ -114,7 +114,10 @@
    "outputs": [],
    "source": [
     "accent_color, color = get_nice_accent_color()\n",
-    "pn.pane.Markdown(f\"# Color: {accent_color}\", background=accent_color, height=70, margin=0, style={\"color\": color, \"padding\": \"10px\"})"
+    "pn.pane.Markdown(\n",
+    "    f\"# Color: {accent_color}\", height=70, margin=0,\n",
+    "    styles={\"color\": color, \"background\": accent_color, \"padding\": \"10px\"},\n",
+    ")"
    ]
   },
   {

--- a/examples/gallery/styles/SeabornStyle.ipynb
+++ b/examples/gallery/styles/SeabornStyle.ipynb
@@ -105,7 +105,10 @@
    "outputs": [],
    "source": [
     "accent_color, color = get_nice_accent_color()\n",
-    "pn.pane.Markdown(f\"# Color: {accent_color}\", background=accent_color, height=70, margin=0, style={\"color\": color, \"padding\": \"10px\"})"
+    "pn.pane.Markdown(\n",
+    "    f\"# Color: {accent_color}\", height=70, margin=0,\n",
+    "    styles={\"color\": color, \"background\": accent_color, \"padding\": \"10px\"},\n",
+    ")"
    ]
   },
   {

--- a/examples/gallery/styles/VegaAltairStyle.ipynb
+++ b/examples/gallery/styles/VegaAltairStyle.ipynb
@@ -113,7 +113,10 @@
    "outputs": [],
    "source": [
     "accent_color, color = get_nice_accent_color()\n",
-    "pn.pane.Markdown(f\"# Color: {accent_color}\", background=accent_color, height=70, margin=0, style={\"color\": color, \"padding\": \"10px\"})"
+    "pn.pane.Markdown(\n",
+    "    f\"# Color: {accent_color}\", height=70, margin=0,\n",
+    "    styles={\"color\": color, \"background\": accent_color, \"padding\": \"10px\"},\n",
+    ")"
    ]
   },
   {

--- a/examples/reference/layouts/Card.ipynb
+++ b/examples/reference/layouts/Card.ipynb
@@ -58,7 +58,7 @@
     "w1 = pn.widgets.TextInput(name='Text:')\n",
     "w2 = pn.widgets.FloatSlider(name='Slider')\n",
     "\n",
-    "card = pn.Card(w1, w2, title='Card', background='WhiteSmoke')\n",
+    "card = pn.Card(w1, w2, title='Card', styles=dict(background='WhiteSmoke'))\n",
     "card"
    ]
   },
@@ -129,9 +129,9 @@
    "source": [
     "logo = 'https://panel.holoviz.org/_static/logo_horizontal.png'\n",
     "\n",
-    "red   = pn.Spacer(background='red', height=50)\n",
-    "green = pn.Spacer(background='green', height=50)\n",
-    "blue  = pn.Spacer(background='blue', height=50)\n",
+    "red   = pn.Spacer(styles=dict(background='red'), height=50)\n",
+    "green = pn.Spacer(styles=dict(background='green'), height=50)\n",
+    "blue  = pn.Spacer(styles=dict(background='blue'), height=50)\n",
     "\n",
     "pn.Card(\n",
     "    red, green, blue,\n",
@@ -157,7 +157,7 @@
    "source": [
     "pn.Card(\n",
     "    pn.indicators.Number(value=42, default_color='white', name='Completion', format='{value}%'),\n",
-    "    background='lightgray',\n",
+    "    styles=dict(background='lightgray'),\n",
     "    hide_header=True,\n",
     "    width=160\n",
     ")"
@@ -178,9 +178,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "red   = pn.Spacer(background='red', sizing_mode='stretch_both')\n",
-    "green = pn.Spacer(background='green', sizing_mode='stretch_both')\n",
-    "blue  = pn.Spacer(background='blue', sizing_mode='stretch_both')\n",
+    "red   = pn.Spacer(styles=dict(background='red'), sizing_mode='stretch_both')\n",
+    "green = pn.Spacer(styles=dict(background='green'), sizing_mode='stretch_both')\n",
+    "blue  = pn.Spacer(styles=dict(background='blue'), sizing_mode='stretch_both')\n",
     "\n",
     "pn.Card(red, green, blue, height=300, width=200, title='Fixed size')"
    ]
@@ -211,9 +211,20 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "panel1-dev38",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
    "name": "python",
-   "pygments_lexer": "ipython3"
+   "pygments_lexer": "ipython3",
+   "version": "3.8.15 | packaged by conda-forge | (default, Nov 22 2022, 08:53:40) \n[Clang 14.0.6 ]"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "637aba8a4ffbb9450b122f53cf75848b7ecdd01e6ffecfed3c9a1724c6e0e4f9"
+   }
   }
  },
  "nbformat": 4,

--- a/examples/reference/layouts/Card.ipynb
+++ b/examples/reference/layouts/Card.ipynb
@@ -211,20 +211,9 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "panel1-dev38",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
    "name": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.8.15 | packaged by conda-forge | (default, Nov 22 2022, 08:53:40) \n[Clang 14.0.6 ]"
-  },
-  "vscode": {
-   "interpreter": {
-    "hash": "637aba8a4ffbb9450b122f53cf75848b7ecdd01e6ffecfed3c9a1724c6e0e4f9"
-   }
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/examples/reference/layouts/Card.ipynb
+++ b/examples/reference/layouts/Card.ipynb
@@ -58,7 +58,7 @@
     "w1 = pn.widgets.TextInput(name='Text:')\n",
     "w2 = pn.widgets.FloatSlider(name='Slider')\n",
     "\n",
-    "card = pn.Card(w1, w2, title='Card', styles=dict(background='WhiteSmoke'))\n",
+    "card = pn.Card(w1, w2, title='Card', background='WhiteSmoke')\n",
     "card"
    ]
   },
@@ -157,7 +157,7 @@
    "source": [
     "pn.Card(\n",
     "    pn.indicators.Number(value=42, default_color='white', name='Completion', format='{value}%'),\n",
-    "    styles=dict(background='lightgray'),\n",
+    "    background='lightgray',\n",
     "    hide_header=True,\n",
     "    width=160\n",
     ")"

--- a/examples/reference/layouts/Column.ipynb
+++ b/examples/reference/layouts/Column.ipynb
@@ -154,20 +154,9 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "panel1-dev38",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
    "name": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.8.15 | packaged by conda-forge | (default, Nov 22 2022, 08:53:40) \n[Clang 14.0.6 ]"
-  },
-  "vscode": {
-   "interpreter": {
-    "hash": "637aba8a4ffbb9450b122f53cf75848b7ecdd01e6ffecfed3c9a1724c6e0e4f9"
-   }
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/examples/reference/layouts/Column.ipynb
+++ b/examples/reference/layouts/Column.ipynb
@@ -42,7 +42,7 @@
     "w1 = pn.widgets.TextInput(name='Text:')\n",
     "w2 = pn.widgets.FloatSlider(name='Slider')\n",
     "\n",
-    "column = pn.Column('# Column', w1, w2, background='WhiteSmoke')\n",
+    "column = pn.Column('# Column', w1, w2, styles=dict(background='WhiteSmoke'))\n",
     "column"
    ]
   },
@@ -93,9 +93,9 @@
    "outputs": [],
    "source": [
     "pn.Column(\n",
-    "    pn.Spacer(background='red',   sizing_mode='stretch_both'),\n",
-    "    pn.Spacer(background='green', sizing_mode='stretch_both'),\n",
-    "    pn.Spacer(background='blue',  sizing_mode='stretch_both'),\n",
+    "    pn.Spacer(styles=dict(background='red'),   sizing_mode='stretch_both'),\n",
+    "    pn.Spacer(styles=dict(background='green'), sizing_mode='stretch_both'),\n",
+    "    pn.Spacer(styles=dict(background='blue'),  sizing_mode='stretch_both'),\n",
     "    height=300, width=200\n",
     ")"
    ]
@@ -138,9 +138,9 @@
    "outputs": [],
    "source": [
     "pn.Column(\n",
-    "    pn.Spacer(background='red', width=200, height=200),\n",
-    "    pn.Spacer(background='green', width=200, height=200),\n",
-    "    pn.Spacer(background='blue', width=200, height=200),\n",
+    "    pn.Spacer(styles=dict(background='red'), width=200, height=200),\n",
+    "    pn.Spacer(styles=dict(background='green'), width=200, height=200),\n",
+    "    pn.Spacer(styles=dict(background='blue'), width=200, height=200),\n",
     "    scroll=True, height=420\n",
     ")"
    ]
@@ -154,9 +154,20 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "panel1-dev38",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
    "name": "python",
-   "pygments_lexer": "ipython3"
+   "pygments_lexer": "ipython3",
+   "version": "3.8.15 | packaged by conda-forge | (default, Nov 22 2022, 08:53:40) \n[Clang 14.0.6 ]"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "637aba8a4ffbb9450b122f53cf75848b7ecdd01e6ffecfed3c9a1724c6e0e4f9"
+   }
   }
  },
  "nbformat": 4,

--- a/examples/reference/layouts/Divider.ipynb
+++ b/examples/reference/layouts/Divider.ipynb
@@ -86,20 +86,9 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "panel1-dev38",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
    "name": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.8.15 | packaged by conda-forge | (default, Nov 22 2022, 08:53:40) \n[Clang 14.0.6 ]"
-  },
-  "vscode": {
-   "interpreter": {
-    "hash": "637aba8a4ffbb9450b122f53cf75848b7ecdd01e6ffecfed3c9a1724c6e0e4f9"
-   }
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/examples/reference/layouts/Divider.ipynb
+++ b/examples/reference/layouts/Divider.ipynb
@@ -48,7 +48,8 @@
     "    '# Lorem Ipsum',\n",
     "    pn.layout.Divider(),\n",
     "    text,\n",
-    "    background='whitesmoke', width=400\n",
+    "    styles=dict(background='whitesmoke'),\n",
+    "    width=400,\n",
     ")"
    ]
   },
@@ -85,9 +86,20 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "panel1-dev38",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
    "name": "python",
-   "pygments_lexer": "ipython3"
+   "pygments_lexer": "ipython3",
+   "version": "3.8.15 | packaged by conda-forge | (default, Nov 22 2022, 08:53:40) \n[Clang 14.0.6 ]"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "637aba8a4ffbb9450b122f53cf75848b7ecdd01e6ffecfed3c9a1724c6e0e4f9"
+   }
   }
  },
  "nbformat": 4,

--- a/examples/reference/layouts/FlexBox.ipynb
+++ b/examples/reference/layouts/FlexBox.ipynb
@@ -49,7 +49,7 @@
     "\n",
     "rcolor = lambda: \"#%06x\" % random.randint(0, 0xFFFFFF)\n",
     "\n",
-    "box = pn.FlexBox(*[pn.pane.HTML(str(i), background=rcolor(), width=100, height=100) for i in range(24)])\n",
+    "box = pn.FlexBox(*[pn.pane.HTML(str(i), styles=dict(background=rcolor()), width=100, height=100) for i in range(24)])\n",
     "box"
    ]
   },
@@ -99,7 +99,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "color = pn.pane.HTML(str(5), background=rcolor(), width=100, height=100)\n",
+    "color = pn.pane.HTML(str(5), styles=dict(background=rcolor()), width=100, height=100)\n",
     "column_box[5] = color"
    ]
   },

--- a/examples/reference/layouts/GridBox.ipynb
+++ b/examples/reference/layouts/GridBox.ipynb
@@ -45,7 +45,7 @@
     "\n",
     "rcolor = lambda: \"#%06x\" % random.randint(0, 0xFFFFFF)\n",
     "\n",
-    "box = pn.GridBox(*[pn.pane.HTML(styles={'background': rcolor()}, width=50, height=50) for i in range(24)], ncols=6)\n",
+    "box = pn.GridBox(*[pn.pane.HTML(styles=dict(background=rcolor()), width=50, height=50) for i in range(24)], ncols=6)\n",
     "box"
    ]
   },
@@ -62,7 +62,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "color = pn.pane.HTML(styles={'background': rcolor()}, width=50, height=50)\n",
+    "color = pn.pane.HTML(styles=dict(background=rcolor()), width=50, height=50)\n",
     "box[5] = color"
    ]
   },

--- a/examples/reference/layouts/GridBox.ipynb
+++ b/examples/reference/layouts/GridBox.ipynb
@@ -45,7 +45,7 @@
     "\n",
     "rcolor = lambda: \"#%06x\" % random.randint(0, 0xFFFFFF)\n",
     "\n",
-    "box = pn.GridBox(*[pn.pane.HTML(background=rcolor(), width=50, height=50) for i in range(24)], ncols=6)\n",
+    "box = pn.GridBox(*[pn.pane.HTML(styles={'background': rcolor()}, width=50, height=50) for i in range(24)], ncols=6)\n",
     "box"
    ]
   },
@@ -62,7 +62,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "color = pn.pane.HTML(background=rcolor(), width=50, height=50)\n",
+    "color = pn.pane.HTML(styles={'background': rcolor()}, width=50, height=50)\n",
     "box[5] = color"
    ]
   },

--- a/examples/reference/layouts/GridSpec.ipynb
+++ b/examples/reference/layouts/GridSpec.ipynb
@@ -43,11 +43,11 @@
    "source": [
     "gspec = pn.GridSpec(width=800, height=600)\n",
     "\n",
-    "gspec[:,   0  ] = pn.Spacer(background='red',    margin=0)\n",
-    "gspec[0,   1:3] = pn.Spacer(background='green',  margin=0)\n",
-    "gspec[1,   2:4] = pn.Spacer(background='orange', margin=0)\n",
-    "gspec[2,   1:4] = pn.Spacer(background='blue',   margin=0)\n",
-    "gspec[0:1, 3:4] = pn.Spacer(background='purple', margin=0)\n",
+    "gspec[:,   0  ] = pn.Spacer(styles=dict(background='red') ,   margin=0)\n",
+    "gspec[0,   1:3] = pn.Spacer(styles=dict(background='green'),  margin=0)\n",
+    "gspec[1,   2:4] = pn.Spacer(styles=dict(background='orange'), margin=0)\n",
+    "gspec[2,   1:4] = pn.Spacer(styles=dict(background='blue'),   margin=0)\n",
+    "gspec[0:1, 3:4] = pn.Spacer(styles=dict(background='purple'), margin=0)\n",
     "\n",
     "gspec"
    ]
@@ -127,8 +127,8 @@
     "\n",
     "gspec = pn.GridSpec(sizing_mode='stretch_both', max_height=800)\n",
     "\n",
-    "gspec[0, :3] = pn.Spacer(background='#FF0000')\n",
-    "gspec[1:3, 0] = pn.Spacer(background='#0000FF')\n",
+    "gspec[0, :3] = pn.Spacer(styles=dict(background='#FF0000'))\n",
+    "gspec[1:3, 0] = pn.Spacer(styles=dict(background='#0000FF'))\n",
     "gspec[1:3, 1:3] = fig\n",
     "gspec[3:5, 0] = hv.Curve([1, 2, 3])\n",
     "gspec[3:5, 1] = 'https://upload.wikimedia.org/wikipedia/commons/4/47/PNG_transparency_demonstration_1.png'\n",

--- a/examples/reference/layouts/GridStack.ipynb
+++ b/examples/reference/layouts/GridStack.ipynb
@@ -50,11 +50,11 @@
    "source": [
     "gstack = GridStack(sizing_mode='stretch_both')\n",
     "\n",
-    "gstack[ : , 0: 3] = pn.Spacer(background='red',    margin=0)\n",
-    "gstack[0:2, 3: 9] = pn.Spacer(background='green',  margin=0)\n",
-    "gstack[2:4, 6:12] = pn.Spacer(background='orange', margin=0)\n",
-    "gstack[4:6, 3:12] = pn.Spacer(background='blue',   margin=0)\n",
-    "gstack[0:2, 9:12] = pn.Spacer(background='purple', margin=0)\n",
+    "gstack[ : , 0: 3] = pn.Spacer(styles=dict(background='red'),    margin=0)\n",
+    "gstack[0:2, 3: 9] = pn.Spacer(styles=dict(background='green'),  margin=0)\n",
+    "gstack[2:4, 6:12] = pn.Spacer(styles=dict(background='orange'), margin=0)\n",
+    "gstack[4:6, 3:12] = pn.Spacer(styles=dict(background='blue'),   margin=0)\n",
+    "gstack[0:2, 9:12] = pn.Spacer(styles=dict(background='purple'), margin=0)\n",
     "\n",
     "gstack"
    ]
@@ -134,8 +134,8 @@
     "\n",
     "gstack = GridStack(width=800, height=600)\n",
     "\n",
-    "gstack[0, :3] = pn.Spacer(background='#FF0000')\n",
-    "gstack[1:3, 0] = pn.Spacer(background='#0000FF')\n",
+    "gstack[0, :3] = pn.Spacer(styles=dict(background='#FF0000'))\n",
+    "gstack[1:3, 0] = pn.Spacer(styles=dict(background='#0000FF'))\n",
     "gstack[1:3, 1:3] = fig\n",
     "gstack[3:5, 0] = hv.Curve([1, 2, 3])\n",
     "gstack[3:5, 1] = 'https://upload.wikimedia.org/wikipedia/commons/4/47/PNG_transparency_demonstration_1.png'\n",

--- a/examples/reference/layouts/Row.ipynb
+++ b/examples/reference/layouts/Row.ipynb
@@ -42,7 +42,7 @@
     "w1 = pn.widgets.TextInput(name='Text:')\n",
     "w2 = pn.widgets.FloatSlider(name='Slider')\n",
     "\n",
-    "row = pn.Row('# Row', w1, w2, background='WhiteSmoke')\n",
+    "row = pn.Row('# Row', w1, w2, styles=dict(background='WhiteSmoke'))\n",
     "row"
    ]
   },
@@ -93,9 +93,9 @@
    "outputs": [],
    "source": [
     "pn.Row(\n",
-    "    pn.Spacer(background='red',   sizing_mode='stretch_both'),\n",
-    "    pn.Spacer(background='green', sizing_mode='stretch_both'),\n",
-    "    pn.Spacer(background='blue',  sizing_mode='stretch_both'),\n",
+    "    pn.Spacer(styles=dict(background='red'),   sizing_mode='stretch_both'),\n",
+    "    pn.Spacer(styles=dict(background='green'), sizing_mode='stretch_both'),\n",
+    "    pn.Spacer(styles=dict(background='blue'),  sizing_mode='stretch_both'),\n",
     "    height=200, width=600\n",
     ")"
    ]
@@ -138,9 +138,9 @@
    "outputs": [],
    "source": [
     "pn.Row(\n",
-    "    pn.Spacer(background='red', width=200, height=200),\n",
-    "    pn.Spacer(background='green', width=200, height=200),\n",
-    "    pn.Spacer(background='blue', width=200, height=200),\n",
+    "    pn.Spacer(styles=dict(background='red'), width=200, height=200),\n",
+    "    pn.Spacer(styles=dict(background='green'), width=200, height=200),\n",
+    "    pn.Spacer(styles=dict(background='blue'), width=200, height=200),\n",
     "    scroll=True, width=420\n",
     ")"
    ]

--- a/examples/reference/layouts/Tabs.ipynb
+++ b/examples/reference/layouts/Tabs.ipynb
@@ -189,9 +189,9 @@
    "outputs": [],
    "source": [
     "tabs = pn.Tabs(\n",
-    "    ('red', pn.Spacer(background='red', width=100, height=100)),\n",
-    "    ('blue', pn.Spacer(background='blue', width=100, height=100)),\n",
-    "    ('green', pn.Spacer(background='green', width=100, height=100)),\n",
+    "    ('red', pn.Spacer(styles=dict(background='red'), width=100, height=100)),\n",
+    "    ('blue', pn.Spacer(styles=dict(background='blue'), width=100, height=100)),\n",
+    "    ('green', pn.Spacer(styles=dict(background='green'), width=100, height=100)),\n",
     "    closable=True\n",
     ")\n",
     "\n",

--- a/panel/layout/card.py
+++ b/panel/layout/card.py
@@ -26,7 +26,7 @@ class Card(Column):
 
     >>> pn.Card(
     ...     some_widget, some_pane, some_python_object,
-    ...     title='Card', background='WhiteSmoke'
+    ...     title='Card', styles=dict(background='WhiteSmoke'),
     ... )
     """
 

--- a/panel/layout/gridstack.py
+++ b/panel/layout/gridstack.py
@@ -28,11 +28,11 @@ class GridStack(ReactiveHTML, GridSpec):
 
     >>> pn.extension('gridstack')
     >>> gstack = GridStack(sizing_mode='stretch_both')
-    >>> gstack[ : , 0: 3] = pn.Spacer(background='red',    margin=0)
-    >>> gstack[0:2, 3: 9] = pn.Spacer(background='green',  margin=0)
-    >>> gstack[2:4, 6:12] = pn.Spacer(background='orange', margin=0)
-    >>> gstack[4:6, 3:12] = pn.Spacer(background='blue',   margin=0)
-    >>> gstack[0:2, 9:12] = pn.Spacer(background='purple', margin=0)
+    >>> gstack[ : , 0: 3] = pn.Spacer(styles=dict(background='red'),    margin=0)
+    >>> gstack[0:2, 3: 9] = pn.Spacer(styles=dict(background='green'),  margin=0)
+    >>> gstack[2:4, 6:12] = pn.Spacer(styles=dict(background='orange'), margin=0)
+    >>> gstack[4:6, 3:12] = pn.Spacer(styles=dict(background='blue'),   margin=0)
+    >>> gstack[0:2, 9:12] = pn.Spacer(styles=dict(background='purple'), margin=0)
     """
 
     allow_resize = param.Boolean(default=True, doc="""

--- a/panel/pane/base.py
+++ b/panel/pane/base.py
@@ -45,7 +45,7 @@ def panel(obj: Any, **kwargs) -> Viewable:
 
     Reference: https://panel.holoviz.org/user_guide/Components.html#panes
 
-    >>> pn.panel(some_python_object, width=500, background="whitesmoke")
+    >>> pn.panel(some_python_object, width=500, styles=dict(background="whitesmoke"))
 
     Arguments
     ---------

--- a/panel/tests/ui/layout/test_card.py
+++ b/panel/tests/ui/layout/test_card.py
@@ -120,7 +120,7 @@ def test_card_title(page, port, card_components):
 def test_card_background(page, port, card_components):
     w1, w2 = card_components
     background = 'rgb(128, 128, 128)'
-    card = Card(w1, w2, background=background)
+    card = Card(w1, w2, styles=dict(background=background))
 
     serve_panel_widget(page, port, card)
 

--- a/panel/tests/ui/test_reactive.py
+++ b/panel/tests/ui/test_reactive.py
@@ -65,9 +65,9 @@ def test_reactive_html_set_background_no_rerender(page, port):
     page.goto(f"http://localhost:{port}")
 
     assert page.text_content(".reactive") == '1'
-    component.background = 'red'
+    component.styles = dict(background='red')
     time.sleep(0.1)
     assert page.text_content(".reactive") == '1'
-    component.background = 'green'
+    component.styles = dict(background='green')
     time.sleep(0.1)
     assert page.text_content(".reactive") == '1'

--- a/panel/tests/widgets/test_speech_to_text.py
+++ b/panel/tests/widgets/test_speech_to_text.py
@@ -163,8 +163,7 @@ def manualtest_get_advanced_app():
     app = pn.Column(
         pn.pane.HTML(
             "<h1>Speech to Text <img style='float:right;height:40px;width:164px;margin-right:40px' src='https://panel.holoviz.org/_static/logo_horizontal.png'></h1>", # noqa
-            background="black",
-            styles={"color": "white", "margin-left": "20px"},
+            styles={"color": "white", "margin-left": "20px", "background": "black"},
             margin=(0, 0, 15, 0),
         ),
         speech_to_text,
@@ -260,10 +259,10 @@ def manualtest_get_color_app():
     def update_result_panel(results_last):
         results_last = results_last.lower()
         if results_last in colors:
-            app.background = results_last
+            app.styles = dict(background=results_last)
             result_panel.object = "Result received: " + results_last
         else:
-            app.background = "white"
+            app.styles = dict(background="white")
             result_panel.object = "Result received: " + results_last + " (Not recognized)"
 
     app[:] = [

--- a/panel/tests/widgets/test_trend_indicator.py
+++ b/panel/tests/widgets/test_trend_indicator.py
@@ -88,8 +88,7 @@ def manualtest_app():
         HTML(
             "<h1>Panel - Streaming to TrendIndicator<h1>",
             sizing_mode="stretch_width",
-            background="black",
-            styles={"color": "white", "padding": "15px"},
+            styles={"color": "white", "padding": "15px", "background": "black"},
         ),
         Row(WidgetBox(settings_panel), trend, sizing_mode="stretch_both"),
         sizing_mode="stretch_both",

--- a/panel/widgets/select.py
+++ b/panel/widgets/select.py
@@ -758,7 +758,10 @@ class CrossSelector(CompositeWidget, MultiSelect):
         selected = [labels[indexOf(v, values)] for v in params.get('value', [])
                     if isIn(v, values)]
         unselected = [k for k in labels if k not in selected]
-        layout = dict(sizing_mode='stretch_both', background=self.background, margin=0)
+        layout = dict(
+            sizing_mode='stretch_both', margin=0,
+            styles=dict(background=self.background),
+        )
         self._lists = {
             False: MultiSelect(options=unselected, size=self.size, **layout),
             True: MultiSelect(options=selected, size=self.size, **layout)


### PR DESCRIPTION
The `background` Parameter has been deprecated in Panel 1.0 and should be removed in Panel 1.1. This PR updates the docs to remove usages of `background`, replacing it by `styles=dict(background='value')`.

It also updates the *Change background* How-To.

I've left a direct usage of `background` in the *Card* documentation as this component has a header background and a body background and I'm not sure how the API will change, or not, to use the new `styles`.