### PR TITLE
Make year greater than or equal to in interactive data workflows

### DIFF
--- a/doc/how_to/interactivity/hvplot_interactive.md
+++ b/doc/how_to/interactivity/hvplot_interactive.md
@@ -26,13 +26,13 @@ species_widget = pn.widgets.Select(name="species", options=["Adelie", "Gentoo", 
 year_widget = pn.widgets.IntSlider(name="year", start=2007, end=2009)
 ```
 
-Let's then use these to filter the data. We can do this by using `hvplot.interactive` and passing the `species_widget` as the `species` parameter and the `year_widget` as the `year` parameter. In our case, we want the year always to be greater than the widget's value.
+Let's then use these to filter the data. We can do this by using `hvplot.interactive` and passing the `species_widget` as the `species` parameter and the `year_widget` as the `year` parameter. In our case, we want the year always to be greater than or equal to the widget's value.
 
 ```{pyodide}
 import hvplot.pandas  # Enable interactive
 
 idf = df.interactive()
-idf = idf[(idf["species"] == species_widget) & (idf["year"] > year_widget)]
+idf = idf[(idf["species"] == species_widget) & (idf["year"] >= year_widget)]
 
 idf.head()
 ```


### PR DESCRIPTION
I noticed that if the dataframe were empty, the hvplot would raise a SkipRendering error and no longer work. 

![image](https://github.com/holoviz/panel/assets/19758978/b72dc4cb-41d3-4047-a33a-2f67e53096db)

https://pyviz-dev.github.io/panel/how_to/interactivity/hvplot_interactive.html

Also getting this error in the console: `Auto-detected dependency holoviews>=>=1.16.0a7 could not be installed.` Though it does not seem to affect the example.