### PR TITLE
Fix ChatBox issues

### DIFF
--- a/panel/widgets/chatbox.py
+++ b/panel/widgets/chatbox.py
@@ -47,37 +47,37 @@ class ChatRow(CompositeWidget):
         """,
     )
 
-    icon = param.String(
-        default=None, doc="""The icon to display adjacent to the value"""
-    )
+    icon = param.String(default=None, doc="""The icon to display adjacent to the value""")
 
-    liked = param.Boolean(default=False, doc="""Whether a user liked the message""")
+    liked = param.Boolean(
+        default=False, doc="""
+        Whether a user liked the message""")
 
     margin = Margin(
         default=0,
         doc="""
         Allows to create additional space around the component. May
         be specified as a two-tuple of the form (vertical, horizontal)
-        or a four-tuple (top, right, bottom, left).""",
+        or a four-tuple (top, right, bottom, left)."""
     )
 
     show_name = param.Boolean(
         default=True,
         doc="""
-        Whether to show the name of the user""",
+        Whether to show the name of the user"""
     )
 
     show_like = param.Boolean(
         default=True,
         doc="""
-        Whether to show the like button""",
+        Whether to show the like button"""
     )
 
     styles = param.Dict(
         default={},
         doc="""
         Dictionary of CSS properties and values to apply
-        message to the bubble.""",
+        message to the bubble."""
     )
 
     _composite_type: ClassVar[Type[ListPanel]] = Column

--- a/panel/widgets/chatbox.py
+++ b/panel/widgets/chatbox.py
@@ -30,34 +30,55 @@ class ChatRow(CompositeWidget):
 
     value = param.List(doc="""The objects to display""")
 
-    align_name = param.Selector(default="start", objects=["start", "end"], doc="""
-        Whether to show the name at the start or end of the row""")
+    align_name = param.Selector(
+        default="start",
+        objects=["start", "end"],
+        doc="""
+        Whether to show the name at the start or end of the row""",
+    )
 
-    default_message_callable = param.Callable(default=None, doc="""
+    default_message_callable = param.Callable(
+        default=None,
+        doc="""
         The type of Panel object or callable to use if an item in value is not
         already rendered as a Panel object; if None, uses the
         pn.panel function to render a displayable Panel object.
         If the item is not serializable, will fall back to pn.panel.
-        """)
+        """,
+    )
 
-    icon = param.String(default=None, doc="""The icon to display adjacent to the value""")
+    icon = param.String(
+        default=None, doc="""The icon to display adjacent to the value"""
+    )
 
     liked = param.Boolean(default=False, doc="""Whether a user liked the message""")
 
-    margin = Margin(default=0, doc="""
+    margin = Margin(
+        default=0,
+        doc="""
         Allows to create additional space around the component. May
         be specified as a two-tuple of the form (vertical, horizontal)
-        or a four-tuple (top, right, bottom, left).""")
+        or a four-tuple (top, right, bottom, left).""",
+    )
 
-    show_name = param.Boolean(default=True, doc="""
-        Whether to show the name of the user""")
+    show_name = param.Boolean(
+        default=True,
+        doc="""
+        Whether to show the name of the user""",
+    )
 
-    show_like = param.Boolean(default=True, doc="""
-        Whether to show the like button""")
+    show_like = param.Boolean(
+        default=True,
+        doc="""
+        Whether to show the like button""",
+    )
 
-    styles = param.Dict(default={}, doc="""
+    styles = param.Dict(
+        default={},
+        doc="""
         Dictionary of CSS properties and values to apply
-        message to the bubble.""")
+        message to the bubble.""",
+    )
 
     _composite_type: ClassVar[Type[ListPanel]] = Column
 
@@ -75,20 +96,22 @@ class ChatRow(CompositeWidget):
             "overflow-x": "auto",
             "overflow-y": "auto",
             "box-shadow": "rgba(0, 0, 0, 0.15) 1.95px 1.95px 2.6px;",
-            "padding": "0.5em"
+            "padding": "0.5em",
         }
         if styles:
             bubble_styles.update(styles)
-        text_style = {'color': bubble_styles.get('color')}
+        text_style = {"color": bubble_styles.get("color")}
         icon_styles = dict((styles or {}))
-        icon_styles.pop('background', None)
-        icon_styles.pop('color', None)
-        icon_styles.update({
-            'border-radius': '50%',
-            'font-weight': 'bold',
-            'font-size': '1.2em',
-            'text-align': 'center'
-        })
+        icon_styles.pop("background", None)
+        icon_styles.pop("color", None)
+        icon_styles.update(
+            {
+                "border-radius": "50%",
+                "font-weight": "bold",
+                "font-size": "1.2em",
+                "text-align": "center",
+            }
+        )
         if "background" not in bubble_styles:
             bubble_styles["background"] = "black"
         super().__init__(value=value, icon=icon, **params)
@@ -102,22 +125,19 @@ class ChatRow(CompositeWidget):
 
         # create the chat bubble
         bubble_objects = [
-            self._serialize_obj(obj, default_message_callable, text_style) for obj in value
+            self._serialize_obj(obj, default_message_callable, text_style)
+            for obj in value
         ]
         self._bubble = Column(
             *bubble_objects,
-            align='center',
+            align="center",
             margin=8,
             styles=bubble_styles,
         )
 
         # create heart icon next to chat
         self._like = Toggle(
-            name="♡",
-            width=30,
-            height=30,
-            align="end",
-            visible=show_like
+            name="♡", width=30, height=30, align="end", visible=show_like
         )
         self._like.link(self, value="liked", bidirectional=True)
         self._like.param.watch(self._update_like, "value")
@@ -148,7 +168,9 @@ class ChatRow(CompositeWidget):
             self._name = Markdown(
                 object=self.name,
                 align=(horizontal_align, "start"),
-                margin=(-15, 15, 0, 0) if horizontal_align == 'end' else (-15, 0, 0, 15),
+                margin=(-15, 15, 0, 0)
+                if horizontal_align == "end"
+                else (-15, 0, 0, 15),
                 styles={"font-size": "0.88em", "color": "grey"},
             )
             if self.align_name == "start":
@@ -160,19 +182,23 @@ class ChatRow(CompositeWidget):
 
         self._composite[:] = [row]
 
-    def _serialize_obj(self, obj: Any, default_message_callable: Callable, text_styles: Dict) -> Viewable:
+    def _serialize_obj(
+        self, obj: Any, default_message_callable: Callable, text_styles: Dict
+    ) -> Viewable:
         """
         Convert an object to a Panel object.
         """
         if isinstance(obj, Viewable):
             return obj
 
-        stylesheets=['p { margin-block-start: 0.2em; margin-block-end: 0.2em;}']
+        stylesheets = ["p { margin-block-start: 0.2em; margin-block-end: 0.2em;}"]
         try:
             if default_message_callable is None or issubclass(
                 default_message_callable, PaneBase
             ):
-                panel_obj = (default_message_callable or _panel)(obj, stylesheets=stylesheets, styles=text_styles)
+                panel_obj = (default_message_callable or _panel)(
+                    obj, stylesheets=stylesheets, styles=text_styles
+                )
             else:
                 panel_obj = default_message_callable(value=obj)
         except ValueError:
@@ -205,47 +231,79 @@ class ChatBox(CompositeWidget):
     >>> ChatBox(value=[{"You": "Hello!"}, {"Bot": ["How may I help?", "I'm a bot."]}])
     """
 
-    value = param.List(default=[], item_type=Dict, doc="""
+    value = param.List(
+        default=[],
+        item_type=Dict,
+        doc="""
         List of messages as dicts, mapping user to message(s),
         e.g. `[{'You': ['Welcome!', 'Good bye!']}]` The message(s) can be
-        any Python object that can be rendered by Panel.""")
+        any Python object that can be rendered by Panel.""",
+    )
 
-    primary_name = param.String(default=None, doc="""
+    primary_name = param.String(
+        default=None,
+        doc="""
         Name of the primary user (the one who inputs messages);
-        the first key found in value will be used if unspecified.""")
+        the first key found in value will be used if unspecified.""",
+    )
 
-    allow_input = param.Boolean(default=True, doc="""
-        Whether to allow the primary user to interactively enter messages.""")
+    allow_input = param.Boolean(
+        default=True,
+        doc="""
+        Whether to allow the primary user to interactively enter messages.""",
+    )
 
-    allow_likes = param.Boolean(default=False, doc="""
-        Whether to allow the primary user to interactively like messages.""")
+    allow_likes = param.Boolean(
+        default=False,
+        doc="""
+        Whether to allow the primary user to interactively like messages.""",
+    )
 
-    ascending = param.Boolean(default=False, doc="""
+    ascending = param.Boolean(
+        default=False,
+        doc="""
         Whether to display messages in ascending time order.  If true,
         the latest messages and message_input_widgets will be at the
-        bottom of the chat box. Otherwise, they will be at the top.""")
+        bottom of the chat box. Otherwise, they will be at the top.""",
+    )
 
-    message_icons = param.Dict(default={}, doc="""
+    message_icons = param.Dict(
+        default={},
+        doc="""
         Dictionary mapping name of messages to their icons,
-        e.g. `[{'You': 'path/to/icon.png'}]`""")
+        e.g. `[{'You': 'path/to/icon.png'}]`""",
+    )
 
-    message_colors = param.Dict(default={}, doc="""
+    message_colors = param.Dict(
+        default={},
+        doc="""
         Dictionary mapping name of messages to their colors, e.g.
-        `[{'You': 'red'}]`""")
+        `[{'You': 'red'}]`""",
+    )
 
-    message_hue = param.Integer(default=None, bounds=(0, 360), doc="""
-        Base hue of the message bubbles if message_colors is not specified for a user.""")
+    message_hue = param.Integer(
+        default=None,
+        bounds=(0, 360),
+        doc="""
+        Base hue of the message bubbles if message_colors is not specified for a user.""",
+    )
 
-    message_input_widgets = param.List(default=[TextInput], doc="""
+    message_input_widgets = param.List(
+        default=[TextInput],
+        doc="""
         List of widgets to use for message input. Multiple widgets will
-        be nested under tabs.""")
+        be nested under tabs.""",
+    )
 
-    default_message_callable = param.Callable(default=None, doc="""
+    default_message_callable = param.Callable(
+        default=None,
+        doc="""
         The type of Panel object to use for items in value if they are
         not already rendered as a Panel object; if None, uses the
         pn.panel function to render a displayable Panel object.
         If the item is not serializable, will fall back to pn.panel.
-        """)
+        """,
+    )
 
     _composite_type: ClassVar[Type[ListPanel]] = Column
 
@@ -316,9 +374,9 @@ class ChatBox(CompositeWidget):
         self._current_hue = hue
 
         return [
-            (f"hsl({hue}, 45%, 50%)", 'white'),
-            (f"hsl({hue}, 30%, 55%)", 'white'),
-            (f"hsl({hue}, 15%, 60%)", 'white')
+            (f"hsl({hue}, 45%, 50%)", "white"),
+            (f"hsl({hue}, 30%, 55%)", "white"),
+            (f"hsl({hue}, 15%, 60%)", "white"),
         ]
 
     def _add_scroll_callback(self, obj: Viewable, what: str):
@@ -336,6 +394,15 @@ class ChatBox(CompositeWidget):
             **{what: code},
         )
 
+    def _link_disabled_loading(self, obj: Viewable):
+        """
+        Link the disabled and loading attributes of the chat box to the
+        given object.
+        """
+        for key in ["disabled", "loading"]:
+            setattr(obj, key, getattr(self, key))
+            self.link(obj, **{key: key})
+
     def _attach_input(self, box_objects: List, layout: Dict[str, str]) -> None:
         """
         Attach the input widgets to the chat box.
@@ -350,8 +417,9 @@ class ChatBox(CompositeWidget):
         self._send_button = Button(
             name="Send",
             button_type="default",
-            sizing_mode="stretch_both",
+            sizing_mode="stretch_width",
             max_width=100,
+            height=35,
         )
         self._send_button.on_click(self._enter_message)
 
@@ -362,6 +430,7 @@ class ChatBox(CompositeWidget):
 
         input_items = Tabs()
         for message_input_name, message_input in self._message_inputs.items():
+            self._link_disabled_loading(message_input)
             message_input.sizing_mode = "stretch_width"
             # for longer form messages, like TextArea / Ace, don't
             # submit when clicking away; only if they manually click
@@ -369,7 +438,9 @@ class ChatBox(CompositeWidget):
             if isinstance(message_input, TextInput):
                 message_input.param.watch(self._enter_message, "value")
                 self._add_scroll_callback(message_input, "value")
-            message_row = Row(message_input, self._send_button.clone(), **row_layout)
+            send_button = self._send_button.clone()
+            self._link_disabled_loading(send_button)
+            message_row = Row(message_input, send_button, **row_layout)
             input_items.append((message_input_name, message_row))
 
         if len(self._message_inputs) == 1:
@@ -404,7 +475,10 @@ class ChatBox(CompositeWidget):
         return user, message_contents
 
     def _instantiate_message_row(
-        self, user: str, message_contents: Union[Any, List[Any]], show_name: bool
+        self,
+        user: str,
+        message_contents: Union[Any, List[Any]],
+        show_name: bool,
     ) -> ChatRow:
         """
         Instantiate a ChatRow object.
@@ -418,7 +492,9 @@ class ChatBox(CompositeWidget):
         # try to get input color; if not generate one and save
         if user in self.message_colors:
             colors = self.message_colors[user]
-            background, color = colors if isinstance(colors, tuple) else (colors, 'black')
+            background, color = (
+                colors if isinstance(colors, tuple) else (colors, "black")
+            )
         elif self.message_hue:
             if len(self._default_colors) == 0:
                 self._default_colors = self._generate_default_hsl(
@@ -428,9 +504,9 @@ class ChatBox(CompositeWidget):
             self.message_colors[user] = (background, color)
         else:
             if user == self.primary_name:
-                background, color = ('rgb(99, 139, 226)', 'white')
+                background, color = ("rgb(99, 139, 226)", "white")
             else:
-                background, color = ('rgb(246, 246, 246)', 'black')
+                background, color = ("rgb(246, 246, 246)", "black")
             self.message_colors[user] = (background, color)
 
         # try to get input icon
@@ -465,15 +541,22 @@ class ChatBox(CompositeWidget):
 
         message_rows = []
         previous_user = None
-        for user_message in user_messages:
+        for i, user_message in enumerate(user_messages):
             user, message_contents = self._separate_user_message(user_message)
 
+            # only show name if it's a new user
             show_name = user != previous_user
             previous_user = user
 
             message_row = self._instantiate_message_row(
                 user, message_contents, show_name
             )
+
+            # try to rebuild liked status
+            if len(self._chat_log.objects) > i:
+                original_message_row = self._chat_log.objects[i]
+                if original_message_row.value == message_row.value:
+                    message_row.liked = original_message_row.liked
             message_rows.append(message_row)
 
         self._chat_log.objects = message_rows
@@ -513,19 +596,7 @@ class ChatBox(CompositeWidget):
         """
         if not isinstance(user_message, dict):
             raise ValueError(f"Expected a dictionary, but got {user_message}")
-        # need to keep it in sync, but do not want to trigger refresh_logs so append
-        self.value.append(user_message)
-
-        if len(self._chat_log) == 0:
-            previous_user = None
-        else:
-            previous_user = self._chat_log[-1].name
-
-        user, message_contents = self._separate_user_message(user_message)
-        message_row = self._instantiate_message_row(
-            user, message_contents, show_name=user != previous_user,
-        )
-        self._chat_log.objects = [*self._chat_log.objects, message_row]
+        self.value = self.value + [user_message]
 
     def extend(self, user_messages: List[Dict[str, Union[List[Any], Any]]]) -> None:
         """

--- a/panel/widgets/chatbox.py
+++ b/panel/widgets/chatbox.py
@@ -34,8 +34,7 @@ class ChatRow(CompositeWidget):
         default="start",
         objects=["start", "end"],
         doc="""
-        Whether to show the name at the start or end of the row""",
-    )
+        Whether to show the name at the start or end of the row""")
 
     default_message_callable = param.Callable(
         default=None,
@@ -44,41 +43,33 @@ class ChatRow(CompositeWidget):
         already rendered as a Panel object; if None, uses the
         pn.panel function to render a displayable Panel object.
         If the item is not serializable, will fall back to pn.panel.
-        """,
-    )
+        """)
 
     icon = param.String(default=None, doc="""The icon to display adjacent to the value""")
 
     liked = param.Boolean(
-        default=False, doc="""
-        Whether a user liked the message""")
+        default=False, doc="""Whether a user liked the message""")
 
     margin = Margin(
         default=0,
         doc="""
         Allows to create additional space around the component. May
         be specified as a two-tuple of the form (vertical, horizontal)
-        or a four-tuple (top, right, bottom, left)."""
-    )
+        or a four-tuple (top, right, bottom, left).""")
 
     show_name = param.Boolean(
         default=True,
-        doc="""
-        Whether to show the name of the user"""
-    )
+        doc="""Whether to show the name of the user""")
 
     show_like = param.Boolean(
         default=True,
-        doc="""
-        Whether to show the like button"""
-    )
+        doc="""Whether to show the like button""")
 
     styles = param.Dict(
         default={},
         doc="""
         Dictionary of CSS properties and values to apply
-        message to the bubble."""
-    )
+        message to the bubble.""")
 
     _composite_type: ClassVar[Type[ListPanel]] = Column
 


### PR DESCRIPTION
While trying to use it for an actual use case, I found some problems with it, namely:
1. Send button height stretches too far https://github.com/holoviz/panel/issues/5100
2. ChatBox inputs cannot be disabled https://github.com/holoviz/panel/issues/5099
3. pn.bind didn't work with `append` because previously, `append` doesn't actually trigger value in the latest patch
4. If `append` now trigger values, it does a whole refresh and `liked` again gets lost so I added logic to match up the messages along with index