### PR TITLE
Allow passing methods with dependencies by reference

### DIFF
--- a/panel/tests/test_reactive.py
+++ b/panel/tests/test_reactive.py
@@ -196,6 +196,33 @@ def test_pass_bind_function_by_reference():
 
     assert text_input.width == 111
 
+def test_pass_parameterized_method_by_reference():
+
+    class Test(param.Parameterized):
+
+        a = param.Parameter(1)
+        b = param.Parameter(2)
+
+        @param.depends('a')
+        def dep_a(self):
+            return self.a
+
+        @param.depends('dep_a', 'b')
+        def dep_ab(self):
+            return self.dep_a() + self.b
+
+    test = Test()
+    int_input = IntInput(start=0, end=400, value=test.dep_ab)
+
+    assert int_input.value == 3
+
+    test.a = 3
+
+    assert int_input.value == 5
+
+    test.b = 5
+
+    assert int_input.value == 8
 
 def test_pass_depends_function_by_reference():
     int_input = IntInput(start=0, end=400, value=42)

--- a/panel/util/__init__.py
+++ b/panel/util/__init__.py
@@ -174,6 +174,32 @@ def get_method_owner(meth):
         return meth.__self__
 
 
+def extract_dependencies(function):
+    """
+    Extract references from a method or function that declares the references.
+    """
+    subparameters = list(function._dinfo['dependencies'])+list(function._dinfo['kw'].values())
+    params = []
+    for p in subparameters:
+        if isinstance(p, str):
+            owner = get_method_owner(function)
+            *subps, p = p.split('.')
+            for subp in subps:
+                owner = getattr(owner, subp, None)
+                if owner is None:
+                    raise ValueError('Cannot depend on undefined sub-parameter {p!r}.')
+            if p in owner.param:
+                pobj = owner.param[p]
+                if pobj not in params:
+                    params.append(pobj)
+            else:
+                for sp in extract_dependencies(getattr(owner, p)):
+                    if sp not in params:
+                        params.append(sp)
+        elif p not in params:
+            params.append(p)
+    return params
+
 
 def value_as_datetime(value):
     """


### PR DESCRIPTION
When I implemented passing parameters and functions by reference I had note considered methods on Parameterized objects. This PR remedies that and adds tests to ensure this continues to work. 