### PR TITLE
Fix false warning emitted when constructing a Param pane with `throttled` or `onkeyup`

### DIFF
--- a/panel/param.py
+++ b/panel/param.py
@@ -469,6 +469,8 @@ class Param(PaneBase):
             kw['description'] = textwrap.dedent(p_obj.doc).strip()
 
         # Update kwargs
+        onkeyup = kw_widget.pop('onkeyup', False)
+        throttled = kw_widget.pop('throttled', False)
         ignored_kws = [repr(k) for k in kw_widget if k not in widget_class.param]
         if ignored_kws:
             self.param.warning(
@@ -509,9 +511,9 @@ class Param(PaneBase):
             def action(change):
                 value(self.object)
             watcher = widget.param.watch(action, 'clicks')
-        elif kw_widget.get('onkeyup', False) and hasattr(widget, 'value_input'):
+        elif onkeyup and hasattr(widget, 'value_input'):
             watcher = widget.param.watch(link_widget, 'value_input')
-        elif kw_widget.get('throttled', False) and hasattr(widget, 'value_throttled'):
+        elif throttled and hasattr(widget, 'value_throttled'):
             watcher = widget.param.watch(link_widget, 'value_throttled')
         else:
             watcher = widget.param.watch(link_widget, 'value')
@@ -573,7 +575,7 @@ class Param(PaneBase):
                 idx = self._internal_callbacks.index(prev_watcher)
                 self._internal_callbacks[idx] = watchers[0]
                 return
-            elif kw_widget.get('throttled', False) and hasattr(widget, 'value_throttled'):
+            elif throttled and hasattr(widget, 'value_throttled'):
                 updates['value_throttled'] = change.new
                 updates['value'] = change.new
             elif isinstance(widget, Row) and len(widget) == 2:

--- a/panel/tests/test_param.py
+++ b/panel/tests/test_param.py
@@ -545,7 +545,11 @@ def test_param_throttled(document, comm):
         b = param.Number(default=1.2, bounds=(0, 5), label='B')
 
     test = Test()
-    test_pane = Param(test, widgets={'b': {'throttled': True}})
+    try:
+        param.parameterized.warnings_as_exceptions = True
+        test_pane = Param(test, widgets={'b': {'throttled': True}})
+    finally:
+        param.parameterized.warnings_as_exceptions = False
 
     model = test_pane.get_root(document, comm=comm)
 
@@ -583,7 +587,11 @@ def test_param_onkeyup(document, comm):
         b = param.String(default='1.2', label='B')
 
     test = Test()
-    test_pane = Param(test, widgets={'b': {'onkeyup': True}})
+    try:
+        param.parameterized.warnings_as_exceptions = True
+        test_pane = Param(test, widgets={'b': {'onkeyup': True}})
+    finally:
+        param.parameterized.warnings_as_exceptions = False
 
     model = test_pane.get_root(document, comm=comm)
 

--- a/panel/tests/test_param.py
+++ b/panel/tests/test_param.py
@@ -605,6 +605,25 @@ def test_param_onkeyup(document, comm):
     assert mb.value == '4'
 
 
+def test_param_event_parameter(document, comm):
+
+    l = []
+    class Test(param.Parameterized):
+        e = param.Event()
+
+        @param.depends('e', watch=True)
+        def incr(self):
+            l.append(1)
+
+    test = Test()
+    test_pane = Param(test)
+
+    test_pane._widgets['e']._process_events({'clicks': 1})
+
+    # Check that a watcher was set on the button that depends on e
+    assert l == [1]
+
+
 def test_param_precedence_ordering(document, comm):
     class Test(param.Parameterized):
         a = param.Number(default=1.2, bounds=(0, 5), precedence=-1)

--- a/panel/tests/test_param.py
+++ b/panel/tests/test_param.py
@@ -571,6 +571,11 @@ def test_param_throttled(document, comm):
     assert test.b == 3
     assert mb.value == 4
 
+    test.b = 5
+    assert mb.value == 5
+    assert test_pane._widgets['b'].value == 5
+    assert test_pane._widgets['b'].value_throttled == 5
+
 
 def test_param_onkeyup(document, comm):
     class Test(param.Parameterized):
@@ -860,6 +865,11 @@ def test_set_widgets_throttled(document, comm):
     pane._widgets['a']._process_events({'value': 4})
     assert test.a == 3
     assert number.value == 4
+
+    test.a = 5
+    assert number.value == 5
+    assert pane._widgets['a'].value == 5
+    assert pane._widgets['a'].value_throttled == 5
 
 
 def test_set_show_name(document, comm):

--- a/panel/tests/test_param.py
+++ b/panel/tests/test_param.py
@@ -520,6 +520,25 @@ def test_param_label(document, comm):
     assert test_pane._widgets['b'].name == 'C'
 
 
+def test_param_widget_type(document, comm):
+    class Test(param.Parameterized):
+        a = param.Number(default=1.2, bounds=(0, 5), label='A')
+        b = param.Number(default=1.2, bounds=(0, 5), label='B')
+
+    test = Test()
+    test_pane = Param(test, widgets={'b': {'widget_type': EditableFloatSlider}})
+
+
+    # Check that b is displayed with an EditableFloatSlider
+    wa = test_pane._widgets['a']
+    wb = test_pane._widgets['b']
+    assert not isinstance(wa, EditableFloatSlider)
+    assert isinstance(wb, EditableFloatSlider)
+    assert wb.value == 1.2
+    assert (wb.fixed_start, wb.fixed_end) == (0, 5)
+    assert wb.name == 'B'
+
+
 def test_param_precedence_ordering(document, comm):
     class Test(param.Parameterized):
         a = param.Number(default=1.2, bounds=(0, 5), precedence=-1)


### PR DESCRIPTION
This fixes the warnings you can currently see on the explorer guide of hvPlot:
![image](https://github.com/holoviz/panel/assets/35924738/fb6121df-b14f-4e7f-b8f7-2f4a7cfc4374)


- Pop `onkeyup` and `throttled` from the widget kwargs dict to avoid the newly emitted warning
- Test that and add some more tests while I was looking at this code
