### PR TITLE
Update set_param to update and fix a related bug

### DIFF
--- a/doc/how_to/links/watchers.md
+++ b/doc/how_to/links/watchers.md
@@ -74,14 +74,14 @@ To initialize the `selections` and `selected` we can explicitly ``trigger`` opti
 toggle.param.trigger('options', 'value')
 ```
 
-We can also override the initial parameters using the ``set_param`` method:
+We can also override the initial parameters using the ``update`` method:
 
 ```{pyodide}
 options = ['A','B','C','D']
-toggle.param.set_param(options=dict(zip(options,options)), value=['D'])
+toggle.param.update(options=dict(zip(options,options)), value=['D'])
 ```
 
-Using `set_param` allows us to batch two separate changes (the options and the value) together, which you can see from the ``print`` output resulted into a single invocation of the callback.  You could instead have set them separately using the usual parameter-setting syntax `toggle.value=['D']; toggle.options=dict(zip(options,options))`, but batching them can be much more efficient for a non-trivial callback like a database query or a complex plot that needs updating.
+Using `update` allows us to batch two separate changes (the options and the value) together, which you can see from the ``print`` output resulted into a single invocation of the callback.  You could instead have set them separately using the usual parameter-setting syntax `toggle.value=['D']; toggle.options=dict(zip(options,options))`, but batching them can be much more efficient for a non-trivial callback like a database query or a complex plot that needs updating.
 
 Now that the widgets are visible, you can toggle the option values and see the selected pane update in response via the callback (if Python is running).
 

--- a/examples/reference/panes/Param.ipynb
+++ b/examples/reference/panes/Param.ipynb
@@ -281,7 +281,7 @@
     "sections = {'InputFiles': ['dirs', 'files'], 'Field': ['grps', 'varns']}\n",
     "\n",
     "def update(target, event):\n",
-    "    target.set_param(options=sections[event.new], value=sections[event.new][0])\n",
+    "    target.update(options=sections[event.new], value=sections[event.new][0])\n",
     "\n",
     "sel = pn.widgets.Select(options=list(sections.keys()))\n",
     "rad = pn.widgets.RadioButtonGroup(options=sections[sel.value])\n",

--- a/panel/layout/card.py
+++ b/panel/layout/card.py
@@ -113,7 +113,7 @@ class Card(Column):
                 'margin': (5, 0)
             }
             if self._header is not None:
-                self._header.param.set_param(**params)
+                self._header.param.update(**params)
                 return
             else:
                 self._header = item = HTML(**params)

--- a/panel/layout/grid.py
+++ b/panel/layout/grid.py
@@ -336,7 +336,7 @@ class GridSpec(Panel):
                 elif 'height' in self.sizing_mode and width:
                     properties['width'] = int(w*width)
 
-            obj.param.set_param(**{k: v for k, v in properties.items()
+            obj.param.update(**{k: v for k, v in properties.items()
                                    if not obj.param[k].readonly})
 
             if obj in old_objects:

--- a/panel/pane/base.py
+++ b/panel/pane/base.py
@@ -600,7 +600,7 @@ class ReplacementPane(PaneBase):
                 equal = False
             if not equal:
                 new_params[k] = v
-        old.set_param(**new_params)
+        old.param.update(**new_params)
 
     @classmethod
     def _update_from_object(cls, object: Any, old_object: Any, was_internal: bool, inplace: bool=False, **kwargs):


### PR DESCRIPTION
Found a small bug in `_recursive_update` by running this:

``` python
import pandas as pd
import panel as pn

pn.extension("tabulator")

n = pn.widgets.IntSlider(name="Frequency", start=0, end=10, value=2)


@pn.depends(n)
def f(n):
    a = pn.widgets.Tabulator(pd.DataFrame(range(n)))
    return pn.Row(a)


pn.Column(n, pn.Row(f)).servable()
```

And was informed by @maximlt that `set_param` is deprecated so I updated it to `update`.
