### PR TITLE
Add dev change to doc_nb_js

### DIFF
--- a/panel/_templates/doc_nb_js.js
+++ b/panel/_templates/doc_nb_js.js
@@ -5,7 +5,7 @@
   if (!docs) {
     return
   }
-  const py_version = docs[0].version.replace('rc', '-rc.')
+  const py_version = docs[0].version.replace('rc', '-rc.').replace('.dev', '-dev.')
   const is_dev = py_version.indexOf("+") !== -1 || py_version.indexOf("-") !== -1
   function embed_document(root) {
     var Bokeh = get_bokeh(root)


### PR DESCRIPTION
Fixes difference between dev labeling of Python and Javascript.

Example from Bokeh: [`3.2.0.dev3`](https://pypi.org/project/bokeh/3.2.0.dev3/) and [`3.2.0-dev.3`](https://www.npmjs.com/package/@bokeh/bokehjs/v/3.2.0-dev.3).