### PR TITLE
Ensure kernel shutdown futures are not collected

### DIFF
--- a/panel/io/jupyter_server_extension.py
+++ b/panel/io/jupyter_server_extension.py
@@ -423,10 +423,10 @@ class PanelWSProxy(WSHandler, JupyterHandler):
         if self.session_id in state._kernels:
             del state._kernels[self.session_id]
         self._ping_job.stop()
-        reply = self.kernel.shutdown(reply=True)
-        future = self.kernel_manager.shutdown_kernel(self.kernel_id, now=True)
-        asyncio.ensure_future(reply)
-        asyncio.ensure_future(future)
+        self._shutdown_futures = [
+            asyncio.ensure_future(self.kernel.shutdown(reply=True)),
+            asyncio.ensure_future(self.kernel_manager.shutdown_kernel(self.kernel_id, now=True))
+        ]
         self.kernel = None
 
 


### PR DESCRIPTION
Asyncio tasks may be reaped if before they are run which in this case would lead to zombie kernels.

See https://twitter.com/willmcgugan/status/1624419352211603461?s=20