### PR TITLE
Optimize rendering of HTML based component

### DIFF
--- a/panel/models/html.ts
+++ b/panel/models/html.ts
@@ -42,6 +42,10 @@ export class HTMLView extends PanelMarkupView {
 
   connect_signals(): void {
     super.connect_signals()
+    this.connect(this.model.properties.text.change, () => {
+      const html = this.process_tex()
+      this.set_html(html)
+    })
     this.connect(this.model.properties.events.change, () => {
       this._remove_event_listeners()
       this._setup_event_listeners()
@@ -53,20 +57,31 @@ export class HTMLView extends PanelMarkupView {
     this.invalidate_layout()
   }
 
-  render(): void {
-    super.render()
-    this.shadow_el.appendChild(this.container)
-
-    if (this.provider.status == "failed" || this.provider.status == "loaded")
-      this._has_finished = true
-
-    const html = this.process_tex()
+  set_html(html: string | null): void {
     if (html) {
       this.container.innerHTML = html
       if (this.model.run_scripts)
 	runScripts(this.container)
       this._setup_event_listeners()
     }
+  }
+
+  render(): void {
+    super.render()
+    this.container.style.visibility = 'hidden';
+    this.shadow_el.appendChild(this.container)
+
+    if (this.provider.status == "failed" || this.provider.status == "loaded")
+      this._has_finished = true
+
+    const html = this.process_tex()
+    this.watch_stylesheets()
+    this.set_html(html)
+  }
+
+  style_redraw(): void {
+    if (this.model.visible)
+      this.container.style.visibility = 'visible';
   }
 
   process_tex(): string {

--- a/panel/models/json.ts
+++ b/panel/models/json.ts
@@ -9,8 +9,8 @@ export class JSONView extends PanelMarkupView {
 
   connect_signals(): void {
     super.connect_signals()
-    const {depth, hover_preview, theme} = this.model.properties
-    this.on_change([depth, hover_preview, theme], () => this.render())
+    const {depth, hover_preview, text, theme} = this.model.properties
+    this.on_change([depth, hover_preview, text, theme], () => this.render())
   }
 
   render(): void {

--- a/panel/models/katex.ts
+++ b/panel/models/katex.ts
@@ -7,10 +7,7 @@ export class KaTeXView extends PanelMarkupView {
 
   connect_signals(): void {
     super.connect_signals();
-    const { text } = p;
-    this.on_change([text], () => {
-      this.render();
-    });
+    this.connect(this.model.properties.text.change, () => this.render());
   }
 
   render(): void {

--- a/panel/models/katex.ts
+++ b/panel/models/katex.ts
@@ -5,6 +5,14 @@ import {PanelMarkupView} from "./layout"
 export class KaTeXView extends PanelMarkupView {
   model: KaTeX
 
+  connect_signals(): void {
+    super.connect_signals();
+    const { text } = p;
+    this.on_change([text], () => {
+      this.render();
+    });
+  }
+
   render(): void {
     super.render();
     this.container.innerHTML = this.model.text;

--- a/panel/models/layout.ts
+++ b/panel/models/layout.ts
@@ -8,6 +8,7 @@ import * as p from "@bokehjs/core/properties"
 export class PanelMarkupView extends WidgetView {
   container: HTMLDivElement
   model: Markup
+  _initialized_stylesheets: any
 
   override async lazy_initialize() {
     await super.lazy_initialize()
@@ -19,11 +20,24 @@ export class PanelMarkupView extends WidgetView {
       })
   }
 
-  override connect_signals(): void {
-    super.connect_signals()
-    this.connect(this.model.change, () => {
-      this.render()
-    })
+  watch_stylesheets(): void {
+    this._initialized_stylesheets = {}
+    for (const sts of this._applied_stylesheets) {
+      const style_el = (sts as any).el
+      if (style_el instanceof HTMLLinkElement) {
+	this._initialized_stylesheets[style_el.href] = false
+	style_el.addEventListener("load", () => {
+	  this._initialized_stylesheets[style_el.href] = true
+	  if (
+	    Object.values(this._initialized_stylesheets).every(Boolean)
+	  )
+	    this.style_redraw()
+	})
+      }
+    }
+  }
+
+  style_redraw(): void {
   }
 
   has_math_disabled() {

--- a/panel/models/mathjax.ts
+++ b/panel/models/mathjax.ts
@@ -7,10 +7,7 @@ export class MathJaxView extends PanelMarkupView {
 
   connect_signals(): void {
     super.connect_signals();
-    const { text, has_math_disabled } = p;
-    this.on_change([text, has_math_disabled], () => {
-      this.render();
-    });
+    this.connect(this.model.properties.text.change, () => this.render());
   }
 
   override render(): void {

--- a/panel/models/mathjax.ts
+++ b/panel/models/mathjax.ts
@@ -5,6 +5,14 @@ import {PanelMarkupView} from "./layout"
 export class MathJaxView extends PanelMarkupView {
   model: MathJax
 
+  connect_signals(): void {
+    super.connect_signals();
+    const { text, has_math_disabled } = p;
+    this.on_change([text, has_math_disabled], () => {
+      this.render();
+    });
+  }
+
   override render(): void {
     super.render()
     this.container.innerHTML = this.has_math_disabled() ? this.model.text : this.process_tex(this.model.text)

--- a/panel/widgets/indicators.py
+++ b/panel/widgets/indicators.py
@@ -303,6 +303,8 @@ class Number(ValueIndicator):
 
     def _process_param_change(self, msg):
         msg = super()._process_param_change(msg)
+        if not any(p in self._source_transforms or p == 'name' for p in msg):
+            return msg
         font_size = msg.pop('font_size', self.font_size)
         title_font_size = msg.pop('title_size', self.title_size)
         name = msg.pop('name', self.name)
@@ -357,6 +359,8 @@ class String(ValueIndicator):
 
     def _process_param_change(self, msg):
         msg = super()._process_param_change(msg)
+        if not any(p in self._source_transforms or p == 'name' for p in msg):
+            return msg
         font_size = msg.pop('font_size', self.font_size)
         title_font_size = msg.pop('title_size', self.title_size)
         name = msg.pop('name', self.name)


### PR DESCRIPTION
Avoids full re-render when it is not needed on Bokeh models that implement a View that is a subclass of `PanelMarkupView`.