### PR TITLE
Improve button styling and add icon support

### DIFF
--- a/examples/reference/widgets/Button.ipynb
+++ b/examples/reference/widgets/Button.ipynb
@@ -29,7 +29,10 @@
     "\n",
     "##### Display\n",
     "\n",
+    "* **`button_style`** (str): The button style, either 'solid' or 'outline'.\n",
     "* **``button_type``** (str): A button theme; should be one of ``'default'`` (white), ``'primary'`` (blue), ``'success'`` (green), ``'info'`` (yellow), ``'light'`` (light), or ``'danger'`` (red)\n",
+    "* **`icon`** (str): An icon to render to the left of the button label. Either an SVG or an icon name which is loaded from https://tabler-icons.io/.\n",
+    "* **`icon_size`** (str): Size of the icon as a string, e.g. 12px or 1em.\n",
     "* **``disabled``** (boolean): Whether the widget is editable\n",
     "* **``name``** (str): The title of the widget\n",
     "\n",
@@ -88,6 +91,29 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### Styles\n",
+    "\n",
+    "The color of the button can be set by selecting one of the available `button_type` values and the `button_style` can be `'solid'` or `'outline'`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pn.Row(\n",
+    "    *(pn.Column(*(pn.widgets.Button(name=p, button_type=p, button_style=bs) for p in pn.widgets.Button.param.button_type.objects))\n",
+    "    for bs in pn.widgets.Button.param.button_style.objects)\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Icons\n",
+    "\n",
     "The ``Button`` name string may contain Unicode characters, providing a convenient way to define common graphical buttons:"
    ]
   },
@@ -108,7 +134,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The color of the button can be set by selecting one of the available button types:"
+    "However you can also provide an explicit `icon`, either as a named icon loaded from https://tabler-icons.io/:"
    ]
   },
   {
@@ -117,7 +143,35 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "pn.Column(*(pn.widgets.Button(name=p, button_type=p) for p in pn.widgets.Button.param.button_type.objects))"
+    "pn.Row(\n",
+    "    pn.widgets.Button(icon='alert-triangle-filled', button_type='warning', name='WARNING'),\n",
+    "    pn.widgets.Button(icon='bug', button_type='danger', name='Error')\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "or as an explicit SVG:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cash_icon = \"\"\"\n",
+    "<svg xmlns=\"http://www.w3.org/2000/svg\" class=\"icon icon-tabler icon-tabler-cash\" width=\"24\" height=\"24\" viewBox=\"0 0 24 24\" stroke-width=\"2\" stroke=\"currentColor\" fill=\"none\" stroke-linecap=\"round\" stroke-linejoin=\"round\">\n",
+    "  <path stroke=\"none\" d=\"M0 0h24v24H0z\" fill=\"none\"/>\n",
+    "  <path d=\"M7 9m0 2a2 2 0 0 1 2 -2h10a2 2 0 0 1 2 2v6a2 2 0 0 1 -2 2h-10a2 2 0 0 1 -2 -2z\" />\n",
+    "  <path d=\"M14 14m-2 0a2 2 0 1 0 4 0a2 2 0 1 0 -4 0\" />\n",
+    "  <path d=\"M17 9v-2a2 2 0 0 0 -2 -2h-10a2 2 0 0 0 -2 2v6a2 2 0 0 0 2 2h2\" />\n",
+    "</svg>\n",
+    "\"\"\"\n",
+    "\n",
+    "pn.widgets.Button(icon=cash_icon, button_type='success', name='Checkout', icon_size='2em')"
    ]
   },
   {

--- a/examples/reference/widgets/CheckButtonGroup.ipynb
+++ b/examples/reference/widgets/CheckButtonGroup.ipynb
@@ -68,6 +68,32 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### Styles\n",
+    "\n",
+    "The color of the button can be set by selecting one of the available `button_type` values and the `button_style` can be `'solid'` or `'outline'`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pn.Row(\n",
+    "    *(pn.Column(*(\n",
+    "        pn.widgets.CheckButtonGroup(\n",
+    "            name=p, button_type=p, button_style=bs, options=['Foo', 'Bar', 'Baz'], value=['Bar']\n",
+    "        )\n",
+    "        for p in pn.widgets.Button.param.button_type.objects\n",
+    "    ))\n",
+    "    for bs in pn.widgets.Button.param.button_style.objects)\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### Controls\n",
     "\n",
     "The `CheckButtonGroup` widget exposes a number of options which can be changed from both Python and Javascript. Try out the effect of these parameters interactively:"

--- a/examples/reference/widgets/RadioButtonGroup.ipynb
+++ b/examples/reference/widgets/RadioButtonGroup.ipynb
@@ -29,6 +29,7 @@
     "\n",
     "##### Display\n",
     "\n",
+    "* **`button_style`** (str): The button style, either 'solid' or 'outline'.\n",
     "* **``button_type``** (str): A button theme should be one of ``'default'`` (white), ``'primary'`` (blue), ``'success'`` (green), ``'info'`` (yellow), or ``'danger'`` (red)\n",
     "* **``disabled``** (boolean): Whether the widget is editable\n",
     "* **``name``** (str): The title of the widget\n",
@@ -64,6 +65,32 @@
    "outputs": [],
    "source": [
     "radio_group.value"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Styles\n",
+    "\n",
+    "The color of the buttons can be set by selecting one of the available `button_type` values and the `button_style` can be `'solid'` or `'outline'`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pn.Row(\n",
+    "    *(pn.Column(*(\n",
+    "        pn.widgets.RadioButtonGroup(\n",
+    "            name=p, button_type=p, button_style=bs, options=['Foo', 'Bar', 'Baz'], value='Bar'\n",
+    "        )\n",
+    "        for p in pn.widgets.Button.param.button_type.objects\n",
+    "    ))\n",
+    "    for bs in pn.widgets.Button.param.button_style.objects)\n",
+    ")"
    ]
   },
   {

--- a/examples/reference/widgets/Toggle.ipynb
+++ b/examples/reference/widgets/Toggle.ipynb
@@ -28,7 +28,10 @@
     "\n",
     "##### Display\n",
     "\n",
+    "* **`button_style`** (str): The button style, either 'solid' or 'outline'.\n",
     "* **``button_type``** (str): A button theme should be one of ``'default'`` (white), ``'primary'`` (blue), ``'success'`` (green), ``'info'`` (yellow), or ``'danger'`` (red)\n",
+    "* **`icon`** (str): An icon to render to the left of the button label. Either an SVG or an icon name which is loaded from https://tabler-icons.io/.\n",
+    "* **`icon_size`** (str): Size of the icon as a string, e.g. 12px or 1em.\n",
     "* **``disabled``** (boolean): Whether the widget is editable\n",
     "* **``name``** (str): The title of the widget\n",
     "\n",
@@ -66,7 +69,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The color of the ``Toggle`` can be selected using one of the available ``button_type``s:"
+    "### Styles\n",
+    "\n",
+    "The color of the button can be set by selecting one of the available `button_type` values and the `button_style` can be `'solid'` or `'outline'`:"
    ]
   },
   {
@@ -75,7 +80,54 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "pn.Column(*(pn.widgets.Toggle(name=p, button_type=p) for p in pn.widgets.Toggle.param.button_type.objects))"
+    "pn.Row(\n",
+    "    *(pn.Column(*(pn.widgets.Toggle(name=p, button_type=p, button_style=bs) for p in pn.widgets.Toggle.param.button_type.objects))\n",
+    "    for bs in pn.widgets.Toggle.param.button_style.objects)\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Icons\n",
+    "\n",
+    "However you can also provide an explicit `icon`, either as a named icon loaded from https://tabler-icons.io/:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pn.widgets.Toggle(icon='2fa', button_type='light', icon_size='2em')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "or as an explicit SVG:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "shuffle_icon = \"\"\"\n",
+    "<svg xmlns=\"http://www.w3.org/2000/svg\" class=\"icon icon-tabler icon-tabler-arrows-shuffle\" width=\"24\" height=\"24\" viewBox=\"0 0 24 24\" stroke-width=\"2\" stroke=\"currentColor\" fill=\"none\" stroke-linecap=\"round\" stroke-linejoin=\"round\">\n",
+    "  <path stroke=\"none\" d=\"M0 0h24v24H0z\" fill=\"none\"/>\n",
+    "  <path d=\"M18 4l3 3l-3 3\" />\n",
+    "  <path d=\"M18 20l3 -3l-3 -3\" />\n",
+    "  <path d=\"M3 7h3a5 5 0 0 1 5 5a5 5 0 0 0 5 5h5\" />\n",
+    "  <path d=\"M21 7h-5a4.978 4.978 0 0 0 -3 1m-4 8a4.984 4.984 0 0 1 -3 1h-3\" />\n",
+    "</svg>\n",
+    "\"\"\"\n",
+    "\n",
+    "pn.widgets.Toggle(icon=shuffle_icon, button_type='success', name='Shuffle', icon_size='2em')"
    ]
   },
   {

--- a/panel/dist/css/button.css
+++ b/panel/dist/css/button.css
@@ -1,0 +1,106 @@
+.bk-btn:active {
+    transform: scale(0.98);
+}
+
+:host(.outline) .bk-btn {
+    background-color: transparent;
+}
+
+:host(.solid) .bk-btn {
+    border: unset;
+}
+
+:host(.solid) .bk-btn.bk-btn-default {
+    background-color: var(--panel-surface-color);
+    color: var(--panel-on-surface-color);
+}
+
+:host(.outline) .bk-btn.bk-btn-default {
+    color: var(--panel-on-background-color);
+}
+
+:host(.outline) .bk-btn.bk-btn-default.bk-active {
+    color: var(--panel-on-background-color);
+    box-shadow: inset 0px 3px 5px rgb(0 0 0 / 25%);
+}
+
+:host(.outline) .bk-btn-group .bk-btn-default.bk-active {
+    background-color: var(--panel-surface-color);
+    color: var(--panel-on-surface-color);
+}
+
+:host(.solid) .bk-btn.bk-btn-primary {
+    background-color: var(--panel-primary-color);
+}
+
+:host(.solid) .bk-btn.bk-btn-primary.bk-active {
+    background-color: var(--panel-primary-color);
+    box-shadow: inset 0px 3px 5px rgb(0 0 0 / 25%);
+}
+
+:host(.outline) .bk-btn-primary {
+    background-color: transparent;
+    color: var(--panel-on-background-color);
+}
+
+:host(.outline) .bk-btn-primary.bk-active,:host(.outline) .bk-btn-primary:hover {
+    color: var(--neutral-foreground-rest);
+}
+
+:host(.outline) .bk-btn-group .bk-btn-primary.bk-active {
+    background-color: var(--panel-primary-color);
+    color: var(--panel-on-primary-color);
+}
+
+:host(.outline) .bk-btn-success {
+    color: var(--success-bg-color);
+}
+
+:host(.outline) .bk-btn-success.bk-active, :host(.outline) .bk-btn-success:hover {
+    color: var(--panel-on-background-color);
+}
+
+:host(.outline) .bk-btn-group .bk-btn-success.bk-active {
+    background-color: var(--success-bg-color);
+    color: var(--success-text-color);
+}
+
+:host(.outline) .bk-btn-warning {
+    color: var(--warning-bg-color);
+}
+
+:host(.outline) .bk-btn-warning.bk-active, :host(.outline) .bk-btn-warning:hover {
+    color: var(--panel-on-background-color);
+}
+
+:host(.outline) .bk-btn-group .bk-btn-warning.bk-active {
+    background-color: var(--warning-bg-color);
+    color: var(--warning-text-color);
+}
+
+:host(.outline) .bk-btn-danger {
+    color: var(--danger-bg-color);
+}
+
+:host(.outline) .bk-btn-danger.bk-active, :host(.outline) .bk-btn-danger:hover {
+    color: var(--panel-on-background-color);
+}
+
+:host(.outline) .bk-btn-group .bk-btn-danger.bk-active {
+    background-color: var(--danger-bg-color);
+    color: var(--danger-text-color);
+}
+
+:host(.outline) .bk-btn-light {
+    border-color: var(--light-bg-color);
+    color: var(--panel-on-background-color);
+}
+
+:host(.outline) .bk-btn-light.bk-active, :host(.outline) .bk-btn-light:hover {
+    color: var(--panel-on-background-color);
+}
+
+:host(.outline) .bk-btn-group .bk-btn-light.bk-active {
+    background-color: var(--light-bg-color);
+    color: var(--light-text-color);
+}

--- a/panel/tests/util.py
+++ b/panel/tests/util.py
@@ -57,6 +57,7 @@ unix_only = pytest.mark.skipif(platform.system() != 'Linux', reason="Only suppor
 
 from panel.pane.alert import Alert
 from panel.pane.markup import Markdown
+from panel.widgets.button import _ButtonBase
 
 
 def mpl_figure():
@@ -84,6 +85,8 @@ def check_layoutable_properties(layoutable, model):
         assert model.css_classes == ['markdown', 'custom_class', 'alert', 'alert-primary']
     elif isinstance(layoutable, Markdown):
         assert model.css_classes == ['markdown', 'custom_class']
+    elif isinstance(layoutable, _ButtonBase):
+        assert model.css_classes == ['solid', 'custom_class']
     else:
         assert model.css_classes == ['custom_class']
 

--- a/panel/theme/css/fast.css
+++ b/panel/theme/css/fast.css
@@ -439,77 +439,81 @@ input[type=file]:active {
 /* Buttons */
 
 .bk-btn {
-    background-color: transparent;
     border-radius: calc(var(--control-corner-radius) * 1px);
     line-height: var(--type-ramp-base-line-height);
     min-width: calc((var(--base-height-multiplier) + var(--density)) * var(--design-unit) * 1px);
 }
 
-.bk-btn.bk-btn-default {
-    background-color: transparent;
-    border: 1px solid var(--accent-fill-rest);
-    color: var(--accent-fill-rest);
+:host(.solid) .bk-btn.bk-btn-default {
+    background-color: var(--neutral-fill-rest);
+    color: var(--neutral-foreground-rest);
 }
 
-.bk-btn.bk-btn-default:hover {
+:host(.solid) .bk-btn.bk-btn-default:hover {
     background-color: var(--neutral-fill-hover);
 }
 
-.bk-btn.bk-btn-default.bk-active {
-    background-color: var(--accent-fill-active);
+:host(.outline) .bk-btn.bk-btn-default {
+    background-color: transparent;
+    border: 1px solid var(--neutral-fill-strong-rest);
+    color: var(--neutral-fill-strong-rest);
+}
+
+:host(.outline) .bk-btn.bk-btn-default:hover {
+    background-color: var(--neutral-fill-hover);
+    color: var(--neutral-foreground-rest);
+}
+
+:host(.outline) .bk-btn.bk-btn-default.bk-active {
     color: var(--foreground-on-accent-rest);
     box-shadow: inset 0px 3px 5px rgb(0 0 0 / 25%);
 }
 
-.bk-btn-primary {
-    color: #3276b1;
+:host(.outline) .bk-btn-group .bk-btn-default.bk-active {
+    background-color: var(--neutral-fill-active);
+    color: var(--foreground-on-accent-active);
 }
 
-.bk-btn-primary.bk-active,.bk-btn-primary:hover {
-    color: var(--secondary-text-color);
+:host(.solid) .bk-btn.bk-btn-primary {
+    background-color: var(--accent-fill-rest);
 }
 
-.bk-btn-secondary {
-    color: var(--secondary-bg-color);
+:host(.solid) .bk-btn.bk-btn-primary.bk-active {
+    background-color: var(--accent-fill-active);
+    box-shadow: inset 0px 3px 5px rgb(0 0 0 / 25%);
 }
 
-.bk-btn-secondary.bk-active, .bk-btn-secondary:hover {
-    color: var(--secondary-text-color);
-}
-
-.bk-btn-success {
-    color: var(--success-bg-color);
-}
-
-.bk-btn-success.bk-active, .bk-btn-success:hover {
-    color: var(--success-text-color);
-}
-
-.bk-btn-warning {
-    color: var(--warning-bg-color);
-}
-
-.bk-btn-warning.bk-active, .bk-btn-warning:hover {
-    color: var(--warning-text-color);
-}
-
-.bk-btn-danger {
-    color: var(--danger-bg-color);
-}
-
-.bk-btn-danger.bk-active, .bk-btn-danger:hover {
-    color: var(--danger-text-color);
-}
-
-.bk-btn-light {
-    border-color: var(--light-bg-color);
+:host(.outline) .bk-btn-primary {
+    background-color: transparent;
     color: var(--neutral-foreground-rest);
 }
 
-.bk-btn-light.bk-active, .bk-btn-light:hover {
-    color: var(--light-text-color);
+:host(.outline) .bk-btn-primary.bk-active,:host(.outline) .bk-btn-primary:hover {
+    color: var(--neutral-foreground-rest);
 }
 
+:host(.outline) .bk-btn-group .bk-btn-primary.bk-active {
+    background-color: var(--accent-fill-rest);
+    color: var(--foreground-on-accent-active);
+}
+
+:host(.outline) .bk-btn-success.bk-active, :host(.outline) .bk-btn-success:hover {
+    color: var(--neutral-foreground-rest);
+}
+
+
+:host(.outline) .bk-btn-warning.bk-active, :host(.outline) .bk-btn-warning:hover {
+    color: var(--neutral-foreground-rest);
+}
+
+:host(.outline) .bk-btn-danger.bk-active, :host(.outline) .bk-btn-danger:hover {
+    color: var(--neutral-foreground-rest);
+}
+
+:host(.outline) .bk-btn-light {
+    border-color: var(--light-bg-color);
+    color: var(--neutral-foreground-rest);
+}
 
 .bk-btn[disabled],
 .bk-btn[disabled]:hover,

--- a/panel/widgets/button.py
+++ b/panel/widgets/button.py
@@ -44,15 +44,17 @@ class _ButtonBase(Widget):
 
     _rename: ClassVar[Mapping[str, str | None]] = {'name': 'label', 'button_style': None}
 
+    _source_transforms: ClassVar[Mapping[str, str | None]] = {'button_style': None}
+
     _stylesheets: ClassVar[List[str]] = [f'{CDN_DIST}css/button.css']
 
     __abstract = True
 
     def _process_param_change(self, params):
         if 'button_style' in params or 'css_classes' in params:
-            params['css_classes'] = params.get('css_classes', self.css_classes) + [
+            params['css_classes'] = [
                 params.pop('button_style', self.button_style)
-            ]
+            ] + params.get('css_classes', self.css_classes)
         return super()._process_param_change(params)
 
 
@@ -65,7 +67,9 @@ class IconMixin(Widget):
     icon_size = param.String(default='1em', doc="""
         Size of the icon as a string, e.g. 12px or 1em.""")
 
-    _rename: ClassVar[Mapping[str, str | None]] = {'icon_size': None}
+    _rename: ClassVar[Mapping[str, str | None]] = {
+        'icon': None, 'icon_size': None
+    }
 
     __abstract = True
 
@@ -86,6 +90,10 @@ class _ClickButton(_ButtonBase, IconMixin):
     __abstract = True
 
     _event: ClassVar[str] = 'button_click'
+
+    _source_transforms: ClassVar[Mapping[str, str | None]] = {
+        'button_style': None, 'icon_size': None, 'icon': None
+    }
 
     def _get_model(
         self, doc: Document, root: Optional[Model] = None,
@@ -168,7 +176,9 @@ class Button(_ClickButton):
     value = param.Event(doc="""
         Toggles from False to True while the event is being processed.""")
 
-    _rename: ClassVar[Mapping[str, str | None]] = {'clicks': None, 'name': 'label', 'value': None}
+    _rename: ClassVar[Mapping[str, str | None]] = {
+        'clicks': None, 'name': 'label', 'value': None
+    }
 
     _target_transforms: ClassVar[Mapping[str, str | None]] = {
         'event:button_click': None, 'value': None
@@ -258,7 +268,9 @@ class Toggle(_ButtonBase, IconMixin):
     value = param.Boolean(default=False, doc="""
         Whether the button is currently toggled.""")
 
-    _rename: ClassVar[Mapping[str, str | None]] = {'value': 'active', 'name': 'label'}
+    _rename: ClassVar[Mapping[str, str | None]] = {
+        'value': 'active', 'name': 'label', 'icon': None, 'icon_size': None
+    }
 
     _supports_embed: ClassVar[bool] = True
 

--- a/panel/widgets/select.py
+++ b/panel/widgets/select.py
@@ -499,7 +499,9 @@ class _RadioGroupBase(SingleSelectBase):
 
     _supports_embed = False
 
-    _rename: ClassVar[Mapping[str, str | None]] = {'name': None, 'options': 'labels', 'value': 'active'}
+    _rename: ClassVar[Mapping[str, str | None]] = {
+        'name': None, 'options': 'labels', 'value': 'active'
+    }
 
     _source_transforms = {'value': "source.labels[value]"}
 
@@ -570,6 +572,10 @@ class RadioButtonGroup(_RadioGroupBase, _ButtonBase):
     orientation = param.Selector(default='horizontal',
         objects=['horizontal', 'vertical'], doc="""
         Button group orientation, either 'horizontal' (default) or 'vertical'.""")
+
+    _source_transforms = {
+        'value': "source.labels[value]", 'button_style': None
+    }
 
     _supports_embed: ClassVar[bool] = True
 
@@ -665,6 +671,10 @@ class CheckButtonGroup(_CheckGroupBase, _ButtonBase):
     orientation = param.Selector(default='horizontal',
         objects=['horizontal', 'vertical'], doc="""
         Button group orientation, either 'horizontal' (default) or 'vertical'.""")
+
+    _source_transforms = {
+        'value': "value.map((index) => source.labels[index])", 'button_style': None
+    }
 
     _widget_type: ClassVar[Type[Model]] = _BkCheckboxButtonGroup
 


### PR DESCRIPTION
- Add support for `button_style` to toggle between 'solid' and 'outline' styles

<img width="443" alt="Screen Shot 2023-05-07 at 16 13 44" src="https://user-images.githubusercontent.com/1550771/236682834-ce8dbc43-d1fb-4305-80e9-0000f8f0abaa.png">

<img width="448" alt="Screen Shot 2023-05-07 at 16 13 56" src="https://user-images.githubusercontent.com/1550771/236682845-d7367c6e-6715-40c3-9b0b-77637df12c48.png">


- Add support for icons
<img width="201" alt="Screen Shot 2023-05-07 at 16 13 19" src="https://user-images.githubusercontent.com/1550771/236682809-9d1283c9-2408-4759-aee4-3b2b0540a9e3.png">
