### PR TITLE
Do not load mathjax bundle in notebook by default

### DIFF
--- a/panel/io/notebook.py
+++ b/panel/io/notebook.py
@@ -11,7 +11,7 @@ import uuid
 from collections import OrderedDict
 from contextlib import contextmanager
 from typing import (
-    TYPE_CHECKING, Any, Dict, Iterator, List, Optional, Tuple,
+    TYPE_CHECKING, Any, Dict, Iterator, List, Literal, Optional, Tuple,
 )
 
 import bokeh
@@ -343,6 +343,7 @@ def block_comm() -> Iterator:
 def load_notebook(
     inline: bool = True,
     reloading: bool = False,
+    enable_mathjax: bool | Literal['auto'] = 'auto',
     load_timeout: int = 5000
 ) -> None:
     from IPython.display import publish_display_data
@@ -354,7 +355,8 @@ def load_notebook(
     resources = Resources.from_bokeh(resources, notebook=nb_endpoint)
     try:
         bundle = bundle_resources(
-            None, resources, notebook=nb_endpoint, reloading=reloading
+            None, resources, notebook=nb_endpoint, reloading=reloading,
+            enable_mathjax=enable_mathjax
         )
         configs, requirements, exports, skip_imports = require_components()
         ipywidget = 'ipywidgets_bokeh' in sys.modules

--- a/panel/io/resources.py
+++ b/panel/io/resources.py
@@ -346,10 +346,8 @@ def bundle_resources(roots, resources, notebook=False, reloading=False, enable_m
     css_files = []
     css_raw = []
 
-    if enable_mathjax == True:
-        use_mathjax = True
-    elif not enable_mathjax:
-        use_mathjax = False
+    if isinstance(enable_mathjax, bool):
+        use_mathjax = enable_mathjax
     else:
         use_mathjax = (_use_mathjax(roots) or 'mathjax' in ext._loaded_extensions) if roots else False
 

--- a/panel/io/resources.py
+++ b/panel/io/resources.py
@@ -348,8 +348,10 @@ def bundle_resources(roots, resources, notebook=False, reloading=False, enable_m
 
     if isinstance(enable_mathjax, bool):
         use_mathjax = enable_mathjax
+    elif roots:
+        use_mathjax = _use_mathjax(roots) or 'mathjax' in ext._loaded_extensions
     else:
-        use_mathjax = (_use_mathjax(roots) or 'mathjax' in ext._loaded_extensions) if roots else False
+        use_mathjax = False     
 
     if js_resources:
         js_resources = js_resources.clone()

--- a/panel/io/resources.py
+++ b/panel/io/resources.py
@@ -4,7 +4,6 @@ resources via the panel.config object.
 """
 from __future__ import annotations
 
-import copy
 import importlib
 import json
 import logging
@@ -334,7 +333,7 @@ def bundled_files(model, file_type='javascript'):
             files.append(url)
     return files
 
-def bundle_resources(roots, resources, notebook=False, reloading=False):
+def bundle_resources(roots, resources, notebook=False, reloading=False, enable_mathjax='auto'):
     from ..config import panel_extension as ext
     global RESOURCE_MODE
     if not isinstance(resources, Resources):
@@ -347,21 +346,19 @@ def bundle_resources(roots, resources, notebook=False, reloading=False):
     css_files = []
     css_raw = []
 
-    use_mathjax = (_use_mathjax(roots) or 'mathjax' in ext._loaded_extensions) if roots else True
+    if enable_mathjax == True:
+        use_mathjax = True
+    elif not enable_mathjax:
+        use_mathjax = False
+    else:
+        use_mathjax = (_use_mathjax(roots) or 'mathjax' in ext._loaded_extensions) if roots else False
 
     if js_resources:
-        if hasattr(BkResources, 'clone'):
-            js_resources = js_resources.clone()
-            if not use_mathjax and "bokeh-mathjax" in js_resources.components:
-                js_resources.components.remove("bokeh-mathjax")
-            if reloading:
-                js_resources.components.clear()
-        else:
-            js_resources = copy.deepcopy(js_resources)
-            if reloading:
-                js_resources.js_components.clear()
-            if not use_mathjax and "bokeh-mathjax" in js_resources.js_components:
-                js_resources.js_components.remove("bokeh-mathjax")
+        js_resources = js_resources.clone()
+        if not use_mathjax and "bokeh-mathjax" in js_resources.components:
+            js_resources.components.remove("bokeh-mathjax")
+        if reloading:
+            js_resources.components.clear()
 
         js_files.extend(js_resources.js_files)
         js_raw.extend(js_resources.js_raw)

--- a/panel/io/resources.py
+++ b/panel/io/resources.py
@@ -351,7 +351,7 @@ def bundle_resources(roots, resources, notebook=False, reloading=False, enable_m
     elif roots:
         use_mathjax = _use_mathjax(roots) or 'mathjax' in ext._loaded_extensions
     else:
-        use_mathjax = False     
+        use_mathjax = False
 
     if js_resources:
         js_resources = js_resources.clone()


### PR DESCRIPTION
In the notebook we were always loading the (huge) bokeh-mathjax bundle even though we already told users that they would have to explicitly request the bundle (with `pn.extension('mathjax')`). This change will necessitate HoloViews to add a flag to load the bundle.