### PR TITLE
Improve notebook detection

### DIFF
--- a/panel/config.py
+++ b/panel/config.py
@@ -787,12 +787,9 @@ class panel_extension(_pyviz_extension):
             return
 
         # Try to detect environment so that we can enable comms
-        try:
-            import google.colab  # noqa
+        if "google.colab" in sys.modules:
             config.comms = "colab"
             return
-        except ImportError:
-            pass
 
         if "VSCODE_CWD" in os.environ or "VSCODE_PID" in os.environ:
             config.comms = "vscode"

--- a/panel/config.py
+++ b/panel/config.py
@@ -794,7 +794,7 @@ class panel_extension(_pyviz_extension):
         except ImportError:
             pass
 
-        if "VSCODE_PID" in os.environ:
+        if "VSCODE_CWD" in os.environ or "VSCODE_PID" in os.environ:
             config.comms = "vscode"
             self._ignore_bokeh_warnings()
             return


### PR DESCRIPTION
Fixes #5200

As far as I can see, `VSCODE_CWD` is always set in a VSCode Notebook. 