### PR TITLE
Add min_width to sync properties for Accordion

### DIFF
--- a/panel/layout/accordion.py
+++ b/panel/layout/accordion.py
@@ -72,7 +72,8 @@ class Accordion(NamedListPanel):
 
     _synced_properties = [
         'active_header_background', 'header_background', 'width',
-        'sizing_mode', 'width_policy', 'height_policy', 'header_color'
+        'sizing_mode', 'width_policy', 'height_policy', 'header_color',
+        'min_width',
     ]
 
     def __init__(self, *objects, **params):

--- a/panel/layout/accordion.py
+++ b/panel/layout/accordion.py
@@ -73,7 +73,7 @@ class Accordion(NamedListPanel):
     _synced_properties = [
         'active_header_background', 'header_background', 'width',
         'sizing_mode', 'width_policy', 'height_policy', 'header_color',
-        'min_width',
+        'min_width', 'max_width'
     ]
 
     def __init__(self, *objects, **params):


### PR DESCRIPTION
This PR adds `min_width` to be synced between for pn.Accordion.

A case could be made for having a default value for it. Maybe 300?

![image](https://user-images.githubusercontent.com/19758978/231844835-c8c0de39-6181-4af8-ac37-6aebf28e0046.png)

![image](https://user-images.githubusercontent.com/19758978/231845147-0f8fee76-05a0-4c70-9c09-57d358a236d8.png)

``` python
pn.Accordion(
    ("Test", "Hello"),
    ("Test2", 2 * "Hello"),
    min_width=300,
)
```