### PR TITLE
Update TextEditor for Bokeh 3

### DIFF
--- a/panel/io/resources.py
+++ b/panel/io/resources.py
@@ -183,7 +183,11 @@ def loading_css():
     }}
     """
 
-def patch_stylesheet(stylesheet, dist_url):
+def patch_stylesheet(stylesheet, dist_url) -> None:
+    global RESOURCE_MODE
+    if RESOURCE_MODE == "server":
+        return
+
     url = stylesheet.url
     if not url.startswith('http') and not url.startswith(dist_url):
         patched_url = f'{dist_url}{url}'

--- a/panel/io/resources.py
+++ b/panel/io/resources.py
@@ -183,11 +183,7 @@ def loading_css():
     }}
     """
 
-def patch_stylesheet(stylesheet, dist_url) -> None:
-    global RESOURCE_MODE
-    if RESOURCE_MODE == "server":
-        return
-
+def patch_stylesheet(stylesheet, dist_url):
     url = stylesheet.url
     if not url.startswith('http') and not url.startswith(dist_url):
         patched_url = f'{dist_url}{url}'

--- a/panel/models/quill.ts
+++ b/panel/models/quill.ts
@@ -70,6 +70,11 @@ export class QuillInputView extends HTMLBoxView {
     });
     if (!this.model.disabled)
       this.quill.enable(!this.model.disabled)
+
+    document.addEventListener("selectionchange", (..._args: any[]) => {
+      // Update selection and some other properties
+      this.quill.selection.update()
+    });
   }
 
   after_layout(): void {


### PR DESCRIPTION
This tries to fix two things, but to be honest, I'm not sure about the implementation for any of them. And more putting it up here to have something to talk out from.

``` python
import panel as pn

pn.extension("texteditor")

pn.widgets.TextEditor(value="Highlight me to edit formatting").servable()
```

With the change in patch_stylesheet, my output looks like this:
![image](https://user-images.githubusercontent.com/19758978/220680987-ba8fd941-334b-483c-a43c-46b2430c845f.png)

<br>
Without the selection addition:

https://user-images.githubusercontent.com/19758978/220684150-9f69420f-3aa8-47b8-abdb-59bad1052713.mp4

<br>
With the selection addition:

https://user-images.githubusercontent.com/19758978/220683337-e3790878-c6e1-4603-ba31-fe238e9aeef0.mp4

<br>


[Reference for the selection](https://stackoverflow.com/questions/67914657/quill-editor-inside-shadow-dom)
