### PR TITLE
Implement per_session cache

### DIFF
--- a/doc/how_to/caching/memoization.md
+++ b/doc/how_to/caching/memoization.md
@@ -4,7 +4,7 @@ This guide addresses how to use the `panel.cache` decorator to memoize (i.e. cac
 
 ---
 
-The `pn.cache` decorator provides an easy way to cache the outputs of a function depending on its inputs (i.e. `memoize`). If you've ever used the Python `@lru_cache` decorator you will be familiar with this concept. However the `pn.cache` functions supports additional cache `policy`'s apart from LRU (least-recently used), including `LFU` (least-frequently-used) and 'FIFO' (first-in-first-out). This means that if the specified number of `max_items` is reached Panel will automatically evict items from the cache based on this `policy`. Additionally items can be deleted from the cache based on a `ttl` (time-to-live) value given in seconds.
+The `pn.cache` decorator provides an easy way to cache the outputs of a function depending on its inputs (i.e. `memoization`). If you've ever used the Python `@lru_cache` decorator you will be familiar with this concept. However the `pn.cache` functions support additional cache `policy`s apart from LRU (least-recently used), including `LFU` (least-frequently-used) and 'FIFO' (first-in-first-out). This means that if the specified number of `max_items` is reached Panel will automatically evict items from the cache based on this `policy`. Additionally items can be deleted from the cache based on a `ttl` (time-to-live) value given in seconds.
 
 ## Caching in memory
 
@@ -47,5 +47,9 @@ If you have `diskcache` installed you can also cache the results to disk by sett
 ## Clearing the cache
 
 Once a function has been decorated with `pn.cache` you can easily clear the cache by calling `.clear()` on that function, e.g. in the example above you could call `load_data.clear()`. If you want to clear all caches you may also call `pn.state.clear_caches()`.
+
+## Per-session caching
+
+By default any functions decorated or wrapped with `pn.cache` will use a global cache that will be reused across multiple sessions, i.e. multiple users visiting your app will all share the same cache. If instead you want a session-local cache, that only reuses cached outputs for the duration of each visit to your application, you can set `pn.cache(..., per_session=True)`.
 
 ## Related Resources

--- a/panel/io/cache.py
+++ b/panel/io/cache.py
@@ -302,7 +302,7 @@ def compute_hash(func, hash_funcs, args, kwargs):
 
 def cache(
     func=None, hash_funcs=None, max_items=None, policy='LRU',
-    ttl=None, to_disk=False, cache_path='./cache'
+    ttl=None, to_disk=False, cache_path='./cache', per_session=False
 ):
     """
     Decorator to memoize functions with options to configure the
@@ -328,6 +328,8 @@ def cache(
         Whether to cache to disk using diskcache.
     cache_dir: str
         Directory to cache to on disk.
+    per_session: bool
+        Whether to cache data only for the current session.
     """
     if policy.lower() not in ('fifo', 'lru', 'lfu'):
         raise ValueError(
@@ -375,6 +377,8 @@ def cache(
             func_hash = (fname, type(args[0]).__name__, func.__name__)
         else:
             func_hash = (fname, func.__name__)
+        if per_session:
+            func_hash += (id(state.curdoc),)
         func_hash = hashlib.sha256(_generate_hash(func_hash)).hexdigest()
 
         func_cache = state._memoize_cache.get(func_hash)
@@ -404,7 +408,7 @@ def cache(
             func_cache[hash_value] = (ret, time, 0, time)
         return ret
 
-    def clear():
+    def clear(session_context=None):
         global func_hash
         if func_hash is None:
             return
@@ -416,6 +420,9 @@ def cache(
             cache = state._memoize_cache.get(func_hash, {})
         cache.clear()
     wrapped_func.clear = clear
+
+    if per_session and state.curdoc and state.curdoc.session_context:
+        state.curdoc.on_session_destroyed(clear)
 
     try:
         wrapped_func.__dict__.update(func.__dict__)

--- a/panel/tests/io/test_cache.py
+++ b/panel/tests/io/test_cache.py
@@ -187,6 +187,8 @@ def test_cache_clear():
     assert fn(0, 0) == 1
 
 def test_per_session_cache(document):
+    global OFFSET
+    OFFSET.clear()
     fn = cache(function_with_args, per_session=True)
     with set_curdoc(document):
         assert fn(a=0, b=0) == 0

--- a/panel/tests/io/test_cache.py
+++ b/panel/tests/io/test_cache.py
@@ -15,6 +15,7 @@ except Exception:
 diskcache_available = pytest.mark.skipif(diskcache is None, reason="requires diskcache")
 
 from panel.io.cache import _find_hash_func, cache
+from panel.io.state import set_curdoc
 
 ################
 # Test hashing #
@@ -184,6 +185,15 @@ def test_cache_clear():
     assert fn(0, 0) == 0
     fn.clear()
     assert fn(0, 0) == 1
+
+def test_per_session_cache(document):
+    fn = cache(function_with_args, per_session=True)
+    with set_curdoc(document):
+        assert fn(a=0, b=0) == 0
+    assert fn(a=0, b=0) == 1
+    with set_curdoc(document):
+        assert fn(a=0, b=0) == 0
+    assert fn(a=0, b=0) == 1
 
 @pytest.mark.xdist_group("cache")
 @diskcache_available


### PR DESCRIPTION
Adds an option to `pn.cache` to cache `per_session`, i.e. to ensure that each new session has a separate cache and also adds a handler that clears the session cache when the session is destroyed.