### PR TITLE
Interactive pane should not resolve interactive pipeline

### DIFF
--- a/panel/pane/holoviews.py
+++ b/panel/pane/holoviews.py
@@ -9,7 +9,7 @@ import sys
 from collections import OrderedDict, defaultdict
 from functools import partial
 from typing import (
-    TYPE_CHECKING, Any, ClassVar, Mapping, Optional, Type,
+    TYPE_CHECKING, Any, ClassVar, Mapping, Optional, Tuple, Type,
 )
 
 import param
@@ -623,6 +623,8 @@ class HoloViews(PaneBase):
 class Interactive(PaneBase):
 
     priority: ClassVar[float | bool | None] = None
+
+    _ignored_refs: ClassVar[Tuple[str]] = ['object']
 
     def __init__(self, object=None, **params):
         super().__init__(object, **params)


### PR DESCRIPTION
Currently the `Interactive` pane treats hvplot.Interactive object as a reference which means it resolves the output of the pipeline and errors.