### PR TITLE
Do not render icon by default

### DIFF
--- a/panel/widgets/button.py
+++ b/panel/widgets/button.py
@@ -60,7 +60,7 @@ class _ButtonBase(Widget):
 
 class IconMixin(Widget):
 
-    icon = param.String(default='', doc="""
+    icon = param.String(default=None, doc="""
         An icon to render to the left of the button label. Either an SVG or an
         icon name which is loaded from https://tabler-icons.io/.""")
 


### PR DESCRIPTION
Setting the default `icon` value to an empty string rendered an empty icon causing some alignment issues.