### PR TITLE
Fix toctree in testing docs

### DIFF
--- a/doc/how_to/test/index.md
+++ b/doc/how_to/test/index.md
@@ -32,7 +32,7 @@ How to test performance by simulating multiple users accessing an app concurrent
 :hidden:
 :maxdepth: 1
 
-loadtests
 pytest
-uitest
+uitests
+loadtests
 ```


### PR DESCRIPTION
This should fix the navigation here: https://pyviz-dev.github.io/panel/how_to/test/index.html

It wasn't showing up in the navigation or page flow because of a typo missing "s" in "uitests".

<img width="967" alt="Screenshot 2023-04-29 at 20 47 06" src="https://user-images.githubusercontent.com/852409/235319204-f82cb555-d8e1-4717-ba1b-0d782607e02a.png">
