### PR TITLE
Unsync location on server destroy

### DIFF
--- a/panel/interact.py
+++ b/panel/interact.py
@@ -170,7 +170,7 @@ class interactive(PaneBase):
 
             pname = 'clicks' if name == 'manual' else v
             watcher = widget_obj.param.watch(update_pane, pname)
-            self._callbacks.append(watcher)
+            self._internal_callbacks.append(watcher)
 
     def _cleanup(self, root: Model | None = None) -> None:
         self._inner_layout._cleanup(root)

--- a/panel/io/document.py
+++ b/panel/io/document.py
@@ -84,10 +84,10 @@ def _cleanup_doc(doc, destroy=True):
                     p._hooks = []
                     p._param_watchers = {}
                     p._documents = {}
-                    p._callbacks = {}
+                    p._internal_callbacks = {}
             pane._param_watchers = {}
             pane._documents = {}
-            pane._callbacks = {}
+            pane._internal_callbacks = {}
         else:
             views[ref] = (pane, root, doc, comm)
     state._views = views

--- a/panel/io/embed.py
+++ b/panel/io/embed.py
@@ -95,13 +95,17 @@ def param_to_jslink(model, widget):
     param_pane = widget._param_pane
     pobj = param_pane.object
     pname = [k for k, v in param_pane._widgets.items() if v is widget]
-    watchers = [w for w in get_watchers(widget) if w not in widget._callbacks
-                and w not in param_pane._callbacks]
+    watchers = [
+        w for w in get_watchers(widget) if w not in widget._internal_callbacks
+        and w not in param_pane._internal_callbacks
+    ]
 
     if isinstance(pobj, Reactive):
         tgt_links = [Watcher(*l[:-4]) for l in pobj._links]
-        tgt_watchers = [w for w in get_watchers(pobj) if w not in pobj._callbacks
-                        and w not in tgt_links and w not in param_pane._callbacks]
+        tgt_watchers = [
+            w for w in get_watchers(pobj) if w not in pobj._internal_callbacks
+            and w not in tgt_links and w not in param_pane._internal_callbacks
+        ]
     else:
         tgt_watchers = []
 
@@ -141,13 +145,13 @@ def links_to_jslinks(model, widget):
     from ..widgets import Widget
 
     src_links = [Watcher(*l[:-4]) for l in widget._links]
-    if any(w not in widget._callbacks and w not in src_links for w in get_watchers(widget)):
+    if any(w not in widget._internal_callbacks and w not in src_links for w in get_watchers(widget)):
         return
 
     links = []
     for link in widget._links:
         target = link.target
-        tgt_watchers = [w for w in get_watchers(target) if w not in target._callbacks]
+        tgt_watchers = [w for w in get_watchers(target) if w not in target._internal_callbacks]
         if link.transformed or (tgt_watchers and not isinstance(target, Widget)):
             return
 
@@ -248,7 +252,7 @@ def embed_state(panel, model, doc, max_states=1000, max_opts=3,
             if link is not None:
                 pobj = widget._param_pane.object
                 if isinstance(pobj, Widget):
-                    if not any(w not in pobj._callbacks and w not in widget._param_pane._callbacks
+                    if not any(w not in pobj._internal_callbacks and w not in widget._param_pane._internal_callbacks
                                for w in get_watchers(pobj)):
                         ignore.append(pobj)
                 continue # Skip if we were able to attach JS link
@@ -259,7 +263,7 @@ def embed_state(panel, model, doc, max_states=1000, max_opts=3,
                 continue
 
         # If the widget does not support embedding or has no external callback skip it
-        if not widget._supports_embed or all(w in widget._callbacks for w in get_watchers(widget)):
+        if not widget._supports_embed or all(w in widget._internal_callbacks for w in get_watchers(widget)):
             continue
 
         # Get data which will let us record the changes on widget events

--- a/panel/io/location.py
+++ b/panel/io/location.py
@@ -21,6 +21,7 @@ from .state import state
 if TYPE_CHECKING:
     from bokeh.document import Document
     from bokeh.model import Model
+    from bokeh.server.contexts import BokehSessionContext
     from pyviz_comms import Comm
 
 
@@ -86,6 +87,14 @@ class Location(Syncable):
         state._views[ref] = (self, root, doc, comm)
         self._documents[doc] = root
         return root
+
+    def _server_destroy(self, session_context: BokehSessionContext) -> None:
+        for p, ps, _, _ in self._synced:
+            try:
+                self.unsync(p, ps)
+            except Exception:
+                pass
+        super()._server_destroy(session_context)
 
     def _cleanup(self, root: Model | None = None) -> None:
         if root:

--- a/panel/pane/base.py
+++ b/panel/pane/base.py
@@ -156,7 +156,7 @@ class PaneBase(Reactive):
             k not in self._skip_layoutable
         }
         self.layout = self.default_layout(self, **kwargs)
-        self._callbacks.extend([
+        self._internal_callbacks.extend([
             self.param.watch(self._sync_layoutable, list(Layoutable.param)),
             self.param.watch(self._update_pane, self._rerender_params)
         ])
@@ -550,7 +550,7 @@ class ReplacementPane(PaneBase):
         self._pane = panel(None)
         self._internal = True
         self._inner_layout = Row(self._pane, **{k: v for k, v in params.items() if k in Row.param})
-        self._callbacks.append(
+        self._internal_callbacks.append(
             self.param.watch(self._update_inner_layout, list(Layoutable.param))
         )
         self._sync_layout()
@@ -637,7 +637,7 @@ class ReplacementPane(PaneBase):
                 for awatchers in pwatchers.values() for w in awatchers
             ]
             custom_watchers = [
-                wfn for wfn in watchers if wfn not in object._callbacks and
+                wfn for wfn in watchers if wfn not in object._internal_callbacks and
                 not hasattr(wfn.fn, '_watcher_name')
             ]
 

--- a/panel/pane/holoviews.py
+++ b/panel/pane/holoviews.py
@@ -123,7 +123,7 @@ class HoloViews(PaneBase):
             if p in Layoutable.param and v != self.param[p].default
         ]
         watcher = self.param.watch(self._update_widgets, self._rerender_params)
-        self._callbacks.append(watcher)
+        self._internal_callbacks.append(watcher)
         self._initialized = True
         self._update_responsive()
         self._update_widgets()
@@ -241,15 +241,15 @@ class HoloViews(PaneBase):
         self._values = values
 
         # Clean up anything models listening to the previous widgets
-        for cb in list(self._callbacks):
+        for cb in list(self._internal_callbacks):
             if cb.inst in self.widget_box.objects:
                 cb.inst.param.unwatch(cb)
-                self._callbacks.remove(cb)
+                self._internal_callbacks.remove(cb)
 
         # Add new widget callbacks
         for widget in widgets:
             watcher = widget.param.watch(self._widget_callback, 'value')
-            self._callbacks.append(watcher)
+            self._internal_callbacks.append(watcher)
 
         self.widget_box[:] = widgets
         if ((widgets and self.widget_box not in self._widget_container) or

--- a/panel/reactive.py
+++ b/panel/reactive.py
@@ -130,7 +130,7 @@ class Syncable(Renderable):
 
         # Sets up watchers to process manual updates to models
         if self._manual_params:
-            self._callbacks.append(
+            self._internal_callbacks.append(
                 self.param.watch(self._update_manual, self._manual_params)
             )
 
@@ -233,7 +233,7 @@ class Syncable(Renderable):
         params = self._synced_params
         if params:
             watcher = self.param.watch(self._param_change, params)
-            self._callbacks.append(watcher)
+            self._internal_callbacks.append(watcher)
 
     def _link_props(
         self, model: Model, properties: List[str] | List[Tuple[str, str]],
@@ -617,7 +617,9 @@ class Reactive(Syncable, Viewable):
                 for sp in extract_dependencies(p):
                     groups[sp.owner].append(sp.name)
         for owner, pnames in groups.items():
-            owner.param.watch(self._sync_refs, list(set(pnames)))
+            self._internal_callbacks.append(
+                owner.param.watch(self._sync_refs, list(set(pnames)))
+            )
 
     #----------------------------------------------------------------
     # Private API
@@ -919,7 +921,7 @@ class SyncableData(Reactive):
                 self.param.watch(self._update_cds, self._data_params)
             )
         callbacks.append(self.param.watch(self._update_selected, 'selection'))
-        self._callbacks += callbacks
+        self._internal_callbacks += callbacks
         self._validate()
         self._update_cds()
 

--- a/panel/tests/pane/test_base.py
+++ b/panel/tests/pane/test_base.py
@@ -88,7 +88,7 @@ def test_pane_untracked_watchers(pane, document, comm):
         w for pwatchers in p._param_watchers.values()
         for awatchers in pwatchers.values() for w in awatchers
     ]
-    assert len([wfn for wfn in watchers if wfn not in p._callbacks and not hasattr(wfn.fn, '_watcher_name')]) == 0
+    assert len([wfn for wfn in watchers if wfn not in p._internal_callbacks and not hasattr(wfn.fn, '_watcher_name')]) == 0
 
 @pytest.mark.parametrize('pane', all_panes)
 def test_pane_clone(pane):

--- a/panel/tests/test_interact.py
+++ b/panel/tests/test_interact.py
@@ -233,7 +233,7 @@ def test_interact_replaces_model(document, comm):
     assert new_pane._models[column.ref['id']][0] is new_div
 
     interact_pane._cleanup(column)
-    assert len(interact_pane._callbacks) == 6
+    assert len(interact_pane._internal_callbacks) == 6
     # Note one of the callbacks is Viewable._set_background
     # the counter should be reduced when this function is removed.
 

--- a/panel/tests/test_param.py
+++ b/panel/tests/test_param.py
@@ -1231,7 +1231,7 @@ def test_param_method_pane_subobject(document, comm):
     assert model.text == '42'
 
     # Ensure that subobject is being watched
-    watchers = pane._callbacks
+    watchers = pane._internal_callbacks
     assert any(w.inst is subobject for w in watchers)
     assert pane._models[row.ref['id']][0] is row
 
@@ -1239,7 +1239,7 @@ def test_param_method_pane_subobject(document, comm):
     new_subobject = View(name='Nested', a=42)
     test.b = new_subobject
     assert pane._models[row.ref['id']][0] is row
-    watchers = pane._callbacks
+    watchers = pane._internal_callbacks
     assert not any(w.inst is subobject for w in watchers)
     assert any(w.inst is new_subobject for w in watchers)
 

--- a/panel/tests/widgets/test_base.py
+++ b/panel/tests/widgets/test_base.py
@@ -38,7 +38,7 @@ def test_widget_untracked_watchers(widget, document, comm):
         w for pwatchers in widg._param_watchers.values()
         for awatchers in pwatchers.values() for w in awatchers
     ]
-    assert len([wfn for wfn in watchers if wfn not in widg._callbacks and not hasattr(wfn.fn, '_watcher_name')]) == 0
+    assert len([wfn for wfn in watchers if wfn not in widg._internal_callbacks and not hasattr(wfn.fn, '_watcher_name')]) == 0
 
 @pytest.mark.parametrize('widget', all_widgets)
 def test_widget_linkable_params(widget, document, comm):

--- a/panel/viewable.py
+++ b/panel/viewable.py
@@ -329,6 +329,7 @@ class ServableMixin:
         else:
             loc_model = loc._get_model(doc, root)
         loc_model.name = 'location'
+        doc.on_session_destroyed(loc._server_destroy) # type: ignore
         doc.add_root(loc_model)
         return loc
 

--- a/panel/viewable.py
+++ b/panel/viewable.py
@@ -515,7 +515,7 @@ class Renderable(param.Parameterized, MimeRenderMixin):
     __abstract = True
 
     def __init__(self, **params):
-        self._callbacks = []
+        self._internal_callbacks = []
         self._documents = {}
         self._models = {}
         self._comms = {}
@@ -678,7 +678,7 @@ class Viewable(Renderable, Layoutable, ServableMixin):
         self._update_loading()
         self._update_background()
         self._update_design()
-        self._callbacks.extend([
+        self._internal_callbacks.extend([
             self.param.watch(self._update_background, 'background'),
             self.param.watch(self._update_design, 'design'),
             self.param.watch(self._update_loading, 'loading')

--- a/panel/widgets/base.py
+++ b/panel/widgets/base.py
@@ -173,7 +173,7 @@ class CompositeWidget(Widget):
                 layout['min_width'] = min_width
         self._composite = self._composite_type(**layout)
         self._models = self._composite._models
-        self._callbacks.append(
+        self._internal_callbacks.append(
             self.param.watch(self._update_layout_params, layout_params)
         )
 

--- a/panel/widgets/codeeditor.py
+++ b/panel/widgets/codeeditor.py
@@ -60,7 +60,7 @@ class CodeEditor(Widget):
         elif 'disabled' in params:
             params['readonly'] = params['disabled']
         super().__init__(**params)
-        self._callbacks.append(
+        self._internal_callbacks.append(
             self.param.watch(self._update_disabled, ['disabled', 'readonly'])
         )
         self.jslink(self, readonly='disabled', bidirectional=True)

--- a/panel/widgets/input.py
+++ b/panel/widgets/input.py
@@ -755,7 +755,7 @@ class LiteralInput(Widget):
         super().__init__(**params)
         self._state = ''
         self._validate(None)
-        self._callbacks.append(self.param.watch(self._validate, 'value'))
+        self._internal_callbacks.append(self.param.watch(self._validate, 'value'))
 
     def _validate(self, event):
         if self.type is None: return

--- a/panel/widgets/select.py
+++ b/panel/widgets/select.py
@@ -197,7 +197,7 @@ class Select(SingleSelectBase):
         super().__init__(**params)
         if self.size == 1:
             self.param.size.constant = True
-        self._callbacks.extend([
+        self._internal_callbacks.extend([
             self.param.watch(
                 self._validate_options_groups,
                 ['options', 'groups']


### PR DESCRIPTION
- Rename `_callbacks` internal attribute to `_internal_callbacks` to avoid clashes with user code
- Clean up any callbacks attached to the Location on server destroy