### PR TITLE
Immediately dispatch ColumnDataChangedEvent

### DIFF
--- a/panel/io/document.py
+++ b/panel/io/document.py
@@ -16,7 +16,9 @@ from typing import (
 
 from bokeh.application.application import SessionContext
 from bokeh.document.document import Document
-from bokeh.document.events import DocumentChangedEvent, ModelChangedEvent
+from bokeh.document.events import (
+    ColumnDataChangedEvent, DocumentChangedEvent, ModelChangedEvent,
+)
 from bokeh.models import CustomJS
 
 from ..config import config
@@ -246,7 +248,7 @@ def unlocked() -> Iterator:
         monkeypatch_events(events)
         remaining_events, dispatch_events = [], []
         for event in events:
-            if isinstance(event, ModelChangedEvent) and not locked:
+            if isinstance(event, (ColumnDataChangedEvent, ModelChangedEvent)) and not locked:
                 dispatch_events.append(event)
             else:
                 remaining_events.append(event)

--- a/panel/io/document.py
+++ b/panel/io/document.py
@@ -17,7 +17,8 @@ from typing import (
 from bokeh.application.application import SessionContext
 from bokeh.document.document import Document
 from bokeh.document.events import (
-    ColumnDataChangedEvent, DocumentChangedEvent, ModelChangedEvent,
+    ColumnDataChangedEvent, ColumnsPatchedEvent, ColumnsStreamedEvent,
+    DocumentChangedEvent, ModelChangedEvent,
 )
 from bokeh.models import CustomJS
 
@@ -31,6 +32,11 @@ logger = logging.getLogger(__name__)
 #---------------------------------------------------------------------
 # Private API
 #---------------------------------------------------------------------
+
+DISPATCH_EVENTS = (
+    ColumnDataChangedEvent, ColumnsPatchedEvent, ColumnsStreamedEvent,
+    ModelChangedEvent
+)
 
 @dataclasses.dataclass
 class Request:
@@ -248,7 +254,7 @@ def unlocked() -> Iterator:
         monkeypatch_events(events)
         remaining_events, dispatch_events = [], []
         for event in events:
-            if isinstance(event, (ColumnDataChangedEvent, ModelChangedEvent)) and not locked:
+            if isinstance(event, DISPATCH_EVENTS) and not locked:
                 dispatch_events.append(event)
             else:
                 remaining_events.append(event)


### PR DESCRIPTION
Certain event types were not marked for immediate dispatch. This meant that when changing ColumnDataSource data the changes were not always reflected on the frontend immediately. By adding the additional events for immediate dispatch we fix some issues with the `Plotly` pane not updating.

Fixes https://github.com/holoviz/panel/issues/5120
Fixes https://github.com/holoviz/panel/issues/5058