### PR TITLE
Enable and document mathjax extension in Markdown reference

### DIFF
--- a/examples/reference/panes/Markdown.ipynb
+++ b/examples/reference/panes/Markdown.ipynb
@@ -10,7 +10,7 @@
    "source": [
     "import panel as pn\n",
     "\n",
-    "pn.extension()"
+    "pn.extension('mathjax')"
    ]
   },
   {
@@ -285,7 +285,7 @@
    "source": [
     "## LaTeX Support\n",
     "\n",
-    "The `Markdown` pane also supports math rendering by encapsulating the string to be rendered with ``$$`` delimiters."
+    "The `Markdown` pane also supports math rendering by encapsulating the string to be rendered with ``$$`` delimiters. To enable LaTeX rendering you must load the 'mathjax' extensions explicitly in the `pn.extension` call."
    ]
   },
   {


### PR DESCRIPTION
Fixes https://github.com/holoviz/panel/issues/5132