### PR TITLE
Temporarily pin older markdown-it-py in pyodide

### DIFF
--- a/lite/files/Getting_Started.ipynb
+++ b/lite/files/Getting_Started.ipynb
@@ -16,7 +16,7 @@
    "outputs": [],
    "source": [
     "import piplite\n",
-    "await piplite.install(['panel', 'pyodide-http', 'altair'])"
+    "await piplite.install(['panel', 'pyodide-http', 'altair', 'markdown-it-py<3'])"
    ]
   },
   {

--- a/panel/io/convert.py
+++ b/panel/io/convert.py
@@ -253,7 +253,7 @@ def script_to_html(
     else:
         panel_req = f'panel=={panel_version}'
         bokeh_req = f'bokeh=={BOKEH_VERSION}'
-    base_reqs = [bokeh_req, panel_req]
+    base_reqs = ['markdown-it-py<3', bokeh_req, panel_req]
     if http_patch:
         base_reqs.append('pyodide-http==0.2.1')
     reqs = base_reqs + [

--- a/scripts/panelite/generate_panelite_content.py
+++ b/scripts/panelite/generate_panelite_content.py
@@ -17,7 +17,7 @@ PANEL_BASE = HERE.parent.parent
 EXAMPLES_DIR = PANEL_BASE / 'examples'
 LITE_FILES = PANEL_BASE / 'lite' / 'files'
 DOC_DIR = PANEL_BASE / 'doc'
-BASE_DEPENDENCIES = ['panel', 'pyodide-http']
+BASE_DEPENDENCIES = ['panel', 'pyodide-http', 'markdown-it-py<3']
 MINIMUM_VERSIONS = {}
 
 # Add piplite command to notebooks


### PR DESCRIPTION
Since not all plugins are compatible yet installing markdown-it-py>=3 causes issues in pyodide.