### PR TITLE
Fixes displaying single newlines in output markdown and add `renderer_options`

### DIFF
--- a/examples/reference/panes/Markdown.ipynb
+++ b/examples/reference/panes/Markdown.ipynb
@@ -29,6 +29,8 @@
     "* **``object``** (str or object): A string containing Markdown, or an object with a ``_repr_markdown_`` method.\n",
     "* **``plugins``** (function): A list of additional markdown-it-py plugins to apply.\n",
     "* **``renderer``** (literal: `'markdown-it'`, `'markdown'`, `'myst'`): Markdown renderer implementation.\n",
+    "* \n",
+    "* **`renderer_options`** (dict): Options to pass to the markdown renderer.\n",
     "\n",
     "___"
    ]

--- a/panel/pane/markup.py
+++ b/panel/pane/markup.py
@@ -418,6 +418,7 @@ class Markdown(HTMLBasePane):
             )
         else:
             html = self._get_parser(self.renderer, tuple(self.plugins)).render(obj)
+        html = html.replace("\n", "<br>")
         return dict(object=escape(html))
 
     def _process_param_change(self, params):

--- a/panel/pane/markup.py
+++ b/panel/pane/markup.py
@@ -338,7 +338,7 @@ class Markdown(HTMLBasePane):
 
     _rename: ClassVar[Mapping[str, str | None]] = {
         'dedent': None, 'disable_math': None, 'extensions': None,
-        'plugins': None, 'renderer': None
+        'plugins': None, 'renderer': None, 'renderer_options': None
     }
 
     _rerender_params: ClassVar[List[str]] = [
@@ -364,9 +364,11 @@ class Markdown(HTMLBasePane):
 
     @classmethod
     @functools.lru_cache(maxsize=None)
-    def _get_parser(cls, renderer, renderer_options, plugins):
+    def _get_parser(cls, renderer, plugins, **renderer_options):
         if renderer == 'markdown':
             return None
+        if "breaks" not in renderer_options:
+            renderer_options["breaks"] = True
         from markdown_it import MarkdownIt
         from markdown_it.renderer import RendererHTML
         from mdit_py_plugins.anchors import anchors_plugin
@@ -429,7 +431,7 @@ class Markdown(HTMLBasePane):
             )
         else:
             html = self._get_parser(
-                self.renderer, self.renderer_options, tuple(self.plugins)
+                self.renderer, tuple(self.plugins), **self.renderer_options
             ).render(obj)
         return dict(object=escape(html))
 

--- a/panel/tests/pane/test_markup.py
+++ b/panel/tests/pane/test_markup.py
@@ -74,7 +74,8 @@ def test_markdown_pane_dedent(document, comm):
     assert model.text.startswith('&lt;pre&gt;&lt;code&gt;ABC')
 
 def test_markdown_pane_newline(document, comm):
-    pane = Markdown("Hello\nWorld\nI'm here!")
+    pane = Markdown("Hello\nWorld\nI'm here!",
+                    renderer="markdown-it", renderer_options={"breaks": True})
 
     # Create pane
     model = pane.get_root(document, comm=comm)

--- a/panel/tests/pane/test_markup.py
+++ b/panel/tests/pane/test_markup.py
@@ -74,20 +74,33 @@ def test_markdown_pane_dedent(document, comm):
     assert model.text.startswith('&lt;pre&gt;&lt;code&gt;ABC')
 
 def test_markdown_pane_newline(document, comm):
-    pane = Markdown("Hello\nWorld\nI'm here!",
-                    renderer="markdown-it", renderer_options={"breaks": True})
-
-    # Create pane
+    # Newlines should be separated by a br
+    pane = Markdown(
+        "Hello\nWorld\nI'm here!",
+        renderer="markdown-it",
+    )
     model = pane.get_root(document, comm=comm)
     assert pane._models[model.ref['id']][0] is model
     # <p>Hello<br>World<br>I'm here!</p>
-    assert model.text == "&lt;p&gt;Hello&lt;br&gt;World&lt;br&gt;I&#x27;m here!&lt;/p&gt;\n"
+    assert model.text == "&lt;p&gt;Hello&lt;br /&gt;\nWorld&lt;br /&gt;\nI&#x27;m here!&lt;/p&gt;\n"
 
+    # Two newlines should be separated by a div
     pane = Markdown("Hello\n\nWorld")
     model = pane.get_root(document, comm=comm)
     assert pane._models[model.ref['id']][0] is model
     # <p>Hello</p><p>World</p>
     assert model.text == "&lt;p&gt;Hello&lt;/p&gt;\n&lt;p&gt;World&lt;/p&gt;\n"
+
+    # Disable newlines
+    pane = Markdown(
+        "Hello\nWorld\nI'm here!",
+        renderer="markdown-it",
+        renderer_options={"breaks": False},
+    )
+    model = pane.get_root(document, comm=comm)
+    assert pane._models[model.ref['id']][0] is model
+    assert model.text == "&lt;p&gt;Hello\nWorld\nI&#x27;m here!&lt;/p&gt;\n"
+
 
 def test_markdown_pane_markdown_it_renderer(document, comm):
     pane = Markdown("""

--- a/panel/tests/pane/test_markup.py
+++ b/panel/tests/pane/test_markup.py
@@ -73,6 +73,21 @@ def test_markdown_pane_dedent(document, comm):
     pane.dedent = False
     assert model.text.startswith('&lt;pre&gt;&lt;code&gt;ABC')
 
+def test_markdown_pane_newline(document, comm):
+    pane = Markdown("Hello\nWorld\nI'm here!")
+
+    # Create pane
+    model = pane.get_root(document, comm=comm)
+    assert pane._models[model.ref['id']][0] is model
+    # <p>Hello<br>World<br>I'm here!</p>
+    assert model.text == "&lt;p&gt;Hello&lt;br&gt;World&lt;br&gt;I&#x27;m here!&lt;/p&gt;\n"
+
+    pane = Markdown("Hello\n\nWorld")
+    model = pane.get_root(document, comm=comm)
+    assert pane._models[model.ref['id']][0] is model
+    # <p>Hello</p><p>World</p>
+    assert model.text == "&lt;p&gt;Hello&lt;/p&gt;\n&lt;p&gt;World&lt;/p&gt;\n"
+
 def test_markdown_pane_markdown_it_renderer(document, comm):
     pane = Markdown("""
     - [x] Task1

--- a/panel/widgets/base.py
+++ b/panel/widgets/base.py
@@ -113,9 +113,10 @@ class Widget(Reactive):
             ] + params['stylesheets']
         if "description" in params:
             description = params["description"]
+            renderer_options = params.pop("renderer_options", {})
             if isinstance(description, str):
                 from ..pane.markup import Markdown
-                parser = Markdown._get_parser('markdown-it', ())
+                parser = Markdown._get_parser('markdown-it', (), **renderer_options)
                 html = parser.render(description)
                 params['description'] = Tooltip(
                     content=HTML(html), position='right',


### PR DESCRIPTION
Fixes https://github.com/holoviz/panel/issues/5375
Before
![image](https://github.com/holoviz/panel/assets/15331990/6ecb40b8-8e99-4d28-8158-0da59fa26731)

After
<img width="581" alt="image" src="https://github.com/holoviz/panel/assets/15331990/035913e0-06a0-4360-8c61-702b85927acb">

Primary use case atm:
Langchain outputs newlines as `\n` so I have to do this:
```python

    def on_llm_new_token(self, token: str, **kwargs) -> None:
        self._entry = self.chat_interface.stream(
            token.replace("\n", "<br>"), self._entry
        )
        return super().on_llm_new_token(token, **kwargs)
```