### PR TITLE
Update python version to 3.9 in build

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,8 +20,8 @@ jobs:
         shell: bash -l {0}
     env:
       CHANS_DEV: "-c pyviz/label/dev -c bokeh/label/dev -c conda-forge"
-      PKG_TEST_PYTHON: "--test-python=py38"
-      PYTHON_VERSION: "3.8"
+      PKG_TEST_PYTHON: "--test-python=py39"
+      PYTHON_VERSION: "3.9"
       MPLBACKEND: "Agg"
     steps:
       - name: remove nodejs
@@ -37,7 +37,7 @@ jobs:
       - uses: conda-incubator/setup-miniconda@v2
         with:
           miniconda-version: "latest"
-          python-version: 3.8
+          python-version: 3.9
       - uses: actions/setup-node@v2
         with:
           node-version: '16'
@@ -93,8 +93,8 @@ jobs:
         shell: bash -l {0}
     env:
       CHANS_DEV: "-c pyviz/label/dev -c bokeh/label/dev -c conda-forge"
-      PKG_TEST_PYTHON: "--test-python=py38"
-      PYTHON_VERSION: "3.8"
+      PKG_TEST_PYTHON: "--test-python=py39"
+      PYTHON_VERSION: "3.9"
       CHANS: "-c pyviz"
       MPLBACKEND: "Agg"
       PYPI: "https://upload.pypi.org/legacy/"


### PR DESCRIPTION
Fixes (for future releases) https://discourse.holoviz.org/t/is-there-a-bokeh-3-2-wheel-to-use-with-panel-1-2-0-in-pyscript/5661

Because Bokeh 3.2 is only supported on Python>=3.9, the pyodide Bokeh wheel used version 3.1.1.

EDIT: I have done a manual upload of Bokeh 3.2 to CDN for Panel version 1.2: https://cdn.holoviz.org/panel/1.2.0/dist/wheels/bokeh-3.2.0-py3-none-any.whl

