### PR TITLE
Add overflow wrap for markdown

### DIFF
--- a/panel/dist/css/markdown.css
+++ b/panel/dist/css/markdown.css
@@ -115,3 +115,7 @@ table, th, td {
     border-collapse: collapse;
     padding: 5px;
 }
+
+p {
+    overflow-wrap: break-word;
+}


### PR DESCRIPTION
To prevent it from going over its borders:

However, when I add it, I get this:
`2023-05-13 21:18:05,828 404 GET /static/extensions/panel/panel.min.js?v=d1a84298f6c757f0208e5cdc8e697f65669f3720cdac00df5be7ac38be35b783 (::1) 1.35ms`

And nothing displays in the browser