### PR TITLE
Reset `config.defer_load` to its initial value in a unit test

### DIFF
--- a/panel/tests/test_config.py
+++ b/panel/tests/test_config.py
@@ -42,13 +42,17 @@ def test_session_override():
 
 @pytest.mark.usefixtures("with_curdoc")
 def test_defer_load():
-    config.defer_load = True
+    try:
+        defer_load_old = config.defer_load
+        config.defer_load = True
 
-    def test():
-        return 1
+        def test():
+            return 1
 
-    assert ParamFunction.applies(test)
-    assert isinstance(panel(test), ParamFunction)
+        assert ParamFunction.applies(test)
+        assert isinstance(panel(test), ParamFunction)
+    finally:
+        config.defer_load = defer_load_old
 
 def test_console_output_replace_stdout(document, comm, get_display_handle):
     pane = HTML()


### PR DESCRIPTION
https://github.com/holoviz/panel/pull/5244 made a change/fix to `pn.config` that consists of calling the watchers of a config Parameter when its value is set in a curdoc context. I think that exposed a bug in the test suite where a unit test was setting `config.defer_load` to `True` without resetting it to `False`. There's indeed a global callback that updates `ParamMethod` when `config.defer_load` changes, which wasn't triggered before https://github.com/holoviz/panel/pull/5244, but is now triggered and made `test_get_param_function_pane_type` fail:

https://github.com/holoviz/panel/blob/bc627168526b2972cbc5159fe1d68268826efa6d/panel/param.py#L946-L948

This should fix the test suite that is currently failing.