### PR TITLE
Implement .embed using mimebundle rendering

### DIFF
--- a/doc/upgrade.md
+++ b/doc/upgrade.md
@@ -161,6 +161,12 @@ at the top of your application. The flipside of this is that if you call `pn.ext
 We recommend always declaring all required extensions at the top of your application.
 :::
 
+### Smaller changes
+
+- `Tabulator.frozen_rows` now respects the order of rows in the data instead of the order in which the `frozen_rows` were defined.
+- `Viewable.embed` now returns a `Mimebundle` object that can be rendered in a notebook but also in other contexts.
+- The `policy` argument toon `pn.cache` used to accept `'LIFO'` but instead implemented a `'FIFO'` policy. This has been fixed and the function now only accepts `'LRU'`, `'LIFO'`, and `'LFU'` policies.
+
 ### Deprecations
 
 The following changes have been deprecated; we will warn you and guide you on how to update them.
@@ -179,9 +185,3 @@ pn.pane.Markdown("# Hello", styles={'background': 'red'})
 #### `Ace` renamed to `CodeEditor`
 
 `pn.widgets.Ace()` has been renamed to `pn.widgets.CodeEditor()` to reflect better what the component does and not the implementation used.
-
-#### Miscellaneous
-
-Small behavior changes:
-
-`Tabulator.frozen_rows` now respects the order of rows in the data instead of the order in which the `frozen_rows` were defined.

--- a/panel/io/notebook.py
+++ b/panel/io/notebook.py
@@ -300,6 +300,17 @@ class JupyterCommManagerBinary(_JupyterCommManager):
 
     client_comm = JupyterCommJSBinary
 
+
+class Mimebundle:
+    """
+    Wraps a generated mimebundle.
+    """
+    def __init__(self, mimebundle):
+        self._mimebundle = mimebundle
+
+    def _repr_mimebundle_(self, include=None, exclude=None):
+        return self._mimebundle
+
 #---------------------------------------------------------------------
 # Public API
 #---------------------------------------------------------------------
@@ -424,7 +435,7 @@ def show_server(panel: Any, notebook_url: str, port: int = 0) -> 'Server':
     })
     return server
 
-def show_embed(
+def render_embed(
     panel, max_states: int = 1000, max_opts: int = 3, json: bool = False,
     json_prefix: str = '', save_path: str = './', load_path: Optional[str] = None,
     progress: bool = True, states: Dict[Widget, List[Any]] = {}
@@ -454,8 +465,6 @@ def show_embed(
     states: dict (default={})
       A dictionary specifying the widget values to embed for each widget
     """
-    from IPython.display import publish_display_data
-
     from ..config import config
 
     doc = Document()
@@ -465,7 +474,11 @@ def show_embed(
         embed_state(panel, model, doc, max_states, max_opts,
                     json, json_prefix, save_path, load_path, progress,
                     states)
-    publish_display_data(*render_model(model))
+    return Mimebundle(render_model(model))
+
+def show_embed(panel, *args, **kwargs):
+    from IPython.display import publish_display_data
+    return publish_display_data(render_embed(panel, *args, **kwargs))
 
 def ipywidget(obj: Any, doc=None, **kwargs: Any):
     """

--- a/panel/viewable.py
+++ b/panel/viewable.py
@@ -38,8 +38,8 @@ from .io.embed import embed_state
 from .io.loading import start_loading_spinner, stop_loading_spinner
 from .io.model import add_to_doc, patch_cds_msg
 from .io.notebook import (
-    JupyterCommManagerBinary as JupyterCommManager, ipywidget,
-    render_mimebundle, render_model, show_embed, show_server,
+    JupyterCommManagerBinary as JupyterCommManager, ipywidget, render_embed,
+    render_mimebundle, render_model, show_server,
 )
 from .io.save import save
 from .io.state import curdoc_locked, state
@@ -905,9 +905,7 @@ class Viewable(Renderable, Layoutable, ServableMixin):
         states: dict (default={})
           A dictionary specifying the widget values to embed for each widget
         """
-        if state._is_pyodide:
-            return self
-        show_embed(
+        return render_embed(
             self, max_states, max_opts, json, json_prefix, save_path,
             load_path, progress, states
         )


### PR DESCRIPTION
Instead of rendering .embed output by publishing it with IPython display functionality we use a wrapper object. This makes it possible for non-IPython based renderers (e.g. PyScript or our pyodide sphinx extension) be able to render the embed output.