### PR TITLE
Run invalidate_render when switching Tabs

### DIFF
--- a/panel/models/tabs.ts
+++ b/panel/models/tabs.ts
@@ -127,7 +127,10 @@ export class TabsView extends BkTabsView {
     }
 
     if (i in child_views) {
-      show(child_views[i].el)
+      const view: any = child_views[i]
+      show(view.el)
+      if (view.invalidate_render == null)
+	view.invalidate_render()
     }
   }
 }


### PR DESCRIPTION
Fixes some issues with tab contents being rendered incorrectly when switching back to it.