### PR TITLE
Docs build

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -54,12 +54,6 @@ jobs:
         run: |
           conda activate test-environment
           pip install --use-deprecated=legacy-resolver pyecharts
-      - name: Install bokeh 3.0 compatibility packages
-        run: |
-          conda activate test-environment
-          conda uninstall holoviews jupyter_bokeh --force -y --offline || echo "packages already removed"
-          pip install "git+https://github.com/holoviz/holoviews.git"
-          pip install "git+https://github.com/bokeh/jupyter_bokeh.git"
       - name: bokeh sampledata
         run: |
           conda activate test-environment

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -24,8 +24,8 @@ on:
 jobs:
   build_docs:
     name: Documentation
-    runs-on: 'ubuntu-latest'
-    timeout-minutes: 120
+    runs-on: 'macos-latest'
+    timeout-minutes: 180
     defaults:
       run:
         shell: bash -l {0}


### PR DESCRIPTION
I think the docs build fails because of a memory issue [ref1](https://github.com/actions/runner/issues/2468). This changes the docs build to `macos-latest`, which has double the ram [ref2](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources). 

This is not a good solution, but it can give us time to figure out what to do next.