### PR TITLE
Remove pkg_resources

### DIFF
--- a/panel/auth.py
+++ b/panel/auth.py
@@ -7,7 +7,6 @@ import re
 import urllib.parse as urlparse
 import uuid
 
-from importlib.metadata import entry_points
 from typing import List, Tuple, Type
 
 import tornado
@@ -19,6 +18,7 @@ from tornado.httputil import url_concat
 from tornado.web import RequestHandler
 
 from .config import config
+from .entry_points import entry_points_for
 from .io import state
 from .io.resources import ERROR_TEMPLATE, _env
 from .util import base64url_decode, base64url_encode
@@ -854,7 +854,7 @@ AUTH_PROVIDERS = {
 }
 
 # Populate AUTH Providers from external extensions
-for entry_point in entry_points('panel.auth'):
-    AUTH_PROVIDERS[entry_point.name] = entry_point.resolve()
+for entry_point in entry_points_for('panel.auth'):
+    AUTH_PROVIDERS[entry_point.name] = entry_point.load()
 
 config.param.objects(False)['_oauth_provider'].objects = list(AUTH_PROVIDERS.keys())

--- a/panel/auth.py
+++ b/panel/auth.py
@@ -7,9 +7,9 @@ import re
 import urllib.parse as urlparse
 import uuid
 
+from importlib.metadata import entry_points
 from typing import List, Tuple, Type
 
-import pkg_resources
 import tornado
 
 from bokeh.server.auth_provider import AuthProvider
@@ -854,7 +854,7 @@ AUTH_PROVIDERS = {
 }
 
 # Populate AUTH Providers from external extensions
-for entry_point in pkg_resources.iter_entry_points('panel.auth'):
+for entry_point in entry_points('panel.auth'):
     AUTH_PROVIDERS[entry_point.name] = entry_point.resolve()
 
 config.param.objects(False)['_oauth_provider'].objects = list(AUTH_PROVIDERS.keys())

--- a/panel/config.py
+++ b/panel/config.py
@@ -786,12 +786,13 @@ class panel_extension(_pyviz_extension):
             )
 
     def _load_entry_points(self):
-        ''' Load entry points from external packages
-        Import is performed here so any importlib/pkg_resources
+        """
+        Load entry points from external packages.
+        Import is performed here, so any importlib
         can be easily bypassed by switching off the configuration flag.
-        also, no reason to waste time on importing this module
-        if it wont be used.
-        '''
+        Also, there is no reason to waste time importing this module
+        if it won't be used.
+        """
         from .entry_points import load_entry_points
         load_entry_points('panel.extension')
 

--- a/panel/entry_points.py
+++ b/panel/entry_points.py
@@ -4,23 +4,23 @@ It is copied almost entirely from the entrypoint handling in the excellent
 Hypothesis package https://github.com/HypothesisWorks/hypothesis.
 """
 
-try:
-    from importlib import metadata as importlib_metadata
-except ImportError:
-    import importlib_metadata  # type: ignore  # mypy thinks this is a redefinition
+import importlib.metadata
 
-def entry_points_for(group):
+from typing import Iterator
+
+
+def entry_points_for(group: str) -> Iterator[importlib.metadata.EntryPoint]:
     try:
-        eps = importlib_metadata.entry_points(group=group)
+        eps = importlib.metadata.entry_points(group=group)
     except TypeError:
         # Load-time selection requires Python >= 3.10 or importlib_metadata >= 3.6,
         # so we'll retain this fallback logic for some time to come.  See also
         # https://importlib-metadata.readthedocs.io/en/latest/using.html
-        eps = importlib_metadata.entry_points().get(group, [])
+        eps = importlib.metadata.entry_points().get(group, [])
     yield from eps
 
 
-def load_entry_points(group):
+def load_entry_points(group: str) -> None:
     for entry in entry_points_for(group):  # pragma: no cover
         hook = entry.load()
         if callable(hook):

--- a/panel/entry_points.py
+++ b/panel/entry_points.py
@@ -5,43 +5,19 @@ Hypothesis package https://github.com/HypothesisWorks/hypothesis.
 """
 
 try:
-    # We prefer to use importlib.metadata, or the backport on Python <= 3.7,
-    # because it's much faster than pkg_resources (200ms import time speedup).
-    try:
-        from importlib import metadata as importlib_metadata
-    except ImportError:
-        import importlib_metadata  # type: ignore  # mypy thinks this is a redefinition
-
-    def entry_points_for(group):
-        try:
-            eps = importlib_metadata.entry_points(group=group)
-        except TypeError:
-            # Load-time selection requires Python >= 3.10 or importlib_metadata >= 3.6,
-            # so we'll retain this fallback logic for some time to come.  See also
-            # https://importlib-metadata.readthedocs.io/en/latest/using.html
-            eps = importlib_metadata.entry_points().get(group, [])
-        yield from eps
-
+    from importlib import metadata as importlib_metadata
 except ImportError:
-    # But if we're not on Python >= 3.8 and the importlib_metadata backport
-    # is not installed, we fall back to pkg_resources anyway.
+    import importlib_metadata  # type: ignore  # mypy thinks this is a redefinition
+
+def entry_points_for(group):
     try:
-        import pkg_resources
-    except ImportError:
-        from .util.warnings import warn
-
-        warn(
-            "Under Python <= 3.7, Panel requires either the importlib_metadata "
-            "or setuptools package in order to load plugins via entrypoints.",
-        )
-
-        def entry_points_for(group):
-            yield from ()
-
-    else:
-
-        def entry_points_for(group):
-            yield from pkg_resources.iter_entry_points(group)
+        eps = importlib_metadata.entry_points(group=group)
+    except TypeError:
+        # Load-time selection requires Python >= 3.10 or importlib_metadata >= 3.6,
+        # so we'll retain this fallback logic for some time to come.  See also
+        # https://importlib-metadata.readthedocs.io/en/latest/using.html
+        eps = importlib_metadata.entry_points().get(group, [])
+    yield from eps
 
 
 def load_entry_points(group):

--- a/panel/io/convert.py
+++ b/panel/io/convert.py
@@ -226,11 +226,11 @@ def script_to_html(
     elif isinstance(requirements, str) and pathlib.Path(requirements).is_file():
         requirements = pathlib.Path(requirements).read_text().split('/n')
         try:
-            import pkg_resources
-            parsed = pkg_resources.parse_requirements(requirements)
-            requirements = [str(requirement) for requirement in parsed]
-        except ImportError:
-            pass
+            from packaging.requirements import Requirement
+            requirements = [
+                r2 for r in requirements
+                if (r2 := r.split("#")[0].strip()) and Requirement(r2)
+            ]
         except Exception as e:
             raise ValueError(
                 f'Requirements parser raised following error: {e}'

--- a/panel/io/rest.py
+++ b/panel/io/rest.py
@@ -3,7 +3,6 @@ import os
 import tempfile
 import traceback
 
-from importlib.metadata import entry_points
 from runpy import run_path
 from unittest.mock import MagicMock
 from urllib.parse import parse_qs
@@ -13,6 +12,7 @@ import param
 from tornado import web
 from tornado.wsgi import WSGIContainer
 
+from ..entry_points import entry_points_for
 from .state import state
 
 
@@ -178,5 +178,5 @@ REST_PROVIDERS = {
 }
 
 # Populate REST Providers from external extensions
-for entry_point in entry_points('panel.io.rest'):
-    REST_PROVIDERS[entry_point.name] = entry_point.resolve()
+for entry_point in entry_points_for('panel.io.rest'):
+    REST_PROVIDERS[entry_point.name] = entry_point.load()

--- a/panel/io/rest.py
+++ b/panel/io/rest.py
@@ -3,12 +3,12 @@ import os
 import tempfile
 import traceback
 
+from importlib.metadata import entry_points
 from runpy import run_path
 from unittest.mock import MagicMock
 from urllib.parse import parse_qs
 
 import param
-import pkg_resources
 
 from tornado import web
 from tornado.wsgi import WSGIContainer
@@ -178,5 +178,5 @@ REST_PROVIDERS = {
 }
 
 # Populate REST Providers from external extensions
-for entry_point in pkg_resources.iter_entry_points('panel.io.rest'):
+for entry_point in entry_points('panel.io.rest'):
     REST_PROVIDERS[entry_point.name] = entry_point.resolve()


### PR DESCRIPTION
Fixes #3282 

`pkg_resources.parse_requirements` was replaced with `from packaging.requirements import Requirement` and was tested on this:
``` python
requirements = """
panel  # this is panel
 #2
datashader >=0.11.1; python_version < '3.11'
  
"""

import pkg_resources
parsed = pkg_resources.parse_requirements(requirements)
[str(requirement) for requirement in parsed]

from packaging.requirements import Requirement
[r2 for r in requirements.split("\n") if (r2 := r.split("#")[0].strip()) and Requirement(r2)]

```

![image](https://user-images.githubusercontent.com/19758978/226561494-1027542c-f05a-464f-a3ba-24e2e21b0e90.png)
