### PR TITLE
Fix race condition in periodic callback resulting in additional callback executions

### DIFF
--- a/panel/io/callbacks.py
+++ b/panel/io/callbacks.py
@@ -82,7 +82,11 @@ class PeriodicCallback(param.Parameterized):
         from .state import set_curdoc
         try:
             with set_curdoc(self._doc):
-                cb = self.callback()
+                if self.running:
+                    self.counter += 1
+                    if self.counter > self.count:
+                        self.stop()
+                cb = self.callback() if self.running else None
         except Exception:
             cb = None
         if post:
@@ -98,7 +102,6 @@ class PeriodicCallback(param.Parameterized):
         if not self._background:
             with edit_readonly(state):
                 state._busy_counter -= 1
-        self.counter += 1
         if self.timeout is not None:
             dt = (time.time() - self._start_time) * 1000
             if dt > self.timeout:


### PR DESCRIPTION
So I am not convinced I properly ran all of the tests locally, but here is a fix that seems to be working as expected. If there is a clearer path to victory then please let me know. Fixes #5339

Not only did the location of the increment need to change, but checking the counter against the count and signaling a stop also needed to happen *before* the callback is executed to prevent executions from being scheduled. This now appears to work as expected for any number of threads.

The logic works as follows:

1. first we check if the periodic is running; this needs to happen to prevent the counter from being incremented after a stop has already been signaled (otherwise, subsequent adds of the periodic do not start at 0). This is important for the case were the count is specified as some number greater than the number of threads allocated.
2. increment the counter
3. check if we need to stop
4. execute the callback if the periodic is still running

A side effect of this is that during execution of the callback, the counter has already been incremented.