### PR TITLE
Don't override `styles` parameter in `StaticText`

### DIFF
--- a/panel/widgets/input.py
+++ b/panel/widgets/input.py
@@ -241,9 +241,6 @@ class StaticText(Widget):
     >>> StaticText(name='Model', value='animagen2')
     """
 
-    styles = param.Dict(default=None, doc="""
-        Dictionary of CSS property:value pairs to apply to this Div.""")
-
     value = param.Parameter(default=None, doc="""
         The current value""")
 


### PR DESCRIPTION
`styles` is now a Parameter of the `Layoutable` class and as such inherited by `StaticText`.