### PR TITLE
Add cache support for single numpy dtype like np.int32

### DIFF
--- a/panel/io/cache.py
+++ b/panel/io/cache.py
@@ -160,7 +160,8 @@ _hash_funcs = {
     "numpy.ufunc"                : lambda obj: obj.__name__.encode(),
     # Functions
     inspect.isbuiltin          : lambda obj: obj.__name__.encode(),
-    inspect.ismodule           : lambda obj: obj.__name__
+    inspect.ismodule           : lambda obj: obj.__name__,
+    lambda x: hasattr(x, "tobytes") and x.shape == (): lambda x: x.tobytes(),  # Single numpy dtype like: np.int32
 }
 
 for name in _FFI_TYPE_NAMES:


### PR DESCRIPTION
Add more types for `_hash_funcs` related to single values of a numpy dtype. This will make the following possible:

``` python
import panel as pn

@pn.cache
def f(x):
    return None

f([np.int32(1)])

```