### PR TITLE
Correctly check the version for deprecation

### DIFF
--- a/panel/pane/markup.py
+++ b/panel/pane/markup.py
@@ -44,7 +44,7 @@ class HTMLBasePane(ModelPane):
         if "style" in params:
             # In Bokeh 3 'style' was changed to 'styles'.
             params["styles"] = params.pop("style")
-            deprecated("1.1", "style",  "styles")
+            deprecated("1.3", "style",  "styles")
         super().__init__(object=object, **params)
 
 

--- a/panel/util/warnings.py
+++ b/panel/util/warnings.py
@@ -42,9 +42,7 @@ def find_stack_level() -> int:
     stacklevel = 0
     while frame:
         fname = inspect.getfile(frame)
-        if (
-            fname.startswith(pkg_dir) or fname.startswith(param_dir)
-        ) and not fname.startswith(test_dir):
+        if fname.startswith((pkg_dir, param_dir)) and not fname.startswith(test_dir):
             frame = frame.f_back
             stacklevel += 1
         else:

--- a/panel/util/warnings.py
+++ b/panel/util/warnings.py
@@ -67,7 +67,7 @@ def deprecated(
     if isinstance(remove_version, str):
         remove_version = Version(remove_version)
 
-    if remove_version < current_version:
+    if remove_version <= current_version:
         # This error is mainly for developers to remove the deprecated.
         raise ValueError(
             f"{old!r} should have been removed in {remove_version}, current version {current_version}."

--- a/panel/viewable.py
+++ b/panel/viewable.py
@@ -724,7 +724,7 @@ class Viewable(Renderable, Layoutable, ServableMixin):
         # Warning
         prev = f'{type(self).name}(..., background={self.background!r})'
         new = f"{type(self).name}(..., styles={{'background': {self.background!r}}})"
-        deprecated("1.1", prev, new)
+        deprecated("1.3", prev, new)
 
         self.styles = dict(self.styles, background=self.background)
 
@@ -860,7 +860,7 @@ class Viewable(Renderable, Layoutable, ServableMixin):
         """
         Prints a compositional repr of the class.
         """
-        deprecated('1.1', f'{type(self).__name__}.pprint', 'print')
+        deprecated('1.3', f'{type(self).__name__}.pprint', 'print')
         print(self)
 
     def select(
@@ -898,7 +898,7 @@ class Viewable(Renderable, Layoutable, ServableMixin):
         port: int (optional, default=0)
           Allows specifying a specific port
         """
-        deprecated('1.1', f'{type(self).__name__}.app', 'panel.io.notebook.show_server')
+        deprecated('1.3', f'{type(self).__name__}.app', 'panel.io.notebook.show_server')
         return show_server(self, notebook_url, port)
 
     def embed(

--- a/panel/widgets/codeeditor.py
+++ b/panel/widgets/codeeditor.py
@@ -86,5 +86,5 @@ class CodeEditor(Widget):
 
 class Ace(CodeEditor):
     def __init__(self, **params):
-        deprecated("1.1", "Ace", "CodeEditor")
+        deprecated("1.3", "Ace", "CodeEditor")
         super().__init__(**params)


### PR DESCRIPTION
I was wondering why I still got a warning when running something like  `pn.pane.HTML("", background="red")`

Let's see how the CI likes this. I would suggest we update the last supported version to 1.2 if it was 1.1. 