### PR TITLE
Clean up resource bundling

### DIFF
--- a/panel/io/save.py
+++ b/panel/io/save.py
@@ -26,7 +26,7 @@ from ..config import config
 from .embed import embed_state
 from .model import add_to_doc
 from .resources import (
-    BASE_TEMPLATE, DEFAULT_TITLE, Bundle, Resources, bundle_resources,
+    BASE_TEMPLATE, DEFAULT_TITLE, Resources, bundle_resources,
     set_resource_mode,
 )
 from .state import state
@@ -159,7 +159,6 @@ def file_html(
         )
         title = _title_from_models(models_seq, title)
         bundle = bundle_resources(models_seq, resources)
-        bundle = Bundle.from_bokeh(bundle)
         return html_page_for_render_items(
             bundle, docs_json, render_items, title=title, template=template,
             template_variables=template_variables


### PR DESCRIPTION
Resource bundling code has evolved a lot over time after we first created a custom `Resources` object and then subsequently created custom `bundle_resources` and `Bundle` implementations. Due to this some of the code that adjusts paths to point to the Panel CDN had been duplicated making it difficult to figure out what happens where. We now adjust all paths via the `Resources` method and the `Bundle` is now only responsible for rendering the JS and CSS blocks for the `<head>` tag without any logic for inferring resources or adjusting paths being mixed into the implementation.