### PR TITLE
Add `examples` folder dynamically added to the distrib

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -27,6 +27,7 @@ global-exclude *.py[co]
 global-exclude *~
 global-exclude *.ipynb_checkpoints/*
 global-exclude *.whl
+graft panel/examples
 graft examples
 graft doc/
 graft panel/dist


### PR DESCRIPTION
Fixes https://github.com/holoviz/panel/issues/4472

Grafting `panel/examples` was done before but removed in https://github.com/holoviz/panel/pull/3481/commits/79e05e630c61c099639ebec42365338f922343f9, not sure why.

I think adding it back is the right change to fix the reported issue.

The way the examples are distributed is a bit confusing (to me at least!) and I've started to track that here https://github.com/holoviz/holoviews/pull/5632. Understanding that is necessary anyway for us to modernize the build process and hopefully move to `pyproject.toml`.