### PR TITLE
Fix issues applying loading indicator CSS classes

### DIFF
--- a/panel/io/convert.py
+++ b/panel/io/convert.py
@@ -312,7 +312,7 @@ def script_to_html(
     # Collect resources
     resources = Resources(mode='cdn')
     loading_base = (DIST_DIR / "css" / "loading.css").read_text()
-    spinner_css = loading_css(shadow_dom=False)
+    spinner_css = loading_css()
     css_resources.append(
         f'<style type="text/css">\n{loading_base}\n{spinner_css}\n</style>'
     )

--- a/panel/io/resources.py
+++ b/panel/io/resources.py
@@ -182,14 +182,13 @@ def component_resource_path(component, attr, path):
     rel_path = component_rel_path(component, path).replace(os.path.sep, '/')
     return f'{component_path}{component.__module__}/{component.__name__}/{attr}/{rel_path}'
 
-def loading_css(shadow_dom=True):
+def loading_css():
     from ..config import config
     with open(ASSETS_DIR / f'{config.loading_spinner}_spinner.svg', encoding='utf-8') as f:
         svg = f.read().replace('\n', '').format(color=config.loading_color)
     b64 = b64encode(svg.encode('utf-8')).decode('utf-8')
-    cls = ':host(.pn-loading)' if shadow_dom else '.pn-loading'
     return textwrap.dedent(f"""
-    {cls}.{config.loading_spinner}:before {{
+    :host(.pn-loading).{config.loading_spinner}:before, .pn-loading.{config.loading_spinner}:before {{
       background-image: url("data:image/svg+xml;base64,{b64}");
       background-size: auto calc(min(50%, {config.loading_max_height}px));
     }}""")

--- a/panel/links.py
+++ b/panel/links.py
@@ -447,7 +447,7 @@ class CallbackGenerator(object):
                     if isinstance(v, BkModel) and k not in references:
                         references[k] = v
 
-            if isinstance(target, HoloViews):
+            if isinstance(target, HoloViews) and ref in target._plots:
                 tgt = target._plots[ref][0]
             else:
                 tgt = target

--- a/panel/pane/holoviews.py
+++ b/panel/pane/holoviews.py
@@ -125,7 +125,7 @@ class HoloViews(PaneBase):
 
     def _param_change(self, *events: param.parameterized.Event) -> None:
         self._track_overrides(*(e for e in events if e.name in Layoutable.param))
-        super()._param_change(*(e for e in events if e.name in self._overrides))
+        super()._param_change(*(e for e in events if e.name in self._overrides+['css_classes']))
 
     @param.depends('center', 'widget_location', watch=True)
     def _update_layout(self):

--- a/panel/pane/plot.py
+++ b/panel/pane/plot.py
@@ -92,7 +92,7 @@ class Bokeh(PaneBase):
 
     def _param_change(self, *events: param.parameterized.Event) -> None:
         self._track_overrides(*(e for e in events if e.name in Layoutable.param))
-        super()._param_change(*(e for e in events if e.name in self._overrides))
+        super()._param_change(*(e for e in events if e.name in self._overrides+['css_classes']))
 
     @classmethod
     def applies(cls, obj: Any) -> float | bool | None:

--- a/panel/tests/pane/test_base.py
+++ b/panel/tests/pane/test_base.py
@@ -60,7 +60,10 @@ def test_pane_linkable_params(pane, document, comm):
 
 @pytest.mark.parametrize('pane', all_panes+[Bokeh])
 def test_pane_loading_param(pane, document, comm):
-    p = pane()
+    try:
+        p = pane()
+    except ImportError:
+        pytest.skip("Dependent library could not be imported.")
 
     root = p.get_root(document, comm)
     model = p._models[root.ref['id']][0]

--- a/panel/tests/pane/test_base.py
+++ b/panel/tests/pane/test_base.py
@@ -3,7 +3,9 @@ import pytest
 
 import panel as pn
 
+from panel.config import config
 from panel.interact import interactive
+from panel.io.loading import LOADING_INDICATOR_CSS_CLASS
 from panel.layout import Row
 from panel.links import CallbackGenerator
 from panel.pane import (
@@ -39,7 +41,7 @@ def test_pane_layout_properties(pane, document, comm):
     check_layoutable_properties(p, model)
 
 
-@pytest.mark.parametrize('pane', all_panes+[Bokeh])
+@pytest.mark.parametrize('pane', all_panes+[Bokeh, HoloViews])
 def test_pane_linkable_params(pane, document, comm):
     try:
         p = pane()
@@ -55,6 +57,22 @@ def test_pane_linkable_params(pane, document, comm):
         raise e
     finally:
         CallbackGenerator.error = False
+
+@pytest.mark.parametrize('pane', all_panes+[Bokeh])
+def test_pane_loading_param(pane, document, comm):
+    p = pane()
+
+    root = p.get_root(document, comm)
+    model = p._models[root.ref['id']][0]
+
+    p.loading = True
+
+    css_classes = [LOADING_INDICATOR_CSS_CLASS, config.loading_spinner]
+    assert all(cls in model.css_classes for cls in css_classes)
+
+    p.loading = False
+
+    assert not any(cls in model.css_classes for cls in css_classes)
 
 @pytest.mark.parametrize('pane', all_panes+[Bokeh])
 def test_pane_untracked_watchers(pane, document, comm):


### PR DESCRIPTION
Some panes weren't syncing the `css_classes` correctly. This resolves that issue and adds some tests.