### PR TITLE
renamed Trend parameter title to name

### DIFF
--- a/examples/gallery/streaming_videostream.ipynb
+++ b/examples/gallery/streaming_videostream.ipynb
@@ -272,7 +272,7 @@
     "    def _report(self, name, duration):\n",
     "        if not name in self._trends:\n",
     "            self._trends[name] = pn.indicators.Trend(\n",
-    "                title=name,\n",
+    "                name=name,\n",
     "                data={\"x\": [1], \"y\": [duration]},\n",
     "                height=100,\n",
     "                width=150,\n",

--- a/examples/reference/indicators/Trend.ipynb
+++ b/examples/reference/indicators/Trend.ipynb
@@ -33,7 +33,7 @@
     "* **``plot_type``** (`str`, `default='bar'`): The plot type to render the plot data as, on of 'line', 'bar', 'step' or 'area'.\n",
     "* **``pos_color``** (`str`, `default='#5cb85c'`): The color used to indicate a positive change.\n",
     "* **``neg_color``** (`str`, `default='#d9534f'`): The color used to indicate a negative change.\n",
-    "* **``title``** (str): The title or a short description of the indicator.\n",
+    "* **``name``** (str): The name or a short description of the indicator.\n",
     "* **``value``** (float or int or \"auto\", `default='auto'`): The primary value to be displayed.\n",
     "* **``value_change``** (float or int or \"auto\", `default='auto'`): The change in the value expressed as a fraction.\n",
     "___"
@@ -55,7 +55,7 @@
     "data = {'x': np.arange(50), 'y': np.random.randn(50).cumsum()}\n",
     "\n",
     "trend = pn.indicators.Trend(\n",
-    "    title='Price', data=data, width=200, height=200\n",
+    "    name='Price', data=data, width=200, height=200\n",
     ")\n",
     "trend"
    ]

--- a/panel/io/admin.py
+++ b/panel/io/admin.py
@@ -337,11 +337,11 @@ def get_cpu():
 def get_process_info():
     memory = Trend(
         data=get_mem(), plot_x='time', plot_y='memory', plot_type='step',
-        title='Memory Usage (MB)', width=300, height=300
+        name='Memory Usage (MB)', width=300, height=300
     )
     cpu = Trend(
         data=get_cpu(), plot_x='time', plot_y='cpu', plot_type='step',
-        title='CPU Usage (%)', width=300, height=300
+        name='CPU Usage (%)', width=300, height=300
     )
     def update_stats():
         memory.stream(get_mem())
@@ -385,19 +385,19 @@ def get_session_info(doc=None):
     df = get_session_data()
     total = Trend(
         data=df[['time', 'total']], plot_x='time', plot_y='total', plot_type='step',
-        title='Total Sessions', width=300, height=300
+        name='Total Sessions', width=300, height=300
     )
     active = Trend(
         data=df[['time', 'live']], plot_x='time', plot_y='live', plot_type='step',
-        title='Active Sessions', width=300, height=300
+        name='Active Sessions', width=300, height=300
     )
     render = Trend(
         data=df[['time', 'render']], plot_x='time', plot_y='render', plot_type='step',
-        title='Avg. Time to Render (s)', width=300, height=300
+        name='Avg. Time to Render (s)', width=300, height=300
     )
     duration = Trend(
         data=df[['time', 'duration']], plot_x='time', plot_y='duration', plot_type='step',
-        title='Avg. Session Duration (s)', width=300, height=300
+        name='Avg. Session Duration (s)', width=300, height=300
     )
     # Set up callbacks
     def update_session_info(event):

--- a/panel/tests/manual/models.py
+++ b/panel/tests/manual/models.py
@@ -198,7 +198,7 @@ terminal = pn.widgets.Terminal(
 
 # Model: trend
 _data = {"x": np.arange(50), "y": np.random.randn(50).cumsum()}
-trend = pn.indicators.Trend(title="Price", data=_data, width=200, height=200)
+trend = pn.indicators.Trend(name="Price", data=_data, width=200, height=200)
 
 # Model: vega
 try:

--- a/panel/tests/widgets/test_trend_indicator.py
+++ b/panel/tests/widgets/test_trend_indicator.py
@@ -8,11 +8,11 @@ from panel.widgets import IntSlider, Trend
 
 
 def test_constructor():
-    Trend(title="Test")
+    Trend(name="Test")
 
 
 def manualtest_constructor():
-    return Trend(title="Test")
+    return Trend(name="Test")
 
 
 def test_trend_auto_value(document, comm):
@@ -45,7 +45,7 @@ def manualtest_app():
     data = {"x": [1, 2, 3, 4, 5], "y": [3800, 3700, 3800, 3900, 4000]}
 
     trend = Trend(
-        title="Panel Users",
+        name="Panel Users",
         value=4000,
         value_change=0.51,
         data=data,

--- a/panel/tests/widgets/test_trend_indicator.py
+++ b/panel/tests/widgets/test_trend_indicator.py
@@ -10,6 +10,9 @@ from panel.widgets import IntSlider, Trend
 def test_constructor():
     Trend(name="Test")
 
+def test_deprecated_parameter():
+    Trend(title="Test")
+
 
 def manualtest_constructor():
     return Trend(name="Test")

--- a/panel/tests/widgets/test_trend_indicator.py
+++ b/panel/tests/widgets/test_trend_indicator.py
@@ -1,9 +1,12 @@
 import random
 
+from pytest import warns
+
 from panel import (
     Column, Param, Row, WidgetBox, state,
 )
 from panel.pane import HTML
+from panel.util.warnings import PanelDeprecationWarning
 from panel.widgets import IntSlider, Trend
 
 
@@ -11,7 +14,8 @@ def test_constructor():
     Trend(name="Test")
 
 def test_deprecated_parameter():
-    Trend(title="Test")
+    with warns(PanelDeprecationWarning):
+        Trend(title="Test")
 
 
 def manualtest_constructor():

--- a/panel/widgets/indicators.py
+++ b/panel/widgets/indicators.py
@@ -43,6 +43,7 @@ from ..models import (
 from ..pane.markup import Str
 from ..reactive import SyncableData
 from ..util import escape, updating
+from ..util.warnings import deprecated
 from ..viewable import Viewable
 from .base import Widget
 
@@ -1065,6 +1066,12 @@ class Trend(SyncableData, Indicator):
     }
 
     _widget_type: ClassVar[Type[Model]] = _BkTrendIndicator
+
+    def __init__(self, **params):
+        if "title" in params:
+            params["name"] = params.pop("title")
+            deprecated("1.3", "title",  "name")
+        super().__init__(**params)
 
     def _get_data(self):
         if self.data is None:

--- a/panel/widgets/indicators.py
+++ b/panel/widgets/indicators.py
@@ -1018,7 +1018,7 @@ class Trend(SyncableData, Indicator):
     :Example:
 
     >>> data = {'x': np.arange(50), 'y': np.random.randn(50).cumsum()}
-    >>> Trend(title='Price', data=data, plot_type='area', width=200, height=200)
+    >>> Trend(name='Price', data=data, plot_type='area', width=200, height=200)
     """
 
     data = param.Parameter(doc="""
@@ -1048,7 +1048,7 @@ class Trend(SyncableData, Indicator):
         'fixed', 'stretch_width', 'stretch_height', 'stretch_both',
         'scale_width', 'scale_height', 'scale_both', None])
 
-    title = param.String(doc="""The title or a short description of the card""")
+    name = param.String(doc="""The name or a short description of the card""")
 
     value = param.Parameter(default='auto', doc="""
       The primary value to be displayed.""")


### PR DESCRIPTION
As the requirement by #3358 , created this PR.

Changes are as follows:
- changed parameter name from `title` to `name`.
- introduced a constructor for `Trend` to handle the deprecated parameter with backward compatibility.
- modified all dependent files where `Trend` is being initiated with `title` as a parameter.
- modified test cases.
- added new test case for deprecated parameter.