### PR TITLE
Handle config.raw_css and config.css_files compatibility with shadow DOM

### DIFF
--- a/panel/io/resources.py
+++ b/panel/io/resources.py
@@ -8,6 +8,7 @@ import json
 import logging
 import mimetypes
 import os
+import re
 
 from base64 import b64encode
 from collections import OrderedDict
@@ -70,6 +71,8 @@ DOC_DIST = "https://panel.holoviz.org/_static/"
 LOCAL_DIST = "static/extensions/panel/"
 COMPONENT_PATH = "components/"
 
+BK_PREFIX_RE = re.compile('\.bk\.')
+
 RESOURCE_URLS = {
     'font-awesome': {
         'zip': 'https://use.fontawesome.com/releases/v5.15.4/fontawesome-free-5.15.4-web.zip',
@@ -130,6 +133,12 @@ def set_resource_mode(mode):
     finally:
         RESOURCE_MODE = old_mode
         _settings.resources.set_value(old_resources)
+
+def process_raw_css(raw_css):
+    """
+    Converts old-style Bokeh<3 compatible CSS to Bokeh 3 compatible CSS.
+    """
+    return [BK_PREFIX_RE.sub('.', css) for css in raw_css]
 
 def resolve_custom_path(obj, path):
     """
@@ -392,7 +401,7 @@ class Resources(BkResources):
 
         if config.loading_spinner:
             raw.append(loading_css())
-        return raw + config.raw_css
+        return raw + process_raw_css(config.raw_css)
 
     @property
     def js_files(self):

--- a/panel/reactive.py
+++ b/panel/reactive.py
@@ -39,7 +39,8 @@ from .models.reactive_html import (
     DOMEvent, ReactiveHTML as _BkReactiveHTML, ReactiveHTMLParser,
 )
 from .util import (
-    classproperty, edit_readonly, escape, eval_function, updating,
+    classproperty, edit_readonly, escape, eval_function, process_raw_css,
+    updating,
 )
 from .viewable import Layoutable, Renderable, Viewable
 
@@ -182,8 +183,9 @@ class Syncable(Renderable):
         if 'height' in properties and self.sizing_mode is None:
             properties['min_height'] = properties['height']
         if 'stylesheets' in properties:
-            base_stylesheets = self._stylesheets+['css/loading.css']
-            stylesheets = [loading_css()] + [
+            from .config import config
+            base_stylesheets = config.css_files+self._stylesheets+['css/loading.css']
+            stylesheets = [loading_css()] + process_raw_css(config.raw_css) + [
                 ImportedStyleSheet(url=stylesheet) for stylesheet in base_stylesheets
             ]
             for stylesheet in properties['stylesheets']:

--- a/panel/reactive.py
+++ b/panel/reactive.py
@@ -33,14 +33,15 @@ from param.parameterized import ParameterizedMetaclass, Watcher
 from .io.document import unlocked
 from .io.model import hold
 from .io.notebook import push
-from .io.resources import CDN_DIST, loading_css, patch_stylesheet
+from .io.resources import (
+    CDN_DIST, loading_css, patch_stylesheet, process_raw_css,
+)
 from .io.state import set_curdoc, state
 from .models.reactive_html import (
     DOMEvent, ReactiveHTML as _BkReactiveHTML, ReactiveHTMLParser,
 )
 from .util import (
-    classproperty, edit_readonly, escape, eval_function, process_raw_css,
-    updating,
+    classproperty, edit_readonly, escape, eval_function, updating,
 )
 from .viewable import Layoutable, Renderable, Viewable
 


### PR DESCRIPTION
Provides initial layer of backward compatibility for `config.raw_css` and `config.css_files` by stripping out any `.bk` prefixes and adding the contents of these variables to the shadow DOM of ALL components. We have to separately decide a policy around either deprecating or messaging to the user how expensive injecting CSS into every single component is.