### PR TITLE
Additional layout compatibility

### DIFF
--- a/panel/config.py
+++ b/panel/config.py
@@ -135,6 +135,12 @@ class _config(_base_config):
     global_loading_spinner = param.Boolean(default=False, doc="""
         Whether to add a global loading spinner for the whole application.""")
 
+    layout_compatibility = param.Boolean(default=True, doc="""
+        Provide compatibility for older layout specifications. Incompatible
+        specifications will warn in compatibility mode but will error
+        when compatibility is disabled. Compatibility to be disabled in
+        Panel 1.1.""")
+
     load_entry_points = param.Boolean(default=True, doc="""
         Load entry points from external packages.""")
 
@@ -284,7 +290,8 @@ class _config(_base_config):
         'admin_plugins', 'autoreload', 'comms', 'cookie_secret',
         'nthreads', 'oauth_provider', 'oauth_expiry', 'oauth_key',
         'oauth_secret', 'oauth_jwt_user', 'oauth_redirect_uri',
-        'oauth_encryption_key', 'oauth_extra_params', 'npm_cdn'
+        'oauth_encryption_key', 'oauth_extra_params', 'npm_cdn',
+        'layout_compatibility'
     ]
 
     _truthy = ['True', 'true', '1', True, 1]

--- a/panel/layout/base.py
+++ b/panel/layout/base.py
@@ -226,18 +226,18 @@ class Panel(Reactive):
             sizing_mode = f'{mode}_width'
         elif expand_height and not self.height:
             sizing_mode = f'{mode}_height'
-        properties = {'sizing_mode': sizing_mode}
+        if sizing_mode is None:
+            return {}
 
-        if sizing_mode is not None and (sizing_mode.endswith('_width') or sizing_mode.endswith('_both')) and not all_expand_width and widths:
-            if widths and self._direction == 'vertical':
-                properties['min_width'] = max(widths)
-            elif len(widths) == len(children) and self._direction == 'horizontal':
-                properties['min_width'] = sum(widths)
-        if sizing_mode is not None and (sizing_mode.endswith('_height') or sizing_mode.endswith('_both')) and not all_expand_height and heights:
-            if heights and self._direction == 'horizontal':
-                properties['min_height'] = max(heights)
-            elif heights and self._direction == 'vertical':
-                properties['min_height'] = sum(heights)
+        properties = {'sizing_mode': sizing_mode}
+        if ((sizing_mode.endswith('_width') or sizing_mode.endswith('_both')) and
+            not all_expand_width and widths and 'min_width' not in properties):
+            width_op = max if self._direction == 'vertical' else sum
+            properties['min_width'] = width_op(widths)
+        if ((sizing_mode.endswith('_height') or sizing_mode.endswith('_both')) and
+            not all_expand_height and heights and 'min_height' not in properties):
+            height_op = max if self._direction == 'horizontal' else sum
+            properties['min_height'] = height_op(heights)
         return properties
 
     #----------------------------------------------------------------

--- a/panel/layout/base.py
+++ b/panel/layout/base.py
@@ -219,26 +219,14 @@ class Panel(Reactive):
                 all_expand_height = False
 
         # Infer new sizing mode based on children
-        properties = {}
         mode = 'scale' if scale else 'stretch'
         if expand_width and expand_height and not self.width and not self.height:
-            if all_expand_width and all_expand_height:
-                properties['sizing_mode'] = f'{mode}_both'
-            else:
-                properties['width_policy'] = 'fit'
-                properties['height_policy'] = 'fit'
+            sizing_mode = f'{mode}_both'
         elif expand_width and not self.width:
-            if all_expand_width:
-                properties['sizing_mode'] = f'{mode}_width'
-            else:
-                properties['width_policy'] = 'fit'
+            sizing_mode = f'{mode}_width'
         elif expand_height and not self.height:
-            if all_expand_height:
-                properties['sizing_mode'] = f'{mode}_height'
-            else:
-                properties['height_policy'] = 'fit'
-        else:
-            properties['sizing_mode'] = sizing_mode
+            sizing_mode = f'{mode}_height'
+        properties = {'sizing_mode': sizing_mode}
 
         if sizing_mode is not None and (sizing_mode.endswith('_width') or sizing_mode.endswith('_both')) and not all_expand_width and widths:
             if widths and self._direction == 'vertical':

--- a/panel/pane/holoviews.py
+++ b/panel/pane/holoviews.py
@@ -389,6 +389,10 @@ class HoloViews(PaneBase):
 
         kwargs = {p: v for p, v in self.param.values().items()
                   if p in Layoutable.param and p != 'name'}
+        if self.sizing_mode and (self.sizing_mode.endswith('width') or self.sizing_mode.endswith('both')):
+            del kwargs['width']
+        if self.sizing_mode and (self.sizing_mode.endswith('height') or self.sizing_mode.endswith('both')):
+            del kwargs['height']
         child_pane = self._get_pane(backend, state, **kwargs)
         self._update_plot(plot, child_pane)
         model = child_pane._get_model(doc, root, parent, comm)

--- a/panel/template/fast/fast.css
+++ b/panel/template/fast/fast.css
@@ -315,6 +315,10 @@ h1, h2, h3, h4, h5, h6 {
     margin-right: auto;
 }
 
+.main .card-margin.stretch_both, .main .card-margin.stretch_height {
+    height: calc(100% - 2em);
+}
+
 .main a, .sidenav a {
     color: var(--accent-foreground-rest);
     text-decoration: underline;

--- a/panel/tests/layout/test_base.py
+++ b/panel/tests/layout/test_base.py
@@ -481,7 +481,7 @@ def test_layout_with_param_setitem(document, comm):
     test.select = 1
     assert model.children[1].text == '&lt;pre&gt;1&lt;/pre&gt;'
 
-@pytest.mark.parametrize('panel', [Card, Column, Row, Tabs, Accordion])
+@pytest.mark.parametrize('panel', [Card, Column, Tabs, Accordion])
 @pytest.mark.parametrize('sizing_mode', ['stretch_width', 'stretch_height', 'stretch_both'])
 def test_expand_sizing_mode_to_match_child(panel, sizing_mode, document, comm):
     div1 = Div()
@@ -492,7 +492,16 @@ def test_expand_sizing_mode_to_match_child(panel, sizing_mode, document, comm):
 
     assert model.sizing_mode == sizing_mode
 
-@pytest.mark.parametrize('panel', [Card, Column, Row, Tabs, Accordion])
+def test_expand_row_sizing_mode_stretch_both(document, comm):
+    div1 = Div(sizing_mode='stretch_both')
+    div2 = Div(sizing_mode='stretch_both')
+    layout = Row(div1, div2)
+
+    model = layout.get_root(document, comm)
+
+    assert model.sizing_mode == 'stretch_both'
+
+@pytest.mark.parametrize('panel', [Card, Column, Tabs, Accordion])
 def test_expand_both_axes(panel, document, comm):
     div1 = Div(sizing_mode='stretch_width')
     div2 = Div(sizing_mode='stretch_height')
@@ -502,11 +511,47 @@ def test_expand_both_axes(panel, document, comm):
 
     assert model.sizing_mode == 'stretch_both'
 
-@pytest.mark.parametrize('panel', [Card, Column, Row, Tabs, Accordion])
+def test_not_expand_row_both_axes(document, comm):
+    div1 = Div(sizing_mode='stretch_width')
+    div2 = Div(sizing_mode='stretch_height')
+    layout = Row(div1, div2)
+
+    model = layout.get_root(document, comm)
+
+    assert model.sizing_mode == 'stretch_width'
+
+def test_expand_row_both_axes(document, comm):
+    div1 = Div(sizing_mode='stretch_both')
+    div2 = Div(sizing_mode='stretch_both')
+    layout = Row(div1, div2)
+
+    model = layout.get_root(document, comm)
+
+    assert model.sizing_mode == 'stretch_both'
+
+@pytest.mark.parametrize('panel', [Card, Column, Tabs, Accordion])
 def test_expand_only_non_fixed_axis_width(panel, document, comm):
     div1 = Div(sizing_mode='stretch_width')
     div2 = Div(sizing_mode='stretch_height')
     layout = panel(div1, div2, width=500)
+
+    model = layout.get_root(document, comm)
+
+    assert model.sizing_mode == 'stretch_height'
+
+def test_not_expand_row_only_non_fixed_axis_width(document, comm):
+    div1 = Div(sizing_mode='stretch_width')
+    div2 = Div(sizing_mode='stretch_height')
+    layout = Row(div1, div2, width=500)
+
+    model = layout.get_root(document, comm)
+
+    assert model.sizing_mode is None
+
+def test_expand_row_all_only_non_fixed_axis_width(document, comm):
+    div1 = Div(sizing_mode='stretch_height')
+    div2 = Div(sizing_mode='stretch_height')
+    layout = Row(div1, div2, width=500)
 
     model = layout.get_root(document, comm)
 

--- a/panel/viewable.py
+++ b/panel/viewable.py
@@ -249,7 +249,7 @@ class Layoutable(param.Parameterized):
                 "setting, otherwise change it to min_height."
             )
             if config.layout_compatibility:
-                error += ' To error on incorrect specification disable the layout_compatibility config option.'
+                error += ' To error on the incorrect specification disable the config.layout_compatibility option.'
                 self.param.warning(error)
             else:
                 raise ValueError(error)
@@ -263,7 +263,7 @@ class Layoutable(param.Parameterized):
                 "setting, otherwise change it to min_height."
             )
             if config.layout_compatibility:
-                error += ' To error on incorrect specification disable the layout_compatibility config option.'
+                error += ' To error on the incorrect specification disable the config.layout_compatibility option.'
                 self.param.warning(error)
             else:
                 raise ValueError(error)

--- a/panel/viewable.py
+++ b/panel/viewable.py
@@ -239,6 +239,35 @@ class Layoutable(param.Parameterized):
     __abstract = True
 
     def __init__(self, **params):
+        sizing_mode = params.get('sizing_mode')
+        if (sizing_mode in ('stretch_width', 'scale_width', 'stretch_both', 'scale_both') and
+            params.get('width') is not None):
+            error = (
+                f"Providing a width-responsive sizing_mode ({params['sizing_mode']!r}) "
+                "and a fixed width is not supported. Converting fixed width to min_width. "
+                "If you intended the component to be fully width-responsive remove the height"
+                "setting, otherwise change it to min_height."
+            )
+            if config.layout_compatibility:
+                error += ' To error on incorrect specification disable the layout_compatibility config option.'
+                self.param.warning(error)
+            else:
+                raise ValueError(error)
+            params['min_width'] = params.pop('width')
+        if (sizing_mode in ('stretch_height', 'scale_height', 'stretch_both', 'scale_both') and
+            params.get('height') is not None):
+            error = (
+                f"Providing a height-responsive sizing_mode ({params['sizing_mode']!r}) "
+                "and a fixed height is not supported. Converting fixed height to min_height. "
+                "If you intended the component to be fully height-responsive remove the height "
+                "setting, otherwise change it to min_height."
+            )
+            if config.layout_compatibility:
+                error += ' To error on incorrect specification disable the layout_compatibility config option.'
+                self.param.warning(error)
+            else:
+                raise ValueError(error)
+            params['min_height'] = params.pop('height')
         if (params.get('width') is not None and
             params.get('height') is not None and
             params.get('width_policy') is None and


### PR DESCRIPTION
Reintroduces a `config.layout_compatibility` flag which toggles between warnings and errors.

- We now warn/error if a responsive sizing_mode is set but you also provide a fixed width/height along that dimension
- We **always** compute known widths/heights inside a responsive container to ensure that we have at least as much size available as the largest object with a known width/height.  