### PR TITLE
Remove holoviews version pins

### DIFF
--- a/panel/io/convert.py
+++ b/panel/io/convert.py
@@ -50,10 +50,7 @@ PYSCRIPT_CSS = '<link rel="stylesheet" href="https://pyscript.net/releases/2022.
 PYSCRIPT_JS = '<script defer src="https://pyscript.net/releases/2022.12.1/pyscript.js"></script>'
 PYODIDE_JS = f'<script src="{PYODIDE_URL}"></script>'
 
-MINIMUM_VERSIONS = {
-    'holoviews': '1.16.0a7',
-    'ipywidgets_bokeh': '1.4.0.dev3'
-}
+MINIMUM_VERSIONS = {}
 
 ICON_DIR = DIST_DIR / 'images'
 PWA_IMAGES = [
@@ -261,12 +258,9 @@ def script_to_html(
     reqs = base_reqs + [
         req for req in requirements if req not in ('panel', 'bokeh')
     ]
-    # Temporary patch for HoloViews
     for name, min_version in MINIMUM_VERSIONS.items():
         if any(name in req for req in reqs):
             reqs = [f'{name}>={min_version}' if name in req else req for req in reqs]
-    if any('hvplot' in req for req in reqs):
-        reqs.insert(2, 'holoviews>=1.16.0a7')
 
     # Execution
     post_code = POST_PYSCRIPT if runtime == 'pyscript' else POST

--- a/scripts/panelite/generate_panelite_content.py
+++ b/scripts/panelite/generate_panelite_content.py
@@ -38,7 +38,7 @@ def _get_dependencies(nbpath: pathlib.Path):
         return []
     for name, min_version in MINIMUM_VERSIONS.items():
         if any(name in req for req in dependencies):
-            deps = [f'{name}>={min_version}' if name in req else req for req in dependencies]
+            dependencies = [f'{name}>={min_version}' if name in req else req for req in dependencies]
     return BASE_DEPENDENCIES + dependencies
 
 def _to_piplite_install_code(dependencies):

--- a/scripts/panelite/generate_panelite_content.py
+++ b/scripts/panelite/generate_panelite_content.py
@@ -12,14 +12,13 @@ from test.notebooks_with_panelite_issues import NOTEBOOK_ISSUES
 import bokeh.sampledata
 import nbformat
 
-from panel.io.convert import MINIMUM_VERSIONS
-
 HERE = pathlib.Path(__file__).parent
 PANEL_BASE = HERE.parent.parent
 EXAMPLES_DIR = PANEL_BASE / 'examples'
 LITE_FILES = PANEL_BASE / 'lite' / 'files'
 DOC_DIR = PANEL_BASE / 'doc'
 BASE_DEPENDENCIES = ['panel', 'pyodide-http']
+MINIMUM_VERSIONS = {}
 
 # Add piplite command to notebooks
 with open(DOC_DIR / 'pyodide_dependencies.json', encoding='utf8') as file:
@@ -40,8 +39,6 @@ def _get_dependencies(nbpath: pathlib.Path):
     for name, min_version in MINIMUM_VERSIONS.items():
         if any(name in req for req in dependencies):
             deps = [f'{name}>={min_version}' if name in req else req for req in dependencies]
-    if any('hvplot' in req for req in dependencies):
-        dependencies.insert(0, 'holoviews>=1.16.0a7')
     return BASE_DEPENDENCIES + dependencies
 
 def _to_piplite_install_code(dependencies):


### PR DESCRIPTION
No longer need a lower bound version pin on holoviews and ipywidget_bokeh.

To be merged when holoviews 1.16.0 is released.