### PR TITLE
Param 2 compatibility to get/set the watchers of an instance

### DIFF
--- a/panel/config.py
+++ b/panel/config.py
@@ -27,6 +27,7 @@ from pyviz_comms import (
 
 from .io.logging import panel_log_handler
 from .io.state import state
+from .util import param_watchers
 
 __version__ = str(param.version.Version(
     fpath=__file__, archive_commit="$Format:%h$", reponame="panel"))
@@ -385,7 +386,7 @@ class _config(_base_config):
             if state.curdoc not in self._session_config:
                 self._session_config[state.curdoc] = {}
             self._session_config[state.curdoc][attr] = value
-            watchers = self._param_watchers.get(attr, {}).get('value', [])
+            watchers = param_watchers(self).get(attr, {}).get('value', [])
             for w in watchers:
                 w.fn()
         elif f'_{attr}' in self.param and hasattr(self, f'_{attr}_'):

--- a/panel/io/document.py
+++ b/panel/io/document.py
@@ -23,6 +23,7 @@ from bokeh.document.events import (
 from bokeh.models import CustomJS
 
 from ..config import config
+from ..util import param_watchers
 from .loading import LOADING_INDICATOR_CSS_CLASS
 from .model import monkeypatch_events
 from .state import curdoc_locked, state
@@ -90,10 +91,10 @@ def _cleanup_doc(doc, destroy=True):
                 pane._hooks = []
                 for p in pane.select():
                     p._hooks = []
-                    p._param_watchers = {}
+                    param_watchers(p, {})
                     p._documents = {}
                     p._internal_callbacks = {}
-            pane._param_watchers = {}
+            param_watchers(pane, {})
             pane._documents = {}
             pane._internal_callbacks = {}
         else:

--- a/panel/io/embed.py
+++ b/panel/io/embed.py
@@ -16,6 +16,7 @@ from bokeh.core.property.bases import Property
 from bokeh.models import CustomJS
 from param.parameterized import Watcher
 
+from ..util import param_watchers
 from .model import add_to_doc, diff
 from .state import state
 
@@ -81,7 +82,7 @@ def save_dict(state, key=(), depth=0, max_depth=None, save_path='', load_path=No
 
 
 def get_watchers(reactive):
-    return [w for pwatchers in reactive._param_watchers.values()
+    return [w for pwatchers in param_watchers(reactive).values()
             for awatchers in pwatchers.values() for w in awatchers]
 
 
@@ -157,7 +158,7 @@ def links_to_jslinks(model, widget):
 
         mappings = []
         for pname, tgt_spec in link.links.items():
-            if Watcher(*link[:-4]) in widget._param_watchers[pname]['value']:
+            if Watcher(*link[:-4]) in param_watchers(widget)[pname]['value']:
                 mappings.append((pname, tgt_spec))
 
         if mappings:

--- a/panel/layout/base.py
+++ b/panel/layout/base.py
@@ -19,7 +19,7 @@ from ..io.resources import CDN_DIST
 from ..io.state import state
 from ..models import Column as PnColumn
 from ..reactive import Reactive
-from ..util import param_name, param_reprs
+from ..util import param_name, param_reprs, param_watchers
 
 if TYPE_CHECKING:
     from bokeh.document import Document
@@ -531,7 +531,7 @@ class NamedListLike(param.Parameterized):
         self.param.watch(self._update_names, 'objects')
         # ALERT: Ensure that name update happens first, should be
         #        replaced by watch precedence support in param
-        self._param_watchers['objects']['value'].reverse()
+        param_watchers(self)['objects']['value'].reverse()
 
     def _to_object_and_name(self, item):
         from ..pane import panel

--- a/panel/pane/base.py
+++ b/panel/pane/base.py
@@ -29,7 +29,7 @@ from ..layout.base import (
 from ..links import Link
 from ..models import ReactiveHTML as _BkReactiveHTML
 from ..reactive import Reactive
-from ..util import param_reprs
+from ..util import param_reprs, param_watchers
 from ..util.checks import is_dataframe, is_series
 from ..viewable import (
     Layoutable, ServableMixin, Viewable, Viewer,
@@ -658,7 +658,7 @@ class ReplacementPane(PaneBase):
         custom_watchers = []
         if isinstance(object, Reactive):
             watchers = [
-                w for pwatchers in object._param_watchers.values()
+                w for pwatchers in param_watchers(object).values()
                 for awatchers in pwatchers.values() for w in awatchers
             ]
             custom_watchers = [

--- a/panel/tests/pane/test_base.py
+++ b/panel/tests/pane/test_base.py
@@ -14,6 +14,7 @@ from panel.pane import (
 )
 from panel.param import Param, ParamMethod
 from panel.tests.util import check_layoutable_properties
+from panel.util import param_watchers
 
 SKIP_PANES = (
     Bokeh, HoloViews, Interactive, IPyWidget, Param, ParamMethod, RGGPlot,
@@ -85,7 +86,7 @@ def test_pane_untracked_watchers(pane, document, comm):
     except ImportError:
         pytest.skip("Dependent library could not be imported.")
     watchers = [
-        w for pwatchers in p._param_watchers.values()
+        w for pwatchers in param_watchers(p).values()
         for awatchers in pwatchers.values() for w in awatchers
     ]
     assert len([wfn for wfn in watchers if wfn not in p._internal_callbacks and not hasattr(wfn.fn, '_watcher_name')]) == 0

--- a/panel/tests/widgets/test_base.py
+++ b/panel/tests/widgets/test_base.py
@@ -5,6 +5,7 @@ from panel.io import block_comm
 from panel.layout import Row
 from panel.links import CallbackGenerator
 from panel.tests.util import check_layoutable_properties
+from panel.util import param_watchers
 from panel.widgets import (
     Ace, CompositeWidget, Dial, FileDownload, FloatSlider, LinearGauge,
     LoadingSpinner, Terminal, TextInput, ToggleGroup, Tqdm, Widget,
@@ -35,7 +36,7 @@ def test_widget_untracked_watchers(widget, document, comm):
     except ImportError:
         pytest.skip("Dependent library could not be imported.")
     watchers = [
-        w for pwatchers in widg._param_watchers.values()
+        w for pwatchers in param_watchers(widg).values()
         for awatchers in pwatchers.values() for w in awatchers
     ]
     assert len([wfn for wfn in watchers if wfn not in widg._internal_callbacks and not hasattr(wfn.fn, '_watcher_name')]) == 0

--- a/panel/util/__init__.py
+++ b/panel/util/__init__.py
@@ -457,3 +457,17 @@ def relative_to(path, other_path):
         return True
     except Exception:
         return False
+
+_unset = object()
+
+def param_watchers(parameterized, value=_unset):
+    if Version(param.__version__) <= Version('2.0.0a2'):
+        if value is not _unset:
+            parameterized._param_watchers = value
+        else:
+            return parameterized._param_watchers
+    else:
+        if value is not _unset:
+            parameterized.param.watchers = value
+        else:
+            return parameterized.param.watchers


### PR DESCRIPTION
Accessing `._param_watchers` in the next release of Param will emit a warning, instead now the watchers can be get/set from `.param.watchers`.