### PR TITLE
Simplify and fix HoloViews widget layouts

### DIFF
--- a/panel/layout/base.py
+++ b/panel/layout/base.py
@@ -253,7 +253,7 @@ class Panel(Reactive):
         elif expand_height and not self.height and allow_height_scale:
             sizing_mode = f'{mode}_height'
         if sizing_mode is None:
-            return {}
+            return {'sizing_mode': props.get('sizing_mode')}
 
         properties = {'sizing_mode': sizing_mode}
         if ((sizing_mode.endswith('_width') or sizing_mode.endswith('_both')) and

--- a/panel/pane/base.py
+++ b/panel/pane/base.py
@@ -140,6 +140,8 @@ class PaneBase(Reactive):
     # List of parameters that trigger a rerender of the Bokeh model
     _rerender_params: ClassVar[List[str]] = ['object']
 
+    _skip_layoutable = ('background', 'css_classes', 'margin', 'name')
+
     __abstract = True
 
     def __init__(self, object=None, **params):
@@ -165,16 +167,15 @@ class PaneBase(Reactive):
 
     def _sync_layoutable(self, *events: param.parameterized.Event):
         included = list(Layoutable.param)
-        skipped = ('background', 'css_classes', 'margin', 'name')
         if events:
             kwargs = {
                 event.name: event.new for event in events
-                if event.name in included and event.name not in skipped
+                if event.name in included and event.name not in self._skip_layoutable
             }
         else:
             kwargs = {
                 k: v for k, v in self.param.values().items()
-                if k in included and k not in skipped
+                if k in included and k not in self._skip_layoutable
             }
         if self.margin:
             margin = self.margin

--- a/panel/pane/base.py
+++ b/panel/pane/base.py
@@ -150,7 +150,10 @@ class PaneBase(Reactive):
         if (isinstance(applies, bool) and not applies) and self.object is not None:
             self._type_error(self.object)
 
-        kwargs = {k: v for k, v in params.items() if k in Layoutable.param}
+        kwargs = {
+            k: v for k, v in params.items() if k in Layoutable.param and
+            k not in self._skip_layoutable
+        }
         self.layout = self.default_layout(self, **kwargs)
         self._callbacks.extend([
             self.param.watch(self._sync_layoutable, list(Layoutable.param)),
@@ -276,6 +279,18 @@ class PaneBase(Reactive):
                 parent.tabs[index] = _BkTabPanel(**props)
             else:
                 parent.children[index] = new_model
+            layout_parent = self.layout._models.get(ref, [None])[0]
+            if parent is layout_parent:
+                parent.update(**self.layout._compute_sizing_mode(
+                    parent.children,
+                    dict(
+                        sizing_mode=self.layout.sizing_mode,
+                        styles=self.layout.styles,
+                        width=self.layout.width,
+                        min_width=self.layout.min_width,
+                        margin=self.layout.margin
+                    )
+                ))
 
         from ..io import state
         ref = root.ref['id']

--- a/panel/pane/holoviews.py
+++ b/panel/pane/holoviews.py
@@ -102,9 +102,12 @@ class HoloViews(PaneBase):
         'widget_type': None
     }
 
-    _skip_layoutable = ('background', 'css_classes', 'margin', 'name', 'sizing_mode', 'width', 'height', 'max_width', 'max_height')
-
     _rerender_params = ['object', 'backend']
+
+    _skip_layoutable = (
+        'background', 'css_classes', 'margin', 'name', 'sizing_mode',
+        'width', 'height', 'max_width', 'max_height'
+    )
 
     def __init__(self, object=None, **params):
         self._initialized = False


### PR DESCRIPTION
The old layout code for HoloViews widgets was kind of messy, deeply nested and had some issues with the new layout engine. This is a rewrite that uses `align` to do most of the work and only sparingly uses `HSpacer` to handle centering.

- Additionally we fix issues with inheritance of width/height/sizing_mode on the layout.