### PR TITLE
Add Pandas to the runtime dependencies

### DIFF
--- a/panel/tests/conftest.py
+++ b/panel/tests/conftest.py
@@ -14,6 +14,7 @@ import time
 from contextlib import contextmanager
 from subprocess import PIPE, Popen
 
+import pandas as pd
 import pytest
 
 from bokeh.client import pull_session
@@ -160,7 +161,6 @@ def port():
 
 @pytest.fixture
 def dataframe():
-    import pandas as pd
     return pd.DataFrame({
         'int': [1, 2, 3],
         'float': [3.14, 6.28, 9.42],

--- a/panel/tests/io/test_cache.py
+++ b/panel/tests/io/test_cache.py
@@ -4,6 +4,7 @@ import pathlib
 import time
 
 import numpy as np
+import pandas as pd
 import param
 import pytest
 
@@ -14,7 +15,6 @@ except Exception:
 diskcache_available = pytest.mark.skipif(diskcache is None, reason="requires diskcache")
 
 from panel.io.cache import _find_hash_func, cache
-from panel.tests.util import pd_available
 
 ################
 # Test hashing #
@@ -125,17 +125,13 @@ def test_ndarray_hash():
         np.array([2, 1, 0])
     )
 
-@pd_available
 def test_dataframe_hash():
-    import pandas as pd
     df1, df2 = pd._testing.makeMixedDataFrame(), pd._testing.makeMixedDataFrame()
     assert hashes_equal(df1, df2)
     df2['A'] = df2['A'].values[::-1]
     assert not hashes_equal(df1, df2)
 
-@pd_available
 def test_series_hash():
-    import pandas as pd
     series1 = pd._testing.makeStringSeries()
     series2 = series1.copy()
     assert hashes_equal(series1, series2)

--- a/panel/tests/pane/test_markup.py
+++ b/panel/tests/pane/test_markup.py
@@ -2,27 +2,24 @@ import base64
 import json
 
 import numpy as np
+import pandas as pd
 
 import panel as pn
 
 from panel.pane import (
     HTML, JSON, DataFrame, Markdown, PaneBase, Str,
 )
-from panel.tests.util import pd_available, streamz_available
+from panel.tests.util import streamz_available
 
 
 def test_get_markdown_pane_type():
     assert PaneBase.get_pane_type("**Markdown**") is Markdown
 
-@pd_available
 def test_get_dataframe_pane_type():
-    import pandas as pd
     df = pd._testing.makeDataFrame()
     assert PaneBase.get_pane_type(df) is DataFrame
 
-@pd_available
 def test_get_series_pane_type():
-    import pandas as pd
     df = pd._testing.makeDataFrame()
     assert PaneBase.get_pane_type(df.iloc[:, 0]) is DataFrame
 
@@ -114,9 +111,7 @@ def test_html_pane(document, comm):
     assert pane._models == {}
 
 
-@pd_available
 def test_dataframe_pane_pandas(document, comm):
-    import pandas as pd
     pane = DataFrame(pd._testing.makeDataFrame())
 
     # Create pane
@@ -135,9 +130,7 @@ def test_dataframe_pane_pandas(document, comm):
     pane._cleanup(model)
     assert pane._models == {}
 
-@pd_available
 def test_dataframe_pane_supports_escape(document, comm):
-    import pandas as pd
     url = "<a href='https://panel.holoviz.org/'>Panel</a>"
     df = pd.DataFrame({"url": [url]})
     pane = DataFrame(df)

--- a/panel/tests/ui/widgets/test_tabulator.py
+++ b/panel/tests/ui/widgets/test_tabulator.py
@@ -4,6 +4,7 @@ import datetime as dt
 import time
 
 import numpy as np
+import pandas as pd
 import param
 import pytest
 
@@ -20,11 +21,6 @@ except ImportError:
     pytestmark = pytest.mark.skip('playwright not available')
 
 pytestmark = pytest.mark.ui
-
-try:
-    import pandas as pd
-except ImportError:
-    pytestmark = pytest.mark.skip('pandas not available')
 
 from panel import state
 from panel.depends import bind

--- a/panel/tests/util.py
+++ b/panel/tests/util.py
@@ -42,12 +42,6 @@ except Exception:
 mpl_available = pytest.mark.skipif(mpl is None, reason="requires matplotlib")
 
 try:
-    import pandas as pd
-except Exception:
-    pd = None
-pd_available = pytest.mark.skipif(pd is None, reason="requires pandas")
-
-try:
     import streamz
 except Exception:
     streamz = None

--- a/panel/tests/widgets/test_tables.py
+++ b/panel/tests/widgets/test_tables.py
@@ -2,24 +2,18 @@ import datetime as dt
 import time
 
 import numpy as np
+import pandas as pd
 import pytest
 import requests
-
-from packaging.version import Version
-
-try:
-    import pandas as pd
-
-    from pandas._testing import (
-        makeCustomDataframe, makeMixedDataFrame, makeTimeDataFrame,
-    )
-except ImportError:
-    pytestmark = pytest.mark.skip('pandas not available')
 
 from bokeh.models.widgets.tables import (
     AvgAggregator, CellEditor, CheckboxEditor, DataCube, DateEditor,
     DateFormatter, IntEditor, MinAggregator, NumberEditor, NumberFormatter,
     SelectEditor, StringEditor, StringFormatter, SumAggregator,
+)
+from packaging.version import Version
+from pandas._testing import (
+    makeCustomDataframe, makeMixedDataFrame, makeTimeDataFrame,
 )
 
 from panel.depends import bind

--- a/panel/tests/widgets/test_tqdm.py
+++ b/panel/tests/widgets/test_tqdm.py
@@ -1,6 +1,8 @@
 """Tests of the Tqdm indicator"""
 import time
 
+import numpy as np
+import pandas as pd
 import pytest
 
 from tqdm.contrib.concurrent import process_map
@@ -60,11 +62,6 @@ def test_tqdm_color():
 
 
 def get_tqdm_app():
-    import time
-
-    import numpy as np
-    import pandas as pd
-
     tqdm = Tqdm(layout="row", sizing_mode="stretch_width")
 
     def run(*events):

--- a/panel/widgets/tables.py
+++ b/panel/widgets/tables.py
@@ -7,7 +7,7 @@ from functools import partial
 from types import FunctionType, MethodType
 from typing import (
     TYPE_CHECKING, Any, Callable, ClassVar, Dict, List, Mapping, Optional,
-    Tuple, Type, TypeVar,
+    Tuple, Type,
 )
 
 import numpy as np
@@ -37,11 +37,7 @@ from .button import Button
 from .input import TextInput
 
 if TYPE_CHECKING:
-    try:
-        import pandas as pd
-        DataFrameType = pd.DataFrame
-    except Exception:
-        DataFrameType = TypeVar('DataFrameType')
+    import pandas as pd
 
     from bokeh.document import Document
     from bokeh.models.sources import DataDict
@@ -155,7 +151,7 @@ class BaseTable(ReactiveData, Widget):
         df = self.value.reset_index() if len(indexes) > 1 else self.value
         return self._get_column_definitions(fields, df)
 
-    def _get_column_definitions(self, col_names: List[str], df: DataFrameType) -> List[TableColumn]:
+    def _get_column_definitions(self, col_names: List[str], df: pd.DataFrame) -> List[TableColumn]:
         import pandas as pd
         indexes = self.indexes
         columns = []
@@ -326,7 +322,7 @@ class BaseTable(ReactiveData, Widget):
             else:
                 self._update_columns(event, model)
 
-    def _sort_df(self, df: DataFrameType) -> DataFrameType:
+    def _sort_df(self, df: pd.DataFrame) -> pd.DataFrame:
         if not self.sorters:
             return df
         fields = [self._renamed_cols.get(s['field'], s['field']) for s in self.sorters]
@@ -367,7 +363,7 @@ class BaseTable(ReactiveData, Widget):
         df_sorted.drop(columns=['_index_'], inplace=True)
         return df_sorted
 
-    def _filter_dataframe(self, df: DataFrameType) -> DataFrameType:
+    def _filter_dataframe(self, df: pd.DataFrame) -> pd.DataFrame:
         """
         Filter the DataFrame.
 
@@ -555,10 +551,10 @@ class BaseTable(ReactiveData, Widget):
             return [str(v) for v in values]
         return values
 
-    def _get_data(self) -> Tuple[DataFrameType, DataDict]:
+    def _get_data(self) -> Tuple[pd.DataFrame, DataDict]:
         return self._process_df_and_convert_to_cds(self.value)
 
-    def _process_df_and_convert_to_cds(self, df: DataFrameType) -> Tuple[DataFrameType, DataDict]:
+    def _process_df_and_convert_to_cds(self, df: pd.DataFrame) -> Tuple[pd.DataFrame, DataDict]:
         import pandas as pd
         df = self._filter_dataframe(df)
         if df is None:
@@ -1896,7 +1892,7 @@ class Tabulator(BaseTable):
         self._on_click_callbacks[column].append(callback)
 
     @property
-    def current_view(self) -> DataFrameType:
+    def current_view(self) -> pd.DataFrame:
         """
         Returns the current view of the table after filtering and
         sorting are applied.

--- a/setup.py
+++ b/setup.py
@@ -113,6 +113,7 @@ install_requires = [
     'bleach',
     'setuptools >=42',
     'typing_extensions',
+    'pandas >=1.2',
 ]
 
 _recommended = [


### PR DESCRIPTION
Bokeh 3 directly depends on Pandas (`>=1.2`) and it makes sense for Panel to also depend on it, which is what this PR does. However, as Bokeh does, Pandas is never a top-level import (except in the tests) to avoid increasing the import time for non-Pandas users.
