### PR TITLE
Remove markdown-it-py pins

### DIFF
--- a/panel/io/convert.py
+++ b/panel/io/convert.py
@@ -253,7 +253,7 @@ def script_to_html(
     else:
         panel_req = f'panel=={panel_version}'
         bokeh_req = f'bokeh=={BOKEH_VERSION}'
-    base_reqs = ['markdown-it-py<3', bokeh_req, panel_req]
+    base_reqs = [bokeh_req, panel_req]
     if http_patch:
         base_reqs.append('pyodide-http==0.2.1')
     reqs = base_reqs + [

--- a/scripts/panelite/generate_panelite_content.py
+++ b/scripts/panelite/generate_panelite_content.py
@@ -17,7 +17,7 @@ PANEL_BASE = HERE.parent.parent
 EXAMPLES_DIR = PANEL_BASE / 'examples'
 LITE_FILES = PANEL_BASE / 'lite' / 'files'
 DOC_DIR = PANEL_BASE / 'doc'
-BASE_DEPENDENCIES = ['panel', 'pyodide-http', 'markdown-it-py<3']
+BASE_DEPENDENCIES = ['panel', 'pyodide-http']
 MINIMUM_VERSIONS = {}
 
 # Add piplite command to notebooks

--- a/setup.py
+++ b/setup.py
@@ -106,7 +106,7 @@ install_requires = [
     'pyviz_comms >=0.7.4',
     'xyzservices >=2021.09.1', # Bokeh dependency, but pyodide 23.0.0 does not always pick it up
     'markdown',
-    'markdown-it-py<3',
+    'markdown-it-py',
     'linkify-it-py',
     'mdit-py-plugins',
     'requests',


### PR DESCRIPTION
`mdit-py-plugins` compatible with `markdown-it-py==3` was released.