### PR TITLE
Allow controlling initial Template sidebar state

### DIFF
--- a/panel/template/base.py
+++ b/panel/template/base.py
@@ -449,6 +449,9 @@ class BasicTemplate(BaseTemplate, ResourceComponent):
     header = param.ClassSelector(class_=ListLike, constant=True, doc="""
         A list-like container which populates the header bar.""")
 
+    initial_sidebar_state = param.Selector(default='expanded', objects=['expanded', 'collapsed'], doc="""
+        Whether the sidebar (if present) is initially expanded or collapsed.""")
+
     main = param.ClassSelector(class_=ListLike, constant=True, doc="""
         A list-like container which populates the main area.""")
 
@@ -757,6 +760,7 @@ class BasicTemplate(BaseTemplate, ResourceComponent):
         self._render_variables['main_max_width'] = self.main_max_width
         self._render_variables['sidebar_width'] = self.sidebar_width
         self._render_variables['theme'] = self._design.theme
+        self._render_variables['collapsed_sidebar'] = self.initial_sidebar_state == 'collapsed'
 
     def _update_busy(self) -> None:
         if self.busy_indicator:

--- a/panel/template/bootstrap/bootstrap.html
+++ b/panel/template/bootstrap/bootstrap.html
@@ -106,7 +106,7 @@
 
   <div class="row overflow-hidden" id="content">
     {% if nav %}
-    <div class="sidenav collapse-horizontal show" id="sidebar">
+    <div class="sidenav collapse-horizontal {{ 'collapse' if collapsed_sidebar else 'show'}}" id="sidebar">
       <ul class="nav flex-column">
 	{% for doc in docs %}
 	{% for root in doc.roots %}

--- a/panel/template/fast/grid/fast_grid_template.html
+++ b/panel/template/fast/grid/fast_grid_template.html
@@ -87,7 +87,7 @@ document.addEventListener('DOMContentLoaded', (event) => {
     <fast-design-system-provider id="header-design-provider">
       <nav id="header" {{ 'class="shadow"' if style.shadow else '' }} >
 	{% if nav or sidebar_footer %}
-	<span onclick="closeNav()" id="sidebar-button">
+	<span onclick="{{ 'openNav()' if collapsed_sidebar else 'closeNav()' }}" id="sidebar-button">
 	  <div class="pn-bar"></div>
 	  <div class="pn-bar"></div>
 	  <div class="pn-bar"></div>
@@ -157,7 +157,7 @@ document.addEventListener('DOMContentLoaded', (event) => {
 
     <div class="row" id="content">
       {% if nav or sidebar_footer %}
-      <div class="sidenav" id="sidebar">
+      <div class="sidenav {{'hidden' if collapsed_sidebar else ''}}" id="sidebar">
 	<ul class="nav flex-column">
 	  {% if nav %}
 	  {% for doc in docs %}

--- a/panel/template/fast/list/fast_list_template.html
+++ b/panel/template/fast/list/fast_list_template.html
@@ -86,7 +86,7 @@ document.addEventListener('DOMContentLoaded', (event) => {
     <fast-design-system-provider id="header-design-provider">
       <nav id="header" {{ 'class="shadow"' if style.shadow else '' }} >
 	{% if nav or sidebar_footer %}
-	<span onclick="closeNav()" id="sidebar-button">
+	<span onclick="{{ 'openNav()' if collapsed_sidebar else 'closeNav()' }}" id="sidebar-button">
 	  <div class="pn-bar"></div>
 	  <div class="pn-bar"></div>
 	  <div class="pn-bar"></div>
@@ -148,7 +148,7 @@ document.addEventListener('DOMContentLoaded', (event) => {
 
     <div class="row" id="content">
       {% if nav or sidebar_footer %}
-      <div class="sidenav" id="sidebar">
+      <div class="sidenav {{'hidden' if collapsed_sidebar else ''}}" id="sidebar">
 	<ul class="nav flex-column">
 	  {% if nav %}
 	  {% for doc in docs %}

--- a/panel/template/material/material.html
+++ b/panel/template/material/material.html
@@ -109,7 +109,7 @@
   </header>
 
   {% if nav %}
-  <aside class="mdc-drawer mdc-top-app-bar--fixed-adjust mdc-drawer--dismissible mdc-drawer--open" id="sidebar">
+  <aside class="mdc-drawer mdc-top-app-bar--fixed-adjust mdc-drawer--dismissible {{ '' if collapsed_sidebar else 'mdc-drawer--open' }}" id="sidebar">
     <div class="mdc-drawer__content">
       <div class="mdc-list">
 	{% for doc in docs %}
@@ -166,8 +166,6 @@
     topAppBar.listen('MDCTopAppBar:nav', function() {
       drawer.open = !drawer.open;
     });
-
-    drawer.open = true;
     {% endif %}
 
     var modal_el = document.getElementById("pn-Modal");

--- a/panel/template/react/react.css
+++ b/panel/template/react/react.css
@@ -70,10 +70,12 @@ img.app-logo {
 }
 
 #content {
-  height: calc(100vh - 76px);
-  margin: 0px;
-  width: 100vw;
+  color: var(--text-color);
   display: flex;
+  height: 100%;
+  margin: 0px;
+  overflow: hidden;
+  width: 100vw;
 }
 
 #responsive-grid {
@@ -86,12 +88,23 @@ img.app-logo {
   margin-right: 10px;
 }
 
+#sidebar.hidden {
+  border: 0px;
+  margin: 0px;
+  min-width: 0px;
+  overflow: hidden;
+  padding: 0px;
+  width: 0px;
+}
+
 #sidebar {
+  border-right: 1px solid var(--panel-surface-color);
+  box-sizing: border-box;
+  height: 100%;
+  overflow: hidden auto;
+  padding: 15px 10px 15px 5px;
   transition: all 0.2s cubic-bezier(0.945, 0.02, 0.27, 0.665);
   transform-origin: center left; /* Set the transformed position of sidebar to center left side. */
-  height: calc(100vh - 76px);
-  overflow-y: scroll;
-  padding: 10px;
 }
 
 #main {

--- a/panel/template/react/react.html
+++ b/panel/template/react/react.html
@@ -52,7 +52,7 @@
 <div id="container">
   <nav id="header">
     {% if nav %}
-    <span style="font-size:30px;cursor:pointer" onclick="closeNav()" id="sidebar-button">
+    <span style="font-size:30px; cursor:pointer" onclick="{{ 'openNav()' if collapsed_sidebar else 'closeNav()' }}" id="sidebar-button">
       <div class="pn-bar"></div>
       <div class="pn-bar"></div>
       <div class="pn-bar"></div>
@@ -85,15 +85,15 @@
 
   <div class="row" id="content">
     {% if nav %}
-    <div class="sidenav" id="sidebar">
+    <div class="sidenav {{'hidden' if collapsed_sidebar else ''}}" id="sidebar">
       <ul class="nav flex-column">
       {% for doc in docs %}
-	    {% for root in doc.roots %}
-	    {% if "nav" in root.tags %}
+      {% for root in doc.roots %}
+      {% if "nav" in root.tags %}
         {{ embed(root) | indent(8) }}
-	    {% endif %}
-	    {% endfor %}
-	    {% endfor %}
+      {% endif %}
+      {% endfor %}
+      {% endfor %}
       </ul>
     </div>
     {% endif %}
@@ -124,19 +124,13 @@
 
 <script>
   function openNav() {
-    document.getElementById("sidebar").style.left = 0;
-    document.getElementById("main").style.marginLeft = "{{ sidebar_width + 30 }}px";
+    document.getElementById("sidebar").classList.remove("hidden");
     document.getElementById("sidebar-button").onclick = closeNav;
-    var interval = setInterval(function () { window.dispatchEvent(new Event('resize')); }, 10);
-    setTimeout(function () { clearInterval(interval) }, 210)
   }
 
   function closeNav() {
-    document.getElementById("sidebar").style.left = "-{{ sidebar_width + 30 }}px";
-    document.getElementById("main").style.marginLeft = 0;
+    document.getElementById("sidebar").classList.add("hidden");
     document.getElementById("sidebar-button").onclick = openNav;
-    var interval = setInterval(function () { window.dispatchEvent(new Event('resize')); }, 10);
-    setTimeout(function () { clearInterval(interval) }, 210)
   }
 
   var modal = document.getElementById("pn-Modal");

--- a/panel/template/vanilla/vanilla.css
+++ b/panel/template/vanilla/vanilla.css
@@ -61,6 +61,8 @@ body {
 }
 
 #header-items {
+  display: flex;
+  flex-direction: row;
   padding-left: 15px;
   width: 100%;
 }

--- a/panel/template/vanilla/vanilla.html
+++ b/panel/template/vanilla/vanilla.html
@@ -55,7 +55,7 @@
 <div id="container">
   <nav id="header">
     {% if nav %}
-    <span onclick="closeNav()" id="sidebar-button">
+    <span onclick="{{ 'openNav()' if collapsed_sidebar else 'closeNav()' }}" id="sidebar-button">
       <div class="pn-bar"></div>
       <div class="pn-bar"></div>
       <div class="pn-bar"></div>
@@ -95,7 +95,7 @@
 
   <div id="content">
     {% if nav %}
-    <div class="sidenav" id="sidebar">
+    <div class="sidenav {{'hidden' if collapsed_sidebar else ''}}" id="sidebar">
       <ul class="nav flex-column">
         {% for doc in docs %}
         {% for root in doc.roots %}


### PR DESCRIPTION
Add `initial_sidebar_state` option to templates to allow controlling whether sidebar initializes as collapsed or expanded.