### PR TITLE
Make it clear that download of pyodide dependencies only happens once

### DIFF
--- a/doc/getting_started/build_app.md
+++ b/doc/getting_started/build_app.md
@@ -5,7 +5,7 @@ At this point you should have [set up your environment and installed Panel](inst
 In this section we're going to be building a basic application using a public dataset and add some interactivity.
 
 :::{important}
-This guide renders static output by default (denoted by the golden border) but you can execute the code cells below by clicking the play button. Only run this if you are willing to download ~40 MB.
+This guide renders static output by default (denoted by the golden border), but you can execute the code cells below by clicking the play button. Only run this if you are willing to download ~40 MB once. The download will be cached and reused the next time you click the play button on any page across the site.
 :::
 
 ## Fetch some data


### PR DESCRIPTION
It was not very clear to me that when clicking the Pyodide run button the download only happens once across the site. So I was a bit reluctant to do this - especially when using it on mobile without wifi.

Therefore I've tried to make it more clear that the download is cached.