### PR TITLE
Update asyncio/Tornado 

### DIFF
--- a/panel/io/server.py
+++ b/panel/io/server.py
@@ -919,7 +919,7 @@ def get_server(
 
     opts = dict(kwargs)
     if loop:
-        loop.make_current()
+        asyncio.set_event_loop(loop.asyncio_loop)
         opts['io_loop'] = loop
     elif opts.get('num_procs', 1) == 1:
         opts['io_loop'] = IOLoop.current()

--- a/panel/io/server.py
+++ b/panel/io/server.py
@@ -705,7 +705,7 @@ def serve(
         location=location, admin=admin
     ))
     if threaded:
-        kwargs['loop'] = loop = IOLoop(make_current=False) if loop is None else loop
+        kwargs['loop'] = loop = IOLoop() if loop is None else loop
         server = StoppableThread(
             target=get_server, io_loop=loop, args=(panels,), kwargs=kwargs
         )
@@ -919,7 +919,7 @@ def get_server(
 
     opts = dict(kwargs)
     if loop:
-        asyncio.set_event_loop(loop.asyncio_loop)
+        loop.make_current()
         opts['io_loop'] = loop
     elif opts.get('num_procs', 1) == 1:
         opts['io_loop'] = IOLoop.current()

--- a/panel/tests/conftest.py
+++ b/panel/tests/conftest.py
@@ -1,6 +1,7 @@
 """
 A module containing testing utilities and fixtures.
 """
+import asyncio
 import atexit
 import os
 import pathlib
@@ -31,6 +32,17 @@ CUSTOM_MARKS = ('ui', 'jupyter')
 JUPYTER_PORT = 8887
 JUPYTER_TIMEOUT = 15 # s
 JUPYTER_PROCESS = None
+
+# Tornado 6.2 has deprecated the use of IOLoop.current,
+# when no asyncio event loop is running.
+# This will start an event loop.
+try:
+    asyncio.get_running_loop()
+except RuntimeError:
+    # Create a new asyncio event loop for this thread.
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+
 
 def port_open(port):
     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)

--- a/tox.ini
+++ b/tox.ini
@@ -73,3 +73,6 @@ deps = unit: {[_unit]deps}
 addopts = -v --pyargs --doctest-ignore-import-errors
 norecursedirs = doc .git dist build _build .ipynb_checkpoints panel/examples
 xfail_strict = true
+filterwarnings =
+       ; 2023-03: https://github.com/tornadoweb/tornado/issues/3216
+       ignore: make_current is deprecated:DeprecationWarning


### PR DESCRIPTION
`make_current` deprecation was reverted in Python and will not give a warning in Tornado 6.3 and forward (https://github.com/tornadoweb/tornado/issues/3216).

The change in `conftest.py` is to avoid this warning, though I'm unsure if it is the right way. 
``` python
  /home/shh/miniconda3/envs/holoviz/lib/python3.10/site-packages/tornado/ioloop.py:265: DeprecationWarning: There is no current event loop
    loop = asyncio.get_event_loop()
```