### PR TITLE
Fix global loading spinner

### DIFF
--- a/panel/io/resources.py
+++ b/panel/io/resources.py
@@ -175,7 +175,7 @@ def loading_css():
         svg = f.read().replace('\n', '').format(color=config.loading_color)
     b64 = b64encode(svg.encode('utf-8')).decode('utf-8')
     return textwrap.dedent(f"""
-    :host(.{LOADING_INDICATOR_CSS_CLASS}.pn-{config.loading_spinner}):before, .pn-loading.{config.loading_spinner}:before {{
+    :host(.{LOADING_INDICATOR_CSS_CLASS}.pn-{config.loading_spinner}):before, .pn-loading.pn-{config.loading_spinner}:before {{
       background-image: url("data:image/svg+xml;base64,{b64}");
       background-size: auto calc(min(50%, {config.loading_max_height}px));
     }}""")


### PR DESCRIPTION
Missing `pn-` prefix in the loading spinner class name means that the `global_loading_spinner` and the pyodide/pyscript load screen was not rendering correctly.