### PR TITLE
Fix divider style issues

### DIFF
--- a/panel/dist/css/divider.css
+++ b/panel/dist/css/divider.css
@@ -1,0 +1,10 @@
+:host{
+    width: 100%;
+} 
+div.bk-clearfix{
+    width:100%;
+}
+hr{
+    margin:0px;
+    margin-bottom:3px;   
+}

--- a/panel/dist/css/divider.css
+++ b/panel/dist/css/divider.css
@@ -1,10 +1,10 @@
 :host{
     width: 100%;
-} 
+}
 div.bk-clearfix{
     width:100%;
 }
 hr{
     margin:0px;
-    margin-bottom:3px;   
+    margin-bottom:3px;
 }

--- a/panel/layout/spacer.py
+++ b/panel/layout/spacer.py
@@ -102,10 +102,11 @@ class Divider(Reactive):
 
     _bokeh_model = BkDiv
 
+    _stylesheets = ["css/divider.css"]
+
     def _get_model(self, doc, root=None, parent=None, comm=None):
         properties = self._process_param_change(self._init_params())
-        properties['styles'] = {'width': '100%', 'height': '100%'}
-        model = self._bokeh_model(text='<hr style="margin: 0px">', **properties)
+        model = self._bokeh_model(text='<hr>', **properties)
         if root is None:
             root = model
         self._models[root.ref['id']] = (model, parent)


### PR DESCRIPTION
Close #4436 

## Example 1

Works now

```python
import panel as pn

pn.extension(sizing_mode="stretch_width")

pn.panel("Header", styles={"background": "lightgray"}).servable()
pn.layout.Divider(styles={"background": "salmon"}).servable()
pn.panel("Footer", styles={"background": "lightgray"}).servable()
```

![image](https://user-images.githubusercontent.com/42288570/218274552-130c22be-cc6d-4102-b95f-ccfd79104291.png)

## Example 2

Works now

```python
import panel as pn

pn.extension(sizing_mode="fixed")

pn.Column("Header", pn.layout.Divider(sizing_mode="stretch_width"), "Footer").servable()
```

![image](https://user-images.githubusercontent.com/42288570/218274604-b7ae7207-17a6-4476-9bc4-f0920c1b4aaf.png)
