### PR TITLE
Allow automatic loading of extensions during launch

### DIFF
--- a/panel/io/state.py
+++ b/panel/io/state.py
@@ -241,6 +241,13 @@ class _state(param.Parameterized):
         return thread_id
 
     @property
+    def _is_launching(self) -> bool:
+        curdoc = self.curdoc
+        if not curdoc or not curdoc.session_context:
+            return False
+        return not bool(curdoc.session_context.server_context.sessions)
+
+    @property
     def _is_pyodide(self) -> bool:
         return '_pyodide' in sys.modules
 

--- a/panel/util/__init__.py
+++ b/panel/util/__init__.py
@@ -332,8 +332,9 @@ def lazy_load(module, model, notebook=False, root=None, ext=None):
         module: ext for ext, module in extension._imports.items()
     }
     ext = ext or module.split('.')[-1]
+    ext_name = external_modules[module]
     loaded_extensions = state._extensions
-    loaded = loaded_extensions is None or external_modules[module] in loaded_extensions
+    loaded = loaded_extensions is None or ext_name in loaded_extensions
     if module in sys.modules and loaded:
         model_cls = getattr(sys.modules[module], model)
         if f'{model_cls.__module__}.{model}' not in Model.model_class_reverse_map:
@@ -348,10 +349,13 @@ def lazy_load(module, model, notebook=False, root=None, ext=None):
             f'\n\npn.extension(\'{ext}\')\n'
         )
     elif not loaded and state._is_launching:
+        # If we are still launching the application it is not too late
+        # to automatically load the extension and therefore ensure it
+        # is included in the resources added to the served page
         if loaded_extensions is None:
-            state._extensions_[state.curdoc] = [external_modules[module]]
+            state._extensions_[state.curdoc] = [ext_name]
         else:
-            loaded_extensions.append(external_modules[module])
+            loaded_extensions.append(ext_name)
     elif not loaded:
         param.main.param.warning(
             f'pn.extension was initialized but {ext!r} extension was not '

--- a/panel/util/__init__.py
+++ b/panel/util/__init__.py
@@ -352,6 +352,13 @@ def lazy_load(module, model, notebook=False, root=None, ext=None):
         # If we are still launching the application it is not too late
         # to automatically load the extension and therefore ensure it
         # is included in the resources added to the served page
+        param.main.param.warning(
+            f'pn.extension was initialized but {ext!r} extension was not '
+            'loaded. Since the application is still launching the extension '
+            'was loaded automatically but we strongly recommend you load '
+            'the extension explicitly with the following argument(s):'
+            f'\n\npn.extension({ext!r})\n'
+        )
         if loaded_extensions is None:
             state._extensions_[state.curdoc] = [ext_name]
         else:

--- a/panel/util/__init__.py
+++ b/panel/util/__init__.py
@@ -332,12 +332,12 @@ def lazy_load(module, model, notebook=False, root=None, ext=None):
         module: ext for ext, module in extension._imports.items()
     }
     ext = ext or module.split('.')[-1]
-    loaded = not state._extensions or external_modules[module] in state._extensions
+    loaded_extensions = state._extensions
+    loaded = loaded_extensions is None or external_modules[module] in loaded_extensions
     if module in sys.modules and loaded:
         model_cls = getattr(sys.modules[module], model)
         if f'{model_cls.__module__}.{model}' not in Model.model_class_reverse_map:
             _default_resolver.add(model_cls)
-
         return model_cls
 
     if notebook:
@@ -347,11 +347,16 @@ def lazy_load(module, model, notebook=False, root=None, ext=None):
             'ensure you load it as part of the extension using:'
             f'\n\npn.extension(\'{ext}\')\n'
         )
+    elif not loaded and state._is_launching:
+        if loaded_extensions is None:
+            state._extensions_[state.curdoc] = [external_modules[module]]
+        else:
+            loaded_extensions.append(external_modules[module])
     elif not loaded:
         param.main.param.warning(
-            f'pn.extension was initialized but {ext!r} extension was not'
+            f'pn.extension was initialized but {ext!r} extension was not '
             'loaded. In order for the required resources to be initialized '
-            'ensure the extension using is loaded with the extension:'
+            'ensure the extension is loaded with the following argument(s):'
             f'\n\npn.extension({ext!r})\n'
         )
     elif root is not None and root.ref['id'] in state._views:


### PR DESCRIPTION
The logic warning users if they correctly loaded an extension was broken in the case where the user called `pn.extension()` without loading any actual extensions. So in this PR we do two things:

1. If the application is launching we can actually allow loading extensions automatically. So if you instantiate a component that requires an extension that wasn't explicitly loaded we now automatically add it to the list of loaded extensions.
2. If the application is fully loaded (and we therefore cannot load any more resources), we correctly warn the user that they forgot to load the extension explicitly. 

Fixes https://github.com/holoviz/panel/issues/5142