### PR TITLE
Ensure we handle JupyterLab4 comm messages correctly

### DIFF
--- a/panel/io/model.py
+++ b/panel/io/model.py
@@ -87,6 +87,9 @@ def diff(
     msg = patch_doc(header, {'use_buffers': binary}, patch_json)
     doc.callbacks._held_events = [e for e in doc.callbacks._held_events if e not in patch_events]
     doc.models.flush_synced(lambda model: not serializer.has_ref(model))
+    if binary:
+        for buffer in serializer.buffers:
+            msg.add_buffer(buffer)
     return msg
 
 def remove_root(obj: 'Model', replace: Optional['Document'] = None) -> None:

--- a/panel/io/notebook.py
+++ b/panel/io/notebook.py
@@ -70,9 +70,12 @@ def push(doc: 'Document', comm: 'Comm', binary: bool = True) -> None:
     msg = diff(doc, binary=binary)
     if msg is None:
         return
+    # WARNING: CommManager model assumes that either JSON content OR a buffer
+    #          is sent. Therefore we must NEVER(!!!) send both at once.
     comm.send(msg.header_json)
     comm.send(msg.metadata_json)
     comm.send(msg.content_json)
+
     for buffer in msg.buffers:
         header = json.dumps(buffer.ref)
         payload = buffer.to_bytes()

--- a/panel/models/comm_manager.ts
+++ b/panel/models/comm_manager.ts
@@ -57,7 +57,11 @@ export class CommManager extends Model {
 	  if (view !== this)
 	    view.msg_handler(msg)
 	}
-	this.msg_handler(msg)
+	try {
+	  this.msg_handler(msg)
+	} catch(e) {
+	  console.error(e)
+	}
       })
       this._client_comm = this.ns.comm_manager.get_client_comm(this.plot_id, this.client_comm_id, (msg: any) => this.on_ack(msg));
       if (this.ns.shared_views == null)
@@ -171,10 +175,12 @@ export class CommManager extends Model {
       if (plot == null)
         return
 
-      if ((buffers != undefined) && (buffers.length > 0))
+      if (content.length)
+        this._receiver.consume(content)
+      else if ((buffers != undefined) && (buffers.length > 0))
         this._receiver.consume(buffers[0].buffer)
       else
-        this._receiver.consume(content)
+	return
 
       const comm_msg = this._receiver.message
       if ((comm_msg != null) && (Object.keys(comm_msg.content as Patch).length > 0) && this.document != null){


### PR DESCRIPTION
Since https://github.com/jupyterlab/jupyterlab/pull/13730 it seems that JupyterLab incorrectly deserializes comm messages with an empty trailing `DataView`. To ensure we correctly interpret messages and ignore this empty array buffer we simply check whether the message contains JSON content before we check for a binary message. This works because we never send a single message containing both.

In debugging this I also found that since the Bokeh3 upgrade we did not send binary buffers at all when working in the notebook. Here we also re-enable this, fixing the regression and restoring previous performance.

Lastly we catch errors processing comm messages to ensure they are no longer silently ignored.