### PR TITLE
Add description to more widgets

### DIFF
--- a/panel/widgets/input.py
+++ b/panel/widgets/input.py
@@ -302,6 +302,9 @@ class DatePicker(Widget):
       Width of this component. If sizing_mode is set to stretch
       or scale mode this will merely be used as a suggestion.""")
 
+    description = param.String(default=None, doc="""
+        An HTML string describing the function of this component.""")
+
     _source_transforms: ClassVar[Mapping[str, str | None]] = {}
 
     _rename: ClassVar[Mapping[str, str | None]] = {
@@ -347,6 +350,9 @@ class _DatetimePickerBase(Widget):
     width = param.Integer(default=300, allow_None=True, doc="""
       Width of this component. If sizing_mode is set to stretch
       or scale mode this will merely be used as a suggestion.""")
+
+    description = param.String(default=None, doc="""
+        An HTML string describing the function of this component.""")
 
     _source_transforms: ClassVar[Mapping[str, str | None]] = {
         'value': None, 'start': None, 'end': None, 'mode': None

--- a/panel/widgets/misc.py
+++ b/panel/widgets/misc.py
@@ -110,6 +110,9 @@ class FileDownload(Widget):
     label = param.String(default="Download file", doc="""
         The label of the download button""")
 
+    description = param.String(default=None, doc="""
+        An HTML string describing the function of this component.""")
+
     _clicks = param.Integer(default=0)
 
     _transfers = param.Integer(default=0)

--- a/panel/widgets/select.py
+++ b/panel/widgets/select.py
@@ -175,6 +175,9 @@ class Select(SingleSelectBase):
       Width of this component. If sizing_mode is set to stretch
       or scale mode this will merely be used as a suggestion.""")
 
+    description = param.String(default=None, doc="""
+        An HTML string describing the function of this component.""")
+
     _rename: ClassVar[Mapping[str, str | None]] = {
         'groups': None,
     }
@@ -317,6 +320,9 @@ class _MultiSelectBase(SingleSelectBase):
     width = param.Integer(default=300, allow_None=True, doc="""
       Width of this component. If sizing_mode is set to stretch
       or scale mode this will merely be used as a suggestion.""")
+
+    description = param.String(default=None, doc="""
+        An HTML string describing the function of this component.""")
 
     _supports_embed: ClassVar[bool] = False
 
@@ -468,6 +474,9 @@ class AutocompleteInput(Widget):
     width = param.Integer(default=300, allow_None=True, doc="""
       Width of this component. If sizing_mode is set to stretch
       or scale mode this will merely be used as a suggestion.""")
+
+    description = param.String(default=None, doc="""
+        An HTML string describing the function of this component.""")
 
     _rename: ClassVar[Mapping[str, str | None]] = {'name': 'title', 'options': 'completions'}
 


### PR DESCRIPTION
I observed during my investigation of which widget supports the new description in Bokeh 3, that some had the functionality but were not enabled on the Panel side.

(I will open an issue with my findings later today)  

 