### PR TITLE
Ensure we do not dispatch events when model is swapped out

### DIFF
--- a/panel/pane/base.py
+++ b/panel/pane/base.py
@@ -570,7 +570,7 @@ class ReplacementPane(PaneBase):
 
     @param.depends('_pane', '_pane.sizing_mode', '_pane.width_policy', '_pane.height_policy', watch=True)
     def _sync_layout(self):
-        if not hasattr(self, '_inner_layout') or (self._pane is not None and self._pane._object_changing):
+        if not hasattr(self, '_inner_layout') or (self._pane is not None and getattr(self._pane, '_object_changing', False)):
             return
         self._inner_layout.param.update({
             k: v for k, v in self._pane.param.values().items()

--- a/panel/pane/base.py
+++ b/panel/pane/base.py
@@ -145,6 +145,7 @@ class PaneBase(Reactive):
     __abstract = True
 
     def __init__(self, object=None, **params):
+        self._object_changing = False
         super().__init__(object=object, **params)
         applies = self.applies(self.object, **(params if self._applies_kw else {}))
         if (isinstance(applies, bool) and not applies) and self.object is not None:
@@ -169,16 +170,14 @@ class PaneBase(Reactive):
                 raise RuntimeError('Value is not valid.')
 
     def _sync_layoutable(self, *events: param.parameterized.Event):
-        included = list(Layoutable.param)
+        included = set(Layoutable.param) - set(self._skip_layoutable)
         if events:
             kwargs = {
-                event.name: event.new for event in events
-                if event.name in included and event.name not in self._skip_layoutable
+                event.name: event.new for event in events if event.name in included
             }
         else:
             kwargs = {
-                k: v for k, v in self.param.values().items()
-                if k in included and k not in self._skip_layoutable
+                k: v for k, v in self.param.values().items() if k in included
             }
         if self.margin:
             margin = self.margin
@@ -194,7 +193,8 @@ class PaneBase(Reactive):
                 kwargs['width'] = kwargs['width'] + l + r
             if kwargs.get('height') is not None:
                 kwargs['height'] = kwargs['height'] + t + b
-        self.layout.param.update(kwargs)
+        old_values = self.layout.param.values()
+        self.layout.param.update({k: v for k, v in kwargs.items() if v != old_values[k]})
 
     def _type_error(self, object):
         raise ValueError("%s pane does not support objects of type '%s'." %
@@ -232,6 +232,11 @@ class PaneBase(Reactive):
     def _synced_params(self) -> List[str]:
         ignored_params = ['name', 'default_layout', 'loading', 'background', 'stylesheets']+self._rerender_params
         return [p for p in self.param if p not in ignored_params and not p.startswith('_')]
+
+    def _param_change(self, *events: param.parameterized.Event) -> None:
+        if self._object_changing:
+            return
+        super()._param_change(*events)
 
     def _update_object(
         self, ref: str, doc: 'Document', root: Model, parent: Model, comm: Comm | None
@@ -565,7 +570,7 @@ class ReplacementPane(PaneBase):
 
     @param.depends('_pane', '_pane.sizing_mode', '_pane.width_policy', '_pane.height_policy', watch=True)
     def _sync_layout(self):
-        if not hasattr(self, '_inner_layout'):
+        if not hasattr(self, '_inner_layout') or (self._pane is not None and self._pane._object_changing):
             return
         self._inner_layout.param.update({
             k: v for k, v in self._pane.param.values().items()
@@ -645,9 +650,22 @@ class ReplacementPane(PaneBase):
                     cls._recursive_update(old_object, i, old, new)
             elif isinstance(object, Reactive):
                 pvals = dict(old_object.param.values())
-                new_params = {k: v for k, v in object.param.values().items()
-                              if k != 'name' and v is not pvals[k]}
-                old_object.param.update(**new_params)
+                new_params = {}
+                for k, v in object.param.values().items():
+                    if k == 'name' or v is pvals[k]:
+                        continue
+                    try:
+                        equal = (v == pvals[k])
+                    except Exception:
+                        equal = False
+                    if not equal:
+                        new_params[k] = v
+                changing = any(p in old_object._rerender_params for p in new_params)
+                old_object._object_changing = changing
+                try:
+                    old_object.param.update(**new_params)
+                finally:
+                    old_object._object_changing = False
             else:
                 old_object.object = object
         else:

--- a/panel/pane/holoviews.py
+++ b/panel/pane/holoviews.py
@@ -129,6 +129,8 @@ class HoloViews(PaneBase):
         self._update_widgets()
 
     def _param_change(self, *events: param.parameterized.Event) -> None:
+        if self._object_changing:
+            return
         self._track_overrides(*(e for e in events if e.name in Layoutable.param))
         super()._param_change(*(e for e in events if e.name in self._overrides+['css_classes']))
 


### PR DESCRIPTION
Previously, when a `ReplacementPane` was updating a Pane inplace it would dispatch a bunch of events on the old model.

Partial fix for https://github.com/holoviz/panel/issues/4825