### PR TITLE
Handle height responsiveness of HoloViews layout correctly

### DIFF
--- a/panel/layout/accordion.py
+++ b/panel/layout/accordion.py
@@ -140,6 +140,7 @@ class Accordion(NamedListPanel):
                 except RerenderError as e:
                     if e.layout is not None and e.layout is not self:
                         raise e
+                    e.layout = None
                     return self._get_objects(
                         model, current_objects[:i], doc, root, comm
                     )

--- a/panel/layout/accordion.py
+++ b/panel/layout/accordion.py
@@ -137,7 +137,9 @@ class Accordion(NamedListPanel):
                     if self.toggle:
                         cb = CustomJS(args={'accordion': model}, code=self._toggle)
                         panel.js_on_change('collapsed', cb)
-                except RerenderError:
+                except RerenderError as e:
+                    if e.layout is not None and e.layout is not self:
+                        raise e
                     return self._get_objects(
                         model, current_objects[:i], doc, root, comm
                     )

--- a/panel/layout/base.py
+++ b/panel/layout/base.py
@@ -156,6 +156,7 @@ class Panel(Reactive):
                 except RerenderError as e:
                     if e.layout is not None and e.layout is not self:
                         raise e
+                    e.layout = None
                     return self._get_objects(model, current_objects[:i], doc, root, comm)
             new_models.append(child)
         return new_models, old_models

--- a/panel/layout/base.py
+++ b/panel/layout/base.py
@@ -153,7 +153,9 @@ class Panel(Reactive):
             else:
                 try:
                     child = pane._get_model(doc, root, model, comm)
-                except RerenderError:
+                except RerenderError as e:
+                    if e.layout is not None and e.layout is not self:
+                        raise e
                     return self._get_objects(model, current_objects[:i], doc, root, comm)
             new_models.append(child)
         return new_models, old_models

--- a/panel/layout/grid.py
+++ b/panel/layout/grid.py
@@ -351,6 +351,7 @@ class GridSpec(Panel):
                 except RerenderError as e:
                     if e.layout is not None and e.layout is not self:
                         raise e
+                    e.layout = None
                     return self._get_objects(model, current_objects[:i], doc, root, comm)
 
             if isinstance(child, BkFlexBox) and len(child.children) == 1:

--- a/panel/layout/grid.py
+++ b/panel/layout/grid.py
@@ -348,7 +348,9 @@ class GridSpec(Panel):
             else:
                 try:
                     child = obj._get_model(doc, root, model, comm)
-                except RerenderError:
+                except RerenderError as e:
+                    if e.layout is not None and e.layout is not self:
+                        raise e
                     return self._get_objects(model, current_objects[:i], doc, root, comm)
 
             if isinstance(child, BkFlexBox) and len(child.children) == 1:

--- a/panel/layout/tabs.py
+++ b/panel/layout/tabs.py
@@ -212,6 +212,7 @@ class Tabs(NamedListPanel):
                 except RerenderError as e:
                     if e.layout is not None and e.layout is not self:
                         raise e
+                    e.layout = None
                     return self._get_objects(model, current_objects[:i], doc, root, comm)
 
             panel = panels[pref] = BkTabPanel(

--- a/panel/layout/tabs.py
+++ b/panel/layout/tabs.py
@@ -209,7 +209,9 @@ class Tabs(NamedListPanel):
             else:
                 try:
                     rendered[pref] = child = pane._get_model(doc, root, model, comm)
-                except RerenderError:
+                except RerenderError as e:
+                    if e.layout is not None and e.layout is not self:
+                        raise e
                     return self._get_objects(model, current_objects[:i], doc, root, comm)
 
             panel = panels[pref] = BkTabPanel(

--- a/panel/pane/base.py
+++ b/panel/pane/base.py
@@ -93,6 +93,11 @@ class RerenderError(RuntimeError):
     Error raised when a pane requests re-rendering during initial render.
     """
 
+    def __init__(self, *args, layout=None, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.layout = layout
+
+
 T = TypeVar('T', bound='PaneBase')
 
 class PaneBase(Reactive):

--- a/panel/pane/holoviews.py
+++ b/panel/pane/holoviews.py
@@ -172,13 +172,14 @@ class HoloViews(PaneBase):
             smode = 'stretch_height'
         else:
             smode = None
+        layout_smode = 'stretch_width' if not smode and center else smode
         if not len(self.widget_box):
             if center:
                 components = [HSpacer(), self, HSpacer()]
             else:
                 components = [self]
             self.layout[:] = components
-            self.layout.sizing_mode = smode
+            self.layout.sizing_mode = layout_smode
             return
 
         items = (self.widget_box, self) if widget_first else (self, self.widget_box)
@@ -195,7 +196,7 @@ class HoloViews(PaneBase):
         else:
             components = [HSpacer(), self, HSpacer(), self.widget_box]
         self.layout[:] = components
-        self.layout.sizing_mode = smode
+        self.layout.sizing_mode = layout_smode
 
     #----------------------------------------------------------------
     # Callback API

--- a/panel/pane/holoviews.py
+++ b/panel/pane/holoviews.py
@@ -415,11 +415,12 @@ class HoloViews(PaneBase):
         force_width = (self.center and responsive and not self._width_responsive)
         if (force_width or self._height_responsive is None):
             self._update_responsive()
-            if force_width:
-                self._width_responsive = True
-            self._update_layout()
-            self._restore_plot = plot
-            raise RerenderError(layout=self.layout)
+            if force_width or self._height_responsive:
+                if force_width:
+                    self._width_responsive = True
+                self._update_layout()
+                self._restore_plot = plot
+                raise RerenderError(layout=self.layout)
 
         kwargs = {p: v for p, v in self.param.values().items()
                   if p in Layoutable.param and p != 'name'}

--- a/panel/pane/holoviews.py
+++ b/panel/pane/holoviews.py
@@ -426,7 +426,7 @@ class HoloViews(PaneBase):
             self._update_layout()
             self._restore_plot = plot
             raise RerenderError(layout=self.layout)
-        elif self._height_responsive:
+        elif self._height_responsive is None:
             self._update_responsive()
             loc = self.widget_location
             center = self.center and not self._width_responsive
@@ -438,7 +438,7 @@ class HoloViews(PaneBase):
                 if not center:
                     if self.default_layout is not layout:
                         self.layout[0].sizing_mode = smode
-                elif layout is Column:
+                elif layout is Column and len(self.layout == 3):
                     self.layout[1].sizing_mode = smode
 
         kwargs = {p: v for p, v in self.param.values().items()

--- a/panel/pane/holoviews.py
+++ b/panel/pane/holoviews.py
@@ -438,7 +438,7 @@ class HoloViews(PaneBase):
                 if not center:
                     if self.default_layout is not layout:
                         self.layout[0].sizing_mode = smode
-                elif layout is Column and len(self.layout == 3):
+                elif layout is Column and len(self.layout) == 3:
                     self.layout[1].sizing_mode = smode
 
         kwargs = {p: v for p, v in self.param.values().items()

--- a/panel/pane/holoviews.py
+++ b/panel/pane/holoviews.py
@@ -184,7 +184,7 @@ class HoloViews(PaneBase):
         items = (self.widget_box, self) if widget_first else (self, self.widget_box)
         kwargs = {'sizing_mode': smode}
         if not center:
-            if False:#self.default_layout is layout:
+            if self.default_layout is layout:
                 components = list(items)
             else:
                 components = [layout(*items, **kwargs)]

--- a/panel/pane/holoviews.py
+++ b/panel/pane/holoviews.py
@@ -415,7 +415,17 @@ class HoloViews(PaneBase):
         force_width = (self.center and responsive and not self._width_responsive)
         if (force_width or self._height_responsive is None):
             self._update_responsive()
-            if force_width or self._height_responsive:
+            if self._height_responsive and len(self.layout) == 1:
+                if self._width_responsive and self._height_responsive:
+                    smode = 'stretch_both'
+                elif self._width_responsive:
+                    smode = 'stretch_width'
+                elif self._height_responsive:
+                    smode = 'stretch_height'
+                else:
+                    smode = None
+                self.layout[0].sizing_mode = smode
+            elif force_width or self._height_responsive:
                 if force_width:
                     self._width_responsive = True
                 self._update_layout()

--- a/panel/tests/pane/test_holoviews.py
+++ b/panel/tests/pane/test_holoviews.py
@@ -158,7 +158,7 @@ def test_holoviews_pane_reflect_responsive(document, comm):
 
     pane.object = hv.Curve([1, 2, 3])
 
-    assert row.sizing_mode == 'stretch_both'
+    assert row.sizing_mode is None
     assert pane.sizing_mode == 'fixed'
 
 @pytest.mark.usefixtures("hv_bokeh")
@@ -222,7 +222,7 @@ def test_holoviews_pane_reflect_responsive_plotly(document, comm):
 
     pane.object = hv.Curve([1, 2, 3])
 
-    assert row.sizing_mode == 'stretch_both'
+    assert row.sizing_mode is None
     assert pane.sizing_mode is None
 
 @hv_available

--- a/panel/tests/pane/test_holoviews.py
+++ b/panel/tests/pane/test_holoviews.py
@@ -158,7 +158,7 @@ def test_holoviews_pane_reflect_responsive(document, comm):
 
     pane.object = hv.Curve([1, 2, 3])
 
-    assert row.sizing_mode is None
+    assert row.sizing_mode == 'stretch_both'
     assert pane.sizing_mode == 'fixed'
 
 @pytest.mark.usefixtures("hv_bokeh")
@@ -170,7 +170,7 @@ def test_holoviews_pane_reflect_responsive_override(document, comm):
     # Create pane
     row = pane.get_root(document, comm=comm)
 
-    assert row.sizing_mode is None
+    assert row.sizing_mode == 'stretch_both'
     assert pane.sizing_mode == 'fixed'
 
     # Unset override
@@ -222,7 +222,7 @@ def test_holoviews_pane_reflect_responsive_plotly(document, comm):
 
     pane.object = hv.Curve([1, 2, 3])
 
-    assert row.sizing_mode is None
+    assert row.sizing_mode == 'stretch_both'
     assert pane.sizing_mode is None
 
 @hv_available
@@ -283,7 +283,7 @@ def test_holoviews_with_widgets(document, comm):
 
     hv_pane = HoloViews(hmap)
     layout = hv_pane.get_root(document, comm)
-    model = layout.children[0].children[0]
+    model = layout.children[0]
     assert len(hv_pane.widget_box.objects) == 2
     assert hv_pane.widget_box.objects[0].name == 'X'
     assert hv_pane.widget_box.objects[1].name == 'Y'
@@ -306,12 +306,12 @@ def test_holoviews_updates_widgets(document, comm):
 
     hv_pane.widgets = {'X': Select}
     assert isinstance(hv_pane.widget_box[0], Select)
-    assert isinstance(layout.children[0].children[1].children[0], BkSelect)
+    assert isinstance(layout.children[1].children[1], BkSelect)
 
     hv_pane.widgets = {'X': DiscreteSlider}
     assert isinstance(hv_pane.widget_box[0], DiscreteSlider)
-    assert isinstance(layout.children[0].children[1].children[0], BkColumn)
-    assert isinstance(layout.children[0].children[1].children[0].children[1], BkSlider)
+    assert isinstance(layout.children[1].children[0], BkColumn)
+    assert isinstance(layout.children[1].children[0].children[1], BkSlider)
 
 @hv_available
 def test_holoviews_widgets_update_plot(document, comm):
@@ -395,13 +395,13 @@ def test_holoviews_layouts(document, comm):
                     wmodel, hv_model = cmodel.children[1],  cmodel.children[0]
             else:
                 if loc.startswith('left'):
-                    assert len(layout) == 1
-                    widgets, hv_obj = layout[0]
-                    wmodel, hv_model = model.children[0].children
+                    assert len(layout) == 2
+                    widgets, hv_obj = layout
+                    wmodel, hv_model = model.children
                 elif loc.startswith('right'):
-                    assert len(layout) == 1
-                    hv_obj, widgets = layout[0]
-                    hv_model, wmodel = model.children[0].children
+                    assert len(layout) == 2
+                    hv_obj, widgets = layout
+                    hv_model, wmodel = model.children
                 elif loc.startswith('top'):
                     assert len(layout) == 1
                     col = layout[0]


### PR DESCRIPTION
Since the Bokeh 3.x layout engine changes layouts have to precisely reflect the sizing_mode of their contents. So while previously we got away with not setting height responsiveness on a container with a responsive HoloViews plot this now results in the plot collapsing in height. Therefore the HoloViews pane now does two things:

1. Correctly computes the height responsiveness
2. If it turns out that the layout it generated is actually incorrect (because information about responsiveness may not be known until the plot is rendered) and it has to invalidate the whole layout the `RerenderError` now has the capability to propagate the invalidation all the way up to the layout that actually needs to be re-rendered.

To expand on this, when a HoloViews pane is instantiated the following happens:

1. A layout is generated on instantiation
2. During rendering this layout is instantiated and the layout models are generated before the HoloViews plot is generated
3. When the HoloViews plot is generated it may turn out that the layout generated during instantiation is actually incorrect.
4. In such a case we need to propagate that fact all the way up to the root layout to tell it that the layouts it generated are actually wrong and it needs to restart the rendering process.

This is a convoluted approach to rendering but the process is relatively cheap and it avoids eagerly evaluating `DynamicMap` before they are actually rendered.