### PR TITLE
Fix chatbox bubble width

### DIFF
--- a/panel/tests/widgets/test_chatbox.py
+++ b/panel/tests/widgets/test_chatbox.py
@@ -444,3 +444,14 @@ def test_chat_row_align_end(document, comm):
 def test_chat_row_not_show_name(document, comm):
     chat_row = ChatRow(value=["Hello"], name="user1", show_name=False)
     assert chat_row._name is None
+
+
+def test_chat_row_bubble_obj_sizing_mode_default(document, comm):
+    chat_row = ChatRow(value=["Hello"], name="user1", show_name=False)
+    assert chat_row._bubble[0].sizing_mode == "stretch_width"
+
+
+def test_chat_row_bubble_obj_sizing_mode_set(document, comm):
+    widget = TextInput(sizing_mode="fixed", width=300, height=100)
+    chat_row = ChatRow(value=[widget], name="user1", show_name=False)
+    assert chat_row._bubble[0].sizing_mode == "fixed"

--- a/panel/widgets/chatbox.py
+++ b/panel/widgets/chatbox.py
@@ -108,7 +108,6 @@ class ChatRow(CompositeWidget):
             align="center",
             margin=8,
             styles=bubble_styles,
-            width_policy="min",
         )
 
         # create heart icon next to chat
@@ -137,7 +136,6 @@ class ChatRow(CompositeWidget):
             row_objects = row_objects[::-1]
 
         container_params = dict(
-            width_policy="min",
             sizing_mode="fixed",
             align=(horizontal_align, "center"),
         )
@@ -185,6 +183,9 @@ class ChatRow(CompositeWidget):
                 panel_obj = self.default_message_callable(value=obj)
         except ValueError:
             panel_obj = _panel(obj, stylesheets=stylesheets, styles=text_styles)
+
+        if panel_obj.sizing_mode is None:
+            panel_obj.sizing_mode = "stretch_width"
 
         if "overflow-wrap" not in panel_obj.styles:
             panel_obj.styles.update({"overflow-wrap": "break-word"})


### PR DESCRIPTION
Fixes https://github.com/holoviz/panel/issues/5171

default
```python
import panel as pn

pn.extension(template="fast", layout_compatibility='error')

chat_box = pn.widgets.ChatBox(
    value=[
        {"System": "You are now a welcoming assistant"},
        {"Assistant": "Welcome"},
        {"User": "Thanks..."},
    ],
    primary_name="User",
    ascending=True,
)

pn.Column(chat_box).servable()
```

<img width="1487" alt="image" src="https://github.com/holoviz/panel/assets/15331990/b96d4c35-17ac-4a7f-84d2-a1ecc820ddeb">

Long words
```python
import panel as pn

pn.extension(template="fast", layout_compatibility='error')

chat_box = pn.widgets.ChatBox(
    value=[
        {"System": "You are now a welcoming assistant"},
        {"User": "Thanks! Testing long words like hippopotamus" * 30},
        {"Assistant": "Welcome"},
    ],
    primary_name="User",
    ascending=True,
)

pn.Column(chat_box).servable()
```

<img width="1496" alt="image" src="https://github.com/holoviz/panel/assets/15331990/d9576838-8e89-452b-a84e-ca7d6591cc7b">

pn.extension stretch_width
```python
import panel as pn

pn.extension(template="fast", layout_compatibility='error', sizing_mode="stretch_width"")

chat_box = pn.widgets.ChatBox(
    value=[
        {"System": "You are now a welcoming assistant"},
        {"User": "Thanks! Testing long words like hippopotamus" * 30},
        {"Assistant": "Welcome"},
    ],
    primary_name="User",
    ascending=True,
)

pn.Column(chat_box).servable()
```

<img width="1279" alt="image" src="https://github.com/holoviz/panel/assets/15331990/8a64a809-de7e-4775-9d94-7e5c26395614">

pn.extension fixed
```python
import panel as pn

pn.extension(template="fast", layout_compatibility='error')

chat_box = pn.widgets.ChatBox(
    value=[
        {"System": "You are now a welcoming assistant"},
        {"User": "Thanks! Testing long words like hippopotamus" * 30},
        {"Assistant": "Welcome"},
    ],
    primary_name="User",
    ascending=True,
    width=400,
    sizing_mode="fixed",
)

pn.Column(chat_box).servable()

```

<img width="1293" alt="image" src="https://github.com/holoviz/panel/assets/15331990/0e235d76-742c-4a95-9579-6d0b10a59744">
