### PR TITLE
Updating pytest-playwright install instructions to use conda

### DIFF
--- a/doc/developer_guide/index.md
+++ b/doc/developer_guide/index.md
@@ -58,9 +58,20 @@ doit develop_install -c pyviz/label/dev -c conda-forge -c bokeh -o build -o test
 
 The above command installs Panel's dependencies using conda, then performs a pip editable install of Panel. If it fails, `nodejs>=14.0.0` may be missing from your environment, fix it with `conda install -c conda-forge nodejs` then rerun above command.
 
-If you also want to run the UI tests run the following:
+If you also want to run the UI tests you'll need to install pytest-playwright with Conda:
 ``` bash
 conda install pytest-playwright -c microsoft -c conda-forge
+```
+
+or with PyPi:
+
+``` bash
+pip install pytest-playwright
+```
+
+then run:
+
+``` bash
 playwright install chromium
 ```
 

--- a/doc/developer_guide/index.md
+++ b/doc/developer_guide/index.md
@@ -60,7 +60,7 @@ The above command installs Panel's dependencies using conda, then performs a pip
 
 If you also want to run the UI tests run the following:
 ``` bash
-pip install playwright pytest-playwright
+conda install pytest-playwright -c microsoft -c conda-forge
 playwright install chromium
 ```
 


### PR DESCRIPTION
With a lot of help from @mxschmitt I created a conda recipe for [pytest-playwright](https://anaconda.org/microsoft/pytest-playwright) which is now available on conda as of [release 0.4.2](https://github.com/microsoft/playwright-pytest/releases/tag/v0.4.2) from the Microsoft channel ([playwright-python](https://github.com/microsoft/playwright-python) already had a [conda recipe](https://anaconda.org/Microsoft/playwright)).

As such I've updated the developer instructions to install pytest-playwright via conda instead of pip in the development environment (this should install playwright-python as a dependency).

I have tested I can still run the UI tests with these conda packages.