### PR TITLE
[Bug Fix] Fix styling with filters in tabulator

### DIFF
--- a/panel/models/tabulator.ts
+++ b/panel/models/tabulator.ts
@@ -872,6 +872,7 @@ export class DataTabulatorView extends HTMLBoxView {
 
   postUpdate(): void {
     this.setSelection()
+    this.setStyles()
   }
 
   updateOrAddData(): void {

--- a/panel/tests/ui/widgets/test_tabulator.py
+++ b/panel/tests/ui/widgets/test_tabulator.py
@@ -2467,7 +2467,6 @@ def test_tabulator_filters_and_styling(page, port, df_mixed):
     page.goto(f"http://localhost:{port}")
 
     # Filtering to one field and then clicking None again should display all data, with styling
-    print(page.locator('option'))
     page.locator('option').nth(1).click()
     page.locator('option').nth(0).click()
 

--- a/panel/tests/ui/widgets/test_tabulator.py
+++ b/panel/tests/ui/widgets/test_tabulator.py
@@ -5,7 +5,6 @@ import time
 
 import numpy as np
 import pandas as pd
-from panel.layout.base import Column
 import param
 import pytest
 
@@ -15,6 +14,8 @@ from bokeh.models.widgets.tables import (
     ScientificFormatter, SelectEditor, StringEditor, StringFormatter,
     TextEditor,
 )
+
+from panel.layout.base import Column
 
 try:
     from playwright.sync_api import expect


### PR DESCRIPTION
This PR fixes the issue identified in #5098, where Tabulator styling would not render after filtering in panel version 1.1.0. 

Previously, there was a race condition causing the table to usually set styling before new data is processed into the table, meaning the table was rerendered without the requisite CSS. The solution is to reapply styling after the rerendering.

The PR also adds a test to check that styling is preserved after filtering, which passes due to the fix in this PR.