### PR TITLE
Add disconnect warning to Notification

### DIFF
--- a/doc/how_to/callbacks/index.md
+++ b/doc/how_to/callbacks/index.md
@@ -54,6 +54,13 @@ How to schedule tasks that run independently of any user visiting an application
 How to safely modify Bokeh models to avoid running into issues with the Bokeh `Document` lock.
 :::
 
+:::{grid-item-card} {octicon}`link;2.5em;sd-mr-1 sd-animate-grow50` Connection Notifications
+:link: notifications
+:link-type: doc
+
+How to add notifications when the application is ready and when it loses the server connection.
+:::
+
 ::::
 
 ## Examples

--- a/doc/how_to/callbacks/notifications.md
+++ b/doc/how_to/callbacks/notifications.md
@@ -11,8 +11,8 @@ import panel as pn
 
 pn.extension(
     disconnect_notification='Connection lost, try reloading the page!',
-	ready_notification='Application fully loaded.',
-	template='bootstrap'
+    ready_notification='Application fully loaded.',
+    template='bootstrap'
 )
 
 slider = pn.widgets.IntSlider(name='Number', start=1, end=10, value=7)

--- a/doc/how_to/callbacks/notifications.md
+++ b/doc/how_to/callbacks/notifications.md
@@ -1,0 +1,26 @@
+# Add notifications on connect and disconnect
+
+This guide addresses how to add notifications when the server connection is established and when it disconnects.
+
+---
+
+Panel includes a notification system that is enabled by default. The notification system also allows registering notification messages when the server connection is ready and when the server connection is lost. These can be configured by setting the `disconnect_notification` and `ready_notification`.
+
+```python
+import panel as pn
+
+pn.extension(
+    disconnect_notification='Connection lost, try reloading the page!',
+	ready_notification='Application fully loaded.',
+	template='bootstrap'
+)
+
+slider = pn.widgets.IntSlider(name='Number', start=1, end=10, value=7)
+
+pn.Column(
+    slider,
+    pn.bind(lambda n: '⭐' * n, slider)
+).servable(title='Connection Notifications')
+```
+
+![Connection notifications](https://assets.holoviz.org/panel/gifs/connection_notifications.gif)

--- a/panel/config.py
+++ b/panel/config.py
@@ -131,6 +131,10 @@ class _config(_base_config):
     design = param.ClassSelector(class_=None, is_instance=False, doc="""
         The design system to use to style components.""")
 
+    disconnect_warning = param.String(doc="""
+        The warning notification to display to the user when the connection
+        to the server is dropped.""")
+
     exception_handler = param.Callable(default=None, doc="""
         General exception handler for events.""")
 
@@ -161,12 +165,16 @@ class _config(_base_config):
     loading_max_height = param.Integer(default=400, doc="""
         Maximum height of the loading indicator.""")
 
-    notifications = param.Boolean(default=False, doc="""
+    notifications = param.Boolean(default=True, doc="""
         Whether to enable notifications functionality.""")
 
     profiler = param.Selector(default=None, allow_None=True, objects=[
         'pyinstrument', 'snakeviz', 'memray'], doc="""
         The profiler engine to enable.""")
+
+    ready_message = param.String(doc="""
+        The notification to display when the application is ready and
+        fully loaded.""")
 
     reuse_sessions = param.Boolean(default=False, doc="""
         Whether to reuse a session for the initial request to speed up

--- a/panel/config.py
+++ b/panel/config.py
@@ -131,8 +131,8 @@ class _config(_base_config):
     design = param.ClassSelector(class_=None, is_instance=False, doc="""
         The design system to use to style components.""")
 
-    disconnect_warning = param.String(doc="""
-        The warning notification to display to the user when the connection
+    disconnect_notification = param.String(doc="""
+        The notification to display to the user when the connection
         to the server is dropped.""")
 
     exception_handler = param.Callable(default=None, doc="""
@@ -165,14 +165,14 @@ class _config(_base_config):
     loading_max_height = param.Integer(default=400, doc="""
         Maximum height of the loading indicator.""")
 
-    notifications = param.Boolean(default=True, doc="""
+    notifications = param.Boolean(default=False, doc="""
         Whether to enable notifications functionality.""")
 
     profiler = param.Selector(default=None, allow_None=True, objects=[
         'pyinstrument', 'snakeviz', 'memray'], doc="""
         The profiler engine to enable.""")
 
-    ready_message = param.String(doc="""
+    ready_notification = param.String(doc="""
         The notification to display when the application is ready and
         fully loaded.""")
 
@@ -647,7 +647,9 @@ class panel_extension(_pyviz_extension):
         newly_loaded = [arg for arg in args if arg not in panel_extension._loaded_extensions]
         if state.curdoc and state.curdoc not in state._extensions_:
             state._extensions_[state.curdoc] = []
-        if params.get('notifications') and 'notifications' not in args:
+        if params.get('ready_notification') or params.get('disconnect_notification'):
+            params['notifications'] = True
+        if params.get('notifications', config.notifications) and 'notifications' not in args:
             args += ('notifications',)
         for arg in args:
             if arg == 'notifications' and 'notifications' not in params:

--- a/panel/config.py
+++ b/panel/config.py
@@ -333,7 +333,7 @@ class _config(_base_config):
         state._thread_pool = ThreadPoolExecutor(max_workers=threads)
 
     @param.depends('notifications', watch=True)
-    def _enable_notifications(self):
+    def _setup_notifications(self):
         from .io.notifications import NotificationArea
         from .reactive import ReactiveHTMLMetaclass
         if self.notifications and 'notifications' not in ReactiveHTMLMetaclass._loaded_extensions:

--- a/panel/io/admin.py
+++ b/panel/io/admin.py
@@ -112,6 +112,11 @@ class _LogTabulator(Tabulator):
 
 
 # Set up logging
+session_filter = MultiSelect(name='Filter by session', options=[])
+message_filter = TextInput(name='Filter by message')
+level_filter = MultiSelect(name="Filter by level", options=["DEBUG", "INFO", "WARNING", "ERROR"])
+app_filter = TextInput(name='Filter by app')
+
 data = Data()
 log_data_handler = LogDataHandler(data)
 log_handler = logging.StreamHandler()
@@ -126,11 +131,6 @@ formatter = logging.Formatter('%(asctime)s %(levelname)s: %(name)s - %(message)s
 log_handler.setFormatter(formatter)
 log_terminal = _LogTabulator(sizing_mode='stretch_both', min_height=400)
 log_handler.setStream(log_terminal)
-
-session_filter = MultiSelect(name='Filter by session', options=[])
-message_filter = TextInput(name='Filter by message')
-level_filter = MultiSelect(name="Filter by level", options=["DEBUG", "INFO", "WARNING", "ERROR"])
-app_filter = TextInput(name='Filter by app')
 
 def _textinput_filter(df, pattern, column):
     if not pattern or df.empty:

--- a/panel/io/notifications.py
+++ b/panel/io/notifications.py
@@ -43,7 +43,7 @@ class Notification(param.Parameterized):
 
 class NotificationAreaBase(ReactiveHTML):
 
-    js_events = param.Dict(doc="""
+    js_events = param.Dict(default={}, doc="""
         A dictionary that configures notifications for specific Bokeh Document
         events, e.g.:
 
@@ -85,7 +85,7 @@ class NotificationAreaBase(ReactiveHTML):
         for event, notification in self.js_events.items():
             doc.js_on_event(event, CustomJS(code=f"""
             var config = {{
-              message: {notification['msg']!r},
+              message: {notification['message']!r},
               duration: {notification.get('duration', 0)},
               notification_type: {notification['type']!r},
               _destroyed: false

--- a/panel/io/state.py
+++ b/panel/io/state.py
@@ -995,7 +995,12 @@ class _state(param.Parameterized):
         from ..config import config
         if config.notifications and self.curdoc and self.curdoc.session_context and self.curdoc not in self._notifications:
             from .notifications import NotificationArea
-            self._notifications[self.curdoc] = notifications = NotificationArea()
+            js_events = {}
+            if config.ready_message:
+                js_events['document_ready'] = {'type': 'success', 'message': config.ready_message, 'duration': 3}
+            if config.disconnect_warning:
+                js_events['connection_lost'] = {'type': 'error', 'message': config.disconnect_warning}
+            self._notifications[self.curdoc] = notifications = NotificationArea(js_events=js_events)
             return notifications
         elif self.curdoc is None or self.curdoc.session_context is None:
             return self._notification

--- a/panel/io/state.py
+++ b/panel/io/state.py
@@ -996,10 +996,10 @@ class _state(param.Parameterized):
         if config.notifications and self.curdoc and self.curdoc.session_context and self.curdoc not in self._notifications:
             from .notifications import NotificationArea
             js_events = {}
-            if config.ready_message:
-                js_events['document_ready'] = {'type': 'success', 'message': config.ready_message, 'duration': 3}
-            if config.disconnect_warning:
-                js_events['connection_lost'] = {'type': 'error', 'message': config.disconnect_warning}
+            if config.ready_notification:
+                js_events['document_ready'] = {'type': 'success', 'message': config.ready_notification, 'duration': 3000}
+            if config.disconnect_notification:
+                js_events['connection_lost'] = {'type': 'error', 'message': config.disconnect_notification}
             self._notifications[self.curdoc] = notifications = NotificationArea(js_events=js_events)
             return notifications
         elif self.curdoc is None or self.curdoc.session_context is None:

--- a/panel/tests/test_server.py
+++ b/panel/tests/test_server.py
@@ -314,14 +314,16 @@ def test_server_session_info(port):
 
         doc = list(html._documents.keys())[0]
         session_context = param.Parameterized()
+        request = param.Parameterized()
+        request.arguments = {}
+        session_context.request = request
         session_context._document = doc
         session_context.id = sid
         doc._session_context = weakref.ref(session_context)
-        state.curdoc = doc
-        state._init_session(None)
-        assert state.session_info['live'] == 1
+        with set_curdoc(doc):
+            state._init_session(None)
+            assert state.session_info['live'] == 1
 
-    state.curdoc = None
     html._server_destroy(session_context)
     state._destroy_session(session_context)
     assert state.session_info['live'] == 0

--- a/panel/tests/ui/io/test_notifications.py
+++ b/panel/tests/ui/io/test_notifications.py
@@ -11,6 +11,7 @@ except ImportError:
 from panel.config import config
 from panel.io.server import serve
 from panel.io.state import state
+from panel.pane import Markdown
 from panel.template import BootstrapTemplate
 from panel.widgets import Button
 
@@ -54,3 +55,39 @@ def test_notifications_with_template(page, port):
     page.click('.bk-btn')
 
     expect(page.locator('.notyf__message')).to_have_text('MyError')
+
+
+def test_ready_notification(page, port):
+    def app():
+        config.ready_notification = 'Ready!'
+        return Markdown('Ready app')
+
+    serve(app, port=port, threaded=True, show=False)
+
+    time.sleep(0.2)
+
+    page.goto(f"http://localhost:{port}")
+
+    expect(page.locator('.notyf__message')).to_have_text('Ready!')
+
+
+def test_disconnect_notification(page, port):
+    def app():
+        config.disconnect_notification = 'Disconnected!'
+        button = Button(name='Stop server')
+        button.js_on_click(code="""
+        Bokeh.documents[0].event_manager.send_event({'event_name': 'connection_lost', 'publish': false})
+        """)
+        return button
+
+    serve(app, port=port, threaded=True, show=False)
+
+    time.sleep(0.2)
+
+    page.goto(f"http://localhost:{port}")
+
+    time.sleep(0.2)
+
+    page.click('.bk-btn')
+
+    expect(page.locator('.notyf__message')).to_have_text('Disconnected!')

--- a/panel/viewable.py
+++ b/panel/viewable.py
@@ -1035,7 +1035,7 @@ class Viewable(Renderable, Layoutable, ServableMixin):
         if location:
             self._add_location(doc, location, model)
         if config.notifications and doc is state.curdoc:
-            notification_model = state.notifications._get_model(doc, model)
+            notification_model = state.notifications.get_root(doc)
             notification_model.name = 'notifications'
             doc.add_root(notification_model)
         if config.browser_info and doc is state.curdoc:


### PR DESCRIPTION
This PR enables a warning via the notification area that informs the user when the Websocket connection is dropped. The warning is enabled by default when the `pn.config.notifications = True` and the warning message can be configured.

Fix for https://github.com/holoviz/panel/issues/5240

- [x] Add test
- [x] Add documentation