### PR TITLE
Reduce number of Pandas warnings emitted when interacting with the Tabulator widget

### DIFF
--- a/examples/reference/widgets/Tabulator.ipynb
+++ b/examples/reference/widgets/Tabulator.ipynb
@@ -3,9 +3,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import datetime as dt\n",
@@ -102,9 +100,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "df = pd.DataFrame({\n",
@@ -132,9 +128,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from bokeh.models.widgets.tables import NumberFormatter, BooleanFormatter\n",
@@ -166,9 +160,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "tabulator_formatters = {\n",
@@ -193,9 +185,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from bokeh.models.widgets.tables import CheckboxEditor, NumberEditor, SelectEditor\n",
@@ -219,9 +209,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "tabulator_editors = {\n",
@@ -253,9 +241,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "edit_table.on_edit(lambda e: print(e.column, e.row, e.old, e.value))"
@@ -277,9 +263,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "custom_df = pd._testing.makeMixedDataFrame().iloc[:3, :]\n",
@@ -297,9 +281,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "pn.widgets.Tabulator(custom_df, widths=130)"
@@ -315,9 +297,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "pn.widgets.Tabulator(custom_df, widths={'index': '5%', 'A': '15%', 'B': '15%', 'C': '25%', 'D': '40%'}, sizing_mode='stretch_width')"
@@ -335,9 +315,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "pn.widgets.Tabulator(custom_df, layout='fit_data', width=400)"
@@ -353,9 +331,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "pn.widgets.Tabulator(custom_df, layout='fit_data_stretch', width=400)"
@@ -371,9 +347,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "pn.widgets.Tabulator(custom_df, layout='fit_data_fill', width=400)"
@@ -389,9 +363,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "pn.widgets.Tabulator(custom_df, layout='fit_data_table')"
@@ -409,9 +381,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "pn.widgets.Tabulator(custom_df, layout='fit_columns', width=650)"
@@ -429,9 +399,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "pn.widgets.Tabulator(df.iloc[:, :2], header_align='center', text_align={'int': 'center', 'float': 'left'}, widths=150)"
@@ -451,9 +419,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "style_df = pd.DataFrame(np.random.randn(4, 5), columns=list('ABCDE'))\n",
@@ -470,9 +436,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "def color_negative_red(val):\n",
@@ -534,9 +498,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "sel_df = pd.DataFrame(np.random.randn(3, 5), columns=list('ABCDE'))\n",
@@ -555,9 +517,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "select_table.selection = [1]\n",
@@ -582,9 +542,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "pn.widgets.Tabulator(sel_df, selection=[0, 2], selectable='checkbox')"
@@ -600,9 +558,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "select_table = pn.widgets.Tabulator(sel_df, selectable_rows=lambda df: list(range(0, len(df), 2)))\n",
@@ -619,9 +575,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "def click(event):\n",
@@ -648,9 +602,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "wide_df = pd._testing.makeCustomDataframe(3, 10, r_idx_names=['index'])\n",
@@ -670,9 +622,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "date_df = pd._testing.makeTimeDataFrame().iloc[:5, :2]\n",
@@ -696,9 +646,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from bokeh.sampledata.periodic_table import elements\n",
@@ -728,9 +676,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "periodic_table.expanded"
@@ -748,9 +694,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "pn.widgets.Tabulator(date_df.iloc[:3], groups={'Group 1': ['A', 'B'], 'Group 2': ['C', 'D']})"
@@ -768,9 +712,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from bokeh.sampledata.autompg import autompg\n",
@@ -792,9 +734,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from bokeh.sampledata.population import data as population_data \n",
@@ -818,9 +758,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "large_df = pd._testing.makeCustomDataframe(100000, 5)\n",
@@ -837,9 +775,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "medium_df = pd._testing.makeCustomDataframe(1000, 5)\n",
@@ -868,9 +804,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "filter_table = pn.widgets.Tabulator(pd._testing.makeMixedDataFrame())\n",
@@ -887,9 +821,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "filter_table.add_filter((0, 3), 'A')"
@@ -905,9 +837,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "slider = pn.widgets.RangeSlider(start=0, end=3, name='A Filter')\n",
@@ -924,9 +854,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "select = pn.widgets.MultiSelect(options=['foo1', 'foo2', 'foo3', 'foo4', 'foo5'], name='C Filter')\n",
@@ -943,9 +871,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "pn.Row(\n",
@@ -964,9 +890,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "select.value = ['foo1', 'foo2']\n",
@@ -990,9 +914,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import sqlite3\n",
@@ -1016,9 +938,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "director_filter = pn.widgets.TextInput(name='Director filter', value='Chaplin')\n",
@@ -1045,9 +965,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "tabulator_editors = {\n",
@@ -1079,9 +997,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "header_filter_table.filters"
@@ -1099,9 +1015,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "movie_filters = {\n",
@@ -1134,9 +1048,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "download_df = pd.DataFrame(np.random.randn(4, 5), columns=list('ABCDE'))\n",
@@ -1173,9 +1085,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "button_table = pn.widgets.Tabulator(df, buttons={\n",
@@ -1204,9 +1114,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "stream_df = pd.DataFrame(np.random.randn(5, 5), columns=list('ABCDE'))\n",
@@ -1225,9 +1133,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "def stream_data(follow=True):\n",
@@ -1247,9 +1153,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "stream_data(follow=False)"
@@ -1267,9 +1171,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "patch_table = pn.widgets.Tabulator(df[['int', 'float', 'str', 'bool']].copy())\n",
@@ -1298,9 +1200,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "patch_table.patch({\n",
@@ -1316,9 +1216,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "tags": []
-   },
+   "metadata": {},
    "source": [
     "## Static Configuration\n",
     "\n",

--- a/examples/reference/widgets/Tabulator.ipynb
+++ b/examples/reference/widgets/Tabulator.ipynb
@@ -3,7 +3,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "import datetime as dt\n",
@@ -100,7 +102,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "df = pd.DataFrame({\n",
@@ -128,7 +132,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "from bokeh.models.widgets.tables import NumberFormatter, BooleanFormatter\n",
@@ -160,7 +166,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "tabulator_formatters = {\n",
@@ -172,7 +180,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -186,7 +193,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "from bokeh.models.widgets.tables import CheckboxEditor, NumberEditor, SelectEditor\n",
@@ -201,7 +210,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -211,7 +219,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "tabulator_editors = {\n",
@@ -243,7 +253,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "edit_table.on_edit(lambda e: print(e.column, e.row, e.old, e.value))"
@@ -265,7 +277,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "custom_df = pd._testing.makeMixedDataFrame().iloc[:3, :]\n",
@@ -283,7 +297,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "pn.widgets.Tabulator(custom_df, widths=130)"
@@ -299,7 +315,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "pn.widgets.Tabulator(custom_df, widths={'index': '5%', 'A': '15%', 'B': '15%', 'C': '25%', 'D': '40%'}, sizing_mode='stretch_width')"
@@ -317,7 +335,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "pn.widgets.Tabulator(custom_df, layout='fit_data', width=400)"
@@ -333,7 +353,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "pn.widgets.Tabulator(custom_df, layout='fit_data_stretch', width=400)"
@@ -349,7 +371,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "pn.widgets.Tabulator(custom_df, layout='fit_data_fill', width=400)"
@@ -365,7 +389,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "pn.widgets.Tabulator(custom_df, layout='fit_data_table')"
@@ -383,7 +409,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "pn.widgets.Tabulator(custom_df, layout='fit_columns', width=650)"
@@ -401,7 +429,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "pn.widgets.Tabulator(df.iloc[:, :2], header_align='center', text_align={'int': 'center', 'float': 'left'}, widths=150)"
@@ -421,7 +451,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "style_df = pd.DataFrame(np.random.randn(4, 5), columns=list('ABCDE'))\n",
@@ -438,7 +470,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "def color_negative_red(val):\n",
@@ -500,7 +534,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "sel_df = pd.DataFrame(np.random.randn(3, 5), columns=list('ABCDE'))\n",
@@ -519,7 +555,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "select_table.selection = [1]\n",
@@ -544,7 +582,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "pn.widgets.Tabulator(sel_df, selection=[0, 2], selectable='checkbox')"
@@ -560,7 +600,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "select_table = pn.widgets.Tabulator(sel_df, selectable_rows=lambda df: list(range(0, len(df), 2)))\n",
@@ -577,7 +619,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "def click(event):\n",
@@ -604,7 +648,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "wide_df = pd._testing.makeCustomDataframe(3, 10, r_idx_names=['index'])\n",
@@ -624,7 +670,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "date_df = pd._testing.makeTimeDataFrame().iloc[:5, :2]\n",
@@ -648,7 +696,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "from bokeh.sampledata.periodic_table import elements\n",
@@ -678,7 +728,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "periodic_table.expanded"
@@ -696,7 +748,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "pn.widgets.Tabulator(date_df.iloc[:3], groups={'Group 1': ['A', 'B'], 'Group 2': ['C', 'D']})"
@@ -714,7 +768,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "from bokeh.sampledata.autompg import autompg\n",
@@ -736,7 +792,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "from bokeh.sampledata.population import data as population_data \n",
@@ -760,7 +818,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "large_df = pd._testing.makeCustomDataframe(100000, 5)\n",
@@ -777,7 +837,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "medium_df = pd._testing.makeCustomDataframe(1000, 5)\n",
@@ -806,7 +868,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "filter_table = pn.widgets.Tabulator(pd._testing.makeMixedDataFrame())\n",
@@ -823,7 +887,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "filter_table.add_filter((0, 3), 'A')"
@@ -839,7 +905,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "slider = pn.widgets.RangeSlider(start=0, end=3, name='A Filter')\n",
@@ -856,7 +924,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "select = pn.widgets.MultiSelect(options=['foo1', 'foo2', 'foo3', 'foo4', 'foo5'], name='C Filter')\n",
@@ -873,7 +943,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "pn.Row(\n",
@@ -892,7 +964,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "select.value = ['foo1', 'foo2']\n",
@@ -916,7 +990,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "import sqlite3\n",
@@ -940,7 +1016,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "director_filter = pn.widgets.TextInput(name='Director filter', value='Chaplin')\n",
@@ -967,7 +1045,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "tabulator_editors = {\n",
@@ -999,7 +1079,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "header_filter_table.filters"
@@ -1017,7 +1099,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "movie_filters = {\n",
@@ -1050,7 +1134,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "download_df = pd.DataFrame(np.random.randn(4, 5), columns=list('ABCDE'))\n",
@@ -1087,7 +1173,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "button_table = pn.widgets.Tabulator(df, buttons={\n",
@@ -1116,7 +1204,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "stream_df = pd.DataFrame(np.random.randn(5, 5), columns=list('ABCDE'))\n",
@@ -1135,7 +1225,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "def stream_data(follow=True):\n",
@@ -1155,7 +1247,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "stream_data(follow=False)"
@@ -1173,10 +1267,12 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
-    "patch_table = pn.widgets.Tabulator(df[['int', 'float', 'str', 'bool']])\n",
+    "patch_table = pn.widgets.Tabulator(df[['int', 'float', 'str', 'bool']].copy())\n",
     "patch_table"
    ]
   },
@@ -1202,7 +1298,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "patch_table.patch({\n",
@@ -1252,7 +1350,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/examples/reference/widgets/Tabulator.ipynb
+++ b/examples/reference/widgets/Tabulator.ipynb
@@ -1311,12 +1311,14 @@
     "    'int': [\n",
     "        (slice(0, 2), [3, 2])\n",
     "    ]\n",
-    "})"
+    "}, as_index=False)"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "## Static Configuration\n",
     "\n",

--- a/panel/reactive.py
+++ b/panel/reactive.py
@@ -1317,10 +1317,18 @@ class ReactiveData(SyncableData):
             values = self._convert_column(
                 np.asarray(values), old_raw[col]
             )
-            try:
-                isequal = (old_raw[col] == values).all() # type: ignore
-            except Exception:
-                isequal = False
+
+            isequal = None
+            if hasattr(old_raw, 'columns') and isinstance(values, np.ndarray):
+                try:
+                    isequal = np.array_equal(old_raw[col], values, equal_nan=True)
+                except Exception:
+                    pass
+            if isequal is None:
+                try:
+                    isequal = (old_raw[col] == values).all() # type: ignore
+                except Exception:
+                    isequal = False
             if not isequal:
                 self._update_column(col, values)
                 updated = True

--- a/panel/widgets/tables.py
+++ b/panel/widgets/tables.py
@@ -593,9 +593,12 @@ class BaseTable(ReactiveData, Widget):
         return df, {k if isinstance(k, str) else str(k): self._process_column(v) for k, v in data.items()}
 
     def _update_column(self, column, array):
+        import pandas as pd
+
         self.value[column] = array
         if self._processed is not None and self.value is not self._processed:
-            self._processed[column] = array
+            with pd.option_context('mode.chained_assignment', None):
+                self._processed[column] = array
 
     #----------------------------------------------------------------
     # Public API
@@ -1491,17 +1494,22 @@ class Tabulator(BaseTable):
         super()._update_selected(*events, **kwargs)
 
     def _update_column(self, column: str, array: np.ndarray):
+        import pandas as pd
+
         if self.pagination != 'remote':
             index = self._processed.index.values
             self.value.loc[index, column] = array
-            self._processed[column] = array
+            with pd.option_context('mode.chained_assignment', None):
+                self._processed[column] = array
             return
         nrows = self.page_size
         start = (self.page-1)*nrows
         end = start+nrows
         index = self._processed.iloc[start:end].index.values
         self.value.loc[index, column] = array
-        self._processed.loc[index, column] = array
+
+        with pd.option_context('mode.chained_assignment', None):
+            self._processed.loc[index, column] = array
 
     def _update_selection(self, indices: List[int]):
         if self.pagination != 'remote':

--- a/panel/widgets/tables.py
+++ b/panel/widgets/tables.py
@@ -1500,8 +1500,8 @@ class Tabulator(BaseTable):
         start = (self.page-1)*nrows
         end = start+nrows
         index = self._processed.iloc[start:end].index.values
-        self.value[column].loc[index] = array
-        self._processed[column].loc[index] = array
+        self.value.loc[index, column] = array
+        self._processed.loc[index, column] = array
 
     def _update_selection(self, indices: List[int]):
         if self.pagination != 'remote':


### PR DESCRIPTION
Supersedes https://github.com/holoviz/panel/pull/4414, in which I went down the route of creating copies of the filtered/sorted dataframes to avoid `SettingWithCopyWarning`. It happens that it actually matters that `_processed` is a view of `value`, for patching in particular which updates directly `value`, patches being then also applied to `_processed` as it's a view. So for now I just decided to silence these warnings.

Fixes https://github.com/holoviz/panel/issues/4406