### PR TITLE
Patch Cannot read properties of undefined for Column

### DIFF
--- a/panel/models/column.ts
+++ b/panel/models/column.ts
@@ -38,11 +38,11 @@ export class ColumnView extends BkColumnView {
   toggle_scroll_button(): void {
     const threshold = this.model.scroll_button_threshold
     const exceeds_threshold = this.distance_from_latest >= threshold
-    requestAnimationFrame(() => {
+    if (this.scroll_down_button_el) {
       this.scroll_down_button_el.classList.toggle(
         "visible", threshold !== 0 && exceeds_threshold
       )
-    });
+    };
   }
 
   render(): void {


### PR DESCRIPTION
Actually fixes #5365

Previously:
Cannot read properties of undefined (reading 'classList')
<img width="343" alt="image" src="https://github.com/holoviz/panel/assets/15331990/a0d83a0d-1717-49f1-b782-f5a22fc8fb7e">

After:
<img width="327" alt="image" src="https://github.com/holoviz/panel/assets/15331990/ce7d87d6-e250-4a20-92be-cda5b2f1e249">

Scroll arrow still works:
<img width="1228" alt="image" src="https://github.com/holoviz/panel/assets/15331990/ec8c010e-20d7-4c6d-ba97-55475f95cc60">
