### PR TITLE
Update Ace model to support Bokeh 3 

### DIFF
--- a/examples/reference/widgets/Ace.ipynb
+++ b/examples/reference/widgets/Ace.ipynb
@@ -56,8 +56,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "py_code = \"\"\"import sys\"\"\"\n",
-    "editor = pn.widgets.Ace(value=py_code, sizing_mode='stretch_both', language='python', height=300)\n",
+    "py_code = \"import sys\"\n",
+    "editor = pn.widgets.Ace(value=py_code, sizing_mode='stretch_width', language='python', height=300)\n",
     "editor"
    ]
   },
@@ -210,9 +210,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "widget = pn.widgets.Ace(name='Ace', value=py_code, sizing_mode='stretch_both', height=300)\n",
+    "widget = pn.widgets.Ace(name='Ace', value=py_code, language='python', sizing_mode='stretch_both', height=300)\n",
     "\n",
-    "pn.Row(widget.controls(jslink=True), widget)"
+    "pn.Row(widget.controls(jslink=True), widget, sizing_mode='stretch_both')"
    ]
   },
   {

--- a/panel/models/ace.py
+++ b/panel/models/ace.py
@@ -48,13 +48,13 @@ class AcePlot(HTMLBox):
         }
     }
 
-    code = String()
+    code = String(default='')
 
     theme = Enum(ace_themes, default='chrome')
 
     filename = Nullable(String())
 
-    language = String()
+    language = String(default='')
 
     annotations = List(Dict(String, Any), default=[])
 

--- a/panel/models/ace.ts
+++ b/panel/models/ace.ts
@@ -45,10 +45,11 @@ export class AcePlotView extends HTMLBoxView {
 
   render(): void {
     super.render()
-    if (!(this._container === this.el.childNodes[0]))
-      this.shadow_el.appendChild(this._container)
+    if (!(this._container === this.shadow_el.childNodes[0]))
+      this.shadow_el.append(this._container)
       this._container.textContent = this.model.code
-      this._editor = (window as any).ace.edit(this._container.id)
+      this._editor = (window as any).ace.edit(this._container)
+      this._editor.renderer.attachToShadowRoot()
       this._langTools = (window as any).ace.require('ace/ext/language_tools')
       this._modelist = (window as any).ace.require("ace/ext/modelist")
       this._editor.setOptions({
@@ -111,7 +112,7 @@ export namespace AcePlot {
   export type Props = HTMLBox.Props & {
     code: p.Property<string>
     language: p.Property<string>
-    filename: p.Property<string>
+    filename: p.Property<string | null>
     theme: p.Property<string>
     annotations: p.Property<any[]>
     print_margin: p.Property<boolean>
@@ -133,10 +134,10 @@ export class AcePlot extends HTMLBox {
   static {
     this.prototype.default_view = AcePlotView
 
-    this.define<AcePlot.Props>(({Any, Array, Boolean, String}) => ({
+    this.define<AcePlot.Props>(({Any, Array, Boolean, String, Nullable}) => ({
       code:         [ String,       '' ],
-      filename:     [ String           ],
-      language:     [ String           ],
+      filename:     [ Nullable(String), null],
+      language:     [ String,       '' ],
       theme:        [ String, 'chrome' ],
       annotations:  [ Array(Any),   [] ],
       readonly:     [ Boolean,   false ],


### PR DESCRIPTION
Update the Ace model to support Bokeh 3, but some sizing problems still exist. Though I think these problems are more general than related to the Ace model. 

1) `stretch_both` in a notebook (`stretch_width` works fine):
![ Screenshot 2023-02-15 14 41 49](https://user-images.githubusercontent.com/19758978/219044002-6ed43d44-6d46-48f3-9c4d-bec075dcf426.png)
![ Screenshot 2023-02-15 14 41 57](https://user-images.githubusercontent.com/19758978/219044021-fd871e02-1b2f-4cba-b036-351fff6ed1eb.png)
2) Widget exceeds Tabs width
![ Screenshot 2023-02-15 14 37 10](https://user-images.githubusercontent.com/19758978/219044484-3a1e72b0-1347-4b20-901f-4b36e09a3f27.png)
3) Column does not respect the sizing_mode of `Ace`.
    ``` python
    import panel as pn
    
    pn.extension("ace")
    
    editor = pn.widgets.Ace(value="import sys", language="python", sizing_mode="stretch_width")
    pn.Row(editor).servable()  # Does not work
    pn.Row(editor, sizing_mode="stretch_width").servable()  # Does work
    editor.servable()  # Does work
    ```
    ![image](https://user-images.githubusercontent.com/19758978/219045372-202a7009-622c-49ca-87d1-d28265127eff.png)

 
