### PR TITLE
Fix undefined scroll arrow by waiting for frame and rename arrow to button

### DIFF
--- a/panel/models/column.ts
+++ b/panel/models/column.ts
@@ -4,7 +4,7 @@ import * as p from "@bokehjs/core/properties";
 
 export class ColumnView extends BkColumnView {
   model: Column;
-  scroll_down_arrow_el: HTMLElement;
+  scroll_down_button_el: HTMLElement;
 
   connect_signals(): void {
     super.connect_signals();
@@ -39,7 +39,7 @@ export class ColumnView extends BkColumnView {
     const threshold = this.model.scroll_button_threshold
     const exceeds_threshold = this.distance_from_latest >= threshold
     requestAnimationFrame(() => {
-      this.scroll_down_arrow_el.classList.toggle(
+      this.scroll_down_button_el.classList.toggle(
         "visible", threshold !== 0 && exceeds_threshold
       )
     });
@@ -54,13 +54,13 @@ export class ColumnView extends BkColumnView {
     this._apply_visible()
 
     this.class_list.add(...this.css_classes())
-    this.scroll_down_arrow_el = DOM.createElement('div', { class: 'scroll-button' });
-    this.shadow_el.appendChild(this.scroll_down_arrow_el);
+    this.scroll_down_button_el = DOM.createElement('div', { class: 'scroll-button' });
+    this.shadow_el.appendChild(this.scroll_down_button_el);
 
     this.el.addEventListener("scroll", () => {
       this.toggle_scroll_button();
     });
-    this.scroll_down_arrow_el.addEventListener("click", () => {
+    this.scroll_down_button_el.addEventListener("click", () => {
       this.scroll_to_latest();
     });
 

--- a/panel/models/column.ts
+++ b/panel/models/column.ts
@@ -12,7 +12,7 @@ export class ColumnView extends BkColumnView {
     const { children, scroll_button_threshold } = this.model.properties;
 
     this.on_change(children, () => this.trigger_auto_scroll());
-    this.on_change(scroll_button_threshold, () => this.toggle_scroll_arrow())
+    this.on_change(scroll_button_threshold, () => this.toggle_scroll_button())
   }
 
   get distance_from_latest(): number {
@@ -35,12 +35,14 @@ export class ColumnView extends BkColumnView {
     this.scroll_to_latest()
   }
 
-  toggle_scroll_arrow(): void {
+  toggle_scroll_button(): void {
     const threshold = this.model.scroll_button_threshold
     const exceeds_threshold = this.distance_from_latest >= threshold
-    this.scroll_down_arrow_el.classList.toggle(
-      "visible", threshold !== 0 && exceeds_threshold
-    )
+    requestAnimationFrame(() => {
+      this.scroll_down_arrow_el.classList.toggle(
+        "visible", threshold !== 0 && exceeds_threshold
+      )
+    });
   }
 
   render(): void {
@@ -56,7 +58,7 @@ export class ColumnView extends BkColumnView {
     this.shadow_el.appendChild(this.scroll_down_arrow_el);
 
     this.el.addEventListener("scroll", () => {
-      this.toggle_scroll_arrow();
+      this.toggle_scroll_button();
     });
     this.scroll_down_arrow_el.addEventListener("click", () => {
       this.scroll_to_latest();
@@ -75,7 +77,7 @@ export class ColumnView extends BkColumnView {
       if (this.model.view_latest) {
         this.scroll_to_latest();
       }
-      this.toggle_scroll_arrow();
+      this.toggle_scroll_button();
     });
   }
 }


### PR DESCRIPTION
Fixes:
```
Uncaught TypeError: Cannot read properties of undefined (reading 'classList')
    at n.toggle_scroll_arrow
```

Also renames toggle_scroll_arrow to toggle_scroll_button