### PR TITLE
Ensure HoloViews layout is correctly initialized

### DIFF
--- a/panel/pane/holoviews.py
+++ b/panel/pane/holoviews.py
@@ -134,6 +134,13 @@ class HoloViews(PaneBase):
         self._track_overrides(*(e for e in events if e.name in Layoutable.param))
         super()._param_change(*(e for e in events if e.name in self._overrides+['css_classes']))
 
+    @param.depends('backend', watch=True, on_init=True)
+    def _load_backend(self):
+        from holoviews import Store, extension
+        if self.backend and self.backend not in Store.renderers:
+            ext = extension._backends[self.backend]
+            __import__(f'holoviews.plotting.{ext}')
+
     @param.depends('center', 'widget_location', watch=True)
     def _update_layout(self):
         loc = self.widget_location

--- a/panel/pane/holoviews.py
+++ b/panel/pane/holoviews.py
@@ -124,9 +124,9 @@ class HoloViews(PaneBase):
         ]
         watcher = self.param.watch(self._update_widgets, self._rerender_params)
         self._internal_callbacks.append(watcher)
-        self._initialized = True
         self._update_responsive()
         self._update_widgets()
+        self._initialized = True
 
     def _param_change(self, *events: param.parameterized.Event) -> None:
         if self._object_changing:

--- a/panel/tests/pane/test_holoviews.py
+++ b/panel/tests/pane/test_holoviews.py
@@ -27,7 +27,9 @@ from bokeh.plotting import figure
 import panel as pn
 
 from panel.depends import bind
-from panel.layout import Column, FlexBox, Row
+from panel.layout import (
+    Column, FlexBox, HSpacer, Row,
+)
 from panel.pane import HoloViews, PaneBase, panel
 from panel.tests.util import hv_available, mpl_available
 from panel.util.warnings import PanelDeprecationWarning
@@ -345,6 +347,18 @@ def test_holoviews_with_widgets_not_shown(document, comm):
     assert hv_pane.widget_box.objects[0].name == 'A'
     assert hv_pane.widget_box.objects[1].name == 'B'
 
+
+@hv_available
+def test_holoviews_center(document, comm):
+    hv_pane = HoloViews(hv.Curve([1, 2, 3]), backend='bokeh', center=True)
+
+    layout = hv_pane.layout
+
+    assert len(layout) == 3
+    hspacer1, hv_out, hspacer2 = layout
+    assert isinstance(hspacer1, HSpacer)
+    assert hv_pane is hv_out
+    assert isinstance(hspacer2, HSpacer)
 
 @hv_available
 def test_holoviews_layouts(document, comm):


### PR DESCRIPTION
Previously initialization was not respecting centering when there were no widgets defined.