### PR TITLE
Add more hash funcs

### DIFF
--- a/panel/io/cache.py
+++ b/panel/io/cache.py
@@ -91,6 +91,9 @@ def _container_hash(obj):
         h.update(_generate_hash(item))
     return h.digest()
 
+def _slice_hash(x):
+    return _container_hash([x.start, x.step, x.stop])
+
 def _partial_hash(obj):
     h = hashlib.new("md5")
     h.update(_generate_hash(obj.args))
@@ -100,6 +103,9 @@ def _partial_hash(obj):
 
 def _pandas_hash(obj):
     import pandas as pd
+
+    if not isinstance(obj, (pd.Series, pd.DataFrame)):
+        obj = pd.Series(obj)
 
     if len(obj) >= _PANDAS_ROWS_LARGE:
         obj = obj.sample(n=_PANDAS_SAMPLE_SIZE, random_state=0)
@@ -133,6 +139,7 @@ _hash_funcs = {
     float        : lambda obj: _int_to_bytes(hash(obj)),
     bool         : lambda obj: b'1' if obj is True else b'0',
     type(None)   : lambda obj: b'0',
+    slice: _slice_hash,
     (bytes, bytearray) : lambda obj: obj,
     (list, tuple, dict): _container_hash,
     pathlib.Path       : lambda obj: str(obj).encode(),
@@ -144,6 +151,9 @@ _hash_funcs = {
     'numpy.ndarray'              : _numpy_hash,
     'pandas.core.series.Series'  : _pandas_hash,
     'pandas.core.frame.DataFrame': _pandas_hash,
+    'pandas.core.indexes.base.Index': _pandas_hash,
+    'pandas.core.indexes.numeric.Int64Index': _pandas_hash,
+    'pandas.core.indexes.range.RangeIndex': _slice_hash,
     'builtins.mappingproxy'      : lambda obj: _container_hash(dict(obj)),
     'builtins.dict_items'        : lambda obj: _container_hash(dict(obj)),
     'builtins.getset_descriptor' : lambda obj: obj.__qualname__.encode(),


### PR DESCRIPTION
Add more types for `_hash_funcs` related to pandas and slicing. This will make it possible to have these types as input:

``` python
import pandas as pd
import panel as pn

@pn.cache
def f(x):
    return None

f(pd.Int64Index(range(1_000_000)))
f(pd.Index(list(range(1_000_000))))
f(pd.RangeIndex(range(1_000_000)))
f(slice(1, 2, 3))

```