### PR TITLE
fix broken link in Streamlit comparision

### DIFF
--- a/doc/explanation/comparisons/compare_streamlit.md
+++ b/doc/explanation/comparisons/compare_streamlit.md
@@ -25,4 +25,4 @@ We don't think Streamlit sucks as the ironic title of the video thumbnail sugges
 
 ## Code Examples
 
-If you want to compare examples with code, check out the [How to Migrate From Streamlit Guide](../../how_to/migrate/from_streamlit).
+If you want to compare examples with code, check out the [How to Migrate From Streamlit Guide](../../how_to/streamlit_migration/index.md).


### PR DESCRIPTION
The link here https://panel.holoviz.org/explanation/comparisons/compare_streamlit.html#code-examples is missing. 

![image](https://github.com/holoviz/panel/assets/42288570/58a86d7f-25f2-442c-ae70-2aa8cfd6fc16)

This fixes it