### PR TITLE
Minor changes to prepare for Param 2.0

### DIFF
--- a/panel/interact.py
+++ b/panel/interact.py
@@ -45,7 +45,7 @@ def _yield_abbreviations_for_parameter(parameter, kwargs):
         if name in kwargs:
             value = kwargs.pop(name)
         elif ann is not empty:
-            param.main.warning("Using function annotations to implicitly specify interactive controls is deprecated. "
+            param.main.param.warning("Using function annotations to implicitly specify interactive controls is deprecated. "
                                "Use an explicit keyword argument for the parameter instead.", DeprecationWarning)
             value = ann
         elif default is not empty:

--- a/panel/io/embed.py
+++ b/panel/io/embed.py
@@ -313,7 +313,7 @@ def embed_state(panel, model, doc, max_states=1000, max_opts=3,
     if len(cross_product) > max_states:
         if config._doc_build:
             return
-        param.main.warning('The cross product of different application '
+        param.main.param.warning('The cross product of different application '
                            'states is very large to explore (N=%d), consider '
                            'reducing the number of options on the widgets or '
                            'increase the max_states specified in the function '

--- a/panel/io/ipywidget.py
+++ b/panel/io/ipywidget.py
@@ -138,7 +138,7 @@ class PanelSessionWebsocket(SessionWebsocket):
             for event in self._queue:
                 self._document.callbacks.trigger_on_change(event)
         except Exception as e:
-            param.main.warning(f'ipywidgets event dispatch failed with: {e}')
+            param.main.param.warning(f'ipywidgets event dispatch failed with: {e}')
         finally:
             self._queue = []
 

--- a/panel/io/rest.py
+++ b/panel/io/rest.py
@@ -147,7 +147,7 @@ def param_rest_provider(files, endpoint):
             try:
                 run_path(filename)
             except Exception:
-                param.main.warning("Could not run app script on REST server startup.")
+                param.main.param.warning("Could not run app script on REST server startup.")
         elif extension == 'ipynb':
             try:
                 import nbconvert  # noqa
@@ -163,7 +163,7 @@ def param_rest_provider(files, endpoint):
                 try:
                     run_path(tmp.name, init_globals={'get_ipython': MagicMock()})
                 except Exception:
-                    param.main.warning("Could not run app notebook on REST server startup.")
+                    param.main.param.warning("Could not run app notebook on REST server startup.")
         else:
             raise ValueError('{} is not a script (.py) or notebook (.ipynb)'.format(filename))
 

--- a/panel/param.py
+++ b/panel/param.py
@@ -985,7 +985,7 @@ class JSONInit(param.Parameterized):
         Optional path to a JSON file containing the parameter settings.""")
 
     def __call__(self, parameterized):
-        warnobj = param.main if isinstance(parameterized, type) else parameterized
+        warnobj = param.main.param if isinstance(parameterized, type) else parameterized.param
         param_class = (parameterized if isinstance(parameterized, type)
                        else parameterized.__class__)
 

--- a/panel/tests/pane/test_holoviews.py
+++ b/panel/tests/pane/test_holoviews.py
@@ -329,7 +329,7 @@ def test_holoviews_widgets_update_plot(document, comm):
 def test_holoviews_with_widgets_not_shown(document, comm):
     hmap = hv.HoloMap({(i, chr(65+i)): hv.Curve([i]) for i in range(3)}, kdims=['X', 'Y'])
 
-    hv_pane = HoloViews(hmap, show_widgets=False)
+    hv_pane = HoloViews(hmap)
     layout_obj = Column(hv_pane, hv_pane.widget_box)
     layout = layout_obj.get_root(document, comm)
     model = layout.children[0]


### PR DESCRIPTION
This PR fixes calls to Param's main warning, as in Param 2.0 the `warning` method is going to be removed from the Parameterized namespace and will only be available in the `.param` namespace.

This PR also removes an unused kwarg passed in a test to the `HoloViews` pane, spotted by Simon in https://github.com/holoviz/param/pull/729.