### PR TITLE
Add the `editable` attribute to `pn.pane.Perspective`

### DIFF
--- a/examples/reference/panes/Perspective.ipynb
+++ b/examples/reference/panes/Perspective.ipynb
@@ -18,7 +18,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/examples/reference/panes/Perspective.ipynb
+++ b/examples/reference/panes/Perspective.ipynb
@@ -18,6 +18,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -31,6 +32,7 @@
     "\n",
     "* **``aggregates``** (dict): Aggregation spec, e.g. {x: \"distinct count\"}\n",
     "* **``columns``** (list or dict): List of column names to display or a dictionery with column configuration options.\n",
+    "* **``editable``** (bool, default=True): Whether items are editable\n",
     "* **``expressions``** (list): List of expressions, e.g. `['\"x\"+\"y\"']`\n",
     "* **``filters``** (list): A list of filters, e.g. `[[\"x\", \"<\", 3], [\"y\", \"contains\", \"abc\"]]`.\n",
     "* **``group_by``** (list): List of columns to group by, e.g. `[\"x\", \"y\"]`\n",

--- a/panel/pane/perspective.py
+++ b/panel/pane/perspective.py
@@ -269,6 +269,9 @@ class Perspective(ModelPane, ReactiveData):
     columns = param.List(default=None, doc="""
         A list of source columns to show as columns. For example ["x", "y"]""")
 
+    editable = param.Boolean(default=True, allow_None=True, doc="""
+      Whether items are editable.""")
+
     expressions = param.List(default=None, doc="""
       A list of expressions computing new columns from existing columns.
       For example [""x"+"index""]""")


### PR DESCRIPTION
fixes #5192

This pull request adds the `editable` attribute to `pn.pane.Perspective`, which allows the user to indicate whether items are editable. Otherwise, users are unable to control this behavior for the `Perspective` pane.

![perspective](https://github.com/holoviz/panel/assets/13134143/49fa4e54-0f8b-4c52-a43f-9cd18170c823)
