### PR TITLE
Make Fast sidebar transition smoother

### DIFF
--- a/panel/template/fast/fast.css
+++ b/panel/template/fast/fast.css
@@ -143,10 +143,19 @@ img.app-logo {
 #sidebar {
   border-right: 2px solid var(--neutral-fill-rest);
   transition: all 0.2s cubic-bezier(0.945, 0.02, 0.27, 0.665);
-  transform-origin: center left; /* Set the transformed position of sidebar to center left side. */
+  transform-origin: center left;
   height: calc(100vh - 76px);
   overflow-y: auto;
   padding: 15px 10px 5px 0;
+}
+
+#sidebar.hidden {
+  border: 0px;
+  margin: 0px;
+  max-width: 0px;
+  min-width: 0px;
+  overflow: hidden;
+  padding: 0px;
 }
 
 #main {
@@ -160,15 +169,6 @@ img.app-logo {
 #sidebarCollapse {
   background: none;
   border: none;
-}
-
-#sidebar.hidden {
-  border: 0px;
-  margin: 0px;
-  min-width: 0px;
-  overflow: hidden;
-  padding: 0px;
-  width: 0px;
 }
 
 .sidenav fast-menu {


### PR DESCRIPTION
Previously collapsing the sidebar was smooth but expanding it was weirdly abrupt.