### PR TITLE
Ignore reference already known warning in VSCode

### DIFF
--- a/panel/config.py
+++ b/panel/config.py
@@ -9,6 +9,7 @@ import importlib
 import inspect
 import os
 import sys
+import warnings
 
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
@@ -791,6 +792,7 @@ class panel_extension(_pyviz_extension):
 
         if "VSCODE_PID" in os.environ:
             config.comms = "vscode"
+            self._ignore_bokeh_warnings()
             return
 
     def _apply_signatures(self):
@@ -842,6 +844,11 @@ class panel_extension(_pyviz_extension):
         """
         from .entry_points import load_entry_points
         load_entry_points('panel.extension')
+
+    def _ignore_bokeh_warnings(self):
+        from bokeh.util.warnings import BokehUserWarning
+        warnings.filterwarnings("ignore", category=BokehUserWarning, message="reference already known")
+
 
 #---------------------------------------------------------------------
 # Private API


### PR DESCRIPTION
Fixes https://github.com/holoviz/holoviews/issues/5731

Another case:
![image](https://github.com/holoviz/panel/assets/19758978/a40a98e9-af50-4c49-8ec6-4ce282744670)

I have been conservative and only ignored it in VSCode.