### PR TITLE
Add cache busting to server CSS resources

### DIFF
--- a/panel/io/resources.py
+++ b/panel/io/resources.py
@@ -240,9 +240,9 @@ def component_resource_path(component, attr, path):
 def patch_stylesheet(stylesheet, dist_url):
     url = stylesheet.url
     if url.startswith(CDN_DIST+dist_url) and dist_url != CDN_DIST:
-        patched_url = url.replace(CDN_DIST+dist_url, dist_url)
+        patched_url = url.replace(CDN_DIST+dist_url, dist_url) + f'?v={JS_VERSION}'
     elif url.startswith(CDN_DIST) and dist_url != CDN_DIST:
-        patched_url = url.replace(CDN_DIST, dist_url)
+        patched_url = url.replace(CDN_DIST, dist_url) + f'?v={JS_VERSION}'
     else:
         return
     try:

--- a/panel/tests/theme/test_base.py
+++ b/panel/tests/theme/test_base.py
@@ -233,9 +233,9 @@ def test_design_apply_with_dist_url(document, comm):
     assert isinstance(s1, str)
     assert 'pn-loading' in s1
     assert isinstance(s2, ImportedStyleSheet)
-    assert s2.url.endswith('https://mock.holoviz.org/css/loading.css')
+    assert s2.url.startswith('https://mock.holoviz.org/css/loading.css?v')
     assert isinstance(s3, ImportedStyleSheet)
-    assert s3.url == 'https://mock.holoviz.org/bundled/theme/default.css'
+    assert s3.url.startswith('https://mock.holoviz.org/bundled/theme/default.css?v')
     assert isinstance(s4, ImportedStyleSheet)
     assert s4.url == 'foo.css'
     assert s5 == '.bk-input {\n  color: red;\n}\n'


### PR DESCRIPTION
When using server resources the URL for the CSS resources does not change between different versions of Panel. This means that it will always use the same cached resources even when a deployed application updates the Panel version it runs on. To address this we add a query parameter to CSS resources containing the current Panel.js version, which will ensure that on each version upgrade the cache is busted.