### PR TITLE
Ensure session arguments are correctly parsed by Jupyter executor

### DIFF
--- a/panel/io/jupyter_executor.py
+++ b/panel/io/jupyter_executor.py
@@ -132,7 +132,7 @@ class PanelExecutor(WSHandler):
 
         # using private attr so users only have access to a read-only property
         session_context._request = _RequestProxy(
-            arguments={k: [v.encode('utf-8') for v in vs] for k, vs in self.payload.get('arguments', {})},
+            arguments={k: [v.encode('utf-8') for v in vs] for k, vs in self.payload.get('arguments', {}).items()},
             cookies=self.payload.get('cookies'),
             headers=self.payload.get('headers')
         )
@@ -173,7 +173,11 @@ class PanelExecutor(WSHandler):
         be served by the `PanelJupyterHandler`.
         """
         if self.session is None:
-            return Mimebundle({'text/error': f'Session did not start correctly: {self.exception}'})
+            import traceback
+
+            # `e` is an exception object that you get from somewhere
+            traceback_str = ''.join(traceback.format_tb(self.exception.__traceback__))
+            return Mimebundle({'text/error': f'Session did not start correctly: {self.exception} {traceback_str}'})
         with set_curdoc(self.session.document):
             if not self.session.document.roots:
                 return Mimebundle({

--- a/panel/io/jupyter_executor.py
+++ b/panel/io/jupyter_executor.py
@@ -173,11 +173,7 @@ class PanelExecutor(WSHandler):
         be served by the `PanelJupyterHandler`.
         """
         if self.session is None:
-            import traceback
-
-            # `e` is an exception object that you get from somewhere
-            traceback_str = ''.join(traceback.format_tb(self.exception.__traceback__))
-            return Mimebundle({'text/error': f'Session did not start correctly: {self.exception} {traceback_str}'})
+            return Mimebundle({'text/error': f'Session did not start correctly: {self.exception}'})
         with set_curdoc(self.session.document):
             if not self.session.document.roots:
                 return Mimebundle({

--- a/panel/tests/ui/io/test_jupyter_server_extension.py
+++ b/panel/tests/ui/io/test_jupyter_server_extension.py
@@ -1,14 +1,14 @@
-import sys
-
 import pytest
+
+try:
+    from playwright.sync_api import expect
+except ImportError:
+    pytestmark = pytest.mark.skip('playwright not available')
 
 from panel.tests.util import wait_until
 
 pytestmark = pytest.mark.jupyter
 
-not_windows = pytest.mark.skipif(sys.platform=='win32', reason="Does not work on Windows")
-
-@not_windows
 @pytest.mark.flaky(max_runs=3)
 def test_jupyter_server(page, jupyter_preview):
     page.goto(f"{jupyter_preview}/app.py", timeout=30000)
@@ -23,7 +23,6 @@ def test_jupyter_server(page, jupyter_preview):
 
     wait_until(lambda: page.text_content('pre') == '2', page)
 
-@not_windows
 @pytest.mark.flaky(max_runs=3)
 def test_jupyter_server_custom_resources(page, jupyter_preview):
     page.goto(f"{jupyter_preview}/app.py", timeout=30000)
@@ -31,7 +30,6 @@ def test_jupyter_server_custom_resources(page, jupyter_preview):
     assert page.locator('.bk-Row').evaluate("""(element) =>
         window.getComputedStyle(element).getPropertyValue('background-color')""") == 'rgb(128, 0, 128)'
 
-@not_windows
 @pytest.mark.flaky(max_runs=3)
 def test_jupyter_server_kernel_error(page, jupyter_preview):
     page.goto(f"{jupyter_preview}/app.py?kernel=blah", timeout=30000)
@@ -45,3 +43,9 @@ def test_jupyter_server_kernel_error(page, jupyter_preview):
     page.click('button')
 
     wait_until(lambda: page.text_content('pre') == '1', page)
+
+@pytest.mark.flaky(max_runs=3)
+def test_jupyter_server_session_arg_theme(page, jupyter_preview):
+    page.goto(f"{jupyter_preview}/app.py?theme=dark", timeout=30000)
+
+    expect(page.locator('body')).to_have_css('color', 'rgb(0, 0, 0)')


### PR DESCRIPTION
Session arguments were not unpacked correctly resulting in the `theme` toggle in the Fast templates to break.