### PR TITLE
Fix Jupyter Panel Preview in Windows

### DIFF
--- a/panel/io/jupyter_server_extension.py
+++ b/panel/io/jupyter_server_extension.py
@@ -111,7 +111,7 @@ import os
 import pathlib
 import sys
 
-app = '{{ path }}'
+app = r'{{ path }}'
 os.chdir(str(pathlib.Path(app).parent))
 sys.path = [os.getcwd()] + sys.path[1:]
 
@@ -186,6 +186,8 @@ class PanelJupyterHandler(JupyterHandler):
                 comm_id = msg['content']['comm_id']
             elif msg_type == 'stream' and msg['content']['name'] == 'stderr':
                 logger.error(msg['content']['text'])
+            elif msg_type == "error":
+                logger.error(msg['content'])
         return result, comm_id, extension_dirs
 
     @tornado.web.authenticated

--- a/panel/io/jupyter_server_extension.py
+++ b/panel/io/jupyter_server_extension.py
@@ -187,7 +187,7 @@ class PanelJupyterHandler(JupyterHandler):
             elif msg_type == 'stream' and msg['content']['name'] == 'stderr':
                 logger.error(msg['content']['text'])
             elif msg_type == "error":
-                logger.error(msg['content'])
+                logger.error(msg['content']['traceback'])
         return result, comm_id, extension_dirs
 
     @tornado.web.authenticated


### PR DESCRIPTION
Fixes #4819

The path string was not raw, which meant on Windows, the path would give a Unicode error. I also added more logging if the msg_type is an error.

![image](https://github.com/holoviz/panel/assets/19758978/c49648ef-864d-4de3-bf93-074e4d5fd87f)

