### PR TITLE
Improve notebook resource and extension loading

### DIFF
--- a/panel/_templates/autoload_panel_js.js
+++ b/panel/_templates/autoload_panel_js.js
@@ -252,6 +252,13 @@ calls it with the rendered model.
   }
 
   function load_or_wait() {
+    // Implement a backoff loop that tries to ensure we do not load multiple
+    // versions of Bokeh and its dependencies at the same time.
+    // In recent versions we use the root._bokeh_is_initializing flag
+    // to determine whether there is an ongoing attempt to initialize
+    // bokeh, however for backward compatibility we also try to ensure
+    // that we do not start loading a newer (Panel>=1.0 and Bokeh>3) version
+    // before older versions are fully initialized.
     if (root._bokeh_is_initializing && Date.now() > root._bokeh_timeout) {
       root._bokeh_is_initializing = false;
       console.log("Bokeh: BokehJS was loaded multiple times but one version failed to initialize.");

--- a/panel/_templates/autoload_panel_js.js
+++ b/panel/_templates/autoload_panel_js.js
@@ -30,11 +30,6 @@ calls it with the rendered model.
   var Bokeh = root.Bokeh;
   var bokeh_loaded = Bokeh != null && (Bokeh.version === py_version || (Bokeh.versions !== undefined && Object.keys(Bokeh.versions).includes(py_version)));
 
-  if ((typeof root._bokeh_onload_callbacks === "undefined") && reloading === false) {
-    root._bokeh_onload_callbacks = [];
-    root._bokeh_is_loading = undefined;
-  }
-
   if (typeof (root._bokeh_timeout) === "undefined" || force) {
     root._bokeh_timeout = Date.now() + {{ timeout|default(0)|json }};
     root._bokeh_failed_load = false;
@@ -257,7 +252,7 @@ calls it with the rendered model.
   }
 
   function load_or_wait() {
-    if (Date.now() > root._bokeh_timeout) {
+    if (root._bokeh_is_initializing && Date.now() > root._bokeh_timeout) {
       root._bokeh_is_initializing = false;
       console.log("Bokeh: BokehJS was loaded multiple times but one version failed to initialize.");
       load_or_wait();

--- a/panel/_templates/autoload_panel_js.js
+++ b/panel/_templates/autoload_panel_js.js
@@ -28,7 +28,7 @@ calls it with the rendered model.
   var is_dev = py_version.indexOf("+") !== -1 || py_version.indexOf("-") !== -1;
   var reloading = {{ reloading|default(False)|json }};
   var Bokeh = root.Bokeh;
-  var bokeh_loaded = Bokeh != null && (Bokeh.version === py_version || (Bokeh.versions !== undefined && Object.keys(Bokeh.versions).includes(py_version)));
+  var bokeh_loaded = Bokeh != null && (Bokeh.version === py_version || (Bokeh.versions !== undefined && Bokeh.versions.has(py_version)));
 
   if (typeof (root._bokeh_timeout) === "undefined" || force) {
     root._bokeh_timeout = Date.now() + {{ timeout|default(0)|json }};
@@ -230,10 +230,10 @@ calls it with the rendered model.
       if (Bokeh != undefined && !reloading) {
 	var NewBokeh = root.Bokeh;
 	if (Bokeh.versions === undefined) {
-	  Bokeh.versions = {}
+	  Bokeh.versions = new Map();
 	}
 	if (NewBokeh.version !== Bokeh.version) {
-	  Bokeh.versions[NewBokeh.version] = NewBokeh
+	  Bokeh.versions.set(NewBokeh.version, NewBokeh)
 	}
 	root.Bokeh = Bokeh;
       }
@@ -267,7 +267,7 @@ calls it with the rendered model.
       setTimeout(load_or_wait, 100);
     } else {
       Bokeh = root.Bokeh;
-      bokeh_loaded = Bokeh != null && (Bokeh.version === py_version || (Bokeh.versions !== undefined && Object.keys(Bokeh.versions).includes(py_version)));
+      bokeh_loaded = Bokeh != null && (Bokeh.version === py_version || (Bokeh.versions !== undefined && Bokeh.versions.has(py_version)));
       root._bokeh_is_initializing = true
       root._bokeh_onload_callbacks = []
       if (!reloading && (!bokeh_loaded || is_dev)) {

--- a/panel/_templates/doc_nb_js.js
+++ b/panel/_templates/doc_nb_js.js
@@ -27,11 +27,11 @@
       if (root.Bokeh.versions === undefined || !Object.keys(root.Bokeh.versions).includes(py_version)) {
 	return null
       }
-      var Bokeh = root.Bokeh.versions[py_version];
-    } else {
-      var Bokeh = root.Bokeh;
+      return root.Bokeh.versions[py_version];
+    } else if (root.Bokeh.version === py_version) {
+      return root.Bokeh
     }
-    return Bokeh
+    return null
   }
   function is_loaded(root) {
     var Bokeh = get_bokeh(root)

--- a/panel/_templates/doc_nb_js.js
+++ b/panel/_templates/doc_nb_js.js
@@ -1,8 +1,15 @@
 (function(root) {
+  var docs_json = {{ docs_json }};
+  var render_items = {{ render_items }};
+  var docs = Object.values(docs_json)
+  if (!docs) {
+    return
+  }
+  const py_version = docs[0].version
+  const is_dev = py_version.indexOf("+") !== -1 || py_version.indexOf("-") !== -1
   function embed_document(root) {
-    var docs_json = {{ docs_json }};
-    var render_items = {{ render_items }};
-    root.Bokeh.embed.embed_items_notebook(docs_json, render_items);
+    var Bokeh = get_bokeh(root)
+    Bokeh.embed.embed_items_notebook(docs_json, render_items);
     for (const render_item of render_items) {
       for (const root_id of render_item.root_ids) {
 	const id_el = document.getElementById(root_id)
@@ -13,12 +20,29 @@
       }
     }
   }
-  if (root.Bokeh !== undefined && root.Bokeh.Panel !== undefined{% for reqs in requirements %} && ({% for req in reqs %}{% if loop.index0 > 0 %}||{% endif %} root['{{ req }}'] !== undefined{% endfor %}){% endfor %}{% if ipywidget %}&& (root.Bokeh.Models.registered_names().indexOf("ipywidgets_bokeh.widget.IPyWidget") > -1){% endif %}) {
+  function get_bokeh(root) {
+    if (root.Bokeh === undefined) {
+      return null
+    } else if (root.Bokeh.version !== py_version && !is_dev) {
+      if (root.Bokeh.versions === undefined || !Object.keys(root.Bokeh.versions).includes(py_version)) {
+	return null
+      }
+      var Bokeh = root.Bokeh.versions[py_version];
+    } else {
+      var Bokeh = root.Bokeh;
+    }
+    return Bokeh
+  }
+  function is_loaded(root) {
+    var Bokeh = get_bokeh(root)
+    return (Bokeh != null && Bokeh.Panel !== undefined{% for reqs in requirements %} && ({% for req in reqs %}{% if loop.index0 > 0 %}&&{% endif %} root['{{ req }}'] !== undefined{% endfor %}){% endfor %}{% if ipywidget %}&& (Bokeh.Models.registered_names().indexOf("ipywidgets_bokeh.widget.IPyWidget") > -1){% endif %})
+  }
+  if (is_loaded(root)) {
     embed_document(root);
   } else {
     var attempts = 0;
     var timer = setInterval(function(root) {
-      if (root.Bokeh !== undefined && root.Bokeh.Panel !== undefined{% for reqs in requirements %} && ({% for req in reqs %}{% if loop.index0 > 0 %} || {% endif %}root['{{ req }}'] !== undefined{% endfor %}){% endfor %}{% if ipywidget %}&& (root.Bokeh.Models.registered_names().indexOf("ipywidgets_bokeh.widget.IPyWidget") > -1){% endif %}) {
+      if (is_loaded(root)) {
         clearInterval(timer);
         embed_document(root);
       } else if (document.readyState == "complete") {

--- a/panel/_templates/doc_nb_js.js
+++ b/panel/_templates/doc_nb_js.js
@@ -24,10 +24,10 @@
     if (root.Bokeh === undefined) {
       return null
     } else if (root.Bokeh.version !== py_version && !is_dev) {
-      if (root.Bokeh.versions === undefined || !Object.keys(root.Bokeh.versions).includes(py_version)) {
+      if (root.Bokeh.versions === undefined || !root.Bokeh.versions.has(py_version)) {
 	return null
       }
-      return root.Bokeh.versions[py_version];
+      return root.Bokeh.versions.get(py_version);
     } else if (root.Bokeh.version === py_version) {
       return root.Bokeh
     }

--- a/panel/config.py
+++ b/panel/config.py
@@ -696,6 +696,9 @@ class panel_extension(_pyviz_extension):
             else:
                 hv.Store.current_backend = backend
 
+        if config.load_entry_points:
+            self._load_entry_points()
+
         # Abort if IPython not found
         try:
             ip = params.pop('ip', None) or get_ipython() # noqa (get_ipython)
@@ -738,17 +741,14 @@ class panel_extension(_pyviz_extension):
             )
         panel_extension._loaded = True
 
-        if config.browser_info and state.browser_info:
+        if not nb_loaded and config.browser_info and state.browser_info:
             doc = Document()
             comm = state._comm_manager.get_server_comm()
             model = state.browser_info._render_model(doc, comm)
             bundle, meta = state.browser_info._render_mimebundle(model, doc, comm)
             display(bundle, metadata=meta, raw=True)  # noqa
-        if config.notifications:
+        if not nb_loaded and config.notifications:
             display(state.notifications)  # noqa
-
-        if config.load_entry_points:
-            self._load_entry_points()
 
     def _detect_comms(self, params):
         called_before = self._comms_detected_before

--- a/panel/io/notebook.py
+++ b/panel/io/notebook.py
@@ -332,8 +332,6 @@ def block_comm() -> Iterator:
 def load_notebook(
     inline: bool = True,
     reloading: bool = False,
-    extensions: list[str] = [],
-    resources: dict[str, dict[str, str] | list[str]] = {},
     load_timeout: int = 5000
 ) -> None:
     from IPython.display import publish_display_data

--- a/panel/io/notebook.py
+++ b/panel/io/notebook.py
@@ -90,7 +90,7 @@ AUTOLOAD_NB_JS: Template = _env.get_template("autoload_panel_js.js")
 NB_TEMPLATE_BASE: Template = _env.get_template('nb_template.html')
 
 def _autoload_js(
-    bundle, configs, requirements, exports, skip_imports, ipywidget,
+    *, bundle, configs, requirements, exports, skip_imports, ipywidget,
     reloading=False, load_timeout=5000
 ):
     config = {'packages': {}, 'paths': {}, 'shim': {}}
@@ -348,8 +348,14 @@ def load_notebook(
         configs, requirements, exports, skip_imports = require_components()
         ipywidget = 'ipywidgets_bokeh' in sys.modules
         bokeh_js = _autoload_js(
-            bundle, configs, requirements, exports, skip_imports, ipywidget,
-            reloading, load_timeout
+            bundle=bundle,
+            configs=configs,
+            requirements=requirements,
+            exports=exports,
+            skip_imports=skip_imports,
+            ipywidget=ipywidget,
+            reloading=reloading,
+            load_timeout=load_timeout
         )
     finally:
         if user_resources:

--- a/panel/io/notebook.py
+++ b/panel/io/notebook.py
@@ -89,7 +89,10 @@ DOC_NB_JS: Template = _env.get_template("doc_nb_js.js")
 AUTOLOAD_NB_JS: Template = _env.get_template("autoload_panel_js.js")
 NB_TEMPLATE_BASE: Template = _env.get_template('nb_template.html')
 
-def _autoload_js(bundle, configs, requirements, exports, skip_imports, ipywidget, load_timeout=5000):
+def _autoload_js(
+    bundle, configs, requirements, exports, skip_imports, ipywidget,
+    reloading=False, load_timeout=5000
+):
     config = {'packages': {}, 'paths': {}, 'shim': {}}
     for conf in configs:
         for key, c in conf.items():
@@ -97,12 +100,14 @@ def _autoload_js(bundle, configs, requirements, exports, skip_imports, ipywidget
     return AUTOLOAD_NB_JS.render(
         bundle    = bundle,
         force     = True,
+        reloading = reloading,
         timeout   = load_timeout,
         config    = config,
         requirements = requirements,
         exports   = exports,
         skip_imports = skip_imports,
-        ipywidget = ipywidget
+        ipywidget = ipywidget,
+        version = bokeh.__version__
     )
 
 def html_for_render_items(docs_json, render_items, template=None, template_variables={}):
@@ -324,7 +329,13 @@ def block_comm() -> Iterator:
     finally:
         state._hold = False
 
-def load_notebook(inline: bool = True, load_timeout: int = 5000) -> None:
+def load_notebook(
+    inline: bool = True,
+    reloading: bool = False,
+    extensions: list[str] = [],
+    resources: dict[str, dict[str, str] | list[str]] = {},
+    load_timeout: int = 5000
+) -> None:
     from IPython.display import publish_display_data
 
     resources = INLINE if inline and not state._is_pyodide else CDN
@@ -333,11 +344,15 @@ def load_notebook(inline: bool = True, load_timeout: int = 5000) -> None:
     nb_endpoint = not state._is_pyodide
     resources = Resources.from_bokeh(resources, notebook=nb_endpoint)
     try:
-        bundle = bundle_resources(None, resources, notebook=nb_endpoint)
+        bundle = bundle_resources(
+            None, resources, notebook=nb_endpoint, reloading=reloading
+        )
         configs, requirements, exports, skip_imports = require_components()
         ipywidget = 'ipywidgets_bokeh' in sys.modules
-        bokeh_js = _autoload_js(bundle, configs, requirements, exports,
-                                skip_imports, ipywidget, load_timeout)
+        bokeh_js = _autoload_js(
+            bundle, configs, requirements, exports, skip_imports, ipywidget,
+            reloading, load_timeout
+        )
     finally:
         if user_resources:
             settings.resources = prev_resources

--- a/panel/models/comm_manager.py
+++ b/panel/models/comm_manager.py
@@ -23,7 +23,7 @@ class CommManager(Model):
 
     def assemble(self, msg):
         header = msg['header']
-        buffers = msg.pop('_buffers')
+        buffers = msg.pop('_buffers') or {}
         header['num_buffers'] = len(buffers)
         cls = self._protocol._messages[header['msgtype']]
         msg_obj = cls(header, msg['metadata'], msg['content'])


### PR DESCRIPTION
In the past we had two major issues with resource and extension loading in notebooks.

## Problems

### Multiple extension calls

To avoid embedding huge inline JS/CSS bundles multiple times we avoided embedding the extension multiple times. This however caused issues if you had multiple extension calls in one cell, e.g.:

```python
import hvplot.pandas
pn.extension('tabulator')
```

OR

```python
import holoviews as hv
hv.extension('bokeh')
pn.extension('tabulator')
```

Properly educating users on these issues is basically impossible and it adds significant friction.

### Version clashes

When a user upgrades from an older Bokeh/Panel version the autoload JS code would detect that an existing Bokeh version is present and skip loading of the newer Bokeh and Panel libraries. Since newer Bokeh model bundles rarely work with older Bokeh/Panel JS versions this would lead to an error and no output showing up.

This situation could occur both in JupyterLab, where multiple tabs could load different versions of Bokeh and therefore you would have to potentially clear out all existing notebooks (and reload the page) when upgrading to a new Bokeh/Panel version. However even in classic notebook you could run into this situation by opening an existing notebook which had an older version of the autoload JS code embedded into it. 

## The solution

Instead of skipping the autoload JS code when multiple extensions are run we instead always run it but do not include Bokeh and Panel bundles when run a second time. This means extra extensions can be loaded in a secondary call to the extension without including the entire bundle each time.

Additionally we now check that the Bokeh JS version matches what we expect and if it does not we go ahead and load the newer Bokeh/Panel bundles. Once loaded we restore the old version BUT store the newer versions in a `Bokeh.versions` object. When a component is rendered we then look up the correct Bokeh version to use for rendering.

- [x] Fix for non-inlined Bokeh/Panel resources