### PR TITLE
Pin urllib3 and conda-build

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -50,10 +50,10 @@ jobs:
         run: |
           conda config --set always_yes True
           conda install "pip<21.2.1"
-          conda install -c pyviz "pyctdev>=0.5"
           # FIXME: downgrade urllib3 until this issue is fixed:
           # https://github.com/Anaconda-Platform/anaconda-client/issues/654
           conda install -c conda-forge "urllib3<2.0.0" "conda-build<3.25"
+          conda install -c pyviz "pyctdev>=0.5"
           doit ecosystem_setup
       - name: build pyodide wheels for CDN
         run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -52,6 +52,9 @@ jobs:
           conda install "pip<21.2.1"
           conda install -c pyviz "pyctdev>=0.5"
           doit ecosystem_setup
+          # FIXME: downgrade urllib3 until this issue is fixed:
+          # https://github.com/Anaconda-Platform/anaconda-client/issues/654
+          conda install -c conda-forge "urllib3<2.0.0"
       - name: build pyodide wheels for CDN
         run: |
           python ./scripts/build_pyodide_wheels.py

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -50,11 +50,11 @@ jobs:
         run: |
           conda config --set always_yes True
           conda install "pip<21.2.1"
-          # FIXME: downgrade urllib3 until this issue is fixed:
-          # https://github.com/Anaconda-Platform/anaconda-client/issues/654
-          conda install -c conda-forge "urllib3<2.0.0" "conda-build<3.25"
           conda install -c pyviz "pyctdev>=0.5"
           doit ecosystem_setup
+          # FIXME: downgrade urllib3 until this issue is fixed:
+          # https://github.com/Anaconda-Platform/anaconda-client/issues/654
+          conda install -c conda-forge "urllib3<2.0.0" "conda-build==3.24"
       - name: build pyodide wheels for CDN
         run: |
           python ./scripts/build_pyodide_wheels.py

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -52,8 +52,7 @@ jobs:
           conda install "pip<21.2.1"
           conda install -c pyviz "pyctdev>=0.5"
           doit ecosystem_setup
-          # FIXME: downgrade urllib3 until this issue is fixed:
-          # https://github.com/Anaconda-Platform/anaconda-client/issues/654
+          # See: https://github.com/holoviz/panel/pull/4979
           conda install -c conda-forge "urllib3<2.0.0" "conda-build==3.24"
       - name: build pyodide wheels for CDN
         run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -54,7 +54,7 @@ jobs:
           doit ecosystem_setup
           # FIXME: downgrade urllib3 until this issue is fixed:
           # https://github.com/Anaconda-Platform/anaconda-client/issues/654
-          conda install -c conda-forge "urllib3<2.0.0"
+          conda install -c conda-forge "urllib3<2.0.0" "conda-build<3.25"
       - name: build pyodide wheels for CDN
         run: |
           python ./scripts/build_pyodide_wheels.py

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -51,10 +51,10 @@ jobs:
           conda config --set always_yes True
           conda install "pip<21.2.1"
           conda install -c pyviz "pyctdev>=0.5"
-          doit ecosystem_setup
           # FIXME: downgrade urllib3 until this issue is fixed:
           # https://github.com/Anaconda-Platform/anaconda-client/issues/654
           conda install -c conda-forge "urllib3<2.0.0" "conda-build<3.25"
+          doit ecosystem_setup
       - name: build pyodide wheels for CDN
         run: |
           python ./scripts/build_pyodide_wheels.py

--- a/setup.py
+++ b/setup.py
@@ -150,6 +150,7 @@ _tests = [
     # via pip tries to build it and fails. To be removed.
     'lxml',
     'numpy <1.24',
+    'urllib <2.0',  # To be able to conda-upload
 ]
 
 _ui = [

--- a/setup.py
+++ b/setup.py
@@ -150,7 +150,7 @@ _tests = [
     # via pip tries to build it and fails. To be removed.
     'lxml',
     'numpy <1.24',
-    'urllib <2.0',  # To be able to conda-upload
+    'urllib3 <2.0',  # To be able to conda-build
 ]
 
 _ui = [
@@ -222,6 +222,7 @@ extras_require['build'] = [
     'bleach',
     'tqdm >=4.48.0',
     'cryptography <39' # Avoid pyOpenSSL issue
+    'urllib3 <2.0',  # To be able to conda-build
 ]
 
 setup_args = dict(

--- a/setup.py
+++ b/setup.py
@@ -150,7 +150,6 @@ _tests = [
     # via pip tries to build it and fails. To be removed.
     'lxml',
     'numpy <1.24',
-    'urllib3 <2.0',  # To be able to conda-build
 ]
 
 _ui = [
@@ -222,7 +221,6 @@ extras_require['build'] = [
     'bleach',
     'tqdm >=4.48.0',
     'cryptography <39' # Avoid pyOpenSSL issue
-    'urllib3 <2.0',  # To be able to conda-build
 ]
 
 setup_args = dict(

--- a/setup.py
+++ b/setup.py
@@ -220,7 +220,8 @@ extras_require['build'] = [
     'pyviz_comms >=0.7.4',
     'bleach',
     'tqdm >=4.48.0',
-    'cryptography <39' # Avoid pyOpenSSL issue
+    'cryptography <39', # Avoid pyOpenSSL issue
+    'urllib3 <2.0',  # To be able to conda-build
 ]
 
 setup_args = dict(

--- a/setup.py
+++ b/setup.py
@@ -221,7 +221,7 @@ extras_require['build'] = [
     'bleach',
     'tqdm >=4.48.0',
     'cryptography <39', # Avoid pyOpenSSL issue
-    'urllib3 <2.0',  # To be able to conda-build
+    'urllib3 <2.0',  # See: https://github.com/holoviz/panel/pull/4979
 ]
 
 setup_args = dict(


### PR DESCRIPTION
Based on changes made in Datashader: https://github.com/holoviz/datashader/commit/28c85812abf1ac55766e71e36677d4d5e55b6ff5  

Ref: https://github.com/Anaconda-Platform/anaconda-client/issues/654

The problem seems to have been because of a new `conda-build`. I will keep the `urllib3` pin for now because it could cause problems when uploading the conda package. 