### PR TITLE
use panelite word

### DIFF
--- a/doc/how_to/wasm/jupyterlite.md
+++ b/doc/how_to/wasm/jupyterlite.md
@@ -1,6 +1,8 @@
 # Setting up JupyterLite
 
-[JupyterLite](https://jupyterlite.readthedocs.io/en/latest/) is a JupyterLab distribution built from all the usual components and extensions that come with JupyterLab, but now running entirely in the browser with no external server needed. In order to use Panel in JupyterLite you will have to build your own distribution. As a starting point we recommend [this guide](https://jupyterlite.readthedocs.io/en/latest/howto/configure/simple_extensions.html) in the JupyterLite documentation, which will tell you how to set up an environment to begin building JupyterLite.
+[JupyterLite](https://jupyterlite.readthedocs.io/en/latest/) is a JupyterLab distribution built from all the usual components and extensions that come with JupyterLab, but now running entirely in the browser with no external server needed. In order to use Panel in JupyterLite you will have to build your own distribution. We call this [Panelite](https://panelite.holoviz.org). You can try out Panelite [here](https://panelite.holoviz.org).
+
+As a starting point we recommend [this guide](https://jupyterlite.readthedocs.io/en/latest/howto/configure/simple_extensions.html) in the JupyterLite documentation, which will tell you how to set up an environment to begin building JupyterLite.
 
 ## Create a `<lite-dir>`
 
@@ -19,6 +21,6 @@ https://cdn.holoviz.org/panel/0.14.2/dist/wheels/bokeh-2.4.3-py3-none-any.whl
 https://cdn.holoviz.org/panel/0.14.2/dist/wheels/panel-0.14.2-py3-none-any.whl
 ```
 
-## Building Panel lite
+## Building Panelite
 
 Finally `cd` into your `<lite-dir>` and run `jupyter lite build --output-dir ./dist`. This will bundle up the file contents, extensions and wheels into your JupyterLite distribution. You can now easily deploy this to [GitHub pages](https://jupyterlite.readthedocs.io/en/latest/quickstart/deploy.html) or elsewhere.


### PR DESCRIPTION
I tried searching the `dev` docs for Panelite without luck. I wanted to know how to how to build it. But there was a miss

![image](https://user-images.githubusercontent.com/42288570/232182353-fbd5c48a-1aaf-4ebb-8ba1-c25a78dfba42.png)

So I figured I would add/ use the Panelite word in the docs.