### PR TITLE
Fixed vizzu data series type conversion for datetime.

### DIFF
--- a/panel/models/vizzu.ts
+++ b/panel/models/vizzu.ts
@@ -117,7 +117,7 @@ export class VizzuChartView extends HTMLBoxView {
     for (const column of this.model.columns) {
       let array = [...this.model.source.get_array(column.name)]
       if (column.type === 'datetime' || column.type == 'date')
-	column.type = 'measure'
+	column.type = 'dimension'
       if (column.type === 'dimension')
 	array = array.map(String)
       series.push({...column, values: array})


### PR DESCRIPTION
Data series with 'datetime' type were passed as 'measure' to Vizzu. However, they should be passed as dimensions; otherwise Vizzu won't handle them correctly.