### PR TITLE
Ensure SlidesTemplate triggers location hash changes

### DIFF
--- a/panel/template/slides/__init__.py
+++ b/panel/template/slides/__init__.py
@@ -22,7 +22,7 @@ class SlidesTemplate(VanillaTemplate):
     SlidesTemplate is built on top of Vanilla web components.
     """
 
-    reveal_config = param.Dict(default={'hash': True}, doc="""
+    reveal_config = param.Dict(default={}, doc="""
         Configuration parameters for reveal.js""")
 
     reveal_theme = param.Selector(default=None, objects=REVEAL_THEMES, doc="""

--- a/panel/template/slides/slides.html
+++ b/panel/template/slides/slides.html
@@ -191,6 +191,10 @@
   config.disableLayout = true;
   Reveal.initialize(config);
 
+  Reveal.on('slidechanged', event => {
+    window.location.hash = `#/${event.currentSlide.id}`
+  })
+
   function openNav() {
     document.getElementById("sidebar").classList.remove("hidden");
     document.getElementById("sidebar-button").onclick = closeNav;


### PR DESCRIPTION
Previously you could not listen on `pn.state.location.hash` to determine which slide the user was on.