### PR TITLE
Small bug fixes 

### DIFF
--- a/panel/io/cache.py
+++ b/panel/io/cache.py
@@ -364,8 +364,7 @@ def cache(
 
         func_cache = state._memoize_cache.get(func_hash)
 
-        empty = func_cache is None
-        if empty:
+        if func_cache is None:
             if to_disk:
                 from diskcache import Index
                 cache = Index(os.path.join(cache_path, func_hash))
@@ -376,7 +375,7 @@ def cache(
         if ttl is not None:
             _cleanup_ttl(func_cache, ttl, time)
 
-        if not empty and hash_value in func_cache:
+        if hash_value in func_cache:
             with lock:
                 ret, ts, count, _ = func_cache[hash_value]
                 func_cache[hash_value] = (ret, ts, count+1, time)

--- a/panel/io/model.py
+++ b/panel/io/model.py
@@ -39,10 +39,10 @@ class comparable_array(np.ndarray):
     """
 
     def __eq__(self, other: Any) -> bool:
-        return super().__eq__(other).all().item()
+        return np.array_equal(self, other, equal_nan=True)
 
     def __ne__(self, other: Any) -> bool:
-        return super().__ne__(other).all().item()
+        return not np.array_equal(self, other, equal_nan=True)
 
 def monkeypatch_events(events: List['DocumentChangedEvent']) -> None:
     """


### PR DESCRIPTION
This fixes two things:
- Make `nan=nan` comparison to True, as I don't see a reason why it shouldn't be for our case.
- Use cache from previous sessions when using `to_disk` 