### PR TITLE
Load index template resources from CDN

### DIFF
--- a/panel/_templates/convert_index.html
+++ b/panel/_templates/convert_index.html
@@ -21,8 +21,8 @@
 
   <!-- Favicon
   –––––––––––––––––––––––––––––––––––––––––––––––––– -->
-  <link rel="apple-touch-icon" sizes="180x180" href="{{ apple_icon|default('https://panel.holoviz.org/_static/icons/apple-touch-icon.png', true) }}">
-  <link rel="icon" type="image/png" sizes="32x32" href="{{ favicon|default('https://panel.holoviz.org/_static/icons/favicon.ico', true) }}">
+  <link rel="apple-touch-icon" sizes="180x180" href="{{ PANEL_CDN }}images/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="{{ PANEL_CDN }}images/favicon.ico">
   <link rel="manifest" href="{{ manifest|default('https://panel.holoviz.org/_static/icons/site.webmanifest', true) }}">
   <meta name="msapplication-TileColor" content="#da532c">
   <meta name="theme-color" content="#ffffff">
@@ -33,8 +33,8 @@
   }
   </script>
   {% endif %}
-  <script type="module" src="{{ npm_cdn|default('https://cdn.jsdelivr.net/npm', true) }}/@microsoft/fast-colors@5.3.1/dist/index.js"></script>
-  <script type="module" src="{{ npm_cdn|default('https://cdn.jsdelivr.net/npm', true) }}/@microsoft/fast-components@1.21.8/dist/fast-components.js"></script>
+  <script type="module" src="{{ PANEL_CDN }}bundled/@microsoft/fast-components@2.30.6/dist/fast-components.js"></script>
+  <script type="module" src="{{ PANEL_CDN }}bundled/fast/js/fast_design.js"></script>
   <script type="text/javascript">
     function setParamsFromSearch(text) {
         const params = new URLSearchParams(location.search);
@@ -56,19 +56,21 @@
 
       setParamsFromSearch(text)
     }
-    function toggleLightDarkTheme(){
-        el=document.getElementById("body-design-provider")
+    function toggleLightDarkTheme(update) {
         const switchEl = document.getElementById("theme-switch")
         const params = new URLSearchParams(location.search);
-
-        if (switchEl.checked){
-            el.setAttribute("background-color", "#ffffff")
+	if (switchEl.checked) {
+	    window.bodyDesign.setLuminance(1)
+	    window.bodyDesign.setBackgroundColor("#ffffff")
             params.set('theme', "default");
         } else {
-            el.setAttribute("background-color", "#000000")
+	    window.bodyDesign.setLuminance(0.1)
+	    window.bodyDesign.setBackgroundColor("#000000")
             params.set('theme', "dark");
         }
-        window.history.replaceState({}, '', `${location.pathname}?${params}`);
+	if (update) {
+            window.history.replaceState({}, '', `${location.pathname}?${params}`);
+	}
     }
     function setSwitchFromParams(){
         const params = new URLSearchParams(window.location.search)
@@ -76,12 +78,14 @@
             const theme = params.get('theme')
             const switchEl = document.getElementById("theme-switch")
             if (theme==='dark'){
-                switchEl.checked=false
+                switchEl.checked = false
             } else {
-                switchEl.checked=true
+                switchEl.checked = true
             }
-            toggleLightDarkTheme()
-        }
+            toggleLightDarkTheme(true)
+        } else {
+            toggleLightDarkTheme(false)
+	}
     }
     function setSearchFromParams(){
         const params = new URLSearchParams(window.location.search)
@@ -94,154 +98,151 @@
     }
   </script>
   <style>
-  html {
-      height:100%;
-  }
-  html, #body-design-provider {
-      min-height: 100vh;
-  }
-  body {
-      margin: 0px;
-      padding: 0;
-      font-style: normal;
-      font-variant-ligatures: normal;
-      font-variant-caps: normal;
-      font-variant-numeric: normal;
-      font-variant-east-asian: normal;
-      font-weight: normal;
-      font-stretch: normal;
-      font-size: 16px;
-      line-height: normal;
-      font-family: aktiv-grotesk, "Segoe UI", Arial, Helvetica, sans-serif;
-      overflow-y: scroll;
-  }
-  .gallery-item:hover {
-      box-shadow: 0 1px 5px var(--neutral-focus);
-  }
-  .gallery-item {
-      cursor: pointer;
-  }
-  .header {
-    background-image: linear-gradient(to top, rgba(0, 0, 0, 0.6), rgba(0, 0, 0, 0) ),url('./images/index_background.png');
-    background-size: cover;
-    background-repeat: no-repeat;
-    background-position: center;
-  }
-  .header-grid {
-    /* Grid styles */
-    padding: 4rem 2rem;
-    display: grid;
-    align-items: center;
-    grid-template-columns: repeat(auto-fit, minmax(480px, 1fr));
-  }
-  .header article {
-      margin-right: 1.0em;
-      padding-left: 1.0em;
-      padding-right: 1.0em;
-      opacity: 0.8;
-      color: white;
-  }
-
-  .article .h2 {
-      font-size: 2em;
-  }
-
-  #title, #divider, #subtitle {
-      background: transparent;
-      font-size: 1.5em;
-      color: white;
-  }
-
-  #search-input {
-      margin-top: 1em;
-      margin-left:2em;
-      margin-bottom:0em;
-      width: calc(100% - 4em);
-  }
-  .theme-toggle-icon {
-      height: 25px;
-      width: 25px;
-      margin-top: 5px;
-  }
-
-  /* The grid layout is inspired by
-  https://css-tricks.com/look-ma-no-media-queries-responsive-layouts-using-css-grid/
-  https://codepen.io/andybelldesign/pen/vMMYKJ */
-  /*
-    AUTO GRID
-    Set the minimum item size with `--cards-grid-min-size` and you'll
-    get a fully responsive grid with no media queries.
-  */
-  .cards-grid {
-    --cards-grid-min-size: 16rem;
-
-    display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(var(--cards-grid-min-size), 1fr));
-    grid-gap: 2rem;
-    list-style: none;
-  }
-  /* Presentational styles */
-  .card {
-    padding: 0px;
-  }
-
-  .cards-grid {
-      margin: 2rem;
-      padding: 0px;
-  }
-
-  .avatar {
-      vertical-align: middle;
-      float: right;
-      width: 30px;
-      height: 30px;
-      margin-top: 5px;
-      border-radius: 50%;
-  }
-  .card-action svg {
-      vertical-align: middle;
-      float: right;
-      height: 20px;
-      color: white;
-      margin-top: 10px;
-      margin-right: 10px;
-      fill: var(--neutral-foreground-rest);
-  }
-
-  .card-image {
-      height: 100px;
-      width: 100%;
-      margin-top: 25px;
-  }
-  .card-content {
-      padding: 10px 10px 10px;
-      color: var(--neutral-foreground-rest);
-  }
-  .card-text {
-      height: 100px;
-  }
-  .card-header {
-      height: 2em;
-      text-align: center;
-  }
-
-  footer {
-      padding: .50rem;
-      text-align: center;
-      font-size: .75rem;
-  }
-  #panel-logo {
-    width: 300px;
-  }
-  .card-link {
-    text-decoration: none;
-    color: var(--neutral-foreground-rest);
-  }
+    :root {
+      --background-color: #ffffff;
+      --header-background: #000000;
+    }
+    html, #body-design-provider {
+	min-height: 100vh;
+    }
+    body {
+	margin: 0px;
+	padding: 0;
+	font-style: normal;
+	font-variant-ligatures: normal;
+	font-variant-caps: normal;
+	font-variant-numeric: normal;
+	font-variant-east-asian: normal;
+	font-weight: normal;
+	font-stretch: normal;
+	font-size: 16px;
+	line-height: normal;
+	font-family: aktiv-grotesk, "Segoe UI", Arial, Helvetica, sans-serif;
+	overflow-y: scroll;
+    }
+    .gallery-item:hover {
+	box-shadow: 0 1px 5px var(--neutral-focus);
+    }
+    .gallery-item {
+	cursor: pointer;
+    }
+    .header {
+	background-image: linear-gradient(to top, rgba(0, 0, 0, 0.6), rgba(0, 0, 0, 0) ),url('./images/index_background.png');
+	background-size: cover;
+	background-repeat: no-repeat;
+	background-position: center;
+    }
+    .header-grid {
+	/* Grid styles */
+	padding: 4rem 2rem;
+	display: grid;
+	align-items: center;
+	grid-template-columns: repeat(auto-fit, minmax(480px, 1fr));
+    }
+    .header article {
+	margin-right: 1.0em;
+	padding-left: 1.0em;
+	padding-right: 1.0em;
+	opacity: 0.8;
+	color: white;
+    }
+    .article .h2 {
+	font-size: 2em;
+    }
+    #header-design-provider {
+      --neutral-fill-hover: var(--header-background);
+      --neutral-fill-rest: var(--header-background);
+      background-color: var(--header-background);
+    }
+    #title, #divider, #subtitle {
+	background: transparent;
+	font-size: 1.5em;
+	color: white;
+    }
+    #search-input {
+	margin-top: 1em;
+	margin-left: 2em;
+	margin-bottom: 0em;
+	width: calc(100% - 4em);
+    }
+    .theme-toggle-icon {
+	height: 25px;
+	width: 25px;
+	margin-top: 5px;
+    }
+    /* The grid layout is inspired by
+       https://css-tricks.com/look-ma-no-media-queries-responsive-layouts-us	ing-css-grid/
+       https://codepen.io/andybelldesign/pen/vMMYKJ */
+    /*
+      AUTO GRID
+      Set the minimum item size with `--cards-grid-min-size` and you'll
+      get a fully responsive grid with no media queries.
+   */
+    .cards-grid {
+	--cards-grid-min-size: 16rem;
+	display: grid;
+	grid-template-columns: repeat(auto-fill, minmax(var(--cards-grid-min-size), 1fr));
+	grid-gap: 2rem;
+	list-style: none;
+    }
+    /* Presentational styles */
+    .card {
+	padding: 0px;
+    }
+    .cards-grid {
+	margin: 2rem;
+	padding: 0px;
+    }
+    .avatar {
+	vertical-align: middle;
+	float: right;
+	width: 30px;
+	height: 30px;
+	margin-top: 5px;
+	border-radius: 50%;
+    }
+    .card-action svg {
+	vertical-align: middle;
+	float: right;
+	height: 20px;
+	color: white;
+	margin-top: 10px;
+	margin-right: 10px;
+	fill: var(--neutral-foreground-rest);
+    }
+    .card-image {
+	height: 100px;
+	width: 100%;
+	margin-top: 25px;
+    }
+    .card-content {
+	padding: 10px 10px 10px;
+	color: var(--neutral-foreground-rest);
+    }
+    .card-text {
+	height: 100px;
+    }
+    .card-header {
+	height: 2em;
+	text-align: center;
+    }
+    footer {
+	padding: .50rem;
+	text-align: center;
+	font-size: .75rem;
+    }
+    #panel-logo {
+	width: 300px;
+    }
+    .card-link {
+	text-decoration: none;
+	color: var(--neutral-foreground-rest);
+    }
   </style>
 </head>
 <body>
-      <fast-design-system-provider id="body-design-provider" use-defaults background-color="#ffffff">
-        <fast-design-system-provider id="header-design-provider" use-defaults background-color="#000000">
+      <fast-design-system-provider id="body-design-provider" use-defaults>
+        <fast-design-system-provider id="header-design-provider" use-defaults>
         <section class="header">
         <fast-switch id="theme-switch" style="float: right; padding-top: 1em; padding-right: 2em;" onChange="toggleLightDarkTheme()" checked>
             <span slot="checked-message">
@@ -294,8 +295,11 @@
         </section>
     </fast-design-system-provider>
     <script type="text/javascript">
-        setSwitchFromParams()
-        setSearchFromParams()
+      document.addEventListener('DOMContentLoaded', (event) => {
+	const body_design = window.bodyDesign = new window.fastDesignProvider("#body-design-provider");
+	setSwitchFromParams()
+	setSearchFromParams()
+      })
     </script>
 </body>
 </html>

--- a/panel/_templates/convert_index.html
+++ b/panel/_templates/convert_index.html
@@ -118,16 +118,16 @@
 	font-size: 16px;
 	line-height: normal;
 	font-family: aktiv-grotesk, "Segoe UI", Arial, Helvetica, sans-serif;
-	overflow-y: scroll;
+	overflow-y: auto;
     }
     .gallery-item:hover {
-	box-shadow: 0 1px 5px var(--neutral-focus);
+	box-shadow: 0 1px 5px var(--neutral-fill-strong-focus);
     }
     .gallery-item {
 	cursor: pointer;
     }
     .header {
-	background-image: linear-gradient(to top, rgba(0, 0, 0, 0.6), rgba(0, 0, 0, 0) ),url('./images/index_background.png');
+	background-image: linear-gradient(to top, rgba(0, 0, 0, 0.6), rgba(0, 0, 0, 0) ),url("{{ './' if manifest else PANEL_CDN }}images/index_background.png");
 	background-size: cover;
 	background-repeat: no-repeat;
 	background-position: center;
@@ -149,10 +149,12 @@
     .article .h2 {
 	font-size: 2em;
     }
+    #body-design-provider {
+	color: var(--neutral-foreground-rest);
+    }
     #header-design-provider {
-      --neutral-fill-hover: var(--header-background);
-      --neutral-fill-rest: var(--header-background);
-      background-color: var(--header-background);
+	background-color: #000000;
+	color: var(--neutral-foreground-rest);
     }
     #title, #divider, #subtitle {
 	background: transparent;
@@ -169,6 +171,7 @@
 	height: 25px;
 	width: 25px;
 	margin-top: 5px;
+	fill: #ffffff;
     }
     /* The grid layout is inspired by
        https://css-tricks.com/look-ma-no-media-queries-responsive-layouts-us	ing-css-grid/
@@ -242,14 +245,14 @@
 </head>
 <body>
       <fast-design-system-provider id="body-design-provider" use-defaults>
-        <fast-design-system-provider id="header-design-provider" use-defaults>
+        <fast-design-system-provider id="header-design-provider">
         <section class="header">
         <fast-switch id="theme-switch" style="float: right; padding-top: 1em; padding-right: 2em;" onChange="toggleLightDarkTheme()" checked>
             <span slot="checked-message">
-                <svg class="theme-toggle-icon" fill="currentColor" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 25 25"><path d="M0 0h24v24H0z" fill="none"/><path d="M6.76 4.84l-1.8-1.79-1.41 1.41 1.79 1.79 1.42-1.41zM4 10.5H1v2h3v-2zm9-9.95h-2V3.5h2V.55zm7.45 3.91l-1.41-1.41-1.79 1.79 1.41 1.41 1.79-1.79zm-3.21 13.7l1.79 1.8 1.41-1.41-1.8-1.79-1.4 1.4zM20 10.5v2h3v-2h-3zm-8-5c-3.31 0-6 2.69-6 6s2.69 6 6 6 6-2.69 6-6-2.69-6-6-6zm-1 16.95h2V19.5h-2v2.95zm-7.45-3.91l1.41 1.41 1.79-1.8-1.41-1.41-1.79 1.8z"/></svg>
+                <svg class="theme-toggle-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 25 25"><path d="M0 0h24v24H0z" fill="none"/><path d="M6.76 4.84l-1.8-1.79-1.41 1.41 1.79 1.79 1.42-1.41zM4 10.5H1v2h3v-2zm9-9.95h-2V3.5h2V.55zm7.45 3.91l-1.41-1.41-1.79 1.79 1.41 1.41 1.79-1.79zm-3.21 13.7l1.79 1.8 1.41-1.41-1.8-1.79-1.4 1.4zM20 10.5v2h3v-2h-3zm-8-5c-3.31 0-6 2.69-6 6s2.69 6 6 6 6-2.69 6-6-2.69-6-6-6zm-1 16.95h2V19.5h-2v2.95zm-7.45-3.91l1.41 1.41 1.79-1.8-1.41-1.41-1.79 1.8z"/></svg>
               </span>
               <span slot="unchecked-message">
-                <svg class="theme-toggle-icon" fill="currentColor" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 25 25"><path d="M0 0h24v24H0z" fill="none"/><path d="M10 2c-1.82 0-3.53.5-5 1.35C7.99 5.08 10 8.3 10 12s-2.01 6.92-5 8.65C6.47 21.5 8.18 22 10 22c5.52 0 10-4.48 10-10S15.52 2 10 2z"/></svg>
+                <svg class="theme-toggle-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 25 25"><path d="M0 0h24v24H0z" fill="none"/><path d="M10 2c-1.82 0-3.53.5-5 1.35C7.99 5.08 10 8.3 10 12s-2.01 6.92-5 8.65C6.47 21.5 8.18 22 10 22c5.52 0 10-4.48 10-10S15.52 2 10 2z"/></svg>
               </span>
         </fast-switch>
         <fast-tooltip anchor="theme-switch">Click to toggle the Theme</fast-tooltip>
@@ -296,7 +299,9 @@
     </fast-design-system-provider>
     <script type="text/javascript">
       document.addEventListener('DOMContentLoaded', (event) => {
-	const body_design = window.bodyDesign = new window.fastDesignProvider("#body-design-provider");
+	const header_design = new window.fastDesignProvider("#header-design-provider");
+	header_design.setBackgroundColor('#ffffff')
+	window.bodyDesign = new window.fastDesignProvider("#body-design-provider");
 	setSwitchFromParams()
 	setSearchFromParams()
       })

--- a/panel/_templates/index.html
+++ b/panel/_templates/index.html
@@ -20,13 +20,13 @@
 
   <!-- Favicon
   -------------------------------------------------- -->
-  <link rel="apple-touch-icon" sizes="180x180" href="https://cdn.holoviz.org/panel/latest/dist/images/apple-touch-icon.png">
-  <link rel="icon" type="image/png" sizes="32x32" href="https://cdn.holoviz.org/panel/latest/dist/images/favicon.ico">
-  <link rel="manifest" href="https://cdn.holoviz.org/panel/latest/dist/images/site.webmanifest">
+  <link rel="apple-touch-icon" sizes="180x180" href="{{ PANEL_CDN }}images/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="{{ PANEL_CDN }}images/favicon.ico">
+  <link rel="manifest" href="{{ PANEL_CDN }}images/site.webmanifest">
   <meta name="msapplication-TileColor" content="#da532c">
   <meta name="theme-color" content="#ffffff">
-  <script type="module" src="https://cdn.holoviz.org/panel/latest/dist/bundled/js/@microsoft/fast-colors@5.3.1/dist/index.js"></script>
-  <script type="module" src="https://cdn.holoviz.org/panel/latest/dist/bundled/js/@microsoft/fast-components@1.21.8/dist/fast-components.js"></script>
+  <script type="module" src="{{ PANEL_CDN }}bundled/@microsoft/fast-components@2.30.6/dist/fast-components.js"></script>
+  <script type="module" src="{{ PANEL_CDN }}bundled/fast/js/fast_design.js"></script>
   <script type="text/javascript">
     function setParamsFromSearch(text){
         const params = new URLSearchParams(location.search);
@@ -48,19 +48,21 @@
 
       setParamsFromSearch(text)
     }
-    function toggleLightDarkTheme(){
-        el=document.getElementById("body-design-provider")
+    function toggleLightDarkTheme(update) {
         const switchEl = document.getElementById("theme-switch")
         const params = new URLSearchParams(location.search);
-
-        if (switchEl.checked){
-            el.setAttribute("background-color", "#ffffff")
+	if (switchEl.checked) {
+	    window.bodyDesign.setLuminance(1)
+	    window.bodyDesign.setBackgroundColor("#ffffff")
             params.set('theme', "default");
         } else {
-            el.setAttribute("background-color", "#000000")
+	    window.bodyDesign.setLuminance(0.1)
+	    window.bodyDesign.setBackgroundColor("#000000")
             params.set('theme', "dark");
         }
-        window.history.replaceState({}, '', `${location.pathname}?${params}`);
+	if (update) {
+            window.history.replaceState({}, '', `${location.pathname}?${params}`);
+	}
     }
     function setSwitchFromParams(){
         const params = new URLSearchParams(window.location.search)
@@ -68,12 +70,14 @@
             const theme = params.get('theme')
             const switchEl = document.getElementById("theme-switch")
             if (theme==='dark'){
-                switchEl.checked=false
+                switchEl.checked = false
             } else {
-                switchEl.checked=true
+                switchEl.checked = true
             }
-            toggleLightDarkTheme()
-        }
+            toggleLightDarkTheme(true)
+        } else {
+            toggleLightDarkTheme(false)
+	}
     }
     function setSearchFromParams(){
         const params = new URLSearchParams(window.location.search)
@@ -87,6 +91,10 @@
   </script>
 
   <style>
+    :root {
+      --background-color: #ffffff;
+      --header-background: #000000;
+    }
     html {
 	height:100%;
     }
@@ -106,7 +114,7 @@
 	font-size: 16px;
 	line-height: normal;
 	font-family: aktiv-grotesk, "Segoe UI", Arial, Helvetica, sans-serif;
-	overflow-y: scroll;
+	overflow-y: auto;
     }
     .gallery-item:hover {
 	box-shadow: 0 1px 5px var(--neutral-focus);
@@ -116,7 +124,7 @@
 	text-align: center;
     }
     .header {
-	background-image: linear-gradient(to top, rgba(0, 0, 0, 0.6), rgba(0, 0, 0, 0) ),url('https://cdn.holoviz.org/panel/latest/dist/images/index_background.png');
+	background-image: linear-gradient(to top, rgba(0, 0, 0, 0.6), rgba(0, 0, 0, 0) ),url('{{ PANEL_CDN }}images/index_background.png');
 	background-size: cover;
 	background-repeat: no-repeat;
 	background-position: center;
@@ -148,7 +156,11 @@
 	width: 25px;
 	margin-top: 5px;
     }
-
+    #header-design-provider {
+      --neutral-fill-hover: var(--header-background);
+      --neutral-fill-rest: var(--header-background);
+      background-color: var(--header-background);
+    }
     /* The grid layout is inspired by
        https://css-tricks.com/look-ma-no-media-queries-responsive-layouts-using-css-grid/
        https://codepen.io/andybelldesign/pen/vMMYKJ */
@@ -159,7 +171,6 @@
    */
     .cards-grid {
 	--cards-grid-min-size: 16rem;
-
 	display: grid;
 	grid-template-columns: repeat(auto-fill, minmax(var(--cards-grid-min-size), 1fr));
 	grid-gap: 2rem;
@@ -224,7 +235,7 @@
   </style>
 </head>
 <body>
-  <fast-design-system-provider id="body-design-provider" use-defaults background-color="#ffffff">
+  <fast-design-system-provider id="body-design-provider" use-defaults>
     <fast-design-system-provider id="header-design-provider" use-defaults background-color="#000000">
       <section class="header">
         <fast-switch id="theme-switch" style="float: right; padding-top: 1em; padding-right: 2em;" onChange="toggleLightDarkTheme()" checked>
@@ -275,8 +286,11 @@
     </section>
   </fast-design-system-provider>
   <script type="text/javascript">
-    setSwitchFromParams()
-    setSearchFromParams()
+    document.addEventListener('DOMContentLoaded', (event) => {
+      const body_design = window.bodyDesign = new window.fastDesignProvider("#body-design-provider");
+      setSwitchFromParams()
+      setSearchFromParams()
+    })
   </script>
 </body>
 </html>

--- a/panel/_templates/index.html
+++ b/panel/_templates/index.html
@@ -136,6 +136,11 @@
 	align-items: center;
 	grid-template-columns: repeat(auto-fit, minmax(480px, 1fr));
     }
+    #header-design-provider {
+      --neutral-fill-hover: var(--header-background);
+      --neutral-fill-rest: var(--header-background);
+      background-color: var(--header-background);
+    }
     #title {
 	background: transparent;
     }
@@ -155,11 +160,6 @@
 	height: 25px;
 	width: 25px;
 	margin-top: 5px;
-    }
-    #header-design-provider {
-      --neutral-fill-hover: var(--header-background);
-      --neutral-fill-rest: var(--header-background);
-      background-color: var(--header-background);
     }
     /* The grid layout is inspired by
        https://css-tricks.com/look-ma-no-media-queries-responsive-layouts-using-css-grid/

--- a/panel/_templates/index.html
+++ b/panel/_templates/index.html
@@ -117,7 +117,7 @@
 	overflow-y: auto;
     }
     .gallery-item:hover {
-	box-shadow: 0 1px 5px var(--neutral-focus);
+	box-shadow: 0 1px 5px var(--neutral-fill-strong-focus);
     }
     .gallery-item {
 	cursor: pointer;
@@ -137,9 +137,10 @@
 	grid-template-columns: repeat(auto-fit, minmax(480px, 1fr));
     }
     #header-design-provider {
-      --neutral-fill-hover: var(--header-background);
-      --neutral-fill-rest: var(--header-background);
       background-color: var(--header-background);
+    }
+    #body-design-provider {
+	color: var(--neutral-foreground-rest);
     }
     #title {
 	background: transparent;
@@ -160,6 +161,7 @@
 	height: 25px;
 	width: 25px;
 	margin-top: 5px;
+	fill: #ffffff;
     }
     /* The grid layout is inspired by
        https://css-tricks.com/look-ma-no-media-queries-responsive-layouts-using-css-grid/
@@ -236,14 +238,14 @@
 </head>
 <body>
   <fast-design-system-provider id="body-design-provider" use-defaults>
-    <fast-design-system-provider id="header-design-provider" use-defaults background-color="#000000">
+    <fast-design-system-provider id="header-design-provider" use-defaults>
       <section class="header">
         <fast-switch id="theme-switch" style="float: right; padding-top: 1em; padding-right: 2em;" onChange="toggleLightDarkTheme()" checked>
           <span slot="checked-message">
-            <svg class="theme-toggle-icon" fill="currentColor" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 25 25"><path d="M0 0h24v24H0z" fill="none"/><path d="M6.76 4.84l-1.8-1.79-1.41 1.41 1.79 1.79 1.42-1.41zM4 10.5H1v2h3v-2zm9-9.95h-2V3.5h2V.55zm7.45 3.91l-1.41-1.41-1.79 1.79 1.41 1.41 1.79-1.79zm-3.21 13.7l1.79 1.8 1.41-1.41-1.8-1.79-1.4 1.4zM20 10.5v2h3v-2h-3zm-8-5c-3.31 0-6 2.69-6 6s2.69 6 6 6 6-2.69 6-6-2.69-6-6-6zm-1 16.95h2V19.5h-2v2.95zm-7.45-3.91l1.41 1.41 1.79-1.8-1.41-1.41-1.79 1.8z"/></svg>
+            <svg class="theme-toggle-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 25 25"><path d="M0 0h24v24H0z" fill="none"/><path d="M6.76 4.84l-1.8-1.79-1.41 1.41 1.79 1.79 1.42-1.41zM4 10.5H1v2h3v-2zm9-9.95h-2V3.5h2V.55zm7.45 3.91l-1.41-1.41-1.79 1.79 1.41 1.41 1.79-1.79zm-3.21 13.7l1.79 1.8 1.41-1.41-1.8-1.79-1.4 1.4zM20 10.5v2h3v-2h-3zm-8-5c-3.31 0-6 2.69-6 6s2.69 6 6 6 6-2.69 6-6-2.69-6-6-6zm-1 16.95h2V19.5h-2v2.95zm-7.45-3.91l1.41 1.41 1.79-1.8-1.41-1.41-1.79 1.8z"/></svg>
           </span>
           <span slot="unchecked-message">
-            <svg class="theme-toggle-icon" fill="currentColor" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 25 25"><path d="M0 0h24v24H0z" fill="none"/><path d="M10 2c-1.82 0-3.53.5-5 1.35C7.99 5.08 10 8.3 10 12s-2.01 6.92-5 8.65C6.47 21.5 8.18 22 10 22c5.52 0 10-4.48 10-10S15.52 2 10 2z"/></svg>
+            <svg class="theme-toggle-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 25 25"><path d="M0 0h24v24H0z" fill="none"/><path d="M10 2c-1.82 0-3.53.5-5 1.35C7.99 5.08 10 8.3 10 12s-2.01 6.92-5 8.65C6.47 21.5 8.18 22 10 22c5.52 0 10-4.48 10-10S15.52 2 10 2z"/></svg>
           </span>
         </fast-switch>
         <fast-tooltip anchor="theme-switch">Click to toggle the Theme</fast-tooltip>
@@ -287,6 +289,8 @@
   </fast-design-system-provider>
   <script type="text/javascript">
     document.addEventListener('DOMContentLoaded', (event) => {
+      const header_design = new window.fastDesignProvider("#header-design-provider");
+      header_design.setBackgroundColor('#ffffff')
       const body_design = window.bodyDesign = new window.fastDesignProvider("#body-design-provider");
       setSwitchFromParams()
       setSearchFromParams()

--- a/panel/dist/images/site.webmanifest
+++ b/panel/dist/images/site.webmanifest
@@ -1,0 +1,1 @@
+{"name":"","short_name":"","icons":[{"src":"/icons-192x192.png","sizes":"192x192","type":"image/png"},{"src":"/icons-512x512.png","sizes":"512x512","type":"image/png"}],"theme_color":"#ffffff","background_color":"#ffffff","display":"standalone"}

--- a/panel/io/convert.py
+++ b/panel/io/convert.py
@@ -150,7 +150,7 @@ def make_index(files, title=None, manifest=True):
     items = {label: './'+os.path.basename(f) for label, f in sorted(files.items())}
     return INDEX_TEMPLATE.render(
         items=items, manifest=manifest, apple_icon=apple_icon,
-        favicon=favicon, title=title, npm_cdn=config.npm_cdn
+        favicon=favicon, title=title, PANEL_CDN=CDN_DIST
     )
 
 def build_pwa_manifest(files, title=None, **kwargs):

--- a/panel/io/server.py
+++ b/panel/io/server.py
@@ -50,11 +50,12 @@ from bokeh.embed.wrappers import wrap_in_script_tag
 from bokeh.io import curdoc
 from bokeh.models import CustomJS
 from bokeh.server.server import Server as BokehServer
-from bokeh.server.urls import per_app_patterns
+from bokeh.server.urls import per_app_patterns, toplevel_patterns
 from bokeh.server.views.autoload_js_handler import (
     AutoloadJsHandler as BkAutoloadJsHandler,
 )
 from bokeh.server.views.doc_handler import DocHandler as BkDocHandler
+from bokeh.server.views.root_handler import RootHandler as BkRootHandler
 from bokeh.server.views.static_handler import StaticHandler
 from bokeh.util.serialization import make_id
 from bokeh.util.token import (
@@ -544,6 +545,19 @@ class AutoloadJsHandler(BkAutoloadJsHandler, SessionPrefixHandler):
         self.write(js)
 
 per_app_patterns[3] = (r'/autoload.js', AutoloadJsHandler)
+
+class RootHandler(BkRootHandler):
+    """
+    Custom RootHandler that provides the CDN_DIST directory as a
+    template variable.
+    """
+
+    def render(self, *args, **kwargs):
+        kwargs['PANEL_CDN'] = CDN_DIST
+        return super().render(*args, **kwargs)
+
+toplevel_patterns[0] = (r'/?', RootHandler)
+bokeh.server.tornado.RootHandler = RootHandler
 
 
 class ComponentResourceHandler(StaticFileHandler):


### PR DESCRIPTION
The index template was loading resources that were no longer bundled and also loading them from the `/latest` directory on the CDN which is note future proof. Here we align the handling with the main fast templates, upgrading to the recent version of fast-components and using our custom color handling implementation.

Fixes https://github.com/holoviz/panel/issues/4881
