### PR TITLE
Describe on_session_destroyed callback signature

### DIFF
--- a/doc/how_to/callbacks/session.md
+++ b/doc/how_to/callbacks/session.md
@@ -12,6 +12,15 @@ WIP
 
 ## pn.state.on_session_destroyed
 
-In many cases it is useful to define on_session_destroyed callbacks to perform any custom cleanup that is required, e.g,  dispose  a database engine, or when a user is logged out. These callbacks can be registered with `pn.state.on_session_destroyed(callback)`
+In many cases it is useful to define `on_session_destroyed` callbacks to perform any custom cleanup that is required, e.g,  dispose  a database engine, log out a user etc.
+
+These callbacks should have the signature
+
+```python
+def callback(session_context):
+    ...
+```
+
+and can be registered with `pn.state.on_session_destroyed(callback)`.
 
 ## Related Resources


### PR DESCRIPTION
Victor was struggling with the callback signature in https://discourse.holoviz.org/t/how-to-use-pn-state-on-session-destroyed/5121. It was not clear to him the callback must have a `session_context` argument.

I add a description of this to the docs.