### PR TITLE
Refactor template, design and theme resource resolution

### DIFF
--- a/panel/compiler.py
+++ b/panel/compiler.py
@@ -188,7 +188,9 @@ def bundle_templates(verbose=False, external=True):
             template_css = [template_css] if template_css else []
         for css in template_css:
             tmpl_name = name.lower()
-            for cls in template.__mro__[1:-5]:
+            for cls in template.__mro__[1:]:
+                if not issubclass(cls, BasicTemplate):
+                    continue
                 tmpl_css = cls._css if isinstance(cls._css, list) else [cls._css]
                 if css in tmpl_css:
                     tmpl_name = cls.__name__.lower()
@@ -202,7 +204,9 @@ def bundle_templates(verbose=False, external=True):
             template_js = [template_js] if template_js else []
         for js in template_js:
             tmpl_name = name.lower()
-            for cls in template.__mro__[1:-5]:
+            for cls in template.__mro__[1:]:
+                if not issubclass(cls, BasicTemplate):
+                    continue
                 tmpl_js = cls._js if isinstance(cls._js, list) else [cls._js]
                 if js in tmpl_js:
                     tmpl_name = cls.__name__.lower()

--- a/panel/config.py
+++ b/panel/config.py
@@ -24,7 +24,6 @@ from pyviz_comms import (
 
 from .io.logging import panel_log_handler
 from .io.state import state
-from .theme import Design
 
 __version__ = str(param.version.Version(
     fpath=__file__, archive_commit="$Format:%h$", reponame="panel"))
@@ -126,7 +125,7 @@ class _config(_base_config):
     defer_load = param.Boolean(default=False, doc="""
         Whether to defer load of rendered functions.""")
 
-    design = param.ClassSelector(class_=Design, is_instance=False, doc="""
+    design = param.ClassSelector(class_=None, is_instance=False, doc="""
         The design system to use to style components.""")
 
     exception_handler = param.Callable(default=None, doc="""
@@ -645,6 +644,7 @@ class panel_extension(_pyviz_extension):
 
         for k, v in params.items():
             if k == 'design' and isinstance(v, str):
+                from .theme import Design
                 try:
                     importlib.import_module(f'panel.theme.{self._design}')
                 except Exception:

--- a/panel/io/resources.py
+++ b/panel/io/resources.py
@@ -615,7 +615,9 @@ class Resources(BkResources):
 
         files += list(config.js_files.values())
         if config.design:
-            design_resources = config.design.resolve_resources()
+            design_resources = config.design().resolve_resources(
+                cdn=self.notebook or 'auto', include_theme=False
+            )
             files += [
                 res for res in design_resources['js'].values() if res not in files
             ]
@@ -643,7 +645,9 @@ class Resources(BkResources):
         modules = list(config.js_modules.values())
         self.extra_resources(modules, '__javascript_modules__')
         if config.design:
-            design_resources = config.design.resolve_resources()
+            design_resources = config.design().resolve_resources(
+                cdn=self.notebook or 'auto', include_theme=False
+            )
             modules += [
                 res for res in design_resources['js_modules'].values()
                 if res not in modules

--- a/panel/io/resources.py
+++ b/panel/io/resources.py
@@ -18,7 +18,9 @@ from base64 import b64encode
 from collections import OrderedDict
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Literal
+from typing import (
+    TYPE_CHECKING, Dict, List, Literal, TypedDict,
+)
 
 import param
 
@@ -37,6 +39,13 @@ from markupsafe import Markup
 from ..config import config, panel_extension as extension
 from ..util import isurl, url_path
 from .state import state
+
+if TYPE_CHECKING:
+    class ResourcesType(TypedDict):
+        css: Dict[str, str]
+        js:  Dict[str, str]
+        js_modules: Dict[str, str]
+        raw_css: List[str]
 
 logger = logging.getLogger(__name__)
 
@@ -135,6 +144,19 @@ def set_resource_mode(mode):
     finally:
         RESOURCE_MODE = old_mode
         _settings.resources.set_value(old_resources)
+
+def use_cdn() -> bool:
+    return _settings.resources(default="server") != 'server'
+
+def get_dist_path(cdn: bool | Literal['auto'] = 'auto') -> str:
+    cdn = use_cdn() if cdn == 'auto' else cdn
+    if cdn:
+        dist_path = CDN_DIST
+    elif state.rel_path:
+        dist_path = f'{state.rel_path}/{LOCAL_DIST}'
+    else:
+        dist_path = f'{LOCAL_DIST}'
+    return dist_path
 
 def process_raw_css(raw_css):
     """
@@ -377,6 +399,91 @@ def bundle_resources(roots, resources, notebook=False, reloading=False):
         js_modules=resources.js_modules,
         notebook=notebook,
     )
+
+
+class ResourceComponent:
+    """
+    Mix-in class for components that define a set of resources
+    that have to be resolved.
+    """
+
+    _resources = {
+        'css': {},
+        'font': {},
+        'js': {},
+        'js_modules': {},
+        'raw_css': [],
+    }
+
+    def resolve_resources(self, cdn: bool | Literal['auto'] = 'auto') -> ResourcesType:
+        """
+        Resolves the resources required for this component.
+
+        Arguments
+        ---------
+        cdn: bool | Literal['auto']
+            Whether to load resources from CDN or local server. If set
+            to 'auto' value will be automatically determine based on
+            global settings.
+
+        Returns
+        -------
+        Dictionary containing JS and CSS resources.
+        """
+        cls = type(self)
+        resources = {}
+        for rt, res in self._resources.items():
+            if not isinstance(res, dict):
+                continue
+            if rt == 'font':
+                rt = 'css'
+            res = {
+                name: url if isurl(url) else f'{cls.__name__.lower()}/{url}'
+                for name, url in res.items()
+            }
+            if rt in resources:
+                resources[rt] = dict(resources[rt], **res)
+            else:
+                resources[rt] = res
+
+        cdn = use_cdn() if cdn == 'auto' else cdn
+        dist_path = get_dist_path(cdn=cdn)
+        resource_types: ResourcesType = {
+            'js': {},
+            'js_modules': {},
+            'css': {},
+            'raw_css': []
+        }
+
+        for resource_type in resource_types:
+            if resource_type not in resources or resource_type == 'raw_css':
+                continue
+            resource_files = resource_types[resource_type]
+            for rname, resource in resources[resource_type].items():
+                if resource.startswith(CDN_DIST):
+                    resource_path = resource.replace(f'{CDN_DIST}bundled/', '')
+                elif resource.startswith(config.npm_cdn):
+                    resource_path = resource.replace(config.npm_cdn, '')[1:]
+                elif resource.startswith('http:'):
+                    resource_path = url_path(resource)
+                else:
+                    resource_path = resource
+
+                if resource_type == 'js_modules' and not (state.rel_path or cdn):
+                    prefixed_dist = f'./{dist_path}'
+                else:
+                    prefixed_dist = dist_path
+
+                bundlepath = BUNDLE_DIR / resource_path.replace('/', os.path.sep)
+                if bundlepath.is_file():
+                    resource_files[rname] = f'{prefixed_dist}bundled/{resource_path}'
+                elif isurl(resource):
+                    resource_files[rname] = resource
+                elif resolve_custom_path(cls, resource):
+                    resource_files[rname] = component_resource_path(
+                        cls, f'_resources/{resource_type}', resource
+                    )
+        return resource_types
 
 
 class Resources(BkResources):

--- a/panel/io/resources.py
+++ b/panel/io/resources.py
@@ -615,7 +615,10 @@ class Resources(BkResources):
 
         files += list(config.js_files.values())
         if config.design:
-            files += list(config.design._resources.get('js', {}).values())
+            design_resources = config.design.resolve_resources()
+            files += [
+                res for res in design_resources['js'].values() if res not in files
+            ]
 
         js_files = self.adjust_paths(files)
 
@@ -639,14 +642,12 @@ class Resources(BkResources):
 
         modules = list(config.js_modules.values())
         self.extra_resources(modules, '__javascript_modules__')
-
         if config.design:
-            design_name = config.design.__name__.lower()
-            for resource in config.design._resources.get('js_modules', {}).values():
-                if not isurl(resource):
-                    resource = f'{CDN_DIST}bundled/{design_name}/{resource}'
-                if resource not in modules:
-                    modules.append(resource)
+            design_resources = config.design.resolve_resources()
+            modules += [
+                res for res in design_resources['js_modules'].values()
+                if res not in modules
+            ]
 
         for model in param.concrete_descendents(ReactiveHTML).values():
             if not (getattr(model, '__javascript_modules__', None) and model._loaded()):

--- a/panel/template/base.py
+++ b/panel/template/base.py
@@ -644,7 +644,7 @@ class BasicTemplate(BaseTemplate, ResourceComponent):
             if isinstance(res, dict):
                 resource_types[rname].update(res)
             else:
-                resource_types[rname] = [
+                resource_types[rname] += [
                     r for r in res if res not in resource_types[rname]
                 ]
 

--- a/panel/template/base.py
+++ b/panel/template/base.py
@@ -11,7 +11,8 @@ import uuid
 from functools import partial
 from pathlib import Path, PurePath
 from typing import (
-    IO, TYPE_CHECKING, Any, ClassVar, Dict, List, Optional, Tuple, Type,
+    IO, TYPE_CHECKING, Any, ClassVar, Dict, List, Literal, Optional, Tuple,
+    Type,
 )
 
 import param
@@ -26,8 +27,8 @@ from ..io.model import add_to_doc
 from ..io.notebook import render_template
 from ..io.notifications import NotificationArea
 from ..io.resources import (
-    BUNDLE_DIR, CDN_DIST, DOC_DIST, LOCAL_DIST, _env, component_resource_path,
-    loading_css, resolve_custom_path,
+    BUNDLE_DIR, DOC_DIST, ResourceComponent, _env, component_resource_path,
+    get_dist_path, loading_css, resolve_custom_path,
 )
 from ..io.save import save
 from ..io.state import curdoc_locked, state
@@ -39,9 +40,9 @@ from ..pane import (
 from ..pane.image import ImageBase
 from ..reactive import ReactiveHTML
 from ..theme.base import (
-    THEME_CSS, THEMES, DefaultTheme, Design, Theme,
+    THEMES, DefaultTheme, Design, Theme,
 )
-from ..util import isurl, relative_to, url_path
+from ..util import isurl
 from ..viewable import (
     MimeRenderMixin, Renderable, ServableMixin, Viewable,
 )
@@ -53,16 +54,9 @@ if TYPE_CHECKING:
     from bokeh.server.contexts import BokehSessionContext
     from jinja2 import Template as _Template
     from pyviz_comms import Comm
-    from typing_extensions import Literal, TypedDict
 
     from ..io.location import Location
-
-    class ResourcesType(TypedDict):
-        css: Dict[str, str]
-        js:  Dict[str, str]
-        js_modules: Dict[str, str]
-        extra_css: List[str]
-        raw_css: List[str]
+    from ..io.resources import ResourcesType
 
 
 _server_info: str = (
@@ -432,7 +426,7 @@ class TemplateActions(ReactiveHTML):
     }
 
 
-class BasicTemplate(BaseTemplate):
+class BasicTemplate(BaseTemplate, ResourceComponent):
     """
     BasicTemplate provides a baseclass for templates with a basic
     organization including a header, sidebar and main area. Unlike the
@@ -539,10 +533,6 @@ class BasicTemplate(BaseTemplate):
     # Resources #
     #############
 
-    # Resource locations for bundled resources
-    _CDN: ClassVar[str] = CDN_DIST
-    _LOCAL: ClassVar[str] = LOCAL_DIST
-
     # pathlib.Path pointing to local CSS file(s)
     _css: ClassVar[Path | str | List[Path | str] | None] = None
 
@@ -623,103 +613,53 @@ class BasicTemplate(BaseTemplate):
             document.theme = self._design.theme.bokeh_theme
         return document
 
-    def _template_resources(self) -> ResourcesType:
-        clsname = type(self).__name__
+    def resolve_resources(self, cdn: bool | Literal['auto'] = 'auto') -> ResourcesType:
+        """
+        Resolves the resources required for this template component.
+
+        Arguments
+        ---------
+        cdn: bool | Literal['auto']
+            Whether to load resources from CDN or local server. If set
+            to 'auto' value will be automatically determine based on
+            global settings.
+
+        Returns
+        -------
+        Dictionary containing JS and CSS resources.
+        """
+        cls = type(self)
+        resource_types = super().resolve_resources(cdn=cdn)
+        js_files = resource_types['js']
+        js_modules = resource_types['js_modules']
+        css_files = resource_types['css']
+        raw_css = resource_types['raw_css']
+
+        clsname = cls.__name__
         name = clsname.lower()
-        use_cdn = _settings.resources(default="server") != 'server'
-        if use_cdn:
-            dist_path = self._CDN
-        elif state.rel_path:
-            dist_path = f'{state.rel_path}/{self._LOCAL}'
-        else:
-            dist_path = f'{self._LOCAL}'
+        dist_path = get_dist_path(cdn=cdn)
 
-        # External resources
-        css_files: Dict[str, str] = {}
-        js_files: Dict[str, str] = {}
-        js_modules: Dict[str, str] = {}
-        resource_types: ResourcesType = {
-            'css': css_files,
-            'js': js_files,
-            'js_modules': js_modules,
-            'extra_css': [],
-            'raw_css': list(self.config.raw_css) + [loading_css()]
-        }
-
-        theme = self._design.theme
-        for attr in ('base_css', 'css'):
-            css = getattr(theme, attr, None)
-            if css is None:
-                continue
-            basename = os.path.basename(css)
-            key = 'theme_base' if 'base' in attr else 'theme'
-            if relative_to(css, THEME_CSS):
-                css_files[key] = dist_path + f'bundled/theme/{basename}'
-            elif resolve_custom_path(theme, css):
-                owner = type(theme).param[attr].owner
-                css_files[key] = component_resource_path(owner, attr, css)
-
-        resolved_resources: List[Literal['css', 'js', 'js_modules']] = ['css', 'js', 'js_modules']
-
-        # Resolve Design resources
-        resources = dict(self._resources)
-        for rt, res in self._design._resources.items():
-            if not isinstance(res, dict):
-                continue
-            if rt == 'font':
-                rt = 'css'
-            res = {
-                name: url if isurl(url) else f'{type(self._design).__name__.lower()}/{url}'
-                for name, url in res.items()
-            }
-            if rt in resources:
-                resources[rt] = dict(resources[rt], **res)
+        raw_css.extend(list(self.config.raw_css) + [loading_css()])
+        for rname, res in self._design.resolve_resources(cdn).items():
+            if isinstance(res, dict):
+                resource_types[rname].update(res)
             else:
-                resources[rt] = res
+                resource_types[rname] = [
+                    r for r in res if res not in resource_types[rname]
+                ]
 
-        for resource_type in resolved_resources:
-            if resource_type not in resources:
-                continue
-            resource_files = resource_types[resource_type]
-            for rname, resource in resources[resource_type].items():
-                if resource.startswith(CDN_DIST):
-                    resource_path = resource.replace(f'{CDN_DIST}bundled/', '')
-                elif resource.startswith(config.npm_cdn):
-                    resource_path = resource.replace(config.npm_cdn, '')[1:]
-                elif resource.startswith('http:'):
-                    resource_path = url_path(resource)
-                else:
-                    resource_path = resource
-
-                if resource_type == 'js_modules' and not (state.rel_path or use_cdn):
-                    prefixed_dist = f'./{dist_path}'
-                else:
-                    prefixed_dist = dist_path
-
-                bundlepath = BUNDLE_DIR / resource_path.replace('/', os.path.sep)
-                if bundlepath.is_file():
-                    resource_files[rname] = f'{prefixed_dist}bundled/{resource_path}'
-                elif isurl(resource):
-                    resource_files[rname] = resource
-                elif resolve_custom_path(self, resource):
-                    resource_files[rname] = component_resource_path(
-                        self, f'_resources/{resource_type}', resource
-                    )
-
-        for name, js in self.config.js_files.items():
+        for rname, js in self.config.js_files.items():
             if '//' not in js and state.rel_path:
                 js = f'{state.rel_path}/{js}'
-            js_files[name] = js
-        for name, js in self.config.js_modules.items():
+            js_files[rname] = js
+        for rname, js in self.config.js_modules.items():
             if '//' not in js and state.rel_path:
                 js = f'{state.rel_path}/{js}'
-            js_modules[name] = js
-
-        extra_css = resource_types['extra_css']
-        for css in list(self.config.css_files):
+            js_modules[rname] = js
+        for i, css in enumerate(list(self.config.css_files)):
             if '//' not in css and state.rel_path:
                 css = f'{state.rel_path}/{css}'
-            extra_css.append(css)
+            css_files[f'config_{i}'] = css
 
         # CSS files
         base_css = self._css
@@ -727,16 +667,17 @@ class BasicTemplate(BaseTemplate):
             base_css = [base_css] if base_css else []
         for css in base_css:
             tmpl_name = name
-            for cls in type(self).__mro__[1:-5]:
-                if not issubclass(cls, BasicTemplate):
+            for scls in cls.__mro__[1:-5]:
+                if not issubclass(scls, BasicTemplate):
                     continue
-                elif cls._css is None:
+                elif scls._css is None:
                     break
-                tmpl_css = cls._css if isinstance(cls._css, list) else [cls._css]
+                tmpl_css = scls._css if isinstance(scls._css, list) else [scls._css]
                 if css in tmpl_css:
-                    tmpl_name = cls.__name__.lower()
+                    tmpl_name = scls.__name__.lower()
 
             css_file = os.path.basename(css)
+            print(tmpl_name, css_file)
             if (BUNDLE_DIR / tmpl_name / css_file).is_file():
                 css_files[f'base_{css_file}'] = dist_path + f'bundled/{tmpl_name}/{css_file}'
             elif isurl(css):
@@ -798,7 +739,7 @@ class BasicTemplate(BaseTemplate):
                 favicon = DOC_DIST + "icons/favicon.ico"
             else:
                 favicon = self.favicon
-        self._render_variables['template_resources'] = self._template_resources()
+        self._render_variables['template_resources'] = self.resolve_resources()
         self._render_variables['app_logo'] = logo
         self._render_variables['app_favicon'] = favicon
         self._render_variables['app_favicon_type'] = self._get_favicon_type(self.favicon)

--- a/panel/template/base.py
+++ b/panel/template/base.py
@@ -677,7 +677,6 @@ class BasicTemplate(BaseTemplate, ResourceComponent):
                     tmpl_name = scls.__name__.lower()
 
             css_file = os.path.basename(css)
-            print(tmpl_name, css_file)
             if (BUNDLE_DIR / tmpl_name / css_file).is_file():
                 css_files[f'base_{css_file}'] = dist_path + f'bundled/{tmpl_name}/{css_file}'
             elif isurl(css):

--- a/panel/template/base.py
+++ b/panel/template/base.py
@@ -667,7 +667,7 @@ class BasicTemplate(BaseTemplate, ResourceComponent):
             base_css = [base_css] if base_css else []
         for css in base_css:
             tmpl_name = name
-            for scls in cls.__mro__[1:-5]:
+            for scls in cls.__mro__[1:]:
                 if not issubclass(scls, BasicTemplate):
                     continue
                 elif scls._css is None:

--- a/panel/template/bootstrap/bootstrap.html
+++ b/panel/template/bootstrap/bootstrap.html
@@ -40,9 +40,6 @@
     {% for css in template_resources['css'].values() %}
     <link rel="stylesheet" href="{{ css }}">
     {% endfor %}
-    {% for src in template_resources['extra_css'] %}
-    <link rel="stylesheet"  href="{{ src }}">
-    {% endfor %}
     {% for raw_css in template_resources['raw_css'] %}
     <style type="text/css">
     {{ raw_css }}

--- a/panel/template/fast/grid/fast_grid_template.html
+++ b/panel/template/fast/grid/fast_grid_template.html
@@ -27,9 +27,6 @@
 {% for css in template_resources['css'].values() %}
 <link rel="stylesheet" href="{{ css }}">
 {% endfor %}
-{% for src in template_resources['extra_css'] %}
-<link rel="stylesheet"  href="{{ src }}">
-{% endfor %}
 {% for raw_css in template_resources['raw_css'] %}
 <style type="text/css">
 {{ raw_css }}

--- a/panel/template/fast/list/fast_list_template.html
+++ b/panel/template/fast/list/fast_list_template.html
@@ -17,9 +17,6 @@
 {% for css in template_resources['css'].values() %}
 <link rel="stylesheet" href="{{ css }}">
 {% endfor %}
-{% for src in template_resources['extra_css'] %}
-<link rel="stylesheet"  href="{{ src }}">
-{% endfor %}
 {% for raw_css in template_resources['raw_css'] %}
 <style type="text/css">
 {{ raw_css }}

--- a/panel/template/golden/golden.html
+++ b/panel/template/golden/golden.html
@@ -18,9 +18,6 @@
 {% for css in template_resources['css'].values() %}
 <link rel="stylesheet" href="{{ css }}">
 {% endfor %}
-{% for src in template_resources['extra_css'] %}
-<link rel="stylesheet"  href="{{ src }}">
-{% endfor %}
 {% for raw_css in template_resources['raw_css'] %}
 <style type="text/css">
 {{ raw_css }}

--- a/panel/template/material/material.html
+++ b/panel/template/material/material.html
@@ -40,9 +40,6 @@
     {% for css in template_resources['css'].values() %}
     <link rel="stylesheet" href="{{ css }}">
     {% endfor %}
-    {% for src in template_resources['extra_css'] %}
-    <link rel="stylesheet"  href="{{ src }}">
-    {% endfor %}
     {% for raw_css in template_resources['raw_css'] %}
     <style type="text/css">
     {{ raw_css }}

--- a/panel/template/react/react.html
+++ b/panel/template/react/react.html
@@ -25,9 +25,6 @@
 {% for css in template_resources['css'].values() %}
 <link rel="stylesheet" href="{{ css }}">
 {% endfor %}
-{% for src in template_resources['extra_css'] %}
-<link rel="stylesheet"  href="{{ src }}">
-{% endfor %}
 {% for raw_css in template_resources['raw_css'] %}
 <style type="text/css">
 {{ raw_css }}

--- a/panel/template/vanilla/vanilla.html
+++ b/panel/template/vanilla/vanilla.html
@@ -17,9 +17,6 @@
 {% for css in template_resources['css'].values() %}
 <link rel="stylesheet" href="{{ css }}">
 {% endfor %}
-{% for src in template_resources['extra_css'] %}
-<link rel="stylesheet"  href="{{ src }}">
-{% endfor %}
 {% for raw_css in template_resources['raw_css'] %}
 <style type="text/css">
 {{ raw_css }}

--- a/panel/theme/base.py
+++ b/panel/theme/base.py
@@ -317,7 +317,9 @@ class Design(param.Parameterized, ResourceComponent):
         for sm in model.references():
             theme.apply_to_model(sm)
 
-    def resolve_resources(self, cdn: bool | Literal['auto'] = 'auto') -> ResourceTypes:
+    def resolve_resources(
+        self, cdn: bool | Literal['auto'] = 'auto', include_theme: bool = True
+    ) -> ResourceTypes:
         """
         Resolves the resources required for this design component.
 
@@ -327,12 +329,16 @@ class Design(param.Parameterized, ResourceComponent):
             Whether to load resources from CDN or local server. If set
             to 'auto' value will be automatically determine based on
             global settings.
+        include_theme: bool
+            Whether to include theme resources.
 
         Returns
         -------
         Dictionary containing JS and CSS resources.
         """
         resource_types = super().resolve_resources(cdn)
+        if not include_theme:
+            return resource_types
         dist_path = get_dist_path(cdn=cdn)
         css_files = resource_types['css']
         theme = self.theme

--- a/panel/theme/base.py
+++ b/panel/theme/base.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
 import functools
+import os
 import pathlib
 
 from typing import (
-    TYPE_CHECKING, Any, ClassVar, Dict, Tuple, Type,
+    TYPE_CHECKING, Any, ClassVar, Dict, Literal, Tuple, Type,
 )
 
 import param
@@ -12,12 +13,18 @@ import param
 from bokeh.models import ImportedStyleSheet
 from bokeh.themes import Theme as _BkTheme, _dark_minimal, built_in_themes
 
+from ..config import config
+from ..io.resources import (
+    ResourceComponent, component_resource_path, get_dist_path,
+    resolve_custom_path,
+)
 from ..util import relative_to
 
 if TYPE_CHECKING:
     from bokeh.document import Document
     from bokeh.model import Model
 
+    from ..io.resources import ResourceTypes
     from ..viewable import Viewable
 
 
@@ -84,7 +91,7 @@ class DarkTheme(Theme):
     _name: ClassVar[str] = 'dark'
 
 
-class Design(param.Parameterized):
+class Design(param.Parameterized, ResourceComponent):
 
     theme = param.ClassSelector(class_=Theme, constant=True)
 
@@ -310,6 +317,38 @@ class Design(param.Parameterized):
         for sm in model.references():
             theme.apply_to_model(sm)
 
+    def resolve_resources(self, cdn: bool | Literal['auto'] = 'auto') -> ResourceTypes:
+        """
+        Resolves the resources required for this design component.
+
+        Arguments
+        ---------
+        cdn: bool | Literal['auto']
+            Whether to load resources from CDN or local server. If set
+            to 'auto' value will be automatically determine based on
+            global settings.
+
+        Returns
+        -------
+        Dictionary containing JS and CSS resources.
+        """
+        resource_types = super().resolve_resources(cdn)
+        dist_path = get_dist_path(cdn=cdn)
+        css_files = resource_types['css']
+        theme = self.theme
+        for attr in ('base_css', 'css'):
+            css = getattr(theme, attr, None)
+            if css is None:
+                continue
+            basename = os.path.basename(css)
+            key = 'theme_base' if 'base' in attr else 'theme'
+            if relative_to(css, THEME_CSS):
+                css_files[key] = dist_path + f'bundled/theme/{basename}'
+            elif resolve_custom_path(theme, css):
+                owner = type(theme).param[attr].owner
+                css_files[key] = component_resource_path(owner, attr, css)
+        return resource_types
+
     def params(
         self, viewable: Viewable, doc: Document | None = None
     ) -> Tuple[Dict[str, Any], Dict[str, Any]]:
@@ -344,6 +383,7 @@ class Design(param.Parameterized):
         return modifiers, child_modifiers
 
 
+config.param.design.class_ = Design
 THEMES = {
     'default': DefaultTheme,
     'dark': DarkTheme


### PR DESCRIPTION
The resource resolution code of the `Design`, `Theme` and `Template` components was a total mess and all implemented on the `BasicTemplate` class. Since it may now be necessary to resolve the resources separately from a template we implement a `ResourceComponent` baseclass that implements a `resolve_resources` method to return the resources in a format that can be easily consumed.