### PR TITLE
Revise getting started section

### DIFF
--- a/doc/explanation/api/examples/outliers_declarative.md
+++ b/doc/explanation/api/examples/outliers_declarative.md
@@ -9,11 +9,12 @@ For such usages, Panel supports objects declared with the separate [Param](http:
 
 ```{pyodide}
 import panel as pn
-pn.extension()
 import hvplot.pandas
+import numpy as np
 import param
 import pandas as pd
-import numpy as np
+
+pn.extension()
 
 
 csv_file = 'https://raw.githubusercontent.com/holoviz/panel/main/examples/assets/occupancy.csv'

--- a/doc/explanation/api/examples/outliers_declarative.md
+++ b/doc/explanation/api/examples/outliers_declarative.md
@@ -1,0 +1,61 @@
+# Simple Outlier App - Declarative API
+
+This app is a complement to the simple app demonstrated in the [Getting Started > Build an app](../../../getting_started/build_app.md) tutorial which utilized the reactive API.
+
+The reactive API approach is very flexible, but it ties your domain-specific code (the parts about sine waves) with your widget display code. That's fine for small, quick projects or projects dominated by visualization code, but what about large-scale, long-lived projects, where the code is used in many different contexts over time, such as in large batch runs, one-off command-line usage, notebooks, and deployed dashboards?  For larger projects like that, it's important to be able to separate the parts of the code that are about the underlying domain (i.e. application or research area) from those that are tied to specific display technologies (such as Jupyter notebooks or web servers).
+
+For such usages, Panel supports objects declared with the separate [Param](http://param.pyviz.org) library, which provides a GUI-independent way of capturing and declaring the parameters of your objects (and dependencies between your code and those parameters), in a way that's independent of any particular application or dashboard technology. For instance, the app in [Getting Started > Build an app](../../../getting_started/build_app.md) can be captured in an object that declares the ranges and values of all parameters, as well as how to generate the plot, independently of the Panel library or any other way of interacting with the object. First, we'll copy the initial steps :
+
+
+```{pyodide}
+import panel as pn
+pn.extension()
+import hvplot.pandas
+import param
+import pandas as pd
+import numpy as np
+
+
+csv_file = 'https://raw.githubusercontent.com/holoviz/panel/main/examples/assets/occupancy.csv'
+data = pd.read_csv(csv_file, parse_dates=['date'], index_col='date')
+
+data.tail()
+```
+
+```{pyodide}
+def view_hvplot(avg, highlight):
+    return avg.hvplot(height=300, width=400, legend=False) * highlight.hvplot.scatter(
+        color="orange", padding=0.1, legend=False
+    )
+
+def find_outliers(variable="Temperature", window=30, sigma=10, view_fn=view_hvplot):
+    avg = data[variable].rolling(window=window).mean()
+    residual = data[variable] - avg
+    std = residual.rolling(window=window).std()
+    outliers = np.abs(residual) > std * sigma
+    return view_fn(avg, avg[outliers])
+```
+
+Now, let's implement the declarative API approach:
+
+```{pyodide}
+class RoomOccupancy(param.Parameterized):
+    variable  = param.Selector(default="Temperature", objects=list(data.columns))
+    window    = param.Integer(default=30, bounds=(1, 60))
+    sigma     = param.Number(default=10, bounds=(0, 20))
+
+    def view(self):
+        return find_outliers(self.variable, self.window, self.sigma, view_fn=view_hvplot)
+
+obj = RoomOccupancy()
+obj
+```
+
+The `RoomOccupancy` class and the `obj` instance have no dependency on Panel, Jupyter, or any other GUI or web toolkit; they simply declare facts about a certain domain (such as that smoothing requires window and sigma parameters, and that window is an integer greater than 0 and sigma is a positive real number).  This information is then enough for Panel to create an editable and viewable representation for this object without having to specify anything that depends on the domain-specific details encapsulated in `obj`:
+
+
+```{pyodide}
+pn.Column(obj.param, obj.view)
+```
+
+To support a particular domain, you can create hierarchies of such classes encapsulating all the parameters and functionality you need across different families of objects, with both parameters and code inheriting across the classes as appropriate, all without any dependency on a particular GUI library or even the presence of a GUI at all.  This approach makes it practical to maintain a large codebase, all fully displayable and editable with Panel, in a way that can be maintained and adapted over time.

--- a/doc/explanation/api/index.md
+++ b/doc/explanation/api/index.md
@@ -37,7 +37,7 @@ Generate a UI by manually declaring callbacks that update panels or panes.
 
 ## Examples
 
-Below are additional recipes using each API to create slightly more advanced apps.
+Below are additional recipes using each API to create additional apps.
 
 ::::{grid} 1 2 2 3
 :gutter: 1 1 1 2
@@ -64,6 +64,13 @@ Build a stock explorer app using the Param based declarative API.
 :link-type: doc
 
 Build a stock explorer app using the reactive API.
+:::
+
+:::{grid-item-card} Outlier Explorer - Declarative API
+:link: examples/outliers_declarative
+:link-type: doc
+
+Build a simple outlier explorer app using the reactive API.
 :::
 
 ::::

--- a/doc/getting_started/build_app.md
+++ b/doc/getting_started/build_app.md
@@ -14,10 +14,11 @@ At first, this website renders code block outputs with limited interactivity, in
 
 ```{pyodide}
 import panel as pn
-pn.extension()
 import hvplot.pandas
 import pandas as pd
 import numpy as np
+
+pn.extension(design='material')
 
 csv_file = ("https://raw.githubusercontent.com/holoviz/panel/main/examples/assets/occupancy.csv")
 data = pd.read_csv(csv_file, parse_dates=["date"], index_col="date")

--- a/doc/getting_started/build_app.md
+++ b/doc/getting_started/build_app.md
@@ -2,174 +2,82 @@
 
 At this point you should have [set up your environment and installed Panel](installation.md) so you should be ready to get going.
 
-In this section we're going to be building a basic application using a public dataset and add some interactivity.
+On this page, we're going to be building a basic interactive application. If you want to implement this app yourself as you follow along, we recommend starting with a Jupyter notebook.
+
+## Fetch the data
+
+First let's load the [UCI ML dataset](http://archive.ics.uci.edu/ml/datasets/Occupancy+Detection+) that measured the environment in a meeting room:
 
 :::{important}
-This guide renders static output by default (denoted by the golden border), but you can execute the code cells below by clicking the play button. Only run this if you are willing to download ~40 MB once. The download will be cached and reused the next time you click the play button on any page across the site.
+At first, this website renders code block outputs with limited interactivity, indicated by the <font color="darkgoldenrod">golden</font> border to the left of the output below. By clicking the play button (<svg class="pyodide-run-icon" style="width:32px;height:25px" viewBox="0 0 24 24"> <path stroke="none" fill="#28a745" d="M8,5.14V19.14L19,12.14L8,5.14Z"></path> </svg>) you can activate full interactivity, indicated by a <font color="green">green</font> left-border.
 :::
 
-## Fetch some data
-
-Panel lets you add interactive controls for just about anything you can display in Python. Panel can help you build simple interactive apps, complex multi-page dashboards, or anything in between. As a simple example, let's say we have loaded the [UCI ML dataset measuring the environment in a meeting room](http://archive.ics.uci.edu/ml/datasets/Occupancy+Detection+):
-
-
 ```{pyodide}
-import pandas as pd; import numpy as np; import matplotlib.pyplot as plt
+import panel as pn
+pn.extension()
+import hvplot.pandas
+import pandas as pd
+import numpy as np
 
-csv_file = 'https://raw.githubusercontent.com/holoviz/panel/main/examples/assets/occupancy.csv'
-data = pd.read_csv(csv_file, parse_dates=['date'], index_col='date')
+csv_file = ("https://raw.githubusercontent.com/holoviz/panel/main/examples/assets/occupancy.csv")
+data = pd.read_csv(csv_file, parse_dates=["date"], index_col="date")
 
 data.tail()
 ```
 
-## Visualize the data
+## Visualize a subset of the data
 
-And we've written some code that smooths a time series and plots it using Matplotlib with outliers highlighted:
-
+Before we utilize Panel, let's write a function that smooths one of our time series and finds the outliers. We will then plot the result using hvplot.
 
 ```{pyodide}
-import matplotlib as mpl
-mpl.use('agg')
+def view_hvplot(avg, highlight):
+    return avg.hvplot(height=300, width=400, legend=False) * highlight.hvplot.scatter(
+        color="orange", padding=0.1, legend=False
+    )
 
-from matplotlib.figure import Figure
-
-def mpl_plot(avg, highlight):
-    fig = Figure()
-    ax = fig.add_subplot()
-    avg.plot(ax=ax)
-    if len(highlight): highlight.plot(style='o', ax=ax)
-    return fig
-
-def find_outliers(variable='Temperature', window=30, sigma=10, view_fn=mpl_plot):
+def find_outliers(variable="Temperature", window=30, sigma=10, view_fn=view_hvplot):
     avg = data[variable].rolling(window=window).mean()
     residual = data[variable] - avg
     std = residual.rolling(window=window).std()
-    outliers = (np.abs(residual) > std * sigma)
+    outliers = np.abs(residual) > std * sigma
     return view_fn(avg, avg[outliers])
 ```
 
-We can call the function with parameters and get a plot:
+We can now call our `find_outliers` function with specific parameters to get a plot with a single set of parameters.
 
 ```{pyodide}
 find_outliers(variable='Temperature', window=20, sigma=10)
 ```
 
-It works! But exploring all these parameters by typing Python is slow and tedious. Plus we want our boss, or the boss's boss, to be able to try it out.
+It works! But now we want explore how values for `window` and `sigma` affect the plot. We could reevaluate the above cell a lot of times, but that would be a slow and painful process. Instead, let's use Panel to quickly add some interactive controls and quickly determine how different parameter values impact the output.
 
-If we wanted to try out lots of combinations of these values to understand how the window and sigma affect the plot, we could reevaluate the above cell lots of times, but that would be a slow and painful process, and is only really appropriate for users who are comfortable with editing Python code. In the next few examples we will demonstrate how to use Panel to quickly add some interactive controls to some object and make a simple app.
+## Explore parameter space
 
-## Reactive functions
-
-Instead of editing code, it's much quicker and more straightforward to use sliders to adjust the values interactively. You can easily make a Panel app by binding some widgets to the arguments of a function using `pn.bind`:
-
+Let's create some Panel slider widgets for the range of parameter values that we want to explore.
 
 ```{pyodide}
-import panel as pn
-pn.extension()
-
-window = pn.widgets.IntSlider(name='window', value=30, start=1, end=60)
-sigma = pn.widgets.IntSlider(name='sigma', value=10, start=0, end=20)
-
-interactive = pn.bind(find_outliers, window=window, sigma=sigma)
+variable_widget = pn.widgets.Select(name="variable", value="Temperature", options=list(data.columns))
+window_widget = pn.widgets.IntSlider(name="window", value=30, start=1, end=60)
+sigma_widget = pn.widgets.IntSlider(name="sigma", value=10, start=0, end=20)
 ```
 
-Once you have bound the widgets to the function's arguments you can lay out the component being returned using Panel layout components such as `Row`, `Column`, or `FlexBox`:
+Now that we have a function and some widgets, let's link them together so that updates to the widgets rerun the function. One easy way to create this link in Panel is with `pn.bind`:
+
+```{pyodide}
+bound_plot = pn.bind(find_outliers, variable=variable_widget, window=window_widget, sigma=sigma_widget)
+```
+
+Once you have bound the widgets to the function's arguments you can lay out the resulting `bound_plot` component along with the `widget` components using a Panel layout such as `Column`:
 
 
 ```{pyodide}
-first_app = pn.Column(window, sigma, interactive)
+first_app = pn.Column(variable_widget, window_widget, sigma_widget, bound_plot)
 
 first_app
 ```
 
-As long as you have a live Python process running, dragging these widgets will trigger a call to the `find_outliers` callback function, evaluating it for whatever combination of parameter values you select and displaying the results. A Panel like this makes it very easy to explore any function that produces a visual result of a [supported type](https://github.com/pyviz/panel/issues/2), such as Matplotlib (as above), Bokeh, Plotly, Altair, or various text and image types.
+As long as you have a live Python process running, dragging these widgets will trigger a call to the `find_outliers` callback function, evaluating it for whatever combination of parameter values you select and displaying the results.
 
-## Deploying Panels
+## Next Steps
 
-The above panels all work in the notebook cell (if you have a live Jupyter kernel running), but unlike other approaches such as ipywidgets, Panel apps work just the same in a standalone server. For instance, the app above can be launched as its own web server on your machine by uncommenting and running the following cell:
-
-
-```{pyodide}
-#first_app.show()
-```
-
-Or, you can simply mark whatever you want to be in the separate web page with `.servable()`, and then run the shell command `panel serve --show Create_App.ipynb` to launch a server containing that object. (Here, we've also added a semicolon to avoid getting another copy of the occupancy app here in the notebook.)
-
-
-```{pyodide}
-first_app.servable();
-```
-
-During development, particularly when working with a raw script using `panel serve --show --autoreload` can be very useful as the application will automatically update whenever the script or notebook or any of its imports change.
-
-## Declarative Panels
-
-The above compositional approach is very flexible, but it ties your domain-specific code (the parts about sine waves) with your widget display code. That's fine for small, quick projects or projects dominated by visualization code, but what about large-scale, long-lived projects, where the code is used in many different contexts over time, such as in large batch runs, one-off command-line usage, notebooks, and deployed dashboards?  For larger projects like that, it's important to be able to separate the parts of the code that are about the underlying domain (i.e. application or research area) from those that are tied to specific display technologies (such as Jupyter notebooks or web servers).
-
-For such usages, Panel supports objects declared with the separate [Param](http://param.pyviz.org) library, which provides a GUI-independent way of capturing and declaring the parameters of your objects (and dependencies between your code and those parameters), in a way that's independent of any particular application or dashboard technology. For instance, the above code can be captured in an object that declares the ranges and values of all parameters, as well as how to generate the plot, independently of the Panel library or any other way of interacting with the object:
-
-
-```{pyodide}
-import param
-import hvplot.pandas
-
-def hvplot(avg, highlight):
-    return avg.hvplot(height=200) * highlight.hvplot.scatter(color='orange', padding=0.1)
-
-class RoomOccupancy(param.Parameterized):
-    variable  = param.Selector(objects=list(data.columns))
-    window    = param.Integer(default=10, bounds=(1, 20))
-    sigma     = param.Number(default=10, bounds=(0, 20))
-
-    def view(self):
-        return find_outliers(self.variable, self.window, self.sigma, view_fn=hvplot)
-
-obj = RoomOccupancy()
-obj
-```
-
-The `RoomOccupancy` class and the `obj` instance have no dependency on Panel, Jupyter, or any other GUI or web toolkit; they simply declare facts about a certain domain (such as that smoothing requires window and sigma parameters, and that window is an integer greater than 0 and sigma is a positive real number).  This information is then enough for Panel to create an editable and viewable representation for this object without having to specify anything that depends on the domain-specific details encapsulated in `obj`:
-
-
-```{pyodide}
-pn.Row(obj.param, obj.view)
-```
-
-To support a particular domain, you can create hierarchies of such classes encapsulating all the parameters and functionality you need across different families of objects, with both parameters and code inheriting across the classes as appropriate, all without any dependency on a particular GUI library or even the presence of a GUI at all.  This approach makes it practical to maintain a large codebase, all fully displayable and editable with Panel, in a way that can be maintained and adapted over time.
-
-## Get help
-
-Now that we have given you a taste of how easy it is to build a little application in Panel its time to introduce you to some of the [core concepts](core_concepts.md) behind Panel. Go to the next guide or visit some of the other resources to help you dive a little deeper:
-
-::::{grid} 1 2 2 4
-:gutter: 1 1 1 2
-
-:::{grid-item-card} {octicon}`rocket;2.5em;sd-mr-1` Core Concepts
-:link: core_concepts
-:link-type: doc
-
-Introduces you to some of the core concepts behind Panel, how to develop Panel applications effectively both in your IDE and in the notebook and some of the core features that make Panel such a powerful library.
-:::
-
-:::{grid-item-card} {octicon}`comment-discussion;2.5em;sd-mr-1` Discourse
-:link: https://discourse.holoviz.org/c/panel/5
-:link-type: url
-
-Visit our community Discourse where you can exchange ideas with the community and ask our helpful community members questions.
-:::
-
-:::{grid-item-card} {octicon}`mark-github;2.5em;sd-mr-1` GitHub
-:link: https://github.com/holoviz/panel/issues
-:link-type: url
-
-Visit us on GitHub and file issues and/or contribute.
-:::
-
-:::{grid-item-card} {octicon}`book;2.5em;sd-mr-1` How-to
-:link: ../how_to/index
-:link-type: doc
-
-How-to guides provide step by step recipes for solving essential problems and tasks that arise during your work.
-:::
-
-::::
+Now that we have given you a taste of how easy it is to build a little application in Panel its time to introduce you to some of the [core concepts](core_concepts.md) behind Panel.

--- a/doc/getting_started/core_concepts.md
+++ b/doc/getting_started/core_concepts.md
@@ -1,38 +1,43 @@
 # {octicon}`mortar-board;2em;sd-mr-1` Core Concepts
 
-Getting started with Panel is pretty straightforward, open your editor, IDE or notebook environment, declare a few Panel components as `servable` (we will discover what that means soon), then launch the script or notebook file with:
+In the last section we learned how to [build a simple app](build_app.md). A Panel app like this makes it very easy to explore any function that produces a visual result of a [supported type](https://github.com/pyviz/panel/issues/2), such as Matplotlib, Bokeh, Plotly, Altair, or various text and image types.
+
+## Development flow
+
+As you prepare to develop your Panel application, there are a couple initial development decisions to make about **API** and **environment**:
+
+1. Will you be programming with a Python class-based approach? If not, or if you are unsure, we recommend starting with the reactive API (`pn.bind`) that you already tasted while [building a simple app](build_app.md).
+
+:::{dropdown} Interested in a class-based approach instead?
+:margin: 4
+:color: muted
+Checkout the same ['outlier' app built using a class-based declarative API](../explanation/api/examples/outliers_declarative.md). And to dive deeper, read the [Explanation > APIs](../explanation/apis.md) section for a discussion on each of the API options.
+:::
+
+2. Will you be developing in a notebook or editor environment? If you are unsure, we recommend starting in a notebook as you get familiar with Panel. Let's talk a bit more about these development environment options:
+
+### Notebook
+
+In a notebook you can quickly iterate on individual components of your application because Panel components render inline. To get started in a notebook simply `import panel` and initialize the extension with `pn.extension()`.
+
+```python
+import panel as pn
+pn.extension()
+```
+
+Now, when you put a Panel component at the end of a notebook cell it will render as part of the output of that cell. By changing the code in your cell and re-running it you can quickly iterate and build the individual units that will make up your final application. This way of working has many benefits because you can work on each component in your application individually without having to re-run your entire application each time.
+
+### Editor
+
+If you are working in an editor, declare the Panel components that you want to display as `servable` (we will discover what that means soon), then launch the script or notebook file. For example, if you were to save the app you built in the previous page into `app.py` and declared `first_app.servable()` within the file, then on the command line you can just run:
 
 ```bash
-panel serve your_script.py --autoreload --show
+panel serve app.py --autoreload --show
 ```
 
 Once you run that command Panel will launch a server that will serve your app, open a tab in your default browser (`--show`) and update the application whenever you update the code (`--autoreload`).
 
-## Development flow
-
-Depending on whether you are using a classical editor/IDE or a notebook environment we recommend two slightly different approaches to working. Both are suited to quick iteration but provide quite different modes of working.
-
-### Notebook
-
-In a notebook you can quickly iterate on individual components of your application because Panel components render inline. To get started in a notebook simply `import panel` and initialize the extension (this loads Panel and any optional extensions you might want to use in your application).
-
-```python
-import panel as pn
-pn.extension('altair', 'tabulator')
-```
-
-Now you are ready to go, all Panel components will render themselves. In other words, when you put a Panel component at the end of a cell it will render as part of the output of that cell. By changing the code in your cell and re-running it you can quickly iterate and build the individual units that will make up your final application. This way of working has many benefits because you can work on each component in your application individually without having to re-run your entire application each time.
-
-:::{admonition} Tip
-:class: success
-
-When working in JupyterLab you will see a little Panel icon (<img src="https://panel.holoviz.org/_static/icons/favicon.ico" alt="Panel Icon" width="20px"/>) in your toolbar. This will let you preview the application you are building quickly and easily.
-:::
-
-### Editor/IDE
-
-The experience when working in an editor or IDE is slightly different. Whenever you save your application script the server will reload your application. This has benefits too, since it let's you quickly see how your whole application fits together.
-
+> Checkout [How-to > Prepare to develop](../how_to/prepare_to_develop.md) for more guidance on each of the development environment options.
 ## Control flow
 
 Now let's get into how Panel actually works. Panel is built on a library called [Param](https://param.holoviz.org/), this controls how information flows through your application. When a parameter changes, e.g. the value of a slider updates or when you update the value manually in code, events are triggered that you can respond to. Panel provides a number of high-level and lower-level approaches for setting up interactivity in response to updates in parameters. Understanding some of the basic concepts behind param is essential to getting a hang of Panel.
@@ -335,10 +340,14 @@ pn.Column(
 ).servable(target='main')
 ```
 
-## Exploring further
+## Next Steps
 
-While `Getting Started`, you have built a simple Panel app and reviewed the core concepts - the basic foundations for you to start using Panel for your own work.
+While `Getting Started`, you have installed Panel, built a simple app, and reviewed core concepts - the basic foundations for you to start using Panel for your own work.
 
-While working, you can find solutions to specific problems in the [How-to](../how_to/index.md) section and you can consult the [API Reference](../api/index.md) or [Component Gallery](../reference/index.rst) sections for technical descriptions or examples.
+While working, you can find solutions to specific problems in the [How-to](../how_to/index.md) section and you can consult the [API Reference](../api/index.md) or [Component Gallery](../reference/index.rst) sections for technical specifications, descriptions, or examples.
 
-If you want to gain clarity or deepen your understanding on particular topics, refer to the [Explanation](../explanation/index.md). For example, the [Explanation > APIs](../explanation/api/api.md) subsection covers the benefits and drawbacks of each Panel API.
+If you want to gain clarity or deepen your understanding on particular topics, refer to the [Explanation](../explanation/index.md). For example, the [Explanation > APIs](../explanation/apis.md) subsection covers the benefits and drawbacks of each Panel API.
+
+## Getting Help
+
+Check out the [HoloViz Community](https://holoviz.org/community.html) page for all of the options to connect with developers and other users.

--- a/doc/getting_started/index.md
+++ b/doc/getting_started/index.md
@@ -29,7 +29,6 @@ Before we dig into some of the core concepts behind Panel this guide gives you a
 [Learn more »](build_app)
 :::
 
-
 :::{grid-item-card} {octicon}`rocket;2.5em;sd-mr-1` Core Concepts
 :link: core_concepts
 :link-type: doc
@@ -41,7 +40,6 @@ Introduces you to some of the core concepts behind Panel, how to develop Panel a
 :::
 
 ::::
-
 
 ```{toctree}
 :titlesonly:

--- a/doc/getting_started/installation.md
+++ b/doc/getting_started/installation.md
@@ -12,8 +12,11 @@ The recommended way to install Panel is using the [conda](https://docs.conda.io/
 
 :::{admonition} Note
 
-To help you choose between Anaconda and Miniconda, review [this page](https://docs.conda.io/projects/conda/en/latest/user-guide/install/download.html#anaconda-or-miniconda)
+To help you choose between Anaconda and Miniconda, review [this page](https://docs.conda.io/projects/conda/en/latest/user-guide/install/download.html#anaconda-or-miniconda).
+:::
 
+:::{admonition} Note
+When you begin using conda, you already have a default environment named `base`. You don't want to install programs into your base environment, though. [Create separate environments](https://conda.io/projects/conda/en/latest/user-guide/getting-started.html) to keep your programs isolated from each other.
 :::
 
 If you choose not to install Anaconda or Miniconda, you can download Python directly from [Python.org](https://www.python.org/downloads/). In this case, you can install Panel using [pip](https://pip.pypa.io/en/stable/), which comes with Python.
@@ -41,3 +44,7 @@ pip install panel
 :::
 
 ::::
+
+## Next Steps
+
+Now that you have installed Panel, let's [build a simple application](build_app.md).

--- a/doc/getting_started/installation.md
+++ b/doc/getting_started/installation.md
@@ -23,7 +23,7 @@ If you choose not to install Anaconda or Miniconda, you can download Python dire
 
 ## Installing Panel
 
-Open up a terminal (Powershell if you are on Windows), and run the following command, which will install Panel with all its dependencies.
+Open up a terminal and run the following command, which will install Panel with all its dependencies.
 
 ::::{tab-set}
 

--- a/doc/how_to/prepare_to_develop.md
+++ b/doc/how_to/prepare_to_develop.md
@@ -12,5 +12,4 @@
 
 Develop in a notebook<notebook/index>
 Develop in an editor<editor/index>
-Choose an API<apis/index>
 ```


### PR DESCRIPTION
- Most of the updates were to the Build an app page. I simplified it quite a bit, moving the declarative approach to a new example page in the explanation > API section and linking to it from the top of the Getting-Started core-concepts. 

![installation2](https://github.com/holoviz/panel/assets/6613202/8a742a96-fbe0-4b2b-b5cf-b9a8129dff6c)

![build_an_app](https://github.com/holoviz/panel/assets/6613202/c3a5e9a5-9ab9-4ae9-93eb-e28649fb503e)

Top o' the core concepts:

![top_core_concepts html](https://github.com/holoviz/panel/assets/6613202/303eaeff-5f7a-4700-b4fc-8c5f3cdec4fe)

Explanation > APIs > examples > Outliers Declarative:

![outliers_declarative](https://github.com/holoviz/panel/assets/6613202/f8a6dee2-4aa7-4d0e-8a20-e8014d3a1064)
