### PR TITLE
Fix Chatbox scroll to latest and add fetch more (pagination)

### DIFF
--- a/panel/widgets/chatbox.py
+++ b/panel/widgets/chatbox.py
@@ -357,9 +357,42 @@ class ChatBox(CompositeWidget):
         self._scroll_button.on_click(self._trigger_scroll_callback)
         self._hidden_scroll_trigger.jscallback(
             value="""
-                const outerColumn = document.querySelector(".bk-Column");
-                const column = outerColumn.shadowRoot.querySelector(".bk-Column");
+                function $$$(selector, rootNode=document.body) {
+                    const arr = []
 
+                    const traverser = node => {
+                        // 1. decline all nodes that are not elements
+                        if(node.nodeType !== Node.ELEMENT_NODE) {
+                            return
+                        }
+
+                        // 2. add the node to the array, if it matches the selector
+                        if(node.matches(selector)) {
+                            arr.push(node)
+                        }
+
+                        // 3. loop through the children
+                        const children = node.children
+                        if (children.length) {
+                            for(const child of children) {
+                                traverser(child)
+                            }
+                        }
+
+                        // 4. check for shadow DOM, and loop through it's children
+                        const shadowRoot = node.shadowRoot
+                        if (shadowRoot) {
+                            const shadowChildren = shadowRoot.children
+                            for(const shadowChild of shadowChildren) {
+                                traverser(shadowChild)
+                            }
+                        }
+                    }
+
+                    traverser(rootNode)
+                    return arr
+                }
+                const column = $$$(".chat-log")[0];
                 if (ascending) {
                     column.scrollTop = column.scrollHeight;
                 } else {


### PR DESCRIPTION
UPDATED comments:
Pretty happy that I found some solutions!

https://github.com/holoviz/panel/assets/15331990/4b132fad-63fe-48b1-8072-b56cdb19001c

To fix scroll, I explicitly set height (or use the provided height/max_height). This significantly reduces complexity since there's only one case to cover instead of getting the window / template main / or column. 

To fix the timing issue mentioned [here](https://github.com/holoviz/panel/issues/5137#issuecomment-1612221063), I used Python callback to call Javascript.

Doing this also makes the chatbox look and feel better in my opinion (the text input isn't jumping around).

To fix performance, I added pagination.

---
OLD comments:
Apparently, this is way more difficult than expected with many edge cases.

1. with/without template
2. fixed height
3. nesting within column

I would like some help on this to work on this together. The current issues:
1. scroll happens immediately, before it gets appended so it only scrolls to the second latest message, rather than the latest
2. if ascending, the text box bounces back to the top
3. how to handle when chatbox isn't the only thing in the template

```
import panel as pn

pn.extension(sizing_mode="stretch_width", layout_compatibility='error')

value = [{"User": c} for c in "ABCDEFGHIJKLMOOPQRSTUVWXYZ"]
chat_box = pn.widgets.ChatBox(
    value=value,
    primary_name="User",
    height=500,
)
(chat_box).servable()
```