### PR TITLE
Fix custom favicon not working in a template if JPG

### DIFF
--- a/panel/_templates/base.html
+++ b/panel/_templates/base.html
@@ -23,7 +23,7 @@ that accepts these same parameters.
     <meta charset="utf-8">
     <title>{% block title %}{{ title | e if title else "Panel App" }}{% endblock %}</title>
     <link rel="apple-touch-icon" sizes="180x180" href="{{ dist_url }}images/apple-touch-icon.png">
-    <link rel="icon" type="image/png" sizes="32x32" href="{{ dist_url }}images/favicon.ico">
+    {% if app_favicon is not defined %} <link rel="icon" type="image/png" sizes="32x32" href="{{ dist_url }}images/favicon.ico"> {% endif %}
     {% if manifest_url %}<link rel="manifest" href="{{ manifest_url }}">{% endif %}
     {% if theme_name == "dark"%}<style>html { background-color: #121212 }</style>{% endif %}
   {%  block preamble -%}{%- endblock %}

--- a/panel/template/golden/__init__.py
+++ b/panel/template/golden/__init__.py
@@ -14,7 +14,7 @@ from ...io.resources import JS_URLS
 from ..base import BasicTemplate
 
 if TYPE_CHECKING:
-    from ..io.resources import ResourcesType
+    from ...io.resources import ResourcesType
 
 
 class GoldenTemplate(BasicTemplate):


### PR DESCRIPTION
I noticed that if a custom favicon were a JPG, it would show up with Panel:

``` python
import panel as pn

pn.extension()

pn.template.BootstrapTemplate(
    title="Favicon Problem",
    main=["Hello"],
    # favicon="https://cdn.jsdelivr.net/npm/twemoji@11.3.0/2/svg/1f47d.svg",  # Works
    # favicon="https://icon-library.com/images/favicon-icon/favicon-icon-24.jpg",  # Did not work, gave Panel favicon
).servable()

# pn.panel("A").servable()  # Should still give Panel favicon
```

(when looking around I found a wrong import inside a type checking)