### PR TITLE
Remove markdown-it-py pin in JupyterLite example

### DIFF
--- a/lite/files/Getting_Started.ipynb
+++ b/lite/files/Getting_Started.ipynb
@@ -16,7 +16,7 @@
    "outputs": [],
    "source": [
     "import piplite\n",
-    "await piplite.install(['panel', 'pyodide-http', 'altair', 'markdown-it-py<3'])"
+    "await piplite.install(['panel', 'pyodide-http', 'altair'])"
    ]
   },
   {


### PR DESCRIPTION
Fixes errors in JupyterLite UI tests causing errors due to old and unnecessary `markdown-it-py` pin.