### PR TITLE
Fix min_width computation on layouts

### DIFF
--- a/panel/layout/base.py
+++ b/panel/layout/base.py
@@ -283,7 +283,7 @@ class Panel(Reactive):
             op_widths = [min_width]
             if 'max_width' in properties:
                 op_widths.append(properties['max_width'])
-            properties['min_height'] = min(op_widths)
+            properties['min_width'] = min(op_widths)
         if ((sizing_mode.endswith('_height') or sizing_mode.endswith('_both')) and
             heights and 'min_height' not in properties):
             height_op = max if self._direction == 'horizontal' else sum

--- a/panel/pane/holoviews.py
+++ b/panel/pane/holoviews.py
@@ -228,7 +228,7 @@ class HoloViews(PaneBase):
                 mode = obj.sizing_mode
                 if mode:
                     wresponsive = '_width' in mode or '_both' in mode
-                    wresponsive = '_width' in mode or '_both' in mode
+                    hresponsive = '_height' in mode or '_both' in mode
                 else:
                     wresponsive = hresponsive = False
             else:

--- a/panel/pane/holoviews.py
+++ b/panel/pane/holoviews.py
@@ -256,7 +256,7 @@ class HoloViews(PaneBase):
             mode = opts.get('sizing_mode')
             if mode:
                 self._width_responsive = '_width' in mode or '_both' in mode
-                self._width_responsive = '_height' in mode or '_both' in mode
+                self._height_responsive = '_height' in mode or '_both' in mode
             else:
                 self._width_responsive = False
                 self._height_responsive = False


### PR DESCRIPTION
Follow up to #5061 where I accidentally started setting `min_height` when I should have been setting `min_width`.

Fixes https://github.com/holoviz/panel/issues/5134