### PR TITLE
Add response callback to ChatBox

### DIFF
--- a/panel/widgets/__init__.py
+++ b/panel/widgets/__init__.py
@@ -34,7 +34,7 @@ https://panel.holoviz.org/getting_started/index.html
 """
 from .base import CompositeWidget, Widget  # noqa
 from .button import Button, MenuButton, Toggle  # noqa
-from .chatbox import ChatBox  # noqa
+from .chatbox import AIChatInterface, ChatBox  # noqa
 from .codeeditor import Ace, CodeEditor  # noqa
 from .debugger import Debugger  # noqa
 from .file_selector import FileSelector  # noqa

--- a/panel/widgets/__init__.py
+++ b/panel/widgets/__init__.py
@@ -34,7 +34,7 @@ https://panel.holoviz.org/getting_started/index.html
 """
 from .base import CompositeWidget, Widget  # noqa
 from .button import Button, MenuButton, Toggle  # noqa
-from .chatbox import AIChatInterface, ChatBox  # noqa
+from .chatbox import ChatBox  # noqa
 from .codeeditor import Ace, CodeEditor  # noqa
 from .debugger import Debugger  # noqa
 from .file_selector import FileSelector  # noqa

--- a/panel/widgets/chatbox.py
+++ b/panel/widgets/chatbox.py
@@ -15,9 +15,10 @@ from ..layout import (
 from ..pane.base import PaneBase, panel as _panel
 from ..pane.image import Image
 from ..pane.markup import Markdown
-from ..viewable import Layoutable, Viewable
+from ..viewable import Layoutable, Renderable, Viewable
 from .base import CompositeWidget
 from .button import Button, Toggle
+from .indicators import LoadingSpinner
 from .input import StaticText, TextInput
 
 
@@ -110,6 +111,8 @@ class ChatRow(CompositeWidget):
             align="center",
             margin=8,
             styles=bubble_styles,
+            min_height=48,
+            min_width=48,
         )
 
         # create heart icon next to chat
@@ -229,6 +232,10 @@ class ChatBox(CompositeWidget):
         Callback function to call when the user enters a message.
         The callback should accept two arguments, the `message`
         and the instance of the `chat_box` widget.""")
+
+    response_placeholder = param.ClassSelector(
+        default=None, class_=(Renderable, str), doc="""
+        Placeholder to display while the response is generating.""")
 
     response_name = param.String(default="AI", doc="""
         Name of the user who responds to the primary user.""")
@@ -564,7 +571,11 @@ class ChatBox(CompositeWidget):
         user, message = self._separate_user_message(last_user_message)
         if self.response_name == user:
             return
-        self.append({self.response_name: ""})
+        if self.response_placeholder is None:
+            self.response_placeholder = LoadingSpinner(
+                value=True, width=17, height=17
+            )
+        self.append({self.response_name: self.response_placeholder})
         result = self.response_callback(message, self)
         if iscoroutinefunction(self.response_callback):
             async for update in result:

--- a/panel/widgets/chatbox.py
+++ b/panel/widgets/chatbox.py
@@ -628,9 +628,9 @@ class ChatBox(CompositeWidget):
 class AIChatInterface(CompositeWidget):
 
     input_callback = param.Callable(doc="""
-        Callback to execute when the user presses Enter in the input
-        widget. The callback should accept a single argument, the
-        message input widget.""")
+        Callback to execute when the user submits a new message.
+        The callback should accept two arguments, the `message`
+        and the instance of AI Chat `interface` widget.""")
 
     ai_name = param.String(default="AI", doc="""
         Name of the AI user.""")

--- a/panel/widgets/chatbox.py
+++ b/panel/widgets/chatbox.py
@@ -316,7 +316,7 @@ class ChatBox(CompositeWidget):
         default=None, class_=(Renderable, str), doc="""
         Placeholder to display while the response is generating.""")
 
-    response_name = param.String(default="AI", doc="""
+    response_name = param.String(default="Assistant", doc="""
         Name of the user who responds to the primary user.""")
 
     allow_input = param.Boolean(default=True, doc="""
@@ -419,8 +419,7 @@ class ChatBox(CompositeWidget):
 
         # add interactivity
         self.param.watch(self._refresh_log, "value")
-        if self.response_callback:
-            self.param.watch(self._on_input, "value", queued=True)
+        self.param.watch(self._on_input, "value")
 
         # populate with initial value
         self.param.trigger("value")
@@ -655,18 +654,21 @@ class ChatBox(CompositeWidget):
         Callback to execute when the user presses Enter in the input
         widget.
         """
-        if not self.value:
+        if not self.value or not self.response_callback:
             return
+
         chat_row = self._chat_log.objects[-1]
         user = chat_row.name
-        if self.response_name == user:
+        if user == self.response_name or user == "":
             return
+
         components = chat_row.components
         if self.response_placeholder is None:
             self.response_placeholder = LoadingSpinner(
                 value=True, width=17, height=17
             )
-        self.append({self.response_name: self.response_placeholder})
+        self.append({"": self.response_placeholder})
+
         contents = []
         for component in components:
             if hasattr(component, "object"):


### PR DESCRIPTION
Instead of having a separate Interface, like [here](https://github.com/holoviz/panel/pull/5313), this supports general callbacks and is more customizable with yields.

![image](https://github.com/holoviz/panel/assets/15331990/ca22c9d9-15b2-4784-ac23-9b552912e0e1)

```python
import time
import panel as pn
pn.extension()

async def echo_callback(message: str, interface: pn.widgets.ChatBox):
    yield pn.indicators.LoadingSpinner(value=True, width=17, height=17)
    
    time.sleep(0.75)
    message_echo = ""
    for character in message:
        time.sleep(0.05)
        message_echo += character
        yield message_echo

interface = pn.widgets.ChatBox(response_callback=echo_callback)
interface.servable()
```

```python
import asyncio
import random
import panel as pn
import openai
pn.extension()

async def openai_callback(message: str, chat_box: pn.widgets.ChatBox):
    yield pn.indicators.LoadingSpinner(value=True, width=17, height=17)

    response = openai.ChatCompletion.create(
        model="gpt-3.5-turbo",
        messages=[{"role": "user", "content": message}],
        temperature=0.9,
        max_tokens=100,
        stream=True
    )
    message = ""
    for chunk in response:
        message += chunk["choices"][0]["delta"].get("content", "")
        yield message

interface = pn.widgets.ChatBox(response_callback=openai_callback)
interface.servable()
```


https://user-images.githubusercontent.com/15331990/255759560-12c46f66-aaf1-453b-91f2-2d687995a0ee.png
