### PR TITLE
Add BrowserInfo model to expose browser window and navigator APIs

### DIFF
--- a/panel/config.py
+++ b/panel/config.py
@@ -16,6 +16,7 @@ from weakref import WeakKeyDictionary
 
 import param
 
+from bokeh.document import Document
 from bokeh.settings import settings as bk_settings
 from pyviz_comms import (
     JupyterCommManager as _JupyterCommManager, extension as _pyviz_extension,
@@ -114,6 +115,9 @@ class _config(_base_config):
 
     autoreload = param.Boolean(default=False, doc="""
         Whether to autoreload server when script changes.""")
+
+    browser_info = param.Boolean(default=True, doc="""
+        Whether to request browser info from the frontend.""")
 
     defer_load = param.Boolean(default=False, doc="""
         Whether to defer load of rendered functions.""")
@@ -716,8 +720,14 @@ class panel_extension(_pyviz_extension):
             load_notebook(config.inline)
         panel_extension._loaded = True
 
+        if config.browser_info:
+            doc = Document()
+            comm = state._comm_manager.get_server_comm()
+            model = state.browser_info._render_model(doc, comm)
+            bundle, meta = state.browser_info._render_mimebundle(model, doc, comm)
+            display(bundle, metadata=meta, raw=True)  # noqa
         if config.notifications:
-            display(state.notifications) # noqa
+            display(state.notifications)  # noqa
 
         if config.load_entry_points:
             self._load_entry_points()

--- a/panel/io/browser.py
+++ b/panel/io/browser.py
@@ -1,0 +1,82 @@
+"""
+Defines a BrowserInfo component exposing the browser window and
+navigator APIs.
+"""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, ClassVar, Mapping
+
+import param  # type: ignore
+
+from ..models.browser import BrowserInfo as _BkBrowserInfo
+from ..reactive import Syncable
+from .document import init_doc
+from .state import state
+
+if TYPE_CHECKING:
+    from bokeh.document import Document
+    from bokeh.model import Model
+    from pyviz_comms import Comm
+
+
+class BrowserInfo(Syncable):
+    """
+    The Location component can be made available in a server context
+    to provide read and write access to the URL components in the
+    browser.
+    """
+
+    dark_mode = param.Boolean(default=None, doc="""
+        Whether the user prefers dark mode.""")
+
+    device_pixel_ratio = param.Number(default=None, doc="""
+        Provides the ratio of the resolution in physical pixels to
+        the resolution in CSS pixels for the current display device.""")
+
+    language = param.String(default=None, doc="""
+        The preferred language of the user, usually the language of the
+        browser UI.""")
+
+    timezone = param.String(default=None, doc="""
+        The timezone configured as the local timezone of the user.""")
+
+    timezone_offset = param.Number(default=None, doc="""
+        The time offset from UTC in minutes.""")
+
+    webdriver = param.Boolean(default=None, doc="""
+        Indicates whether the user agent is controlled by automation.""")
+
+    # Mapping from parameter name to bokeh model property name
+    _rename: ClassVar[Mapping[str, str | None]] = {"name": None}
+
+    def _get_model(
+        self, doc: Document, root: Model | None = None,
+        parent: Model | None = None, comm: Comm | None = None
+    ) -> Model:
+        model = _BkBrowserInfo()
+        root = root or model
+        self._models[root.ref['id']] = (model, parent)
+        self._link_props(model, self._linked_properties, doc, root, comm)
+        return model
+
+    def get_root(
+        self, doc: Document | None = None, comm: Comm | None = None,
+        preprocess: bool = True
+    ) -> 'Model':
+        doc = init_doc(doc)
+        root = self._get_model(doc, comm=comm)
+        ref = root.ref['id']
+        state._views[ref] = (self, root, doc, comm)
+        self._documents[doc] = root
+        return root
+
+    def _cleanup(self, root: Model | None = None) -> None:
+        if root:
+            if root.document in self._documents:
+                del self._documents[root.document]
+            ref = root.ref['id']
+        else:
+            ref = None
+        super()._cleanup(root)
+        if ref in state._views:
+            del state._views[ref]

--- a/panel/io/notebook.py
+++ b/panel/io/notebook.py
@@ -25,7 +25,7 @@ from bokeh.embed import server_document
 from bokeh.embed.elements import div_for_render_item, script_for_render_items
 from bokeh.embed.util import standalone_docs_json_and_render_items
 from bokeh.embed.wrappers import wrap_in_script_tag
-from bokeh.models import LayoutDOM, Model
+from bokeh.models import Model
 from bokeh.resources import CDN, INLINE
 from bokeh.settings import _Unset, settings
 from bokeh.util.serialization import make_id
@@ -196,7 +196,7 @@ def render_mimebundle(
     Displays bokeh output inside a notebook using the PyViz display
     and comms machinery.
     """
-    if not isinstance(model, LayoutDOM):
+    if not isinstance(model, Model):
         raise ValueError('Can only render bokeh LayoutDOM models')
     add_to_doc(model, doc, True)
     if manager is not None:

--- a/panel/models/browser.py
+++ b/panel/models/browser.py
@@ -1,0 +1,26 @@
+"""
+This module provides a Bokeh BrowserInfo Model exposing the browser
+window and navigator APIs.
+"""
+from bokeh.core.properties import (
+    Bool, Float, Nullable, String,
+)
+from bokeh.models import Model
+
+
+class BrowserInfo(Model):
+    """
+    A python wrapper around the JS `window` and `navigator` APIs.
+    """
+
+    dark_mode = Nullable(Bool())
+
+    device_pixel_ratio = Nullable(Float())
+
+    language = Nullable(String())
+
+    timezone = Nullable(String())
+
+    timezone_offset = Nullable(Float())
+
+    webdriver = Nullable(Bool())

--- a/panel/models/browser.ts
+++ b/panel/models/browser.ts
@@ -1,0 +1,59 @@
+import * as p from "@bokehjs/core/properties"
+import {View} from "@bokehjs/core/view"
+import {Model} from "@bokehjs/model"
+
+export class BrowserInfoView extends View {
+  model: BrowserInfo
+
+  initialize(): void {
+    super.initialize();
+
+    if (window.matchMedia != null) {
+      this.model.dark_mode = window.matchMedia('(prefers-color-scheme: dark)').matches
+    }
+    this.model.device_pixel_ratio = window.devicePixelRatio
+    if (navigator != null) {
+      this.model.language = navigator.language
+      this.model.webdriver = navigator.webdriver
+    }
+    this.model.timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+    this.model.timezone_offset = new Date().getTimezoneOffset();
+  }
+}
+
+export namespace BrowserInfo {
+  export type Attrs = p.AttrsOf<Props>
+  export type Props = Model.Props & {
+    dark_mode: p.Property<boolean | null>
+    device_pixel_ratio: p.Property<number | null>
+    language: p.Property<string | null>
+    timezone: p.Property<string | null>
+    timezone_offset: p.Property<number | null>
+    webdriver: p.Property<boolean | null>
+  }
+}
+
+export interface BrowserInfo extends BrowserInfo.Attrs { }
+
+export class BrowserInfo extends Model {
+  properties: BrowserInfo.Props
+
+  static __module__ = "panel.models.browser"
+
+  constructor(attrs?: Partial<BrowserInfo.Attrs>) {
+    super(attrs)
+  }
+
+  static {
+    this.prototype.default_view = BrowserInfoView
+
+    this.define<BrowserInfo.Props>(({Boolean, Nullable, Number, String}) => ({
+      dark_mode:          [ Nullable(Boolean), null ],
+      device_pixel_ratio: [ Nullable(Number),  null ],
+      language:           [ Nullable(String),  null ],
+      timezone:           [ Nullable(String),  null ],
+      timezone_offset:    [ Nullable(Number),  null ],
+      webdriver:          [ Nullable(Boolean), null ]
+    }))
+  }
+}

--- a/panel/models/browser.ts
+++ b/panel/models/browser.ts
@@ -18,6 +18,8 @@ export class BrowserInfoView extends View {
     }
     this.model.timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
     this.model.timezone_offset = new Date().getTimezoneOffset();
+    this._has_finished = true
+    this.notify_finished()
   }
 }
 

--- a/panel/models/index.ts
+++ b/panel/models/index.ts
@@ -1,5 +1,6 @@
 export {AcePlot} from "./ace"
 export {Audio} from "./audio"
+export {BrowserInfo} from "./browser"
 export {Card} from "./card"
 export {CommManager} from "./comm_manager"
 export {CustomSelect} from "./customselect"

--- a/panel/template/base.py
+++ b/panel/template/base.py
@@ -546,6 +546,9 @@ class BasicTemplate(BaseTemplate):
         if 'embed(roots.notifications)' in template and self.notifications:
             self._render_items['notifications'] = (self.notifications, [])
             self._render_variables['notifications'] = True
+        if config.browser_info and 'embed(roots.browser_info)' in template and state.browser_info:
+            self._render_items['browser_info'] = (state.browser_info, [])
+            self._render_variables['browser_info'] = True
         self._update_busy()
         self.main.param.watch(self._update_render_items, ['objects'])
         self.modal.param.watch(self._update_render_items, ['objects'])

--- a/panel/template/base.py
+++ b/panel/template/base.py
@@ -17,6 +17,7 @@ from typing import (
 import param
 
 from bokeh.document.document import Document
+from bokeh.models import LayoutDOM
 from bokeh.settings import settings as _settings
 from pyviz_comms import JupyterCommManager as _JupyterCommManager
 
@@ -184,10 +185,10 @@ class BaseTemplate(param.Parameterized, ServableMixin):
             model.name = name
             model.tags = tags
             mref = model.ref['id']
-            sizing_modes[mref] = model.sizing_mode
-
-            if self._design._apply_hooks not in obj._hooks:
-                obj._hooks.append(self._design._apply_hooks)
+            if isinstance(model, LayoutDOM):
+                sizing_modes[mref] = model.sizing_mode
+                if self._design._apply_hooks not in obj._hooks:
+                    obj._hooks.append(self._design._apply_hooks)
 
             # Alias model ref with the fake root ref to ensure that
             # pre-processor correctly operates on fake root

--- a/panel/template/base.py
+++ b/panel/template/base.py
@@ -190,23 +190,24 @@ class BaseTemplate(param.Parameterized, ServableMixin):
                 if self._design._apply_hooks not in obj._hooks:
                     obj._hooks.append(self._design._apply_hooks)
 
-            # Alias model ref with the fake root ref to ensure that
-            # pre-processor correctly operates on fake root
-            for sub in obj.select(Viewable):
-                submodel = sub._models.get(mref)
-                if submodel is None:
-                    continue
-                sub._models[ref] = submodel
-                if isinstance(sub, HoloViews) and mref in sub._plots:
-                    sub._plots[ref] = sub._plots.get(mref)
+                # Alias model ref with the fake root ref to ensure that
+                # pre-processor correctly operates on fake root
+                for sub in obj.select(Viewable):
+                    submodel = sub._models.get(mref)
+                    if submodel is None:
+                        continue
+                    sub._models[ref] = submodel
+                    if isinstance(sub, HoloViews) and mref in sub._plots:
+                        sub._plots[ref] = sub._plots.get(mref)
 
-            # Apply any template specific hooks to root
-            self._apply_root(name, model, tags)
+                # Apply any template specific hooks to root
+                self._apply_root(name, model, tags)
 
-            # Add document
-            obj._documents[document] = model
-            objs.append(obj)
-            models.append(model)
+                # Add document
+                obj._documents[document] = model
+                objs.append(obj)
+                models.append(model)
+
             add_to_doc(model, document, hold=bool(comm))
             document.on_session_destroyed(obj._server_destroy) # type: ignore
 

--- a/panel/template/base.py
+++ b/panel/template/base.py
@@ -42,7 +42,9 @@ from ..theme.base import (
     THEME_CSS, THEMES, DefaultTheme, Design, Theme,
 )
 from ..util import isurl, relative_to, url_path
-from ..viewable import Renderable, ServableMixin, Viewable
+from ..viewable import (
+    MimeRenderMixin, Renderable, ServableMixin, Viewable,
+)
 from ..widgets import Button
 from ..widgets.indicators import BooleanIndicator, LoadingSpinner
 
@@ -71,7 +73,7 @@ _server_info: str = (
 FAVICON_URL: str = "/static/extensions/panel/images/favicon.ico"
 
 
-class BaseTemplate(param.Parameterized, ServableMixin):
+class BaseTemplate(param.Parameterized, MimeRenderMixin, ServableMixin):
 
     location = param.Boolean(default=False, doc="""
         Whether to add a Location component to this Template.

--- a/panel/template/bootstrap/bootstrap.html
+++ b/panel/template/bootstrap/bootstrap.html
@@ -154,5 +154,8 @@
 {% if notifications %}
 {{ embed(roots.notifications) }}
 {% endif %}
+{% if browser_info %}
+{{ embed(roots.browser_info) }}
+{% endif %}
 
 {% endblock %}

--- a/panel/template/fast/grid/fast_grid_template.html
+++ b/panel/template/fast/grid/fast_grid_template.html
@@ -360,5 +360,8 @@ document.addEventListener('DOMContentLoaded', (event) => {
 {% if notifications %}
 {{ embed(roots.notifications) }}
 {% endif %}
+{% if browser_info %}
+{{ embed(roots.browser_info) }}
+{% endif %}
 
 {% endblock %}

--- a/panel/template/fast/list/fast_list_template.html
+++ b/panel/template/fast/list/fast_list_template.html
@@ -253,5 +253,8 @@ document.addEventListener('DOMContentLoaded', (event) => {
 {% if notifications %}
 {{ embed(roots.notifications) }}
 {% endif %}
+{% if browser_info %}
+{{ embed(roots.browser_info) }}
+{% endif %}
 
 {% endblock %}

--- a/panel/template/golden/golden.html
+++ b/panel/template/golden/golden.html
@@ -182,5 +182,8 @@
 {% if notifications %}
 {{ embed(roots.notifications) }}
 {% endif %}
+{% if browser_info %}
+{{ embed(roots.browser_info) }}
+{% endif %}
 
 {% endblock %}

--- a/panel/template/material/material.html
+++ b/panel/template/material/material.html
@@ -180,5 +180,8 @@
   {% if notifications %}
   {{ embed(roots.notifications) }}
   {% endif %}
+  {% if browser_info %}
+  {{ embed(roots.browser_info) }}
+  {% endif %}
 </div>
 {% endblock %}

--- a/panel/template/react/react.html
+++ b/panel/template/react/react.html
@@ -267,5 +267,8 @@
 {% if notifications %}
 {{ embed(roots.notifications) }}
 {% endif %}
+{% if browser_info %}
+{{ embed(roots.browser_info) }}
+{% endif %}
 
 {% endblock %}

--- a/panel/template/vanilla/vanilla.html
+++ b/panel/template/vanilla/vanilla.html
@@ -176,5 +176,8 @@
 {% if notifications %}
 {{ embed(roots.notifications) }}
 {% endif %}
+{% if browser_info %}
+{{ embed(roots.browser_info) }}
+{% endif %}
 
 {% endblock %}

--- a/panel/tests/test_template.py
+++ b/panel/tests/test_template.py
@@ -199,7 +199,7 @@ def test_list_template_insert_order(template_class):
 
     template.main.extend([2, 3])
 
-    objs = list(template._render_items.values())[3:]
+    objs = list(template._render_items.values())[4:]
     ((obj1, tag1), (obj2, tag2), (obj3, tag3), (obj4, tag4)) = objs
 
     assert tag1 == tag2 == tag3 == tag4 == ['main']
@@ -228,7 +228,7 @@ def test_grid_template_override():
     template.main[0, 0] = item
     template.main[0, 0] = override
 
-    objs = list(template._render_items.values())[3:]
+    objs = list(template._render_items.values())[4:]
     assert len(objs) == 1
     ((obj, tags),) = objs
 

--- a/panel/tests/ui/io/test_browser.py
+++ b/panel/tests/ui/io/test_browser.py
@@ -1,0 +1,34 @@
+import time
+
+import pytest
+
+pytestmark = pytest.mark.ui
+
+from panel.config import config
+from panel.io.server import serve
+from panel.io.state import state
+from panel.pane import Markdown
+
+
+def test_browser_sync(page, port):
+    info = {}
+    def app():
+        with config.set(browser_info=True):
+            sync = lambda *events: info.update({e.name: e.new for e in events})
+            state.browser_info.param.watch(sync, list(state.browser_info.param))
+            Markdown('# Test').servable()
+
+    serve(app, port=port, threaded=True, show=False)
+
+    time.sleep(0.2)
+
+    page.goto(f"http://localhost:{port}")
+
+    time.sleep(0.2)
+
+    assert info['dark_mode'] == page.evaluate("() => window.matchMedia('(prefers-color-scheme: dark)').matches")
+    assert info['device_pixel_ratio'] == page.evaluate('() => window.devicePixelRatio')
+    assert info['language'] == page.evaluate('() => navigator.language')
+    assert info['webdriver'] == page.evaluate('() => navigator.webdriver')
+    assert info['timezone'] == page.evaluate('() => Intl.DateTimeFormat().resolvedOptions().timeZone')
+    assert info['timezone_offset'] == page.evaluate('() => new Date().getTimezoneOffset()')

--- a/panel/tests/ui/io/test_convert.py
+++ b/panel/tests/ui/io/test_convert.py
@@ -154,7 +154,7 @@ def wait_for_app(launch_app, app, page, runtime, wait=True, **kwargs):
 
     convert_apps(
         [app_path], app_path.parent, runtime=runtime, build_pwa=False,
-        prerender=False, panel_version='local', **kwargs
+        prerender=False, panel_version='local', inline=True, **kwargs
     )
 
     msgs = []


### PR DESCRIPTION
Provides various pieces information about the browser.

- `dark_mode`: Whether the user prefers dark mode.
- `device_pixel_ratio`: Provides the ratio of the resolution in physical pixels to the resolution in CSS pixels for the current display device.
- `language`: The preferred language of the user, usually the language of the browser UI.
- `timezone`: The timezone configured as the local timezone of the user.
- `timezone_offset`: The time offset from UTC in minutes.
- `webdriver`: Indicates whether the user agent is controlled by automation.