### PR TITLE
Improve FloatPanel docs

### DIFF
--- a/examples/reference/layouts/FloatPanel.ipynb
+++ b/examples/reference/layouts/FloatPanel.ipynb
@@ -4,7 +4,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "5c557435-c052-4622-8023-81ed6f63f231",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "import panel as pn\n",
@@ -16,11 +18,11 @@
    "id": "a44c5eae-9c73-4626-96ff-019cf959d647",
    "metadata": {},
    "source": [
-    "The `FloatPanel` layout provides a draggable container which can be placed inside its parent or be completely free floating. It is built on-top of [jsPanel](https://jspanel.de/) and is highly customizable. It has a list-like API with methods to `append`, `extend`, `clear`, `insert`, `pop`, `remove` and `__setitem__`, which make it possible to interactively update and modify the layout and components inside it are laid out like a `Column`.\n",
+    "The `FloatPanel` layout provides a draggable container which can be placed inside its parent or be completely free floating. It is built on-top of [jsPanel](https://jspanel.de/) and is highly customizable. It has a list-like API with methods to `append`, `extend`, `clear`, `insert`, `pop`, `remove` and `__setitem__`, which make it possible to interactively update and modify the layout. Components inside it are laid out like a `Column`.\n",
     "\n",
     "#### Parameters:\n",
     "\n",
-    "* **`contained`** (boolean): Whether the component is contained within parent container or completely free floating.\n",
+    "* **`contained`** (boolean): Whether the component is contained within the parent container or completely free floating.\n",
     "* **`config`** (dict): Additional [jsPanel configuration](https://jspanel.de/#options/overview) with precedence over parameter values.\n",
     "* **`objects`** (list): The list of objects to display in the Column, should not generally be modified directly except when replaced in its entirety.\n",
     "* **`position`**: The initial position if the container is free-floating.\n",
@@ -54,15 +56,17 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "9fd46bf9-a63e-457c-bcc2-a1578b8f9bda",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "w1 = pn.widgets.TextInput(name='Text:')\n",
     "w2 = pn.widgets.FloatSlider(name='Slider')\n",
     "\n",
-    "floatpanel = pn.layout.FloatPanel(w1, w2, name='FloatPanel', margin=20)\n",
+    "floatpanel = pn.layout.FloatPanel(w1, w2, name='Basic FloatPanel', margin=20)\n",
     "\n",
-    "pn.Column('# Float Container', floatpanel, height=300)"
+    "pn.Column('**Example: Basic `FloatPanel`**', floatpanel, height=250)"
    ]
   },
   {
@@ -77,10 +81,50 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "090d239b-c073-4d57-acc7-2beb8408edcf",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
-    "pn.layout.FloatPanel('# My free floating Panel.', contained=False, position='center')"
+    "pn.layout.FloatPanel(\"Try dragging me around.\", name=\"Free Floating FloatPanel\", contained=False, position='center')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1789615a-b143-4bdd-9279-2a755e8b493b",
+   "metadata": {},
+   "source": [
+    "### Configuration\n",
+    "\n",
+    "As mentioned the `FloatPanel` is highly customizable via the `config` parameter. As an example lets remove the *close* button."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "060cdf46-b7bc-47f7-ae28-f9bf725cba8d",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "config={\"headerControls\": {\"close\": \"remove\"}}\n",
+    "\n",
+    "pn.Column(\n",
+    "    \"Example: `FloatPanel` without *close button*\",\n",
+    "    pn.layout.FloatPanel(\"You can't close me!\", name='FloatPanel without close button', margin=20, config=config),\n",
+    "    height=200,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c01e2c2b-1a16-4d50-8d77-55c66813750e",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "For more configuration options check out the excellent [jsPanel docs](https://jspanel.de/)."
    ]
   },
   {
@@ -90,17 +134,19 @@
    "source": [
     "### Controls\n",
     "\n",
-    "The `CheckButtonGroup` widget exposes a number of options which can be changed from both Python and Javascript. Try out the effect of these parameters interactively:"
+    "The `FloatPanel` widget exposes a number of options which can be changed from both Python and Javascript. Try out the effect of these parameters interactively:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "b49ed4d6-b06b-47e1-a917-88ff3141936b",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
-    "floatpanel = pn.layout.FloatPanel(w1, w2, name='FloatPanel', margin=20)\n",
+    "floatpanel = pn.layout.FloatPanel(w1, w2, name='FloatPanel with Controls', margin=20)\n",
     "\n",
     "pn.Row(floatpanel.controls(jslink=True), floatpanel)"
    ]


### PR DESCRIPTION
I added a few improvements to the `FloatPanel` reference notebook.

The primary improvement is an example where you remove the `maximize` button. If you put widgets into a `FloatPanel` I think that normally you don't want the user to accidentally close the panel and not be able to recover it 😄 It can take some time to figure out this is possible and how. So I believe it helps a lot.