### PR TITLE
Update JPEG filetype from jpg to jpeg.

### DIFF
--- a/panel/pane/image.py
+++ b/panel/pane/image.py
@@ -357,7 +357,7 @@ class JPG(ImageBase):
     ... )
     """
 
-    filetype: ClassVar[str] = 'jpg'
+    filetype: ClassVar[str] = 'jpeg'
 
     _extensions: ClassVar[Tuple[str, ...]] = ('jpeg', 'jpg')
 


### PR DESCRIPTION
Pillow library does not have the `_repr_jpg_` method. Recently the `_repr_jpeg_` method is added https://github.com/python-pillow/Pillow/pull/7135