### PR TITLE
Add ChatBox export method

### DIFF
--- a/panel/tests/widgets/test_chatbox.py
+++ b/panel/tests/widgets/test_chatbox.py
@@ -232,7 +232,7 @@ def test_chat_box_primary_name(document, comm):
     assert chat_box.value == value + [{"Panel User": "Hello!"}]
 
 
-def test_chat_box_export(document, comm):
+def test_chat_box_export_json(document, comm):
     value = [
         {"user1": "Hello"},
         {"user2": "Hi"},
@@ -241,7 +241,44 @@ def test_chat_box_export(document, comm):
         {"user3": Column(TextInput(value="B"), TextInput(value="C"))},
     ]
     chat_box = ChatBox(value=value.copy(), primary_name="Panel User")
-    messages = chat_box.export(serialize=True)
+    messages = chat_box.export(serialize=True, format="json")
+    assert messages == [
+        {"user1": "Hello"},
+        {"user2": "Hi"},
+        {"user1": "Some valueo!"},
+        {"user2": "another val!\nA"},
+        {"user3": "B\nC"},
+    ]
+
+def test_chat_box_export_tuple(document, comm):
+    value = [
+        {"user1": "Hello"},
+        {"user2": "Hi"},
+        {"user1": TextInput(value="Some valueo!")},
+        {"user2": [TextInput(value="another val!"), Select(options=["A"], value="A")]},
+        {"user3": Column(TextInput(value="B"), TextInput(value="C"))},
+    ]
+    chat_box = ChatBox(value=value.copy(), primary_name="Panel User")
+    messages = chat_box.export(serialize=True, format="tuple")
+    assert messages == [
+        ("user1", "Hello"),
+        ("user2", "Hi"),
+        ("user1", "Some valueo!"),
+        ("user2", "another val!\nA"),
+        ("user3", "B\nC")
+    ]
+
+
+def test_chat_box_export_openai(document, comm):
+    value = [
+        {"user1": "Hello"},
+        {"user2": "Hi"},
+        {"user1": TextInput(value="Some valueo!")},
+        {"user2": [TextInput(value="another val!"), Select(options=["A"], value="A")]},
+        {"user3": Column(TextInput(value="B"), TextInput(value="C"))},
+    ]
+    chat_box = ChatBox(value=value.copy(), primary_name="Panel User")
+    messages = chat_box.export(serialize=True, format="openai")
 
     assert messages == [
         {
@@ -275,10 +312,7 @@ def test_chat_box_export_not_serialize(document, comm):
     messages = chat_box.export(serialize=False)
 
     assert messages == [
-        {
-            "role": "user1",
-            "content": text_input,
-        },
+        {"user1": text_input},
     ]
 
 

--- a/panel/tests/widgets/test_chatbox.py
+++ b/panel/tests/widgets/test_chatbox.py
@@ -344,9 +344,7 @@ def test_chat_box_export_not_serialize(document, comm):
     chat_box = ChatBox(value=value.copy(), primary_name="Panel User")
     messages = chat_box.export(serialize=False)
 
-    assert messages == [
-        {"user1": text_input},
-    ]
+    assert messages == [{'user': 'user1', 'value': text_input}]
 
 
 def test_chat_box_inferred_primary_name(document, comm):

--- a/panel/tests/widgets/test_chatbox.py
+++ b/panel/tests/widgets/test_chatbox.py
@@ -236,6 +236,7 @@ def test_chat_box_export(document, comm):
     value = [
         {"user1": "Hello"},
         {"user2": "Hi"},
+        {"user1": TextInput(value="Some valueo!")},
     ]
     chat_box = ChatBox(value=value.copy(), primary_name="Panel User")
     messages = chat_box.export()
@@ -248,6 +249,10 @@ def test_chat_box_export(document, comm):
         {
             "role": "user2",
             "content": "Hi",
+        },
+        {
+            "role": "user1",
+            "content": "Some valueo!",
         },
     ]
 

--- a/panel/tests/widgets/test_chatbox.py
+++ b/panel/tests/widgets/test_chatbox.py
@@ -243,6 +243,39 @@ def test_chat_box_export_json(document, comm):
     chat_box = ChatBox(value=value.copy(), primary_name="Panel User")
     messages = chat_box.export(serialize=True, format="json")
     assert messages == [
+        {
+            "user": "user1",
+            "value": "Hello",
+        },
+        {
+            "user": "user2",
+            "value": "Hi",
+        },
+        {
+            "user": "user1",
+            "value": "Some valueo!",
+        },
+        {
+            "user": "user2",
+            "value": "another val!\nA",
+        },
+        {
+            "user": "user3",
+            "value": "B\nC",
+        },
+    ]
+
+def test_chat_box_export_legacy(document, comm):
+    value = [
+        {"user1": "Hello"},
+        {"user2": "Hi"},
+        {"user1": TextInput(value="Some valueo!")},
+        {"user2": [TextInput(value="another val!"), Select(options=["A"], value="A")]},
+        {"user3": Column(TextInput(value="B"), TextInput(value="C"))},
+    ]
+    chat_box = ChatBox(value=value.copy(), primary_name="Panel User")
+    messages = chat_box.export(serialize=True, format="legacy")
+    assert messages == [
         {"user1": "Hello"},
         {"user2": "Hi"},
         {"user1": "Some valueo!"},

--- a/panel/tests/widgets/test_chatbox.py
+++ b/panel/tests/widgets/test_chatbox.py
@@ -232,6 +232,26 @@ def test_chat_box_primary_name(document, comm):
     assert chat_box.value == value + [{"Panel User": "Hello!"}]
 
 
+def test_chat_box_export(document, comm):
+    value = [
+        {"user1": "Hello"},
+        {"user2": "Hi"},
+    ]
+    chat_box = ChatBox(value=value.copy(), primary_name="Panel User")
+    messages = chat_box.export()
+
+    assert messages == [
+        {
+            "role": "user1",
+            "content": "Hello",
+        },
+        {
+            "role": "user2",
+            "content": "Hi",
+        },
+    ]
+
+
 def test_chat_box_inferred_primary_name(document, comm):
     value = [
         {"user1": "Hello"},

--- a/panel/tests/widgets/test_chatbox.py
+++ b/panel/tests/widgets/test_chatbox.py
@@ -1,7 +1,7 @@
 from panel.depends import bind
 from panel.layout import Column
 from panel.pane import JPG
-from panel.widgets import FileInput, TextInput
+from panel.widgets import FileInput, Select, TextInput
 from panel.widgets.chatbox import ChatBox, ChatRow
 
 JPG_FILE = "https://assets.holoviz.org/panel/samples/jpg_sample.jpg"
@@ -237,9 +237,11 @@ def test_chat_box_export(document, comm):
         {"user1": "Hello"},
         {"user2": "Hi"},
         {"user1": TextInput(value="Some valueo!")},
+        {"user2": [TextInput(value="another val!"), Select(options=["A"], value="A")]},
+        {"user3": Column(TextInput(value="B"), TextInput(value="C"))},
     ]
     chat_box = ChatBox(value=value.copy(), primary_name="Panel User")
-    messages = chat_box.export()
+    messages = chat_box.export(serialize=True)
 
     assert messages == [
         {
@@ -253,6 +255,29 @@ def test_chat_box_export(document, comm):
         {
             "role": "user1",
             "content": "Some valueo!",
+        },
+        {
+            "role": "user2",
+            "content": "another val!\nA",
+        },
+        {
+            "role": "user3",
+            "content": "B\nC",
+        },
+    ]
+
+def test_chat_box_export_not_serialize(document, comm):
+    text_input = TextInput(value="Some valueo!")
+    value = [
+        {"user1": text_input},
+    ]
+    chat_box = ChatBox(value=value.copy(), primary_name="Panel User")
+    messages = chat_box.export(serialize=False)
+
+    assert messages == [
+        {
+            "role": "user1",
+            "content": text_input,
         },
     ]
 

--- a/panel/widgets/chatbox.py
+++ b/panel/widgets/chatbox.py
@@ -611,5 +611,16 @@ class ChatBox(CompositeWidget):
         """
         self.value = []
 
+    def export(self) -> List[Dict[str, Union[List[Any], Any]]]:
+        """
+        Exports the chat log into a list of dictionaries with
+        "role" and "content" as keys.
+        """
+        messages = []
+        for user_message in self.value:
+            user, message = self._separate_user_message(user_message)
+            messages.append({"role": user, "content": message})
+        return messages
+
     def __len__(self) -> int:
         return len(self.value)

--- a/panel/widgets/chatbox.py
+++ b/panel/widgets/chatbox.py
@@ -611,14 +611,22 @@ class ChatBox(CompositeWidget):
         """
         self.value = []
 
-    def export(self) -> List[Dict[str, Union[List[Any], Any]]]:
+    def export(self, serialize: bool = True) -> List[Dict[str, Union[List[Any], Any]]]:
         """
         Exports the chat log into a list of dictionaries with
         "role" and "content" as keys.
+
+        Arguments
+        ---------
+        serialize (bool): Whether to serialize the messages into a string.
         """
         messages = []
         for user_message in self.value:
             user, message = self._separate_user_message(user_message)
+            if hasattr(message, "value"):
+                message = message.value
+            elif hasattr(message, "object"):
+                message = message.object
             messages.append({"role": user, "content": message})
         return messages
 

--- a/panel/widgets/chatbox.py
+++ b/panel/widgets/chatbox.py
@@ -637,10 +637,10 @@ class ChatBox(CompositeWidget):
         return message
 
     def export(
-            self,
-            serialize: bool = True,
-            format: Union[ChatExportFormat, str] = ChatExportFormat.JSON
-        ) -> List[Union[Dict[str, Any], Tuple[str, Any]]]:
+        self,
+        serialize: bool = True,
+        format: Union[ChatExportFormat, str] = ChatExportFormat.JSON
+    ) -> List[Union[Dict[str, Any], Tuple[str, Any]]]:
         """
         Exports the chat log into a list of the specified field
 

--- a/panel/widgets/chatbox.py
+++ b/panel/widgets/chatbox.py
@@ -623,10 +623,11 @@ class ChatBox(CompositeWidget):
         messages = []
         for user_message in self.value:
             user, message = self._separate_user_message(user_message)
-            if hasattr(message, "value"):
-                message = message.value
-            elif hasattr(message, "object"):
-                message = message.object
+            if serialize:
+                if hasattr(message, "value"):
+                    message = message.value
+                elif hasattr(message, "object"):
+                    message = message.object
             messages.append({"role": user, "content": message})
         return messages
 

--- a/panel/widgets/chatbox.py
+++ b/panel/widgets/chatbox.py
@@ -28,6 +28,7 @@ class ChatExportFormat(Enum):
     """
 
     JSON = "json"
+    LEGACY = "legacy"
     TUPLE = "tuple"
     OPENAI = "openai"
 
@@ -647,7 +648,7 @@ class ChatBox(CompositeWidget):
         ---------
         serialize (bool): Whether to serialize the messages into a string.
         format (str | ChatExportFormat): The format to export the chat log in;
-            'json', 'tuple', or 'openai'.
+            'json', 'legacy', 'tuple', or 'openai'.
 
         Returns
         -------
@@ -662,6 +663,8 @@ class ChatBox(CompositeWidget):
                 format = ChatExportFormat(format.lower())
 
             if format == ChatExportFormat.JSON:
+                messages.append({"user": user, "value": message})
+            elif format == ChatExportFormat.LEGACY:
                 messages.append({user: message})
             elif format == ChatExportFormat.TUPLE:
                 messages.append((user, message))

--- a/panel/widgets/chatbox.py
+++ b/panel/widgets/chatbox.py
@@ -631,6 +631,10 @@ class ChatBox(CompositeWidget):
         Arguments
         ---------
         serialize (bool): Whether to serialize the messages into a string.
+
+        Returns
+        -------
+        messages (list): List of dictionaries with "role" and "content" as keys.
         """
         messages = []
         for user_message in self.value:

--- a/panel/widgets/chatbox.py
+++ b/panel/widgets/chatbox.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Iterable
 from typing import (
     Any, ClassVar, Dict, List, Optional, Tuple, Type, Union,
 )
@@ -611,6 +612,17 @@ class ChatBox(CompositeWidget):
         """
         self.value = []
 
+    def _serialize_message(self, message: Union[List[Any], Any]) -> str:
+        if isinstance(message, Iterable) and not isinstance(message, str):
+            return "\n".join(self._serialize_message(m) for m in message)
+
+        if hasattr(message, "value"):
+            message = message.value
+        elif hasattr(message, "object"):
+            message = message.object
+        message = str(message)
+        return message
+
     def export(self, serialize: bool = True) -> List[Dict[str, Union[List[Any], Any]]]:
         """
         Exports the chat log into a list of dictionaries with
@@ -624,10 +636,7 @@ class ChatBox(CompositeWidget):
         for user_message in self.value:
             user, message = self._separate_user_message(user_message)
             if serialize:
-                if hasattr(message, "value"):
-                    message = message.value
-                elif hasattr(message, "object"):
-                    message = message.object
+                message = self._serialize_message(message)
             messages.append({"role": user, "content": message})
         return messages
 


### PR DESCRIPTION
Partially addresses https://github.com/holoviz/panel/issues/5135

To convert into this format:
```
[
        {"role": "system", "content": "You are a helpful assistant."},
        {"role": "user", "content": "Who won the world series in 2020?"},
        {"role": "assistant", "content": "The Los Angeles Dodgers won the World Series in 2020."},
        {"role": "user", "content": "Where was it played?"}
    ]
```

However, I'm not sure what the best way to handle widgets / panes. 

@MarcSkovMadsen would love your thoughts on this