### PR TITLE
Add ability to add global loading spinner to application(s)

### DIFF
--- a/panel/command/serve.py
+++ b/panel/command/serve.py
@@ -213,6 +213,10 @@ class Serve(_BkServe):
             action  = 'store_true',
             help    = "Whether to reuse sessions when serving the initial request.",
         )),
+        ('--global-loading-spinner', dict(
+            action  = 'store_true',
+            help    = "Whether to add a global loading spinner to the application(s).",
+        )),
     )
 
     # Supported file extensions
@@ -281,6 +285,7 @@ class Serve(_BkServe):
             raise ValueError("rest-provider %r not recognized." % args.rest_provider)
 
         config.autoreload = args.autoreload
+        config.global_loading_spinner = args.global_loading_spinner
         config.reuse_sessions = args.reuse_sessions
 
         if config.autoreload:

--- a/panel/config.py
+++ b/panel/config.py
@@ -128,6 +128,9 @@ class _config(_base_config):
     exception_handler = param.Callable(default=None, doc="""
         General exception handler for events.""")
 
+    global_loading_spinner = param.Boolean(default=False, doc="""
+        Whether to add a global loading spinner for the whole application.""")
+
     load_entry_points = param.Boolean(default=True, doc="""
         Load entry points from external packages.""")
 
@@ -380,7 +383,7 @@ class _config(_base_config):
             curdoc and attr not in session_config[curdoc]):
             new_obj = copy.copy(super().__getattribute__(attr))
             setattr(self, attr, new_obj)
-        if attr in global_params or attr == 'theme':
+        if attr in global_params or attr in ('global_loading_spinner', 'theme'):
             return super().__getattribute__(attr)
         elif curdoc and curdoc in session_config and attr in session_config[curdoc]:
             return session_config[curdoc][attr]

--- a/panel/config.py
+++ b/panel/config.py
@@ -383,7 +383,7 @@ class _config(_base_config):
             curdoc and attr not in session_config[curdoc]):
             new_obj = copy.copy(super().__getattribute__(attr))
             setattr(self, attr, new_obj)
-        if attr in global_params or attr in ('global_loading_spinner', 'theme'):
+        if attr in global_params or attr == 'theme':
             return super().__getattribute__(attr)
         elif curdoc and curdoc in session_config and attr in session_config[curdoc]:
             return session_config[curdoc][attr]

--- a/panel/io/document.py
+++ b/panel/io/document.py
@@ -17,7 +17,10 @@ from typing import (
 from bokeh.application.application import SessionContext
 from bokeh.document.document import Document
 from bokeh.document.events import DocumentChangedEvent, ModelChangedEvent
+from bokeh.models import CustomJS
 
+from ..config import config
+from .loading import LOADING_INDICATOR_CSS_CLASS
 from .model import monkeypatch_events
 from .state import curdoc_locked, state
 
@@ -115,6 +118,13 @@ def init_doc(doc: Optional[Document]) -> Document:
     if thread:
         state._thread_id_[curdoc] = thread.ident
 
+    if config.global_loading_spinner:
+        doc.js_on_event(
+            'document_ready', CustomJS(code=f"""
+            const body = document.getElementsByTagName('body')[0]
+            body.classList.remove({LOADING_INDICATOR_CSS_CLASS!r}, {config.loading_spinner!r})
+            """)
+        )
     session_id = curdoc.session_context.id
     sessions = state.session_info['sessions']
     if session_id not in sessions:

--- a/panel/io/pyodide.py
+++ b/panel/io/pyodide.py
@@ -33,6 +33,7 @@ from ..config import config
 from ..util import edit_readonly, is_holoviews, isurl
 from . import resources
 from .document import MockSessionContext
+from .loading import LOADING_INDICATOR_CSS_CLASS
 from .mime_render import WriteCallbackStream, exec_with_return, format_mime
 from .state import state
 
@@ -413,7 +414,7 @@ def hide_loader() -> None:
     from js import document
 
     body = document.getElementsByTagName('body')[0]
-    body.classList.remove("pn-loading", config.loading_spinner)
+    body.classList.remove(LOADING_INDICATOR_CSS_CLASS, config.loading_spinner)
 
 def sync_location():
     """

--- a/panel/io/resources.py
+++ b/panel/io/resources.py
@@ -482,6 +482,9 @@ class Resources(BkResources):
                 css_txt = f.read()
                 if css_txt not in raw:
                     raw.append(css_txt)
+        if config.global_loading_spinner:
+            loading_base = (DIST_DIR / "css" / "loading.css").read_text()
+            raw.extend([loading_base, loading_css()])
         return raw + process_raw_css(config.raw_css)
 
     @property

--- a/panel/io/server.py
+++ b/panel/io/server.py
@@ -69,6 +69,7 @@ from ..config import config
 from ..util import edit_readonly, fullpath
 from ..util.warnings import warn
 from .document import init_doc, unlocked, with_lock  # noqa
+from .loading import LOADING_INDICATOR_CSS_CLASS
 from .logging import (
     LOG_SESSION_CREATED, LOG_SESSION_DESTROYED, LOG_SESSION_LAUNCHING,
 )
@@ -229,8 +230,15 @@ def server_html_page_for_session(
         template_variables = {}
 
     bundle = bundle_resources(session.document.roots, resources)
-    return html_page_for_render_items(bundle, {}, [render_item], title,
+    html = html_page_for_render_items(bundle, {}, [render_item], title,
         template=template, template_variables=template_variables)
+
+    if config.global_loading_spinner:
+        html = html.replace(
+            '<body>', f'<body class="{LOADING_INDICATOR_CSS_CLASS} {config.loading_spinner}">'
+        )
+    return html
+
 
 def autoload_js_script(doc, resources, token, element_id, app_path, absolute_url, absolute=False):
     resources = Resources.from_bokeh(resources, absolute=absolute)

--- a/panel/tests/ui/io/test_loading.py
+++ b/panel/tests/ui/io/test_loading.py
@@ -1,0 +1,27 @@
+import time
+
+import pytest
+
+try:
+    from playwright.sync_api import expect
+except ImportError:
+    pytestmark = pytest.mark.skip('playwright not available')
+
+from panel.config import config
+from panel.io.server import serve
+from panel.pane import Markdown
+
+pytestmark = pytest.mark.ui
+
+def test_global_loading_indicator(page, port):
+    def app():
+        config.global_loading_spinner = True
+        return Markdown('Blah')
+
+    serve(app, port=port, threaded=True, show=False)
+
+    time.sleep(0.5)
+
+    page.goto(f"http://localhost:{port}")
+
+    expect(page.locator("body")).not_to_have_class('pn-loading')


### PR DESCRIPTION
In converted pyodide applications we have had the ability to add a global loading indicator for a long time. There is no reason not to also support it for other applications that may take a little while to load.