### PR TITLE
Remove layout compatibility mode flag

### DIFF
--- a/panel/config.py
+++ b/panel/config.py
@@ -124,13 +124,6 @@ class _config(_base_config):
     exception_handler = param.Callable(default=None, doc="""
         General exception handler for events.""")
 
-    layout_compatibility = param.Boolean(default=True, doc="""
-        Enables the layout compatibility mode. This mode aims to provide
-        backward compatibility for layouts to behave like they did before
-        version 1. When a sizing_mode is incorrectly defined according to
-        the new layout modes a warning will be raised. The compatibility
-        mode will be disabled by default starting in v1.1.0""")
-
     load_entry_points = param.Boolean(default=True, doc="""
         Load entry points from external packages.""")
 


### PR DESCRIPTION
In our testing we found that these warnings were not really all that helpful and it's pretty unlikely that we can (or should) ever remove the layout compatibility. Accurately setting `sizing_mode` in the new setup is not straightforward so we want to help the user as much as possible.