### PR TITLE
Fix fast template issues

### DIFF
--- a/panel/template/fast/fast.css
+++ b/panel/template/fast/fast.css
@@ -61,5 +61,18 @@ h1, h2, h3, h4, h5, h6 {
 fast-card {
     margin: 0px;
     padding: 1em;
+}
+
+.pn-overflow-auto {
     overflow: auto;
+}
+
+fast-card div[class^='bk-panel'], fast-card div[class*=' bk-panel']{
+    margin-right: 0px;
+    margin-left: 0px;
+}
+
+.fast-card-margin {
+    margin: 1em;
+    margin-right: 0em;
 }

--- a/panel/template/fast/grid/fast_grid_template.css
+++ b/panel/template/fast/grid/fast_grid_template.css
@@ -418,5 +418,7 @@ img.app-logo {
 
 div.pn-wrapper {
     position: relative;
-    background: var(--background-color)
+    background: var(--background-color);
+    margin-right: 0px;
+    margin-left: 0px;
 }

--- a/panel/template/fast/grid/fast_grid_template.html
+++ b/panel/template/fast/grid/fast_grid_template.html
@@ -430,10 +430,10 @@
           {% for doc in docs %}{% for root in doc.roots %}{% if "main" in root.tags %}
             <div className="fast-card-margin" key="{{count|length + 1 }}" style={% raw %}{{borderRadius: '5px'}}{% endraw %}>
               {% if main_layout %}
-              <fast-card class="pn-wrapper"><div class="pn-overflow-auto">
-	      {% else %}
-              <div class="pn-wrapper">
-	      {% endif %}
+                <fast-card class="pn-wrapper"><div class="pn-overflow-auto">
+	            {% else %}
+                <div class="pn-wrapper pn-overflow-auto">
+	            {% endif %}
                 <span className="drag-handle"></span>
                 <span className="fullscreen-button">
                   <svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 18 18">

--- a/panel/template/fast/grid/fast_grid_template.html
+++ b/panel/template/fast/grid/fast_grid_template.html
@@ -428,9 +428,9 @@
          >
           {% set count = [] %}
           {% for doc in docs %}{% for root in doc.roots %}{% if "main" in root.tags %}
-            <div className="card-margin" key="{{count|length + 1 }}" style={% raw %}{{borderRadius: '5px'}}{% endraw %}>
+            <div className="fast-card-margin" key="{{count|length + 1 }}" style={% raw %}{{borderRadius: '5px'}}{% endraw %}>
               {% if main_layout %}
-              <fast-card class="pn-wrapper">
+              <fast-card class="pn-wrapper"><div class="pn-overflow-auto">
 	      {% else %}
               <div class="pn-wrapper">
 	      {% endif %}
@@ -442,7 +442,7 @@
                 </span>
                 {{ embed(root) | indent(4) | replace("class", "className") | replace('style="display: contents;"', 'style={{display: "contents"}}') }}
              {% if main_layout %}
-             </fast-card>
+            </div></fast-card>
 	     {% else %}
              </div>
 	     {% endif %}

--- a/panel/template/fast/list/fast_list_template.html
+++ b/panel/template/fast/list/fast_list_template.html
@@ -274,7 +274,7 @@
 	  {% if main_layout %}
 	  <fast-card class="pn-wrapper"><div class="pn-overflow-auto">
 	  {% else %}
-	  <div class="pn-wrapper">
+	  <div class="pn-wrapper pn-overflow-auto">
 	  {% endif %}
 	    <span class="fullscreen-button" onclick="toggleFullScreen(this)">
 	      <svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 18 18"><path d="M4.5 11H3v4h4v-1.5H4.5V11zM3 7h1.5V4.5H7V3H3v4zm10.5 6.5H11V15h4v-4h-1.5v2.5zM11 3v1.5h2.5V7H15V3h-4z"/></svg>

--- a/panel/template/fast/list/fast_list_template.html
+++ b/panel/template/fast/list/fast_list_template.html
@@ -270,9 +270,9 @@
 	{% for doc in docs %}
 	{% for root in doc.roots %}
 	{% if "main" in root.tags %}
-        <div class="card-margin">
+        <div class="fast-card-margin">
 	  {% if main_layout %}
-	  <fast-card class="pn-wrapper">
+	  <fast-card class="pn-wrapper"><div class="pn-overflow-auto">
 	  {% else %}
 	  <div class="pn-wrapper">
 	  {% endif %}
@@ -281,7 +281,7 @@
 	    </span>
 	    {{ embed(root) | indent(4) }}
 	  {% if main_layout %}
-	  </fast-card>
+    </div></fast-card>
 	  {% else %}
 	  </div>
 	  {% endif %}


### PR DESCRIPTION
Closes #4439 and closes #4438 . 

Also moves the overflow scrollbars inside the fast-card. It did not look great that when you started scrolling the content was expanding to the full height of the fast-card.

Works as shown below

https://user-images.githubusercontent.com/42288570/218246498-fe5f456e-994c-4036-a820-65e6a5a03407.mp4

```python
import panel as pn
from bokeh.sampledata.airport_routes import airports

pn.extension("tabulator", sizing_mode="stretch_width", template="fast")

pn.pane.Markdown("""\
# Ultima et iuvenem

## Et Oresteae qua excidit viscera dederat

Lorem markdownum illi: **sed** esse **inperfectus spatium carent** sine esse,
formamque statuit! Perire fortissima dicenti [enixa
recurvatis](http://animus-trahens.io/) insequor moenibus vulgus
[prece](http://www.lacertis.com/ducerequoque.php), exigit: Iuppiter: quoque
illic! Documenta in cum huius; quam hastas iam tamen abies aures eripuisse apte
plagas florilegae multos.
""").servable()
table = pn.pane.DataFrame(airports.head(100), sizing_mode="stretch_both", max_height=300).servable()

table = pn.widgets.Tabulator(airports.head(100), sizing_mode="stretch_both", max_height=300,).servable()

```