### PR TITLE
Fix to remove call to registered_names which no longer exists in bokeh

### DIFF
--- a/panel/_templates/doc_nb_js.js
+++ b/panel/_templates/doc_nb_js.js
@@ -35,7 +35,7 @@
   }
   function is_loaded(root) {
     var Bokeh = get_bokeh(root)
-    return (Bokeh != null && Bokeh.Panel !== undefined{% for reqs in requirements %} && ({% for req in reqs %}{% if loop.index0 > 0 %}||{% endif %} root['{{ req }}'] !== undefined{% endfor %}){% endfor %}{% if ipywidget %}&& Bokeh.Panel.IPyWidget !== undefined {% endif %})
+    return (Bokeh != null && Bokeh.Panel !== undefined{% for reqs in requirements %} && ({% for req in reqs %}{% if loop.index0 > 0 %}||{% endif %} root['{{ req }}'] !== undefined{% endfor %}){% endfor %}{% if ipywidget %}&& Bokeh.Models._known_models.has("ipywidgets_bokeh.widget.IPyWidget") !== undefined {% endif %})
   }
   if (is_loaded(root)) {
     embed_document(root);

--- a/panel/_templates/doc_nb_js.js
+++ b/panel/_templates/doc_nb_js.js
@@ -35,7 +35,7 @@
   }
   function is_loaded(root) {
     var Bokeh = get_bokeh(root)
-    return (Bokeh != null && Bokeh.Panel !== undefined{% for reqs in requirements %} && ({% for req in reqs %}{% if loop.index0 > 0 %}||{% endif %} root['{{ req }}'] !== undefined{% endfor %}){% endfor %}{% if ipywidget %}&& Bokeh.Models._known_models.has("ipywidgets_bokeh.widget.IPyWidget") !== undefined {% endif %})
+    return (Bokeh != null && Bokeh.Panel !== undefined{% for reqs in requirements %} && ({% for req in reqs %}{% if loop.index0 > 0 %}||{% endif %} root['{{ req }}'] !== undefined{% endfor %}){% endfor %}{% if ipywidget %}&& Bokeh.Models._known_models.has("ipywidgets_bokeh.widget.IPyWidget") {% endif %})
   }
   if (is_loaded(root)) {
     embed_document(root);

--- a/panel/_templates/doc_nb_js.js
+++ b/panel/_templates/doc_nb_js.js
@@ -35,7 +35,7 @@
   }
   function is_loaded(root) {
     var Bokeh = get_bokeh(root)
-    return (Bokeh != null && Bokeh.Panel !== undefined{% for reqs in requirements %} && ({% for req in reqs %}{% if loop.index0 > 0 %}||{% endif %} root['{{ req }}'] !== undefined{% endfor %}){% endfor %}{% if ipywidget %}&& (Bokeh.Models.registered_names().indexOf("ipywidgets_bokeh.widget.IPyWidget") > -1){% endif %})
+    return (Bokeh != null && Bokeh.Panel !== undefined{% for reqs in requirements %} && ({% for req in reqs %}{% if loop.index0 > 0 %}||{% endif %} root['{{ req }}'] !== undefined{% endfor %}){% endfor %}{% if ipywidget %}&& Bokeh.Panel.IPyWidget !== undefined {% endif %})
   }
   if (is_loaded(root)) {
     embed_document(root);

--- a/panel/io/notebook.py
+++ b/panel/io/notebook.py
@@ -5,6 +5,7 @@ inside the Jupyter notebook.
 from __future__ import annotations
 
 import json
+import os
 import sys
 import uuid
 
@@ -176,7 +177,10 @@ def render_model(
     render_json = render_item.to_json()
     requirements = [pnext._globals[ext] for ext in pnext._loaded_extensions
                     if ext in pnext._globals]
+
     ipywidget = 'ipywidgets_bokeh' in sys.modules
+    if not state._is_pyodide:
+        ipywidget &= "PANEL_IPYWIDGET" in os.environ
 
     script = DOC_NB_JS.render(
         docs_json=serialize_json(docs_json),


### PR DESCRIPTION
I'm really sure this is the correct change. It appears the IPyWidget is available like other things via Bokeh.Panel.IPyWidget 

The issue is the use of registered_names generates a lot of JavaScript exceptions when we use things like the Tabulator.