### PR TITLE
Improve Markdown reference notebook

### DIFF
--- a/examples/reference/panes/Markdown.ipynb
+++ b/examples/reference/panes/Markdown.ipynb
@@ -3,7 +3,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "import panel as pn\n",
@@ -35,33 +37,76 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The ``Markdown`` pane accepts all valid Markdown, including embedded HTML. It also supports a ``style`` dictionary to apply styles to control the appearance of the ``<div>`` tag the Markdown contents will be rendered in."
+    "The ``Markdown`` pane accepts all *basic* Markdown syntax, including embedded HTML. It also supports most of the *extended* Markdown syntax."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "pn.pane.Markdown(\"\"\"\n",
     "\n",
+    "# Markdown Sample\n",
+    "\n",
+    "This sample text is from [The Markdown Guide](https://www.markdownguide.org)!\n",
+    "\n",
+    "## Basic Syntax\n",
+    "\n",
+    "These are the elements outlined in John Gruber’s original design document. All Markdown applications support these elements.\n",
+    "\n",
+    "### Heading\n",
+    "\n",
     "# H1\n",
     "## H2\n",
     "### H3\n",
-    "#### H4\n",
-    "##### H5\n",
-    "###### H6\n",
     "\n",
-    "### Emphasis\n",
+    "### Bold\n",
     "\n",
-    "Emphasis, aka italics, with *asterisks* or _underscores_.\n",
+    "**bold text**\n",
     "\n",
-    "Strong emphasis, aka bold, with **asterisks** or __underscores__.\n",
+    "### Italic\n",
     "\n",
-    "Combined emphasis with ** asterisks and _underscores_ **.\n",
+    "*italicized text*\n",
     "\n",
-    "<br>\n",
+    "### Blockquote\n",
+    "\n",
+    "> blockquote\n",
+    "\n",
+    "### Ordered List\n",
+    "\n",
+    "1. First item\n",
+    "2. Second item\n",
+    "3. Third item\n",
+    "\n",
+    "### Unordered List\n",
+    "\n",
+    "- First item\n",
+    "- Second item\n",
+    "- Third item\n",
+    "\n",
+    "### Code\n",
+    "\n",
+    "`code`\n",
+    "\n",
+    "### Horizontal Rule\n",
+    "\n",
+    "---\n",
+    "\n",
+    "### Link\n",
+    "\n",
+    "[Markdown Guide](https://www.markdownguide.org)\n",
+    "\n",
+    "### Image\n",
+    "\n",
+    "![alt text](https://www.markdownguide.org/assets/images/tux.png)\n",
+    "\n",
+    "## Extended Syntax\n",
+    "\n",
+    "These elements extend the basic syntax by adding additional features. Not all Markdown applications support these elements.\n",
     "\n",
     "### Table\n",
     "\n",
@@ -70,11 +115,9 @@
     "| Header | Title |\n",
     "| Paragraph | Text |\n",
     "\n",
-    "<br>\n",
+    "### Fenced Code Block\n",
     "\n",
-    "### Fenced code\n",
-    "\n",
-    "```python\n",
+    "```\n",
     "{\n",
     "  \"firstName\": \"John\",\n",
     "  \"lastName\": \"Smith\",\n",
@@ -82,15 +125,33 @@
     "}\n",
     "```\n",
     "\n",
-    "### Nested list\n",
+    "### Footnote\n",
     "\n",
-    "1. First list item\n",
-    "    - First nested list item\n",
-    "        - Second nested list item\n",
+    "Here's a sentence with a footnote. [^1]\n",
     "\n",
-    "[This is a link to panel web portal](https://panel.pyviz.org/)\n",
+    "[^1]: This is the footnote.\n",
     "\n",
-    "------------\n",
+    "### Definition List\n",
+    "\n",
+    "term\n",
+    ": Some definition of the term goes here\n",
+    "\n",
+    "### Strikethrough\n",
+    "\n",
+    "~~The world is flat.~~\n",
+    "\n",
+    "### Task List\n",
+    "\n",
+    "- [x] Write the press release\n",
+    "- [ ] Update the website\n",
+    "- [ ] Contact the media\n",
+    "\n",
+    "### Emoji\n",
+    "\n",
+    "That is so funny! 😂\n",
+    "\n",
+    "(See also [Copying and Pasting Emoji](https://www.markdownguide.org/extended-syntax/#copying-and-pasting-emoji))\n",
+    "\n",
     "\"\"\", width=500)"
    ]
   },
@@ -98,13 +159,17 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If you want to control the behavior of the HTML that is generated from the Markdown source, it is often possible to do that by passing parameters to the `style` parameter of this pane.  For instance, you can add a blue border around a Markdown table as follows:"
+    "## Style\n",
+    "\n",
+    "If you want to control the behavior of the HTML that is generated from the Markdown source, it is often possible to do that by passing parameters to the `styles` parameter of this pane.  For instance, you can add a blue border around a Markdown table as follows:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "pn.pane.Markdown(\"\"\"\n",
@@ -120,7 +185,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "However, styles specified in this way will only be applied to the outermost Div, and there is not currently any way to apply styling in this way to specific internal elements of the HTML.  In this case, we cannot use the `style` parameter to control styling of the rows or headings of the generated table. \n",
+    "However, styles specified in this way will only be applied to the outermost Div, and there is not currently any way to apply styling in this way to specific internal elements of the HTML.  In this case, we cannot use the `styles` parameter to control styling of the rows or headings of the generated table. \n",
     "\n",
     "If we do want to change specific internal elements of the generated HTML, we can do so by providing an HTML/CSS &lt;style&gt; section. For instance, we can change the border thickness for headers and data as follows, but note that the changes will apply to subsequent Markdown as well, including other cells if in a notebook context:\n",
     "\n",
@@ -163,7 +228,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "css = \"\"\"\n",
@@ -189,13 +256,15 @@
    "source": [
     "## Renderer\n",
     "\n",
-    "Since the 1.0 release Panel uses `markdown-it` as the the default markdown renderer. If you want to restore the previous default `'markdown'` or switch to `MyST` flavored Markdown you can set it via the `renderer` parameter. As an example here we render a task list using 'markdown-it' and 'markdown':"
+    "Since the 1.0 release Panel uses [`markdown-it`](https://markdown-it-py.readthedocs.io/en/latest/) as the the default markdown renderer. If you want to restore the previous default `'markdown'` or switch to `MyST` flavored Markdown you can set it via the `renderer` parameter. As an example here we render a task list using 'markdown-it' and 'markdown':"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "tasklist = \"\"\"\n",
@@ -222,7 +291,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "pn.pane.Markdown(r\"\"\"\n",
@@ -240,7 +311,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "pn.pane.Markdown(\"$$\\frac{1}{n}$$\")"
@@ -256,7 +329,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "pn.pane.Markdown(r\"$$\\frac{1}{n}$$\")"


### PR DESCRIPTION
I fixed some typos, separated into more sections and added the Markdown syntax currently supported by Panel to the example.