### PR TITLE
Rebuild child views when re-rendering Card layouts

### DIFF
--- a/panel/models/card.ts
+++ b/panel/models/card.ts
@@ -9,8 +9,10 @@ export class CardView extends ColumnView {
 
   connect_signals(): void {
     super.connect_signals()
-    this.connect(this.model.properties.collapsed.change, () => this._collapse())
-    const {active_header_background, collapsed, header_background, header_color, hide_header} = this.model.properties
+
+    const {active_header_background, children, collapsed, header_background, header_color, hide_header} = this.model.properties
+    this.on_change(children, () => this.render())
+    this.on_change(collapsed, () => this._collapse())
     this.on_change([header_color, hide_header], () => this.render())
 
     this.on_change([active_header_background, collapsed, header_background], () => {
@@ -77,6 +79,7 @@ export class CardView extends ColumnView {
   }
 
   async update_children(): Promise<void> {
+    await this.build_child_views()
     this.render()
     this.invalidate_layout()
   }

--- a/panel/tests/ui/layout/test_card.py
+++ b/panel/tests/ui/layout/test_card.py
@@ -100,12 +100,19 @@ def test_card_objects(page, port, card_components):
     card.objects = new_objects
 
     card_elements = page.locator('.card > div, .card > button')
-    expect(card_elements).to_have_count(len(new_objects) + 1)
+    expect(card_elements).to_have_count(2)
 
     card_header = card_elements.nth(0)
     w2_object = card_elements.nth(1)
     assert 'card-header' in card_header.get_attribute('class')
     assert 'class_w2' in w2_object.get_attribute('class')
+
+    w3 = TextInput(name='Text:', css_classes=['class_w3'])
+    card.append(w3)
+    card_elements = page.locator('.card > div, .card > button')
+    expect(card_elements).to_have_count(3)
+    w3_object = card_elements.nth(2)
+    assert 'class_w3' in w3_object.get_attribute('class')
 
 
 def test_card_title(page, port, card_components):


### PR DESCRIPTION
We weren't re-building the child views when updating the Card so any models that weren't previously rendered wouldn't show up.

- [x] Fixes https://github.com/holoviz/panel/issues/4897
- [x] Add test