### PR TITLE
Add Integer volume and non-null default value

### DIFF
--- a/panel/pane/media.py
+++ b/panel/pane/media.py
@@ -232,6 +232,8 @@ class Video(_MediaBase):
     ...     width=640, height=360, loop=True
     ... )
     """
+    volume = param.Integer(default=100, bounds=(0, 100), doc="""
+        The volume of the media player.""")
 
     _bokeh_model = _BkVideo
 


### PR DESCRIPTION
I can see the video pane model uses an integer for volumen and have a default value of 100 when null is used. 

``` python
import panel as pn
pn.extension()

video = pn.pane.Video('/home/shh/Downloads/sample-mp4-file-small.mp4', width=640, loop=True)
#pn.Row(video.controls(jslink=True), video)

video
```

https://github.com/holoviz/panel/assets/19758978/8edbc3d3-b0cf-4e81-95ca-3a612dc8d46c

