### PR TITLE
Add AI Chat Interface

### DIFF
--- a/panel/widgets/__init__.py
+++ b/panel/widgets/__init__.py
@@ -34,7 +34,7 @@ https://panel.holoviz.org/getting_started/index.html
 """
 from .base import CompositeWidget, Widget  # noqa
 from .button import Button, MenuButton, Toggle  # noqa
-from .chatbox import ChatBox  # noqa
+from .chatbox import AIChatInterface, ChatBox  # noqa
 from .codeeditor import Ace, CodeEditor  # noqa
 from .debugger import Debugger  # noqa
 from .file_selector import FileSelector  # noqa

--- a/panel/widgets/chatbox.py
+++ b/panel/widgets/chatbox.py
@@ -628,9 +628,9 @@ class ChatBox(CompositeWidget):
 class AIChatInterface(CompositeWidget):
 
     input_callback = param.Callable(doc="""
-        Callback to execute when the user presses Enter in the input
-        widget. The callback should accept a single argument, the
-        message input widget.""")
+        Callback to execute when the user submits a new message.
+        The callback should accept two arguments, the `message`
+        and the instance of AI Chat `interface` widget.""")
 
     ai_name = param.String(default="AI", doc="""
         Name of the AI user.""")


### PR DESCRIPTION
Addresses https://github.com/holoviz/panel/issues/5277 and alternative of https://github.com/holoviz/panel/pull/5279

This PR simplifies what I had in the [Discourse Showcase](https://discourse.holoviz.org/t/openai-conversation-using-chatbox/5548/3?u=ahuang11) and also, generalizes it so it's not tied to OpenAI.

1. Like the showcase, it uses composition, rather than inheritance, of the ChatBox (thanks Marc for the name).
2. It accepts an `input_callback` object that requires `message: str` and `interface: AIChatInterface` args; the user can use this to process the new message any way they like.
3. Users can utilize the convenience method, `stream`, in their callback to stream the output in chunks (I'd like to know how [TextFragment](https://github.com/holoviz/panel/pull/5279#issuecomment-1642631070) would work / optimize this)
4. Upon new `ChatBox` values, it creates a loading placeholder (As I'm writing this, an edge case is if the user doesn't use 
stream, this doesn't get replaced; I'm thinking maybe I should drop this feature?).

This supports both async / sync callbacks, (but I think there might be a better way than to use `inspect.isawaitable`; not sure how pn.bind does it).

No dependency echo example:
```python
import time
import panel as pn
pn.extension()

def echo_callback(message: str, interface: pn.widgets.AIChatInterface):
    time.sleep(0.75)
    for character in message:
        time.sleep(0.05)
        interface.stream(character)

interface = pn.widgets.AIChatInterface(input_callback=echo_callback)
interface.servable()
```
https://github.com/holoviz/panel/assets/15331990/df339e48-4320-449d-94dc-e37b4b6b956c

OpenAI example:
```python
import panel as pn
import openai
pn.extension()

async def openai_callback(message: str, interface: pn.widgets.AIChatInterface):
    response = await openai.ChatCompletion.acreate(
        model="gpt-3.5-turbo",
        messages=[{"role": "user", "content": message}],
        temperature=0.9,
        max_tokens=100,
        stream=True
    )
    async for chunk in response:
        interface.stream(chunk["choices"][0]["delta"]["content"])

interface = pn.widgets.AIChatInterface(input_callback=openai_callback)
interface.servable()
```
https://github.com/holoviz/panel/assets/15331990/b80eb9c3-d908-42c4-a4b9-f0b3158a503e

My upcoming vision for this is:
1. Create an interface for OpenAI + Langchain on top of AIChatInterface with specifics to each (temperature, openai_key, model, etc).
2. Improve composability; specifically, expose and migrate the ChatRow as a pane(?) and create a ChatMessage dataclass(?) / param.Parametrized class containing metadata about the message (name, icon, value, timestamp, liked).
3. Rewrite ChatRow as ReactiveHTML since currently, it's a nested Column/Row/Column.
4. Not sure how hard this is, but create a general TextFileInput widget that allows users to either type, paste, or upload files.
<img width="748" alt="image" src="https://github.com/holoviz/panel/assets/15331990/12c46f66-aaf1-453b-91f2-2d687995a0ee">

