### PR TITLE
Support binary JS -> Python communication in notebooks

### DIFF
--- a/panel/io/notebook.py
+++ b/panel/io/notebook.py
@@ -30,7 +30,8 @@ from bokeh.resources import CDN, INLINE
 from bokeh.settings import _Unset, settings
 from bokeh.util.serialization import make_id
 from pyviz_comms import (
-    PYVIZ_PROXY, Comm, JupyterCommManager as _JupyterCommManager, nb_mime_js,
+    PYVIZ_PROXY, Comm, JupyterCommJS,
+    JupyterCommManager as _JupyterCommManager, nb_mime_js,
 )
 
 from ..util import escape
@@ -277,6 +278,22 @@ def require_components():
                         exports[r] = model_exports[r]
 
     return configs, requirements, exports, skip_import
+
+
+class JupyterCommJSBinary(JupyterCommJS):
+    """
+    Extends pyviz_comms.JupyterCommJS with support for repacking
+    binary buffers.
+    """
+
+    @classmethod
+    def decode(cls, msg):
+        buffers = {i: v for i, v in enumerate(msg['buffers'])}
+        return dict(msg['content']['data'], _buffers=buffers)
+
+class JupyterCommManagerBinary(_JupyterCommManager):
+
+    client_comm = JupyterCommJSBinary
 
 #---------------------------------------------------------------------
 # Public API

--- a/panel/models/comm_manager.py
+++ b/panel/models/comm_manager.py
@@ -23,5 +23,10 @@ class CommManager(Model):
 
     def assemble(self, msg):
         header = msg['header']
+        buffers = msg.pop('_buffers')
+        header['num_buffers'] = len(buffers)
         cls = self._protocol._messages[header['msgtype']]
-        return cls(header, msg['metadata'], msg['content'])
+        msg_obj = cls(header, msg['metadata'], msg['content'])
+        for (bid, buff) in buffers.items():
+            msg_obj.assemble_buffer({'id': bid}, buff.tobytes())
+        return msg_obj

--- a/panel/viewable.py
+++ b/panel/viewable.py
@@ -29,7 +29,7 @@ import param  # type: ignore
 from bokeh.document import Document
 from bokeh.resources import Resources
 from jinja2 import Template
-from pyviz_comms import Comm, JupyterCommManager  # type: ignore
+from pyviz_comms import Comm  # type: ignore
 
 from ._param import Align, Aspect, Margin
 from .config import config, panel_extension
@@ -39,7 +39,8 @@ from .io.embed import embed_state
 from .io.loading import start_loading_spinner, stop_loading_spinner
 from .io.model import add_to_doc, patch_cds_msg
 from .io.notebook import (
-    ipywidget, render_mimebundle, render_model, show_embed, show_server,
+    JupyterCommManagerBinary as JupyterCommManager, ipywidget,
+    render_mimebundle, render_model, show_embed, show_server,
 )
 from .io.save import save
 from .io.state import curdoc_locked, state


### PR DESCRIPTION
Since Bokeh 3.x it is possible for Bokeh to send binary buffers from JS to Python. This PR ensures those messages are handled correctly.

- Required for fixing https://github.com/holoviz/holoviews/issues/5600