### PR TITLE
Explain apps to website visitors

### DIFF
--- a/doc/gallery/index.md
+++ b/doc/gallery/index.md
@@ -1,6 +1,6 @@
 # App Gallery
 
-These Panel applications demonstrate what you can build with Panel and how to do it. Click on each thumbnail to see the app running live, and click on "See source" to look at how each of the components are configured and put together. The source is fully runnable in your browser thanks to [wasm/pyodide](https://panel.holoviz.org/how_to/wasm/standalone.html); just press the <span style="color:green">▶</span> button on the first code cell to run all the cells.
+These Panel applications demonstrate what you can build with Panel and how to do it. Click on each thumbnail to see the app running live, and click on "See source" to look at how each of the components are configured and put together. The source is fully runnable in your browser thanks to [WASM & Pyodide](../how_to/wasm/index.md); just press the <span style="color:green">▶</span> button on the first code cell to run all the cells.
 
 ::::{grid} 1 2 2 3
 :gutter: 1 1 1 2

--- a/doc/gallery/index.md
+++ b/doc/gallery/index.md
@@ -1,6 +1,6 @@
 # App Gallery
 
-These Panel applications demonstrate what you can build with Panel and how to do it. Click on each thumbnail to see the app running live, and click on "See source" to look at how each of the components are configured and put together. The source is fully runnable in your browser thanks to [wasm/pyodide](https://panel.holoviz.org/how_to/wasm/standalone.html); just press the <span style="color:green">▶</span> button to run each code cell.
+These Panel applications demonstrate what you can build with Panel and how to do it. Click on each thumbnail to see the app running live, and click on "See source" to look at how each of the components are configured and put together. The source is fully runnable in your browser thanks to [wasm/pyodide](https://panel.holoviz.org/how_to/wasm/standalone.html); just press the <span style="color:green">▶</span> button on the first code cell to run all the cells.
 
 ::::{grid} 1 2 2 3
 :gutter: 1 1 1 2

--- a/doc/gallery/index.md
+++ b/doc/gallery/index.md
@@ -1,5 +1,7 @@
 # App Gallery
 
+These Panel applications demonstrate what you can build with Panel and how to do it. Click on each thumbnail to see the app running live, and click on "See source" to look at how each of the components are configured and put together. The source is fully runnable in your browser thanks to [wasm/pyodide](https://panel.holoviz.org/how_to/wasm/standalone.html); just press the <span style="color:green">▶</span> button to run each code cell.
+
 ::::{grid} 1 2 2 3
 :gutter: 1 1 1 2
 


### PR DESCRIPTION
Added text for the top of https://panel.holoviz.org/gallery/index.html to explain how to use it. Also wanted to add similar text to the Component Gallery, but I can't actually see where the source code for that page is:

```
These pages demonstrate what each Panel component can do and how to use it. 
Click on each thumbnail to see the component used in a fully runnable web page 
in your browser thanks to [wasm/pyodide](https://panel.holoviz.org/how_to/wasm/standalone.html); 
just press the <span style="color:green">▶</span> button on the first code cell to run all the cells.
```