### PR TITLE
Ensure Image always fits in containing box

### DIFF
--- a/panel/pane/image.py
+++ b/panel/pane/image.py
@@ -164,7 +164,7 @@ class ImageBase(FileBase):
         alt = f'alt={self.alt_text!r}' if self.alt_text else ''
         width = f' width: {width};' if width else ''
         height = f' height: {height};' if height else ''
-        html = f'<img src="{src}" {alt} style="{width}{height}"></img>'
+        html = f'<img src="{src}" {alt} style="max-width: 100%; max-height: 100%; object-fit: contain;{width}{height}"></img>'
         if self.link_url:
             html = f'<a href="{self.link_url}" target="_blank">{html}</a>'
         return escape(html)
@@ -423,7 +423,7 @@ class SVG(ImageBase):
         if self.encode:
             ws = f' width: {w};' if w else ''
             hs = f' height: {h};' if h else ''
-            data = f'<img src="{self._b64(data)}" style="object-fit: contain;{ws}{hs}"></img>'
+            data = f'<img src="{self._b64(data)}" style="max-width: 100%; max-height: 100%; object-fit: contain;{ws}{hs}"></img>'
         elif self.width or self.height or self.sizing_mode not in (None, 'fixed'):
             self.param.warning(
                 'SVG sizing cannot be scaled if the SVG has been embedded '

--- a/panel/tests/ui/pane/test_image.py
+++ b/panel/tests/ui/pane/test_image.py
@@ -12,7 +12,7 @@ PDF_FILE = 'https://assets.holoviz.org/panel/samples/pdf_sample.pdf'
 PNG_FILE = 'https://assets.holoviz.org/panel/samples/png_sample.png'
 SVG_FILE = 'https://assets.holoviz.org/panel/samples/svg_sample.svg'
 
-def get_bbox(page, port, obj, wait=0.2):
+def get_bbox(page, port, obj, wait=0.5):
     serve(obj, port=port, threaded=True, show=False)
     if isinstance(obj, Row):
         obj = obj[0]
@@ -78,7 +78,7 @@ def test_png_scale_both(sizing_mode, embed, page, port):
     row = Row(png, width=800, height=500)
     bbox = get_bbox(page, port, row)
     assert bbox['width'] == 780
-    assert bbox['height'] == 585
+    assert bbox['height'] == 480
 
 @pytest.mark.parametrize('embed', [False, True])
 def test_png_stretch_width(embed, page, port):
@@ -143,7 +143,7 @@ def test_svg_scale_both(sizing_mode, embed, page, port):
     row = Row(svg, width=800, height=500)
     bbox = get_bbox(page, port, row)
     assert bbox['width'] == 780
-    assert bbox['height'] == 657.921875
+    assert bbox['height'] == 480
 
 @pytest.mark.parametrize('embed', [False, True])
 def test_svg_stretch_width(embed, page, port):


### PR DESCRIPTION
Small adjustment for Image scaling to ensure it always fits in the allocated size.