### PR TITLE
Improve tooltip rendering

### DIFF
--- a/panel/param.py
+++ b/panel/param.py
@@ -465,7 +465,7 @@ class Param(PaneBase):
                 kw['fixed_end'] = p_obj.bounds[1]
 
         if p_obj.doc:
-            kw['description'] = textwrap.dedent(p_obj.doc.lstrip())
+            kw['description'] = textwrap.dedent(p_obj.doc).lstrip()
 
         # Update kwargs
         kw.update(kw_widget)

--- a/panel/param.py
+++ b/panel/param.py
@@ -465,7 +465,7 @@ class Param(PaneBase):
                 kw['fixed_end'] = p_obj.bounds[1]
 
         if p_obj.doc:
-            kw['description'] = textwrap.dedent(p_obj.doc).lstrip()
+            kw['description'] = textwrap.dedent(p_obj.doc).strip()
 
         # Update kwargs
         kw.update(kw_widget)

--- a/panel/widgets/base.py
+++ b/panel/widgets/base.py
@@ -117,7 +117,7 @@ class Widget(Reactive):
             html = parser.render(params['description'])
             params['description'] = Tooltip(
                 content=HTML(html), position='right',
-                stylesheets=[':host { white-space: initial; max-width: 250px; }'],
+                stylesheets=[':host { white-space: initial; max-width: 300px; }'],
                 syncable=False
             )
         return params

--- a/panel/widgets/base.py
+++ b/panel/widgets/base.py
@@ -14,7 +14,8 @@ from typing import (
 
 import param  # type: ignore
 
-from bokeh.models import ImportedStyleSheet
+from bokeh.models import ImportedStyleSheet, Tooltip
+from bokeh.models.dom import HTML
 
 from .._param import Margin
 from ..layout.base import Row
@@ -96,6 +97,13 @@ class Widget(Reactive):
         )
         return layout[0]
 
+    @property
+    def _linked_properties(self) -> Tuple[str]:
+        props = list(super()._linked_properties)
+        if 'description' in props:
+            props.remove('description')
+        return tuple(props)
+
     def _process_param_change(self, params: Dict[str, Any]) -> Dict[str, Any]:
         params = super()._process_param_change(params)
         if self._widget_type is not None and 'stylesheets' in params:
@@ -103,6 +111,15 @@ class Widget(Reactive):
             params['stylesheets'] = [
                 ImportedStyleSheet(url=ss) for ss in css
             ] + params['stylesheets']
+        if 'description' in params:
+            from ..pane.markup import Markdown
+            parser = Markdown._get_parser('markdown-it', ())
+            html = parser.render(params['description'])
+            params['description'] = Tooltip(
+                content=HTML(html), position='right',
+                stylesheets=[':host { white-space: initial; max-width: 250px; }'],
+                syncable=False
+            )
         return params
 
     def _get_model(


### PR DESCRIPTION
- `lstrip` followed by dedent does not work as desired because it strips indentation on the first line which then breaks dedenting on subsequent lines.
- Switches from `title` property based tooltip to explicit HTML tooltip rendered using markdown

![tooltips](https://github.com/holoviz/panel/assets/1550771/71592a5a-7b3f-410f-bf0b-80cfb05c315a)



Fix https://github.com/holoviz/panel/issues/4887