### PR TITLE
Ensure that relative server URLs unless absolute is requested

### DIFF
--- a/panel/io/resources.py
+++ b/panel/io/resources.py
@@ -30,7 +30,7 @@ from bokeh.embed.bundle import (
 )
 from bokeh.model import Model
 from bokeh.models import ImportedStyleSheet
-from bokeh.resources import Resources as BkResources
+from bokeh.resources import Resources as BkResources, _get_server_urls
 from bokeh.settings import settings as _settings
 from jinja2.environment import Environment
 from jinja2.loaders import FileSystemLoader
@@ -41,6 +41,8 @@ from ..util import isurl, url_path
 from .state import state
 
 if TYPE_CHECKING:
+    from bokeh.resources import Urls
+
     class ResourcesType(TypedDict):
         css: Dict[str, str]
         js:  Dict[str, str]
@@ -500,9 +502,9 @@ class ResourceComponent:
 class Resources(BkResources):
 
     def __init__(self, *args, absolute=False, notebook=False, **kwargs):
-        super().__init__(*args, **kwargs)
         self.absolute = absolute
         self.notebook = notebook
+        super().__init__(*args, **kwargs)
 
     @classmethod
     def from_bokeh(cls, bkr, absolute=False, notebook=False):
@@ -545,6 +547,13 @@ class Resources(BkResources):
                         external_resources.append(e)
 
         return external_resources
+
+    def _server_urls(self) -> Urls:
+        return _get_server_urls(
+            self.root_url if self.absolute else '',
+            False if self.dev else self.minified,
+            self.path_versioner
+        )
 
     def extra_resources(self, resources, resource_type):
         """

--- a/panel/tests/io/test_resources.py
+++ b/panel/tests/io/test_resources.py
@@ -48,8 +48,8 @@ def test_resources_cdn():
         f'https://cdn.bokeh.org/bokeh/{bk_prefix}/bokeh-mathjax-{BOKEH_VERSION}.min.js',
     ]
 
-def test_resources_server():
-    resources = Resources(mode='server')
+def test_resources_server_absolute():
+    resources = Resources(mode='server', absolute=True)
     assert resources.js_raw == ['Bokeh.set_log_level("info");']
     assert resources.js_files == [
         'http://localhost:5006/static/js/bokeh.min.js',
@@ -57,6 +57,17 @@ def test_resources_server():
         'http://localhost:5006/static/js/bokeh-widgets.min.js',
         'http://localhost:5006/static/js/bokeh-tables.min.js',
         'http://localhost:5006/static/js/bokeh-mathjax.min.js'
+    ]
+
+def test_resources_server():
+    resources = Resources(mode='server')
+    assert resources.js_raw == ['Bokeh.set_log_level("info");']
+    assert resources.js_files == [
+        'static/js/bokeh.min.js',
+        'static/js/bokeh-gl.min.js',
+        'static/js/bokeh-widgets.min.js',
+        'static/js/bokeh-tables.min.js',
+        'static/js/bokeh-mathjax.min.js'
     ]
 
 def test_resources_config_css_files(document):


### PR DESCRIPTION
Seems like bokeh now generates absolute resource URLs by default.

Fixes https://github.com/holoviz/panel/issues/4816