### PR TITLE
Allow to clear enabled_dates in DatetimePicker

### DIFF
--- a/panel/models/datetime_picker.ts
+++ b/panel/models/datetime_picker.ts
@@ -41,11 +41,20 @@ export class DatetimePickerView extends InputWidgetView {
     this.connect(max_date.change, () => this._picker?.set("maxDate", this.model.max_date))
     this.connect(disabled_dates.change, () => {
       const {disabled_dates} = this.model
-      this._picker?.set("disable", disabled_dates != null ? _convert_date_list(disabled_dates) : undefined)
+      this._picker?.set("disable", disabled_dates != null ? _convert_date_list(disabled_dates) : [])
     })
     this.connect(enabled_dates.change, () => {
       const {enabled_dates} = this.model
-      this._picker?.set("enable", enabled_dates != null ? _convert_date_list(enabled_dates) : undefined)
+      if (enabled_dates != null) {
+        this._picker?.set("enable", _convert_date_list(enabled_dates))
+      } else {
+        // this reimplements `set()` for the `undefined` case
+        if (this._picker) {
+          this._picker.config._enable = undefined
+          this._picker.redraw()
+          this._picker.updateValue(true)
+        }
+      }
     })
     this.connect(inline.change, () => this._picker?.set("inline", this.model.inline))
     this.connect(enable_time.change, () => this._picker?.set("enableTime", this.model.enable_time))

--- a/panel/tests/ui/widgets/test_input.py
+++ b/panel/tests/ui/widgets/test_input.py
@@ -435,6 +435,11 @@ def test_datetimepicker_enabled_dates(page, port, march_2021, enabled_dates):
     disabled_days = page.locator('.flatpickr-calendar .flatpickr-day.flatpickr-disabled')
     expect(disabled_days).to_have_count(num_days - len(enabled_list))
 
+    # enable all days
+    datetime_picker_widget.enabled_dates = None
+    disabled_days = page.locator('.flatpickr-calendar .flatpickr-day.flatpickr-disabled')
+    expect(disabled_days).to_have_count(0)
+
 
 def test_datetimepicker_enable_time(page, port):
     datetime_picker_widget = DatetimePicker(enable_time=False)


### PR DESCRIPTION
Fixes #4949

Implementation is like the changes made upstream https://github.com/bokeh/bokeh/pull/13194 to fix the problem.