### PR TITLE
Attempt rendering even if not all dependencies could be loaded

### DIFF
--- a/panel/_templates/doc_nb_js.js
+++ b/panel/_templates/doc_nb_js.js
@@ -49,7 +49,13 @@
         attempts++;
         if (attempts > 200) {
           clearInterval(timer);
-          console.log("Bokeh: ERROR: Unable to run BokehJS code because BokehJS library is missing");
+	  var Bokeh = get_bokeh(root)
+	  if (Bokeh == null || Bokeh.Panel == null) {
+            console.warn("Panel: ERROR: Unable to run Panel code because Bokeh or Panel library is missing");
+	  } else {
+	    console.warn("Panel: WARNING: Attempting to render but not all required libraries could be resolved.")
+	    embed_document(root)
+	  }
         }
       }
     }, 25, root)


### PR DESCRIPTION
In the notebook we always check that all the required dependencies were loaded correctly. This makes sense but if we reach the timeout and Bokeh and Panel are loaded we should just go ahead and try to render anyway since not all output will require all JS dependencies and some output >>> no output.