### PR TITLE
Add append mode for reactive generator output

### DIFF
--- a/panel/pane/base.py
+++ b/panel/pane/base.py
@@ -24,7 +24,7 @@ from ..io.document import create_doc_if_none_exists, unlocked
 from ..io.notebook import push
 from ..io.state import state
 from ..layout.base import (
-    ListPanel, NamedListPanel, Panel, Row,
+    Column, ListPanel, NamedListPanel, Panel, Row,
 )
 from ..links import Link
 from ..models import ReactiveHTML as _BkReactiveHTML
@@ -559,7 +559,7 @@ class ReplacementPane(PaneBase):
         super().__init__(object, **params)
         self._pane = panel(None)
         self._internal = True
-        self._inner_layout = Row(self._pane, **{k: v for k, v in params.items() if k in Row.param})
+        self._inner_layout = Column(self._pane, **{k: v for k, v in params.items() if k in Column.param})
         self._internal_callbacks.append(
             self.param.watch(self._update_inner_layout, list(Layoutable.param))
         )
@@ -706,7 +706,7 @@ class ReplacementPane(PaneBase):
             return
 
         self._pane = new_pane
-        self._inner_layout[0] = self._pane
+        self._inner_layout[:] = [self._pane]
         self._internal = internal
 
     def _cleanup(self, root: Model | None = None) -> None:

--- a/panel/param.py
+++ b/panel/param.py
@@ -823,12 +823,11 @@ class ParamMethod(ReplacementPane):
         try:
             if isinstance(awaitable, types.AsyncGeneratorType):
                 append_mode = self.generator_mode == 'append'
-                async for i, new_obj in enumerate(awaitable):
+                if append_mode:
+                    self._inner_layout[:] = []
+                async for new_obj in awaitable:
                     if append_mode:
-                        if i == 0:
-                            self._inner_layout[:] = [new_obj]
-                        else:
-                            self._inner_layout.append(new_obj)
+                        self._inner_layout.append(new_obj)
                         self._pane = self._inner_layout[-1]
                     else:
                         self._update_inner(new_obj)
@@ -858,12 +857,11 @@ class ParamMethod(ReplacementPane):
                 return
             elif isinstance(new_object, Generator):
                 append_mode = self.generator_mode == 'append'
-                for i, new_obj in enumerate(new_object):
+                if append_mode:
+                    self._inner_layout[:] = []
+                for new_obj in new_object:
                     if append_mode:
-                        if i == 0:
-                            self._inner_layout[:] = [new_obj]
-                        else:
-                            self._inner_layout.append(new_obj)
+                        self._inner_layout.append(new_obj)
                         self._pane = self._inner_layout[-1]
                     else:
                         self._update_inner(new_obj)

--- a/panel/tests/test_param.py
+++ b/panel/tests/test_param.py
@@ -1182,7 +1182,7 @@ def test_param_function_pane(document, comm):
 
     # Create pane
     row = pane.get_root(document, comm=comm)
-    assert isinstance(row, BkRow)
+    assert isinstance(row, BkColumn)
     assert len(row.children) == 1
     model = row.children[0]
     assert pane._models[row.ref['id']][0] is row
@@ -1227,7 +1227,7 @@ def test_param_function_pane_defer_load(document, comm):
     # Create pane
     with set_curdoc(document):
         row = pane.get_root(document, comm=comm)
-    assert isinstance(row, BkRow)
+    assert isinstance(row, BkColumn)
     assert len(row.children) == 1
     model = row.children[0]
     assert pane._models[row.ref['id']][0] is row
@@ -1343,7 +1343,7 @@ def test_param_method_pane(document, comm):
 
     # Create pane
     row = pane.get_root(document, comm=comm)
-    assert isinstance(row, BkRow)
+    assert isinstance(row, BkColumn)
     assert len(row.children) == 1
     model = row.children[0]
     assert pane._models[row.ref['id']][0] is row
@@ -1372,7 +1372,7 @@ def test_param_method_pane_subobject(document, comm):
 
     # Create pane
     row = pane.get_root(document, comm=comm)
-    assert isinstance(row, BkRow)
+    assert isinstance(row, BkColumn)
     assert len(row.children) == 1
     model = row.children[0]
     assert isinstance(model, Div)
@@ -1406,7 +1406,7 @@ def test_param_method_pane_mpl(document, comm):
 
     # Create pane
     row = pane.get_root(document, comm=comm)
-    assert isinstance(row, BkRow)
+    assert isinstance(row, BkColumn)
     assert len(row.children) == 1
     model = row.children[0]
     assert pane._models[row.ref['id']][0] is row
@@ -1435,7 +1435,7 @@ def test_param_method_pane_changing_type(document, comm):
 
     # Create pane
     row = pane.get_root(document, comm=comm)
-    assert isinstance(row, BkRow)
+    assert isinstance(row, BkColumn)
     assert len(row.children) == 1
     model = row.children[0]
     text = model.text
@@ -1766,6 +1766,28 @@ def test_param_generator(document, comm):
     assert root.children[0].text == '&lt;p&gt;True&lt;/p&gt;\n'
 
 
+def test_param_generator_append(document, comm):
+    checkbox = Checkbox(value=False)
+
+    def function(value):
+        yield Markdown(f"{value}")
+        yield Markdown(f"{not value}")
+
+    pane = ParamFunction(bind(function, checkbox), generator_mode='append')
+
+    root = pane.get_root(document, comm)
+
+    assert len(root.children) == 2
+    assert root.children[0].text == '&lt;p&gt;False&lt;/p&gt;\n'
+    assert root.children[1].text == '&lt;p&gt;True&lt;/p&gt;\n'
+
+    checkbox.value = True
+
+    assert len(root.children) == 2
+    assert root.children[0].text == '&lt;p&gt;True&lt;/p&gt;\n'
+    assert root.children[1].text == '&lt;p&gt;False&lt;/p&gt;\n'
+
+
 @pytest.mark.asyncio
 async def test_param_async_generator(document, comm):
     checkbox = Checkbox(value=False)
@@ -1786,6 +1808,38 @@ async def test_param_async_generator(document, comm):
     await asyncio.sleep(0.01)
 
     assert root.children[0].text == '&lt;p&gt;True&lt;/p&gt;\n'
+
+
+@pytest.mark.asyncio
+async def test_param_async_generator_append(document, comm):
+    checkbox = Checkbox(value=False)
+
+    async def function(value):
+        yield Markdown(f"{value}")
+        await asyncio.sleep(0.01)
+        yield Markdown(f"{not value}")
+
+    pane = ParamFunction(bind(function, checkbox), generator_mode='append')
+
+    root = pane.get_root(document, comm)
+
+    await asyncio.sleep(0.01)
+    assert len(root.children) == 1
+    assert root.children[0].text == '&lt;p&gt;False&lt;/p&gt;\n'
+    await asyncio.sleep(0.01)
+    assert len(root.children) == 2
+    assert root.children[0].text == '&lt;p&gt;False&lt;/p&gt;\n'
+    assert root.children[1].text == '&lt;p&gt;True&lt;/p&gt;\n'
+
+    checkbox.value = True
+
+    await asyncio.sleep(0.01)
+    assert len(root.children) == 1
+    assert root.children[0].text == '&lt;p&gt;True&lt;/p&gt;\n'
+    await asyncio.sleep(0.01)
+    assert len(root.children) == 2
+    assert root.children[0].text == '&lt;p&gt;True&lt;/p&gt;\n'
+    assert root.children[1].text == '&lt;p&gt;False&lt;/p&gt;\n'
 
 
 def test_param_generator_multiple(document, comm):


### PR DESCRIPTION
Allows generator output to append to output rather than simply replacing it:

```python
import random
import time
import panel as pn

pn.extension(sizing_mode="stretch_width")

def model():
    time.sleep(1)
    return random.randint(0, 100)

def results(running):
    if not running:
        yield "The model has not run yet"
        return

    for i in range(0, 10):
        yield f"Result {i}: {model()}"

run_input = pn.widgets.Button(name="Run model")
pn.Column(
    run_input,
    pn.panel(pn.bind(results, run_input), loading_indicator=True, generator_mode='append'),
).servable()
```

![gen_append](https://github.com/holoviz/panel/assets/1550771/25510442-fe3b-4bf5-9a32-ea5f83e919ae)
