### PR TITLE
Param 2.0 updates: rename style to styles

### DIFF
--- a/doc/how_to/pipeline/simple_pipeline.md
+++ b/doc/how_to/pipeline/simple_pipeline.md
@@ -90,7 +90,7 @@ class Stage2(param.Parameterized):
     @param.depends('c', 'exp')
     def view(self):
         out = pn.pane.LaTeX('${%s}^{%s}={%.3f}$' % (self.c, self.exp, self.c**self.exp),
-                      style={'font-size': '2em'})
+                      styles={'font-size': '2em'})
         return pn.Column(out, margin=(40, 10), styles={'background': '#f0f0f0'})
 
     def panel(self):
@@ -134,9 +134,9 @@ class Stage1(param.Parameterized):
     def view(self):
         c, d = self.output()
         c_out = pn.pane.LaTeX('${a} * {b} = {c}$'.format(
-            a=self.a, b=self.b, c=c), style={'font-size': '2em'})
+            a=self.a, b=self.b, c=c), styles={'font-size': '2em'})
         d_out = pn.pane.LaTeX('${a}^{{{b}}} = {d}$'.format(
-            a=self.a, b=self.b, d=d), style={'font-size': '2em'})
+            a=self.a, b=self.b, d=d), styles={'font-size': '2em'})
         return pn.Column(c_out, d_out,  margin=(40, 10), styles={'background': '#f0f0f0'})
 
     def panel(self):
@@ -150,7 +150,7 @@ class Stage2(param.Parameterized):
     @param.depends('c', 'exp')
     def view(self):
         out = pn.pane.LaTeX('${%s}^{%s}={%.3f}$' % (self.c, self.exp, self.c**self.exp),
-                      style={'font-size': '2em'})
+                      styles={'font-size': '2em'})
         return pn.Column(out, margin=(40, 10), styles={'background': '#f0f0f0'})
 
     def panel(self):

--- a/doc/how_to/pipeline/simple_pipeline.md
+++ b/doc/how_to/pipeline/simple_pipeline.md
@@ -40,9 +40,9 @@ class Stage1(param.Parameterized):
     def view(self):
         c, d = self.output()
         c_out = pn.pane.LaTeX('${a} * {b} = {c}$'.format(
-            a=self.a, b=self.b, c=c), style={'font-size': '2em'})
+            a=self.a, b=self.b, c=c), styles={'font-size': '2em'})
         d_out = pn.pane.LaTeX('${a}^{{{b}}} = {d}$'.format(
-            a=self.a, b=self.b, d=d), style={'font-size': '2em'})
+            a=self.a, b=self.b, d=d), styles={'font-size': '2em'})
         return pn.Column(
 		    c_out, d_out,  margin=(40, 10), styles={'background': '#f0f0f0'}
 		)

--- a/panel/tests/manual/models.py
+++ b/panel/tests/manual/models.py
@@ -119,7 +119,7 @@ json_editor = pn.widgets.JSONEditor(
 # Model: katex
 latex1 = pn.pane.LaTeX(
     "The LaTeX pane supports two delimiters: $LaTeX$ and \(LaTeX\)",
-    style={"font-size": "18pt"},
+    styles={"font-size": "18pt"},
     width=800,
 )
 
@@ -127,7 +127,7 @@ latex1 = pn.pane.LaTeX(
 
 # Model: mathjax
 latex2 = pn.pane.LaTeX(
-    "$\sum_{j}{\sum_{i}{a*w_{j, i}}}$", renderer="mathjax", style={"font-size": "18pt"}
+    "$\sum_{j}{\sum_{i}{a*w_{j, i}}}$", renderer="mathjax", styles={"font-size": "18pt"}
 )
 
 # Model: perspective


### PR DESCRIPTION
Noted the test suite partly failed in the downstream tests after releasing Param 2.0.0a1.