### PR TITLE
Resolving design modifiers based on the theme type

### DIFF
--- a/panel/theme/base.py
+++ b/panel/theme/base.py
@@ -185,7 +185,7 @@ class Design(param.Parameterized, ResourceComponent):
         from ..io.resources import (
             CDN_DIST, component_resource_path, resolve_custom_path,
         )
-        modifiers, child_modifiers = cls._resolve_modifiers(type(viewable), theme)
+        modifiers, child_modifiers = cls._resolve_modifiers(type(viewable), type(theme))
         modifiers = dict(modifiers)
         if 'stylesheets' in modifiers:
             if isolated:

--- a/panel/theme/base.py
+++ b/panel/theme/base.py
@@ -185,7 +185,8 @@ class Design(param.Parameterized, ResourceComponent):
         from ..io.resources import (
             CDN_DIST, component_resource_path, resolve_custom_path,
         )
-        modifiers, child_modifiers = cls._resolve_modifiers(type(viewable), type(theme))
+        theme_type  = type(theme) if isinstance(theme, Theme) else theme 
+        modifiers, child_modifiers = cls._resolve_modifiers(type(viewable), them_type)
         modifiers = dict(modifiers)
         if 'stylesheets' in modifiers:
             if isolated:

--- a/panel/theme/base.py
+++ b/panel/theme/base.py
@@ -18,6 +18,7 @@ from ..io.resources import (
     ResourceComponent, component_resource_path, get_dist_path,
     resolve_custom_path,
 )
+from ..io.state import state
 from ..util import relative_to
 
 if TYPE_CHECKING:
@@ -157,7 +158,7 @@ class Design(param.Parameterized, ResourceComponent):
 
     @classmethod
     @functools.lru_cache
-    def _resolve_modifiers(cls, vtype, theme):
+    def _resolve_modifiers(cls, vtype, theme, is_server=False):
         """
         Iterate over the class hierarchy in reverse order and accumulate
         all modifiers that apply to the objects class and its super classes.
@@ -185,8 +186,9 @@ class Design(param.Parameterized, ResourceComponent):
         from ..io.resources import (
             CDN_DIST, component_resource_path, resolve_custom_path,
         )
-        theme_type  = type(theme) if isinstance(theme, Theme) else theme
-        modifiers, child_modifiers = cls._resolve_modifiers(type(viewable), theme_type)
+        theme_type = type(theme) if isinstance(theme, Theme) else theme
+        is_server = bool(state.curdoc.session_context) if not state._is_pyodide and state.curdoc else False
+        modifiers, child_modifiers = cls._resolve_modifiers(type(viewable), theme_type, is_server=is_server)
         modifiers = dict(modifiers)
         if 'stylesheets' in modifiers:
             if isolated:

--- a/panel/theme/base.py
+++ b/panel/theme/base.py
@@ -185,8 +185,8 @@ class Design(param.Parameterized, ResourceComponent):
         from ..io.resources import (
             CDN_DIST, component_resource_path, resolve_custom_path,
         )
-        theme_type  = type(theme) if isinstance(theme, Theme) else theme 
-        modifiers, child_modifiers = cls._resolve_modifiers(type(viewable), them_type)
+        theme_type  = type(theme) if isinstance(theme, Theme) else theme
+        modifiers, child_modifiers = cls._resolve_modifiers(type(viewable), theme_type)
         modifiers = dict(modifiers)
         if 'stylesheets' in modifiers:
             if isolated:


### PR DESCRIPTION
Found this while trying out [objgraph](https://pypi.org/project/objgraph/) on a dummy app (to find a memory leak on a bigger app) and it proved useful as it detected that opening a new session of the same app generated some new `NativeDefaultTheme` objects that weren't cleaned up. This happened because `_resolve_modifiers` - which is decorated with `@functools.lru_cache` - was passed a new instance of the theme instead of its type, while I believe passing the type is enough (I haven't followed all the *modifiers* related code though).