### PR TITLE
Ensure design stylesheets are not replaced on update

### DIFF
--- a/panel/reactive.py
+++ b/panel/reactive.py
@@ -658,7 +658,7 @@ class Reactive(Syncable, Viewable):
     def _update_properties(self, *events: param.parameterized.Event, doc: Document) -> Dict[str, Any]:
         params, _ = self._design.params(self, doc) if self._design else ({}, None)
         changes = {event.name: event.new for event in events}
-        if 'stylesheets' in changes and 'stylsheets' in params:
+        if 'stylesheets' in changes and 'stylesheets' in params:
             changes['stylesheets'] = params['stylesheets'] + changes['stylesheets']
         return self._process_param_change(changes)
 

--- a/panel/tests/test_reactive.py
+++ b/panel/tests/test_reactive.py
@@ -679,3 +679,16 @@ def test_reactive_html_templated_variable_not_in_declared_node():
             """
     assert 'could not be expanded because the <select> node' in str(excinfo)
     assert '{%- for option in children %}' in str(excinfo)
+
+def test_reactive_design_stylesheets_update(document, comm):
+    widget = TextInput(stylesheets=[':host { --design-background-color: red }'])
+
+    model = widget.get_root(document, comm)
+
+    assert len(model.stylesheets) == 5
+    assert model.stylesheets[-1] == widget.stylesheets[0]
+
+    widget.stylesheets = [':host { --design-background-color: blue }']
+
+    assert len(model.stylesheets) == 5
+    assert model.stylesheets[-1] == widget.stylesheets[0]


### PR DESCRIPTION
Typo caused design stylesheets to be replaced when stylesheets were updated.

- [x] Add test