### PR TITLE
Add support-Panel-with-a-star shield to side nav

### DIFF
--- a/doc/_static/css/custom.css
+++ b/doc/_static/css/custom.css
@@ -72,3 +72,8 @@ button.copybtn:hover {
 .o-tooltip--left:after {
   background: none;
 }
+
+.github-star-badge {
+  text-align: center;
+  margin-bottom: 10px;
+}

--- a/doc/_static/css/custom.css
+++ b/doc/_static/css/custom.css
@@ -72,8 +72,3 @@ button.copybtn:hover {
 .o-tooltip--left:after {
   background: none;
 }
-
-.github-star-badge {
-  text-align: center;
-  margin-bottom: 10px;
-}

--- a/doc/_templates/github_stars.html
+++ b/doc/_templates/github_stars.html
@@ -1,0 +1,5 @@
+<div class="github-star-badge">
+    <a href="https://github.com/holoviz/panel">
+        <img src="https://img.shields.io/github/stars/holoviz/panel?style=social&label=Support%20Panel%20with%20%20a%20%E2%AD%90" alt="Support Panel with a star on GitHub">
+    </a>
+</div>

--- a/doc/_templates/github_stars.html
+++ b/doc/_templates/github_stars.html
@@ -1,5 +1,5 @@
 <div class="github-star-badge">
     <a href="https://github.com/holoviz/panel">
-        <img src="https://img.shields.io/github/stars/holoviz/panel?style=social&label=Support%20Panel%20with%20%20a%20%E2%AD%90" alt="Support Panel with a star on GitHub">
+        <img src="https://img.shields.io/github/stars/holoviz/panel?style=social&label=Star%20on%20%20GitHub%E2%AD%90" alt="Support Panel with a star on GitHub">
     </a>
 </div>

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -37,6 +37,10 @@ html_css_files += [
     'css/custom.css',
 ]
 
+html_sidebars = {
+    "**": ["github_stars.html", "sidebar-nav-bs"]
+}
+
 html_theme = "pydata_sphinx_theme"
 html_favicon = "_static/icons/favicon.ico"
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -37,10 +37,6 @@ html_css_files += [
     'css/custom.css',
 ]
 
-html_sidebars = {
-    "**": ["github_stars.html", "sidebar-nav-bs"]
-}
-
 html_theme = "pydata_sphinx_theme"
 html_favicon = "_static/icons/favicon.ico"
 
@@ -72,6 +68,7 @@ html_theme_options = {
     "pygment_dark_style": "material",
     "header_links_before_dropdown": 5,
     'secondary_sidebar_items': [
+        "github_stars",
         "panelitelink",
         "page-toc",
     ],


### PR DESCRIPTION
Just an idea to help address the discrepancy between the number of active users and # of stars on github.

Feedback welcome. I'm not thrilled about the UX, but maybe it's fine...

![image](https://github.com/holoviz/panel/assets/6613202/44b706ed-49f8-4b26-8bf3-f905dcbc07a8)

<img width="1198" alt="image" src="https://github.com/holoviz/panel/assets/6613202/56f76f28-9f39-4eac-8f9f-02c818277903">
