### PR TITLE
Fix Tabulator expanded row rendering

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -58,7 +58,7 @@ jobs:
       PYCTDEV_SELF_CHANNEL: "pyviz/label/dev"
       OMP_NUM_THREADS: 1
     steps:
-      - uses: holoviz-dev/holoviz_tasks/install@v0.1a14
+      - uses: holoviz-dev/holoviz_tasks/install@v0.1a15
         with:
           name: unit_test_suite
           python-version: ${{ matrix.python-version }}
@@ -124,7 +124,7 @@ jobs:
       # it as one of the sources.
       PYCTDEV_SELF_CHANNEL: "pyviz/label/dev"
     steps:
-      - uses: holoviz-dev/holoviz_tasks/install@v0.1a14
+      - uses: holoviz-dev/holoviz_tasks/install@v0.1a15
         with:
           name: ui_test_suite
           python-version: 3.9
@@ -133,7 +133,6 @@ jobs:
           cache: true
           nodejs: true
           playwright: true
-          conda-mamba: mamba
         id: install
       - name: doit develop_install
         if: steps.install.outputs.cache-hit != 'true'

--- a/panel/models/tabulator.ts
+++ b/panel/models/tabulator.ts
@@ -466,7 +466,6 @@ export class DataTabulatorView extends HTMLBoxView {
     this.tabulator.on("scrollVertical", debounce(() => {
       this.setStyles()
     }, 50, false))
-    this.tabulator.on("rowFormatter", (row: any) => this._render_row(row))
 
     // Sync state with model
     this.tabulator.on("rowSelectionChanged", (data: any, rows: any) => this.rowSelectionChanged(data, rows))
@@ -577,6 +576,7 @@ export class DataTabulatorView extends HTMLBoxView {
       paginationSize: this.model.page_size,
       paginationInitialPage: 1,
       groupBy: this.groupBy,
+      rowFormatter: (row: any) => this._render_row(row),
       frozenRows: (row: any) => {
 	return this.model.frozen_rows.length ? this.model.frozen_rows.includes(row._row.data._index) : false
       }


### PR DESCRIPTION
When rendering an expanded row and then scrolling until it is off-screen it will disappear and no event will cause the children inside the expanded row to be rendered once it is in view again. This is because we were registering the `rowFormatter` event rather than the `rowFormatter` callback.