### PR TITLE
Improve ipywidgets handling

### DIFF
--- a/panel/io/ipywidget.py
+++ b/panel/io/ipywidget.py
@@ -60,15 +60,9 @@ def _on_widget_constructed(widget, doc=None):
         return
     widget._document = doc
     kernel = _get_kernel(doc=doc)
-    if comm and isinstance(widget.comm, comm.DummyComm):
-        raise RuntimeError(
-            "When rendering ipywidgets inside a Panel application the "
-            "'ipywidgets' extension must be loaded (using "
-            "`pn.extension('ipywidgets', ...)`) before any IPyWidget "
-            "IPyWidget is instantiated."
-        )
-    elif (widget.comm and widget.comm.target_name != 'panel-temp-comm' and
-          isinstance(widget.comm.kernel, PanelKernel)):
+    if (widget.comm and widget.comm.target_name != 'panel-temp-comm' and
+        (not (comm and isinstance(widget.comm, comm.DummyComm)) and
+         isinstance(widget.comm.kernel, PanelKernel))):
         return
     args = dict(
         kernel=kernel,

--- a/panel/io/ipywidget.py
+++ b/panel/io/ipywidget.py
@@ -30,12 +30,12 @@ try:
 
     from comm.base_comm import BaseComm
 
-    class DummyComm(BaseComm):
+    class TempComm(BaseComm):
         def publish_msg(self, *args, **kwargs): pass
 
-    comm.create_comm = lambda *args, **kwargs: DummyComm(target_name='panel-temp-comm', primary=False)
+    comm.create_comm = lambda *args, **kwargs: TempComm(target_name='panel-temp-comm', primary=False)
 except Exception:
-    pass
+    comm = None
 
 def _get_kernel(cls=None, doc=None):
     doc = doc or state.curdoc
@@ -60,7 +60,15 @@ def _on_widget_constructed(widget, doc=None):
         return
     widget._document = doc
     kernel = _get_kernel(doc=doc)
-    if widget.comm and widget.comm.target_name != 'panel-temp-comm' and isinstance(widget.comm.kernel, PanelKernel):
+    if comm and isinstance(widget.comm, comm.DummyComm):
+        raise RuntimeError(
+            "When rendering ipywidgets inside a Panel application the "
+            "'ipywidgets' extension must be loaded (using "
+            "`pn.extension('ipywidgets', ...)`) before any IPyWidget "
+            "IPyWidget is instantiated."
+        )
+    elif (widget.comm and widget.comm.target_name != 'panel-temp-comm' and
+          isinstance(widget.comm.kernel, PanelKernel)):
         return
     args = dict(
         kernel=kernel,

--- a/panel/pane/ipywidget.py
+++ b/panel/pane/ipywidget.py
@@ -51,9 +51,9 @@ class IPyWidget(PaneBase):
         if isinstance(comm, JupyterComm) and not config.embed and "PANEL_IPYWIDGET" not in os.environ:
             IPyWidget = _BkIPyWidget
         else:
+            # panel.io.ipywidgets MUST be loaded before ipywidgets_bokeh
+            from ..io.ipywidget import _get_ipywidgets, _on_widget_constructed # isort: skip
             from ipywidgets_bokeh.widget import IPyWidget
-
-            from ..io.ipywidget import _get_ipywidgets, _on_widget_constructed
 
             # Ensure all widgets are initialized
             for w in _get_ipywidgets().values():


### PR DESCRIPTION
The new `comm` library install a `DummyComm` unless we apply the patches in `panel.io.ipywidget`, so we handle this case and override the comm. Separately we must ensure that `panel.io.ipywidget` is loaded before `ipywidgets_bokeh`.

Fixes https://github.com/holoviz/panel/issues/2435