### PR TITLE
Align widget and pane margins

### DIFF
--- a/panel/models/layout.ts
+++ b/panel/models/layout.ts
@@ -34,7 +34,7 @@ export class PanelMarkupView extends WidgetView {
     super.render()
     set_size(this.el, this.model)
     this.container = div()
-    set_size(this.container, this.model)
+    set_size(this.container, this.model, false)
     this.shadow_el.appendChild(this.container)
 
     if (this.provider.status == "failed" || this.provider.status == "loaded")
@@ -42,7 +42,7 @@ export class PanelMarkupView extends WidgetView {
   }
 }
 
-export function set_size(el: HTMLElement, model: HTMLBox): void {
+export function set_size(el: HTMLElement, model: HTMLBox, adjustMargin: boolean = true): void {
   let width_policy = model.width != null ? "fixed" : "fit"
   let height_policy = model.height != null ? "fixed" : "fit"
   const {sizing_mode, margin} = model
@@ -75,7 +75,9 @@ export function set_size(el: HTMLElement, model: HTMLBox): void {
     }
   }
   let wm: number, hm: number
-  if (isArray(margin)) {
+  if (!adjustMargin) {
+    hm = wm = 0
+  } else if (isArray(margin)) {
     if (margin.length === 4) {
       hm = margin[0] + margin[2]
       wm = margin[1] + margin[3]

--- a/panel/pane/base.py
+++ b/panel/pane/base.py
@@ -108,7 +108,7 @@ class PaneBase(Reactive):
         Defines the layout the model(s) returned by the pane will
         be placed in.""")
 
-    margin = Margin(default=5, doc="""
+    margin = Margin(default=(5, 10), doc="""
         Allows to create additional space around the component. May
         be specified as a two-tuple of the form (vertical, horizontal)
         or a four-tuple (top, right, bottom, left).""")

--- a/panel/tests/ui/pane/test_image.py
+++ b/panel/tests/ui/pane/test_image.py
@@ -68,8 +68,8 @@ def test_png_scale_height(sizing_mode, embed, page, port):
     png = PNG(PNG_FILE, sizing_mode=sizing_mode, fixed_aspect=True, embed=embed)
     row = Row(png, height=500)
     bbox = get_bbox(page, port, row)
-    assert bbox['width'] == 640
-    assert bbox['height'] == 480
+    assert int(bbox['width']) == 653
+    assert bbox['height'] == 490
 
 @pytest.mark.parametrize('sizing_mode', ['stretch_both', 'scale_both'])
 @pytest.mark.parametrize('embed', [False, True])
@@ -78,7 +78,7 @@ def test_png_scale_both(sizing_mode, embed, page, port):
     row = Row(png, width=800, height=500)
     bbox = get_bbox(page, port, row)
     assert bbox['width'] == 780
-    assert bbox['height'] == 480
+    assert bbox['height'] == 490
 
 @pytest.mark.parametrize('embed', [False, True])
 def test_png_stretch_width(embed, page, port):
@@ -94,7 +94,7 @@ def test_png_stretch_height(embed, page, port):
     row = Row(png, height=500)
     bbox = get_bbox(page, port, row)
     assert bbox['width'] == 500
-    assert bbox['height'] == 480
+    assert bbox['height'] == 490
 
 @pytest.mark.parametrize('embed', [False, True])
 def test_png_stretch_both(embed, page, port):
@@ -102,7 +102,7 @@ def test_png_stretch_both(embed, page, port):
     row = Row(png, width=800, height=500)
     bbox = get_bbox(page, port, row)
     assert bbox['width'] == 780
-    assert bbox['height'] == 480
+    assert bbox['height'] == 490
 
 @pytest.mark.parametrize('embed', [False, True])
 def test_svg_native_size(embed, page, port):
@@ -133,8 +133,8 @@ def test_svg_scale_height(sizing_mode, embed, page, port):
     svg = SVG(SVG_FILE, sizing_mode=sizing_mode, fixed_aspect=True, embed=embed)
     row = Row(svg, height=500)
     bbox = get_bbox(page, port, row)
-    assert int(bbox['width']) == 569
-    assert bbox['height'] == 480
+    assert int(bbox['width']) == 580
+    assert bbox['height'] == 490
 
 @pytest.mark.parametrize('sizing_mode', ['stretch_both', 'scale_both'])
 @pytest.mark.parametrize('embed', [False, True])
@@ -143,7 +143,7 @@ def test_svg_scale_both(sizing_mode, embed, page, port):
     row = Row(svg, width=800, height=500)
     bbox = get_bbox(page, port, row)
     assert bbox['width'] == 780
-    assert bbox['height'] == 480
+    assert bbox['height'] == 490
 
 @pytest.mark.parametrize('embed', [False, True])
 def test_svg_stretch_width(embed, page, port):
@@ -159,7 +159,7 @@ def test_svg_stretch_height(embed, page, port):
     row = Row(svg, height=500)
     bbox = get_bbox(page, port, row)
     assert bbox['width'] == 500
-    assert bbox['height'] == 480
+    assert bbox['height'] == 490
 
 @pytest.mark.parametrize('embed', [False, True])
 def test_svg_stretch_both(embed, page, port):
@@ -167,7 +167,7 @@ def test_svg_stretch_both(embed, page, port):
     row = Row(svg, width=800, height=500)
     bbox = get_bbox(page, port, row)
     assert bbox['width'] == 780
-    assert bbox['height'] == 480
+    assert bbox['height'] == 490
 
 def test_pdf_embed(page, port):
     pdf_pane = PDF(PDF_FILE, embed=True)

--- a/panel/widgets/base.py
+++ b/panel/widgets/base.py
@@ -16,6 +16,7 @@ import param  # type: ignore
 
 from bokeh.models import ImportedStyleSheet
 
+from .._param import Margin
 from ..layout.base import Row
 from ..reactive import Reactive
 from ..viewable import Layoutable, Viewable
@@ -45,7 +46,7 @@ class Widget(Reactive):
 
     width = param.Integer(default=None, bounds=(0, None))
 
-    margin = param.Parameter(default=(5, 10), doc="""
+    margin = Margin(default=(5, 10), doc="""
         Allows to create additional space around the component. May
         be specified as a two-tuple of the form (vertical, horizontal)
         or a four-tuple (top, right, bottom, left).""")


### PR DESCRIPTION
This is a wide-ranging change. It was intended to have been done in https://github.com/holoviz/panel/pull/4528 but the margin for Panes was set to `5` rather than `(10, 5)`. So it's unfortunate this did not go out as part of the RC releases but alignment on this is preferable over the current situation.

- Aligns default margin on widgets and panes
- Fixes https://github.com/holoviz/panel/issues/3736