### PR TITLE
Tabulator: handle Numpy 1.24 warning when a table contains datetime columns with NaT values

### DIFF
--- a/panel/reactive.py
+++ b/panel/reactive.py
@@ -42,7 +42,8 @@ from .models.reactive_html import (
     DOMEvent, ReactiveHTML as _BkReactiveHTML, ReactiveHTMLParser,
 )
 from .util import (
-    classproperty, edit_readonly, escape, eval_function, updating,
+    BOKEH_JS_NAT, classproperty, edit_readonly, escape, eval_function,
+    updating,
 )
 from .viewable import Layoutable, Renderable, Viewable
 
@@ -1270,7 +1271,8 @@ class ReactiveData(SyncableData):
         converted: List | np.ndarray | None = None
         if dtype.kind == 'M':
             if values.dtype.kind in 'if':
-                converted = (values * 10e5).astype(dtype)
+                NATs = values == BOKEH_JS_NAT
+                converted = np.where(NATs, np.nan, values * 10e5).astype(dtype)
         elif dtype.kind == 'O':
             if (all(isinstance(ov, dt.date) for ov in old_values) and
                 not all(isinstance(iv, dt.date) for iv in values)):

--- a/panel/util/__init__.py
+++ b/panel/util/__init__.py
@@ -39,6 +39,9 @@ from .checks import (  # noqa
 
 bokeh_version = Version(bokeh.__version__)
 
+# Bokeh serializes NaT as this value
+# Discussion on why https://github.com/bokeh/bokeh/pull/10449/files#r479988469
+BOKEH_JS_NAT = -9223372036854776.0
 
 PARAM_NAME_PATTERN = re.compile(r'^.*\d{5}$')
 


### PR DESCRIPTION
Numpy 1.24 added more [warnings when casting](https://numpy.org/doc/stable/release/1.24.0-notes.html#numpy-now-gives-floating-point-errors-in-casts). Arrays that have NaT values are serialized by Bokeh to a large negative float value, that led to that warning being emitted when Panel tries to cast it back to a numpy NaT.

The suggested change consists in turning that special Bokeh value into NaN first, before casting to datetime. Numpy will then convert it to NaT, without complaining.

Note that the test suite currently only installs Numpy 1.23. I tested the change locally.

---

The warning that was emitted:
```
RuntimeWarning: invalid value encountered in cast
```

To reproduce, modify a value in a Tabulator table that has a datetime column with at least one NaT.