### PR TITLE
Speed up dynamic layout updates

### DIFF
--- a/panel/io/convert.py
+++ b/panel/io/convert.py
@@ -322,7 +322,9 @@ def script_to_html(
     # Collect resources
     resources = Resources(mode='inline' if inline else 'cdn')
     loading_base = (DIST_DIR / "css" / "loading.css").read_text(encoding='utf-8')
-    spinner_css = loading_css()
+    spinner_css = loading_css(
+        config.loading_spinner, config.loading_color, config.loading_max_height
+    )
     css_resources.append(
         f'<style type="text/css">\n{loading_base}\n{spinner_css}\n</style>'
     )

--- a/panel/layout/accordion.py
+++ b/panel/layout/accordion.py
@@ -92,7 +92,7 @@ class Accordion(NamedListPanel):
         models and cleaning up any dropped objects.
         """
         from panel.pane.base import RerenderError, panel
-        new_models = []
+        new_models, old_models = [], []
         if len(self._names) != len(self):
             raise ValueError(
                 'Accordion names do not match objects, ensure that the '
@@ -130,6 +130,7 @@ class Accordion(NamedListPanel):
                 self._panels[id(pane)] = card
             if ref in card._models:
                 panel = card._models[ref][0]
+                old_models.append(panel)
             else:
                 try:
                     panel = card._get_model(doc, root, model, comm)
@@ -146,7 +147,7 @@ class Accordion(NamedListPanel):
         self._set_active()
         self._update_cards()
         self._update_active()
-        return new_models
+        return new_models, old_models
 
     def _compute_sizing_mode(self, children, props):
         children = [subchild for child in children for subchild in child.children[1:]]

--- a/panel/layout/base.py
+++ b/panel/layout/base.py
@@ -206,9 +206,10 @@ class Panel(Reactive):
         heights, widths = [], []
         all_expand_width, all_expand_height, expand_width, expand_height, scale = True, True, False, False, False
         for child in children:
-            if child.sizing_mode and 'scale' in child.sizing_mode:
+            smode = child.sizing_mode
+            if smode and 'scale' in smode:
                 scale = True
-            if child.sizing_mode in ('stretch_width', 'stretch_both', 'scale_width', 'scale_both'):
+            if smode in ('stretch_width', 'stretch_both', 'scale_width', 'scale_both'):
                 expand_width = True
             else:
                 width = child.width or child.min_width
@@ -222,7 +223,7 @@ class Panel(Reactive):
                         width += margin*2
                     widths.append(width)
                 all_expand_width = False
-            if child.sizing_mode in ('stretch_height', 'stretch_both', 'scale_height', 'scale_both'):
+            if smode in ('stretch_height', 'stretch_both', 'scale_height', 'scale_both'):
                 expand_height = True
             else:
                 height = child.height or child.min_height

--- a/panel/layout/base.py
+++ b/panel/layout/base.py
@@ -91,7 +91,9 @@ class Panel(Reactive):
         obj_key = self._property_mapping['objects']
         if obj_key in msg:
             old = events['objects'].old
-            msg[obj_key] = children = self._get_objects(model, old, doc, root, comm)
+            children, old_children = self._get_objects(model, old, doc, root, comm)
+            msg[obj_key] = children
+
             msg.update(self._compute_sizing_mode(
                 children,
                 dict(
@@ -102,18 +104,21 @@ class Panel(Reactive):
                     margin=msg.get('margin', model.margin)
                 )
             ))
+        else:
+            old_children = None
 
         with hold(doc):
             update = Panel._batch_update
             Panel._batch_update = True
             try:
-                super()._update_model(events, msg, root, model, doc, comm)
-                if update:
-                    return
-                from ..io import state
-                ref = root.ref['id']
-                if ref in state._views and preprocess:
-                    state._views[ref][0]._preprocess(root)
+                with doc.models.freeze():
+                    super()._update_model(events, msg, root, model, doc, comm)
+                    if update:
+                        return
+                    from ..io import state
+                    ref = root.ref['id']
+                    if ref in state._views and preprocess:
+                        state._views[ref][0]._preprocess(root, self, old_children)
             finally:
                 Panel._batch_update = update
 
@@ -130,7 +135,7 @@ class Panel(Reactive):
         models and cleaning up any dropped objects.
         """
         from ..pane.base import RerenderError, panel
-        new_models = []
+        new_models, old_models = [], []
         for i, pane in enumerate(self.objects):
             pane = panel(pane)
             self.objects[i] = pane
@@ -144,13 +149,14 @@ class Panel(Reactive):
         for i, pane in enumerate(self.objects):
             if pane in old_objects and ref in pane._models:
                 child, _ = pane._models[root.ref['id']]
+                old_models.append(child)
             else:
                 try:
                     child = pane._get_model(doc, root, model, comm)
                 except RerenderError:
                     return self._get_objects(model, current_objects[:i], doc, root, comm)
             new_models.append(child)
-        return new_models
+        return new_models, old_models
 
     def _get_model(
         self, doc: Document, root: Optional[Model] = None,
@@ -161,7 +167,7 @@ class Panel(Reactive):
         model = self._bokeh_model()
         root = root or model
         self._models[root.ref['id']] = (model, parent)
-        objects = self._get_objects(model, [], doc, root, comm)
+        objects, _ = self._get_objects(model, [], doc, root, comm)
         props = self._get_properties(doc)
         props[self._property_mapping['objects']] = objects
         props.update(self._compute_sizing_mode(objects, props))

--- a/panel/layout/card.py
+++ b/panel/layout/card.py
@@ -126,12 +126,13 @@ class Card(Column):
 
     def _get_objects(self, model, old_objects, doc, root, comm=None):
         ref = root.ref['id']
+        models, old_models = super()._get_objects(model, old_objects, doc, root, comm)
         if ref in self._header_layout._models:
             header = self._header_layout._models[ref][0]
+            old_models.append(header)
         else:
             header = self._header_layout._get_model(doc, root, model, comm)
-        objects = super()._get_objects(model, old_objects, doc, root, comm)
-        return [header]+objects
+        return [header]+models, old_models
 
     def _compute_sizing_mode(self, children, props):
         return super()._compute_sizing_mode(children[1:], props)

--- a/panel/layout/grid.py
+++ b/panel/layout/grid.py
@@ -183,7 +183,7 @@ class GridBox(ListPanel):
         model = self._bokeh_model()
         root = root or model
         self._models[root.ref['id']] = (model, parent)
-        objects = self._get_objects(model, [], doc, root, comm)
+        objects, _ = self._get_objects(model, [], doc, root, comm)
         children = self._get_children(objects, self.nrows, self.ncols)
         css_classes = self._compute_css_classes(children)
         properties = {k: v for k, v in self._get_properties(doc).items() if k not in ('ncols', 'nrows')}
@@ -206,21 +206,24 @@ class GridBox(ListPanel):
                 old = events['objects'].old
             else:
                 old = self.objects
-            objects = self._get_objects(model, old, doc, root, comm)
+            objects, old_models = self._get_objects(model, old, doc, root, comm)
             children = self._get_children(objects, self.nrows, self.ncols)
             msg[self._rename['objects']] = children
+        else:
+            old_models = None
 
         with hold(doc):
             msg = {k: v for k, v in msg.items() if k not in ('nrows', 'ncols')}
             update = Panel._batch_update
             Panel._batch_update = True
             try:
-                super(Panel, self)._update_model(events, msg, root, model, doc, comm)
-                if update:
-                    return
-                ref = root.ref['id']
-                if ref in state._views and preprocess:
-                    state._views[ref][0]._preprocess(root)
+                with doc.models.freeze():
+                    super(Panel, self)._update_model(events, msg, root, model, doc, comm)
+                    if update:
+                        return
+                    ref = root.ref['id']
+                    if ref in state._views and preprocess:
+                        state._views[ref][0]._preprocess(root, self, old_models)
             finally:
                 Panel._batch_update = update
 
@@ -315,7 +318,7 @@ class GridSpec(Panel):
             if old not in current_objects:
                 old._cleanup(root)
 
-        children = []
+        children, old_children = [], []
         for i, ((y0, x0, y1, x1), obj) in enumerate(self.objects.items()):
             x0 = 0 if x0 is None else x0
             x1 = (self.ncols) if x1 is None else x1
@@ -341,6 +344,7 @@ class GridSpec(Panel):
 
             if obj in old_objects:
                 child, _ = obj._models[root.ref['id']]
+                old_children.append(child)
             else:
                 try:
                     child = obj._get_model(doc, root, model, comm)
@@ -352,7 +356,7 @@ class GridSpec(Panel):
             else:
                 child.update(**properties)
             children.append((child, r, c, h, w))
-        return children
+        return children, old_children
 
     def _compute_sizing_mode(self, children, props):
         children = [child for (child, _, _, _, _) in children]

--- a/panel/layout/tabs.py
+++ b/panel/layout/tabs.py
@@ -160,7 +160,7 @@ class Tabs(NamedListPanel):
         models and cleaning up any dropped objects.
         """
         from ..pane.base import RerenderError, panel
-        new_models = []
+        new_models, old_models = [], []
         if len(self._names) != len(self):
             raise ValueError('Tab names do not match objects, ensure '
                              'that the Tabs.objects are not modified '
@@ -200,6 +200,7 @@ class Tabs(NamedListPanel):
 
             if prev_hidden and not hidden and pref in rendered:
                 child = rendered[pref]
+                old_models.append(child)
             elif hidden:
                 child = BkSpacer(**{k: v for k, v in pane.param.values().items()
                                     if k in Layoutable.param and v is not None and
@@ -215,4 +216,4 @@ class Tabs(NamedListPanel):
                 title=name, name=pane.name, child=child, closable=self.closable
             )
             new_models.append(panel)
-        return new_models
+        return new_models, old_models

--- a/panel/links.py
+++ b/panel/links.py
@@ -159,6 +159,9 @@ class Callback(param.Parameterized):
         """
         Registers the Callback
         """
+        if Callback._process_callbacks not in Viewable._preprocessing_hooks:
+            Viewable._preprocessing_hooks.append(Callback._process_callbacks)
+
         source = self.source
         if source is None:
             return
@@ -750,8 +753,6 @@ class JSLinkCallbackGenerator(JSCallbackGenerator):
 
 Callback.register_callback(callback=JSCallbackGenerator)
 Link.register_callback(callback=JSLinkCallbackGenerator)
-
-Viewable._preprocessing_hooks.append(Callback._process_callbacks)
 
 __all__ = (
     "Callback",

--- a/panel/reactive.py
+++ b/panel/reactive.py
@@ -187,7 +187,9 @@ class Syncable(Renderable):
             properties['min_height'] = properties['height']
         if 'stylesheets' in properties:
             from .config import config
-            stylesheets = [loading_css(), f'{CDN_DIST}css/loading.css']
+            stylesheets = [loading_css(
+                config.loading_spinner, config.loading_color, config.loading_max_height
+            ), f'{CDN_DIST}css/loading.css']
             stylesheets += process_raw_css(config.raw_css)
             stylesheets += config.css_files
             stylesheets += [

--- a/panel/template/base.py
+++ b/panel/template/base.py
@@ -647,7 +647,9 @@ class BasicTemplate(BaseTemplate, ResourceComponent):
         name = clsname.lower()
         dist_path = get_dist_path(cdn=cdn)
 
-        raw_css.extend(list(self.config.raw_css) + [loading_css()])
+        raw_css.extend(list(self.config.raw_css) + [loading_css(
+            config.loading_spinner, config.loading_color, config.loading_max_height
+        )])
         for rname, res in self._design.resolve_resources(cdn).items():
             if isinstance(res, dict):
                 resource_types[rname].update(res)

--- a/panel/viewable.py
+++ b/panel/viewable.py
@@ -574,13 +574,17 @@ class Renderable(param.Parameterized, MimeRenderMixin):
         if ref in state._handles:
             del state._handles[ref]
 
-    def _preprocess(self, root: 'Model') -> None:
+    def _preprocess(self, root: 'Model', changed=None, old_models=None) -> None:
         """
         Applies preprocessing hooks to the model.
         """
+        changed = self if changed is None else changed
         hooks = self._preprocessing_hooks+self._hooks
         for hook in hooks:
-            hook(self, root)
+            try:
+                hook(self, root, changed, old_models)
+            except Exception:
+                hook(self, root)
 
     def _render_model(self, doc: Optional[Document] = None, comm: Optional[Comm] = None) -> 'Model':
         if doc is None:

--- a/panel/viewable.py
+++ b/panel/viewable.py
@@ -576,14 +576,20 @@ class Renderable(param.Parameterized, MimeRenderMixin):
 
     def _preprocess(self, root: 'Model', changed=None, old_models=None) -> None:
         """
-        Applies preprocessing hooks to the model.
+        Applies preprocessing hooks to the root model.
+
+        Some preprocessors have to always iterate over the entire
+        model tree but others only have to update newly added models.
+        To support the optimized case we optionally provide the
+        Panel object that was changed and any old, unchanged models
+        so they can be skipped (see https://github.com/holoviz/panel/pull/4989)
         """
         changed = self if changed is None else changed
         hooks = self._preprocessing_hooks+self._hooks
         for hook in hooks:
             try:
                 hook(self, root, changed, old_models)
-            except Exception:
+            except TypeError:
                 hook(self, root)
 
     def _render_model(self, doc: Optional[Document] = None, comm: Optional[Comm] = None) -> 'Model':


### PR DESCRIPTION
Addresses some of the slowness when dynamically updating a layout encountered in https://github.com/holoviz/panel/issues/4976

- Cache loading_css (loading this from file each time is expensive)
- Bokeh property access is expensive so we minimize it inside `Panel._compute_sizing_mode`
- Preprocessors currently always iterate over the entire object tree, we implement an alternative preprocessor signature that is given access to both the Panel object that was changed and all submodels that were unchanged.
- Do not add Link preprocessor unless Link is added
- Do not run Link preprocessor unless Document has links

## Before

<img width="641" alt="Screen Shot 2023-05-31 at 11 55 08" src="https://github.com/holoviz/panel/assets/1550771/de9be8e1-c30d-4305-88e2-28915d20ebd8">

## After 

<img width="695" alt="Screen Shot 2023-05-31 at 12 22 01" src="https://github.com/holoviz/panel/assets/1550771/82a63eab-8d01-4261-9ebf-d6de0b88da44">


