### PR TITLE
Add more guards to Tabulator rendering pipelines

### DIFF
--- a/panel/models/tabulator.ts
+++ b/panel/models/tabulator.ts
@@ -601,7 +601,7 @@ export class DataTabulatorView extends HTMLBoxView {
   get child_models(): LayoutDOM[] {
     const children = []
     for (const idx of this.model.expanded) {
-      if (this.model.children.has(idx))
+      if (this.model.children?.has(idx))
         children.push(this.model.children.get(idx))
     }
     return children
@@ -617,7 +617,8 @@ export class DataTabulatorView extends HTMLBoxView {
         this._render_row(row, false)
       }
       this._update_children()
-      this.tabulator.rowManager.adjustTableSize()
+      if (this.tabulator.rowManager.renderer != null)
+	this.tabulator.rowManager.adjustTableSize()
       this.invalidate_layout()
     })
   }
@@ -997,7 +998,7 @@ export class DataTabulatorView extends HTMLBoxView {
   }
 
   setSelection(): void {
-    if (this.tabulator == null || this._selection_updating)
+    if (this.tabulator == null || this._initializing || this._selection_updating)
       return
 
     const indices = this.model.source.selected.indices;

--- a/panel/tests/ui/widgets/test_tabulator.py
+++ b/panel/tests/ui/widgets/test_tabulator.py
@@ -1669,6 +1669,8 @@ def test_tabulator_row_content_expand_from_python_after(page, port, df_mixed):
     # Expanding the rows after the server is launched
     widget.expanded = [0, 2]
 
+    time.sleep(0.2)
+
     for i in range(len(df_mixed)):
         row_content = page.locator(f'text="{df_mixed.iloc[i]["str"]}-row-content"')
         if i in widget.expanded:


### PR DESCRIPTION
More checks to ensure everything is initialized by the time it runs to ensure we don't error while Tabulator is still updating.