### PR TITLE
Resolve issue with empty styles on Tabulator update

### DIFF
--- a/panel/models/tabulator.ts
+++ b/panel/models/tabulator.ts
@@ -934,7 +934,7 @@ export class DataTabulatorView extends HTMLBoxView {
 
   setStyles(): void {
     const style_data = this.model.cell_styles.data
-    if (this.tabulator == null || this.tabulator.getDataCount() == 0 || !style_data.size)
+    if (this.tabulator == null || this.tabulator.getDataCount() == 0 || style_data == null || !style_data.size)
       return
     this._applied_styles = false
     for (const r of style_data.keys()) {


### PR DESCRIPTION
Seems like under some circumstances the style_data can be none which triggered an error when Tabulator data was updated.