### PR TITLE
Fix handling of queued events in pyodide worker

### DIFF
--- a/panel/_templates/pyodide_handler.js
+++ b/panel/_templates/pyodide_handler.js
@@ -28,7 +28,7 @@ pyodideWorker.onmessage = async (event) => {
   const loading_msgs = document.getElementsByClassName('pn-loading-msg')
   if (msg.type === 'idle') {
     if (pyodideWorker.queue.length) {
-      const patch = pyodideWorker.jsdoc.create_json_patch_string(pyodideWorker.queue)
+      const patch = pyodideWorker.jsdoc.create_json_patch(pyodideWorker.queue)
       pyodideWorker.busy = true
       pyodideWorker.queue = []
       pyodideWorker.postMessage({type: 'patch', patch: patch})


### PR DESCRIPTION
Queued events were not handled correctly, using an old method for turning events into JSON patches.