### PR TITLE
Add layout compatibility mode

### DIFF
--- a/panel/config.py
+++ b/panel/config.py
@@ -124,6 +124,13 @@ class _config(_base_config):
     exception_handler = param.Callable(default=None, doc="""
         General exception handler for events.""")
 
+    layout_compatibility = param.Boolean(default=True, doc="""
+        Enables the layout compatibility mode. This mode aims to provide
+        backward compatibility for layouts to behave like they did before
+        version 1. When a sizing_mode is incorrectly defined according to
+        the new layout modes a warning will be raised. The compatibility
+        mode will be disabled by default starting in v1.1.0""")
+
     load_entry_points = param.Boolean(default=True, doc="""
         Load entry points from external packages.""")
 

--- a/panel/layout/accordion.py
+++ b/panel/layout/accordion.py
@@ -146,7 +146,7 @@ class Accordion(NamedListPanel):
         return new_models
 
     def _compute_sizing_mode(self, children, sizing_mode):
-        children = [subchild for child in children for subchild in child.children]
+        children = [subchild for child in children for subchild in child.children[1:]]
         return super()._compute_sizing_mode(children, sizing_mode)
 
     def _cleanup(self, root: Model | None = None) -> None:

--- a/panel/layout/accordion.py
+++ b/panel/layout/accordion.py
@@ -145,6 +145,10 @@ class Accordion(NamedListPanel):
         self._update_active()
         return new_models
 
+    def _compute_sizing_mode(self, children, sizing_mode):
+        children = [subchild for child in children for subchild in child.children]
+        return super()._compute_sizing_mode(children, sizing_mode)
+
     def _cleanup(self, root: Model | None = None) -> None:
         for panel in self._panels.values():
             panel._cleanup(root)

--- a/panel/layout/base.py
+++ b/panel/layout/base.py
@@ -171,11 +171,11 @@ class Panel(Reactive):
             if child.sizing_mode in ('stretch_height', 'stretch_both', 'scale_height', 'scale_both'):
                 expand_height = True
         new_mode = None
-        if expand_width and expand_height:
+        if expand_width and expand_height and not self.width and not self.height:
             new_mode = 'stretch_both'
-        elif expand_width:
+        elif expand_width and not self.width:
             new_mode = 'stretch_width'
-        elif expand_height:
+        elif expand_height and not self.height:
             new_mode = 'stretch_height'
         if new_mode and config.layout_compatibility and new_mode != sizing_mode:
             self.param.warning(

--- a/panel/layout/card.py
+++ b/panel/layout/card.py
@@ -79,8 +79,7 @@ class Card(Column):
     _stylesheets: ClassVar[List[str]] = ['css/card.css']
 
     def __init__(self, *objects, **params):
-        self._header_layout = Row(css_classes=['card-header-row'],
-                                  sizing_mode='stretch_width')
+        self._header_layout = Row(css_classes=['card-header-row'], sizing_mode='stretch_width')
         super().__init__(*objects, **params)
         self._header = None
         self.param.watch(self._update_header, ['title', 'header', 'title_css_classes'])
@@ -116,9 +115,7 @@ class Card(Column):
                 self._header.param.set_param(**params)
                 return
             else:
-                self._header = item = HTML(
-                    sizing_mode='stretch_width', **params
-                )
+                self._header = item = HTML(**params)
         else:
             item = panel(self.header)
             self._header = None
@@ -132,3 +129,6 @@ class Card(Column):
             header = self._header_layout._get_model(doc, root, model, comm)
         objects = super()._get_objects(model, old_objects, doc, root, comm)
         return [header]+objects
+
+    def _compute_sizing_mode(self, children, sizing_mode):
+        return super()._compute_sizing_mode(children[1:], sizing_mode)

--- a/panel/layout/grid.py
+++ b/panel/layout/grid.py
@@ -326,6 +326,10 @@ class GridSpec(Panel):
             children.append((child, r, c, h, w))
         return children
 
+    def _compute_sizing_mode(self, children, sizing_mode):
+        children = [child for (child, _, _, _, _) in children]
+        return super()._compute_sizing_mode(children, sizing_mode)
+
     @property
     def _xoffset(self):
         min_xidx = [x0 for (_, x0, _, _) in self.objects if x0 is not None]

--- a/panel/layout/tabs.py
+++ b/panel/layout/tabs.py
@@ -138,6 +138,10 @@ class Tabs(NamedListPanel):
                 self.param.trigger('objects')
                 return
 
+    def _compute_sizing_mode(self, children, sizing_mode):
+        children = [child.child for child in children]
+        return super()._compute_sizing_mode(children, sizing_mode)
+
     #----------------------------------------------------------------
     # Model API
     #----------------------------------------------------------------

--- a/panel/tests/layout/test_base.py
+++ b/panel/tests/layout/test_base.py
@@ -480,3 +480,54 @@ def test_layout_with_param_setitem(document, comm):
     model = test._layout.get_root(document, comm=comm)
     test.select = 1
     assert model.children[1].text == '&lt;pre&gt;1&lt;/pre&gt;'
+
+@pytest.mark.parametrize('panel', [Card, Column, Row, Tabs, Accordion])
+@pytest.mark.parametrize('sizing_mode', ['stretch_width', 'stretch_height', 'stretch_both'])
+def test_expand_sizing_mode_to_match_child(panel, sizing_mode, document, comm):
+    div1 = Div()
+    div2 = Div(sizing_mode=sizing_mode)
+    layout = panel(div1, div2)
+
+    model = layout.get_root(document, comm)
+
+    assert model.sizing_mode == sizing_mode
+
+@pytest.mark.parametrize('panel', [Card, Column, Row, Tabs, Accordion])
+def test_expand_both_axes(panel, document, comm):
+    div1 = Div(sizing_mode='stretch_width')
+    div2 = Div(sizing_mode='stretch_height')
+    layout = panel(div1, div2)
+
+    model = layout.get_root(document, comm)
+
+    assert model.sizing_mode == 'stretch_both'
+
+@pytest.mark.parametrize('panel', [Card, Column, Row, Tabs, Accordion])
+def test_expand_only_non_fixed_axis_width(panel, document, comm):
+    div1 = Div(sizing_mode='stretch_width')
+    div2 = Div(sizing_mode='stretch_height')
+    layout = panel(div1, div2, width=500)
+
+    model = layout.get_root(document, comm)
+
+    assert model.sizing_mode == 'stretch_height'
+
+@pytest.mark.parametrize('panel', [Card, Column, Row, Tabs, Accordion])
+def test_expand_only_non_fixed_axis_height(panel, document, comm):
+    div1 = Div(sizing_mode='stretch_width')
+    div2 = Div(sizing_mode='stretch_height')
+    layout = panel(div1, div2, height=500)
+
+    model = layout.get_root(document, comm)
+
+    assert model.sizing_mode == 'stretch_width'
+
+@pytest.mark.parametrize('panel', [Card, Column, Row, Tabs, Accordion])
+def test_no_expand_fixed(panel, document, comm):
+    div1 = Div(sizing_mode='stretch_width')
+    div2 = Div(sizing_mode='stretch_height')
+    layout = panel(div1, div2, height=500, width=500)
+
+    model = layout.get_root(document, comm)
+
+    assert model.sizing_mode == 'fixed'


### PR DESCRIPTION
This PR adds a compatibility mode to Panel layouts that adjusts the `sizing_mode` of the parent based on the sizing mode of its children. If a parent does not have a sizing_mode (i.e. it is None) it will always check whether any of its children are set to stretch or scale along the width/height axes and will follow suit. The compatibility mode additionally checks whether a parent has the wrong `sizing_mode`, i.e. if a child is set to `stretch_both` but the parent is only set to `stretch_width` then we will override the incorrectly set value and override it.

It may turn out that we simply keep the compatibility mode but for now I have introduced a `config.layout_compatibility` option that is `True` by default. So far in my testing this resolves all issues with layouts in even complex apps I've looked at or at least produces output that a user can then easily fix.