### PR TITLE
Move user/ default avatars to ChatEntry

### DIFF
--- a/examples/reference/widgets/ChatEntry.ipynb
+++ b/examples/reference/widgets/ChatEntry.ipynb
@@ -43,7 +43,8 @@
     "* **`renderers`** (List[Callable]): A callable or list of callables that accept the value and return a Panel object to render the value. If a list is provided, will attempt to use the first renderer that does not raise an exception. If None, will attempt to infer the renderer from the value.\n",
     "* **`user`** (str): Name of the user who sent the message.\n",
     "* **`avatar`** (str | BinaryIO): The avatar to use for the user. Can be a single character text, an emoji, or anything supported by `pn.pane.Image`. If not set, uses the first character of the name.\n",
-    "* **`default_avatars`** (Dict[str, str | BinaryIO]): A default mapping of user names to their corresponding avatars to use when the user is set but the avatar is not. You can modify, but not replace the dictionary.\n",
+    "* **`default_avatars`** (Dict[str, str | BinaryIO]): A default mapping of user names to their corresponding avatars to use when the user is set but the avatar is not. You can modify, but not replace the dictionary. Note, the keys are *only* alphanumeric sensitive, meaning spaces, special characters, and case sensitivity is disregarded, e.g. `\"Chat-GPT3.5\"`, `\"chatgpt 3.5\"` and `\"Chat GPT 3.5\"` all map to the same value.\n",
+    "* **`avatar_lookup`** (Callable): A function that can lookup an `avatar` from a user name. The function signature should be `(user: str) -> Avatar`. If this is set, `default_avatars` is disregarded.\n",
     "* **`reactions`** (List): Reactions associated with the message.\n",
     "* **`reaction_icons`** (ChatReactionIcons | dict): A mapping of reactions to their reaction icons; if not provided defaults to `{\"favorite\": \"heart\"}`. Provides a visual representation of reactions.\n",
     "* **`timestamp`** (datetime): Timestamp of the message. Defaults to the instantiation time.\n",
@@ -173,7 +174,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "chat_entry.value = pn.widgets.StaticText(value=\"Cheers!\")"
+    "chat_entry.value = pn.pane.Markdown(\"## Cheers!\")"
    ]
   },
   {
@@ -196,7 +197,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If you don't specify an `avatar` on construction, then an `avatar` will be looked up in the `default_avatars` dictionary"
+    "If you don't specify an `avatar` on construction, then an `avatar` will be looked up in the `default_avatars` dictionary."
    ]
   },
   {
@@ -212,7 +213,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "You can modify the `ChatEntry.default_avatars` in-place"
+    "You can modify the `ChatEntry.default_avatars` in-place.\n",
+    "\n",
+    "Note, the keys are *only* alphanumeric sensitive, meaning spaces, special characters, and case sensitivity is disregarded, e.g. `\"Chat-GPT3.5\"`, `\"chatgpt 3.5\"` and `\"Chat GPT 3.5\"` all map to the same value."
    ]
   },
   {
@@ -221,13 +224,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ChatEntry.default_avatars[\"wolfram\"]=\"🐺\"\n",
-    "ChatEntry.default_avatars[\"test\"]=\"👍\"\n",
+    "ChatEntry.default_avatars[\"Wolfram\"] = \"🐺\"\n",
+    "ChatEntry.default_avatars[\"#1 Good to Go Guy\"] = \"👍\"\n",
     "\n",
-    "pn.Row(\n",
-    "    ChatEntry(value=\"Hi\", user=\"wolfram\"),\n",
-    "    ChatEntry(value=\"Hi\", user=\"test\"),\n",
-    "    max_width=300\n",
+    "pn.Column(\n",
+    "    ChatEntry(value=\"Mathematics!\", user=\"Wolfram\"),\n",
+    "    ChatEntry(value=\"Good to go!\", user=\"#1 Good-to-Go Guy\"),\n",
+    "    ChatEntry(value=\"What's up?\", user=\"Other Guy\"),\n",
+    "    max_width=300,\n",
     ")"
    ]
   },

--- a/examples/reference/widgets/ChatEntry.ipynb
+++ b/examples/reference/widgets/ChatEntry.ipynb
@@ -43,6 +43,7 @@
     "* **`renderers`** (List[Callable]): A callable or list of callables that accept the value and return a Panel object to render the value. If a list is provided, will attempt to use the first renderer that does not raise an exception. If None, will attempt to infer the renderer from the value.\n",
     "* **`user`** (str): Name of the user who sent the message.\n",
     "* **`avatar`** (str | BinaryIO): The avatar to use for the user. Can be a single character text, an emoji, or anything supported by `pn.pane.Image`. If not set, uses the first character of the name.\n",
+    "* **`default_avatars`** (Dict[str, str | BinaryIO]): A default mapping of user names to their corresponding avatars to use when the user is set but the avatar is not. You can modify, but not replace the dictionary.\n",
     "* **`reactions`** (List): Reactions associated with the message.\n",
     "* **`reaction_icons`** (ChatReactionIcons | dict): A mapping of reactions to their reaction icons; if not provided defaults to `{\"favorite\": \"heart\"}`. Provides a visual representation of reactions.\n",
     "* **`timestamp`** (datetime): Timestamp of the message. Defaults to the instantiation time.\n",
@@ -64,7 +65,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ChatEntry(value=\"Hi. Welcome\")\n"
+    "ChatEntry(value=\"Hi. Welcome\")"
    ]
   },
   {
@@ -93,7 +94,7 @@
     "    ChatEntry(value=pn.widgets.Button(name=\"Click\")),\n",
     "    ChatEntry(value=df),\n",
     "    ChatEntry(value=fig),\n",
-    ")\n"
+    ")"
    ]
   },
   {
@@ -139,7 +140,7 @@
     "        user=\"Beat Boxer\",\n",
     "        avatar=\"🎶\",\n",
     "    ),\n",
-    ")\n"
+    ")"
    ]
   },
   {
@@ -156,7 +157,7 @@
    "outputs": [],
    "source": [
     "chat_entry = pn.widgets.ChatEntry()\n",
-    "chat_entry\n"
+    "chat_entry"
    ]
   },
   {
@@ -172,7 +173,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "chat_entry.value = pn.widgets.StaticText(value=\"Cheers!\")\n"
+    "chat_entry.value = pn.widgets.StaticText(value=\"Cheers!\")"
    ]
   },
   {
@@ -188,7 +189,46 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "chat_entry.param.update(user=\"Jolly Guy\", avatar=\"🎅\")\n"
+    "chat_entry.param.update(user=\"Jolly Guy\", avatar=\"🎅\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If you don't specify an `avatar` on construction, then an `avatar` will be looked up in the `default_avatars` dictionary"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ChatEntry.default_avatars"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can modify the `ChatEntry.default_avatars` in-place"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ChatEntry.default_avatars[\"wolfram\"]=\"🐺\"\n",
+    "ChatEntry.default_avatars[\"test\"]=\"👍\"\n",
+    "\n",
+    "pn.Row(\n",
+    "    ChatEntry(value=\"Hi\", user=\"wolfram\"),\n",
+    "    ChatEntry(value=\"Hi\", user=\"test\"),\n",
+    "    max_width=300\n",
+    ")"
    ]
   },
   {
@@ -204,7 +244,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "pn.widgets.ChatEntry(timestamp_format=\"%b %d, %Y %I:%M %p\")\n"
+    "pn.widgets.ChatEntry(timestamp_format=\"%b %d, %Y %I:%M %p\")"
    ]
   },
   {
@@ -401,7 +441,7 @@
     "    value=respond_when_ready,\n",
     "    user=\"Assistant\",\n",
     "    avatar=\"https://upload.wikimedia.org/wikipedia/commons/6/63/Yumi_UBports.png\",\n",
-    ")\n"
+    ")"
    ]
   },
   {

--- a/examples/reference/widgets/ChatFeed.ipynb
+++ b/examples/reference/widgets/ChatFeed.ipynb
@@ -554,6 +554,28 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "You can pass `ChatEntry` params through `entry_params`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "entry_params = dict(\n",
+    "    default_avatars={\"System\": \"S\", \"User\": \"👤\"}, reaction_icons={\"like\": \"thumb-up\"}\n",
+    ")\n",
+    "chat_feed = pn.widgets.ChatFeed(entry_params=entry_params)\n",
+    "chat_feed.send(user=\"System\", value=\"This is the System speaking.\")\n",
+    "chat_feed.send(user=\"User\", value=\"This is the User speaking.\")\n",
+    "chat_feed"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "You can build your own custom chat interface too on top of `ChatFeed`, but remember there's a pre-built [`ChatInterface`](ChatInterface.ipynb)!"
    ]
   },

--- a/panel/tests/widgets/test_chat.py
+++ b/panel/tests/widgets/test_chat.py
@@ -251,6 +251,23 @@ class TestChatEntry:
         entry.reactions = ["favorite"]
         assert entry.value == "favorite"
 
+    def test_default_avatars(self):
+        assert isinstance(ChatEntry.default_avatars, dict)
+        assert ChatEntry(user="Assistant").avatar==ChatEntry(user="assistant").avatar=="🤖"
+        assert ChatEntry(value="Hello", user="NoDefaultUserAvatar").avatar==ChatEntry.param.avatar.default
+        ChatEntry.default_avatars["test1"]="1"
+        ChatEntry.default_avatars["test2"]="2"
+
+        entry = ChatEntry(value="Hello", user="test1")
+        assert entry.avatar=="1"
+        entry.user="test2"
+        assert entry.avatar=="1"
+
+    def test_cannot_replace_default_avatars(self):
+        with pytest.raises(TypeError):
+            ChatEntry.default_avatars={"user": "X"}
+
+
 class TestChatFeed:
     @pytest.fixture
     def chat_feed(self):
@@ -541,32 +558,32 @@ class TestChatFeed:
         chat_feed.send("Message 1")
         assert chat_feed.value[0].width == 420
 
-    @pytest.mark.parametrize("user", ["system", "System", " System", " system ", "system-"])
-    def test_user_avatars_default(self, chat_feed, user):
+    @pytest.mark.parametrize("user", ["system", "System",])
+    def test_default_avatars_default(self, chat_feed, user):
         chat_feed.send("Message 1", user=user)
 
         assert chat_feed.value[0].user == user
         assert chat_feed.value[0].avatar == "⚙️"
 
-    def test_user_avatars_superseded_in_dict(self, chat_feed):
+    def test_default_avatars_superseded_in_dict(self, chat_feed):
         chat_feed.send({"user": "System", "avatar": "👨", "value": "Message 1"})
 
         assert chat_feed.value[0].user == "System"
         assert chat_feed.value[0].avatar == "👨"
 
-    def test_user_avatars_superseded_by_keyword(self, chat_feed):
+    def test_default_avatars_superseded_by_keyword(self, chat_feed):
         chat_feed.send({"user": "System", "value": "Message 1"}, avatar="👨")
 
         assert chat_feed.value[0].user == "System"
         assert chat_feed.value[0].avatar == "👨"
 
-    def test_user_avatars_superseded_in_entry(self, chat_feed):
+    def test_default_avatars_superseded_in_entry(self, chat_feed):
         chat_feed.send(ChatEntry(**{"user": "System", "avatar": "👨", "value": "Message 1"}))
 
         assert chat_feed.value[0].user == "System"
         assert chat_feed.value[0].avatar == "👨"
 
-    def test_user_avatars_superseded_by_callback_avatar(self, chat_feed):
+    def test_default_avatars_superseded_by_callback_avatar(self, chat_feed):
         def callback(contents, user, instance):
             yield "Message back"
 

--- a/panel/tests/widgets/test_chat.py
+++ b/panel/tests/widgets/test_chat.py
@@ -263,6 +263,9 @@ class TestChatEntry:
         entry.user="test2"
         assert entry.avatar=="1"
 
+        ChatEntry.default_avatars.pop("test1")
+        ChatEntry.default_avatars.pop("test2")
+
     def test_cannot_replace_default_avatars(self):
         with pytest.raises(TypeError):
             ChatEntry.default_avatars={"user": "X"}
@@ -595,6 +598,13 @@ class TestChatFeed:
         assert len(chat_feed.value) == 2
         assert chat_feed.value[1].user == "System"
         assert chat_feed.value[1].avatar == "👨"
+
+    def test_default_avatars(self, chat_feed):
+        ChatEntry.default_avatars["test1"]="1"
+
+        assert chat_feed.send(value="", user="test1").avatar=="1"
+
+        ChatEntry.default_avatars.pop("test1")
 
 
 class TestChatFeedCallback:

--- a/panel/tests/widgets/test_chat.py
+++ b/panel/tests/widgets/test_chat.py
@@ -561,7 +561,7 @@ class TestChatFeed:
         chat_feed.send("Message 1")
         assert chat_feed.value[0].width == 420
 
-    @pytest.mark.parametrize("user", ["system", "System",])
+    @pytest.mark.parametrize("user", ["system", "System", " System", " system ", "system-"])
     def test_default_avatars_default(self, chat_feed, user):
         chat_feed.send("Message 1", user=user)
 
@@ -592,12 +592,11 @@ class TestChatFeed:
 
         chat_feed.callback = callback
         chat_feed.callback_user = "System"
-        chat_feed.callback_avatar = "👨"
         chat_feed.send("Message", respond=True)
         time.sleep(0.2)
         assert len(chat_feed.value) == 2
         assert chat_feed.value[1].user == "System"
-        assert chat_feed.value[1].avatar == "👨"
+        assert chat_feed.value[1].avatar == ChatEntry.avatar_lookup("System")
 
     def test_default_avatars(self, chat_feed):
         ChatEntry.default_avatars["test1"]="1"
@@ -613,17 +612,18 @@ class TestChatFeedCallback:
         return ChatFeed()
 
     def test_user_avatar(self, chat_feed):
+        ChatEntry.default_avatars["bob"]="👨"
         def echo(contents, user, instance):
             return f"{user}: {contents}"
 
         chat_feed.callback = echo
         chat_feed.callback_user = "Bob"
-        chat_feed.callback_avatar = "👨"
         chat_feed.send("Message", respond=True)
         time.sleep(0.75)
         assert len(chat_feed.value) == 2
         assert chat_feed.value[1].user == "Bob"
         assert chat_feed.value[1].avatar == "👨"
+        ChatEntry.default_avatars.pop("bob")
 
     def test_return(self, chat_feed):
         def echo(contents, user, instance):

--- a/panel/widgets/chat.py
+++ b/panel/widgets/chat.py
@@ -35,14 +35,14 @@ from .button import Button
 from .indicators import LoadingSpinner
 from .input import FileInput, TextInput
 
+Avatar = Union[str, BytesIO]
+AvatarDict = Dict[str, Avatar]
+
 GPT_3_LOGO = "https://upload.wikimedia.org/wikipedia/commons/thumb/0/04/ChatGPT_logo.svg/1024px-ChatGPT_logo.svg.png?20230318122128"
 GPT_4_LOGO = "https://upload.wikimedia.org/wikipedia/commons/a/a4/GPT-4.png"
 WOLFRAM_LOGO = "https://upload.wikimedia.org/wikipedia/commons/thumb/e/eb/WolframCorporateLogo.svg/1920px-WolframCorporateLogo.svg.png"
 
-Avatar = str | BytesIO
-AvatarDict = Dict[str, Avatar]
-
-DEFAULT_USER_AVATARS: AvatarDict = {
+DEFAULT_AVATARS: AvatarDict = {
     "user": "😊",
     "assistant": "🤖",
     "system": "⚙️",
@@ -240,13 +240,6 @@ class ChatReactionIcons(ReactiveHTML):
             if reaction not in self._reactions:
                 self.value.remove(reaction)
 
-def _to_alpha_numeric(user: str)->str:
-    return re.sub(r"\W+", "", user).lower()
-
-def _avatar_lookup(user: str)->Avatar:
-    clean_user =  _to_alpha_numeric(user)
-    return DEFAULT_USER_AVATARS.get(clean_user, "")
-
 
 class ChatEntry(CompositeWidget):
     """
@@ -279,12 +272,18 @@ class ChatEntry(CompositeWidget):
         Name of the user who sent the message.
     avatar : str | BinaryIO
         The avatar to use for the user. Can be a single character text, an emoji,
-        or anything supported by `pn.pane.Image`. If not set, uses the
+        or anything supported by `pn.pane.Image`. If not set, checks if
+        the user is available in the default_avatars mapping; else uses the
         first character of the name.
     default_avatars : dict
         A default mapping of user names to their corresponding avatars
-        to use when the user is specified but not the avatar. You can modify, but not replace the
-        dictionary.
+        to use when the user is specified but the avatar is. You can modify, but not replace the
+        dictionary. Note, the keys are *only* alphanumeric sensitive, meaning spaces, special characters,
+        and case sensitivity is disregarded, e.g. `"Chat-GPT3.5"`, `"chatgpt 3.5"` and `"Chat GPT 3.5"`
+        all map to the same value.
+    avatar_lookup : Callable
+        A function that can lookup an `avatar` from a user name. The function signature should be
+        `(user: str) -> Avatar`. If this is set, `default_avatars` is disregarded.
     reactions : List
         Reactions to associate with the message.
     reaction_icons : ChatReactionIcons | dict
@@ -316,20 +315,20 @@ class ChatEntry(CompositeWidget):
     user = param.Parameter(default="User", doc="""
         Name of the user who sent the message.""")
 
-    avatar: Avatar = param.ClassSelector(default="😊", class_=(str, BinaryIO), doc="""
+    avatar = param.ClassSelector(default="", class_=(str, BinaryIO), doc="""
         The avatar to use for the user. Can be a single character text, an emoji,
-        or anything supported by `pn.pane.Image`. If not set, uses the
+        or anything supported by `pn.pane.Image`. If not set, checks if
+        the user is available in the default_avatars mapping; else uses the
         first character of the name.""")
 
-    default_avatars: AvatarDict = param.Dict(default=DEFAULT_USER_AVATARS, readonly=True, doc="""
-    A default mapping of user names to their corresponding avatars
-    to use when the user is specified but the avatar is. You can modify, but not replace the
-    dictionary.""")
+    default_avatars = param.Dict(default=DEFAULT_AVATARS, doc="""
+        A default mapping of user names to their corresponding avatars
+        to use when the user is specified but the avatar is. You can modify, but not replace the
+        dictionary.""")
 
-    avatar_lookup = param.Callable(_avatar_lookup, doc="""
-    A function that can lookup an `avatar` from a user name. The function signature should be
-    `(user: str)->Avatar`.
-    """)
+    avatar_lookup = param.Callable(default=None, doc="""
+        A function that can lookup an `avatar` from a user name. The function signature should be
+        `(user: str) -> Avatar`. If this is set, `default_avatars` is disregarded.""")
 
     reactions = param.List(doc="""
         Reactions to associate with the message.""")
@@ -369,14 +368,13 @@ class ChatEntry(CompositeWidget):
         if isinstance(params["reaction_icons"], dict):
             params["reaction_icons"] = ChatReactionIcons(
                 options=params["reaction_icons"], width=15, height=15)
-        if "avatar" not in params and "user" in params:
-            user = params["user"]
-            avatar = self.avatar_lookup(user)
-            if avatar:
-                params["avatar"]=avatar
+        if params.get("avatar_lookup") is None:
+            params["avatar_lookup"] = self._avatar_lookup
         super().__init__(**params)
         self.reaction_icons.link(self, value="reactions", bidirectional=True)
         self.param.trigger("reactions")
+        if not self.avatar:
+            self._update_avatar()
 
         render_kwargs = dict(
             inplace=True, stylesheets=self._stylesheets
@@ -403,6 +401,31 @@ class ChatEntry(CompositeWidget):
         )
         self._composite._stylesheets = self._stylesheets
         self._composite[:] = [left_col, right_col]
+
+    @staticmethod
+    def _to_alpha_numeric(user: str) -> str:
+        """
+        Convert the user name to an alpha numeric string,
+        removing all non-alphanumeric characters.
+        """
+        return re.sub(r"\W+", "", user).lower()
+
+    def _avatar_lookup(self, user: str) -> Avatar:
+        """
+        Lookup the avatar for the user.
+        """
+        alpha_numeric_key =  self._to_alpha_numeric(user)
+        # always use the default first
+        updated_avatars = DEFAULT_AVATARS.copy()
+        # update with the user input
+        updated_avatars.update(self.default_avatars)
+        # correct the keys to be alpha numeric
+        updated_avatars = {
+            self._to_alpha_numeric(key): value
+            for key, value in updated_avatars.items()
+        }
+        # now lookup the avatar
+        return updated_avatars.get(alpha_numeric_key, self.avatar)
 
     def _select_renderer(
             self,
@@ -517,7 +540,7 @@ class ChatEntry(CompositeWidget):
         return value_panel
 
     @param.depends("avatar", "show_avatar")
-    def _render_avatar(self) -> None:
+    def _render_avatar(self) -> Union[HTML, Image]:
         """
         Render the avatar pane as some HTML text or Image pane.
         """
@@ -539,14 +562,14 @@ class ChatEntry(CompositeWidget):
         return avatar_pane
 
     @param.depends("user", "show_user")
-    def _render_user(self) -> None:
+    def _render_user(self) -> HTML:
         """
         Render the user pane as some HTML text or Image pane.
         """
         return HTML(self.user, css_classes=["name"], visible=self.show_user)
 
     @param.depends("value")
-    def _render_value(self):
+    def _render_value(self) -> Viewable:
         """
         Renders value as a panel object.
         """
@@ -558,7 +581,7 @@ class ChatEntry(CompositeWidget):
         return value_panel
 
     @param.depends("timestamp", "timestamp_format", "show_timestamp")
-    def _render_timestamp(self) -> None:
+    def _render_timestamp(self) -> HTML:
         """
         Formats the timestamp and renders it as HTML pane.
         """
@@ -567,6 +590,18 @@ class ChatEntry(CompositeWidget):
             css_classes=["timestamp"],
             visible=self.show_timestamp,
         )
+
+    @param.depends("avatar_lookup", "user", watch=True)
+    def _update_avatar(self):
+        """
+        Update the avatar based on the user name.
+
+        We do not use on_init here because if avatar is set,
+        we don't want to override the provided avatar.
+
+        However, if the user is updated, we want to update the avatar.
+        """
+        self.avatar = self.avatar_lookup(self.user)
 
     def _cleanup(self, root=None) -> None:
         """
@@ -644,8 +679,8 @@ class ChatFeed(CompositeWidget):
         Params to pass to Card, like `header`,
         `header_background`, `header_color`, etc.
     entry_params : Dict
-        Params to pass to each ChatEntry, like `reaction_icons`, `timestamp_format`,
-        `show_avatar`, `show_user`, and `show_timestamp`.
+        Params to pass to each ChatEntry, like `reaction_icons`, `default_avatars`,
+        `timestamp_format`, `show_avatar`, `show_user`, and `show_timestamp`.
     """
     value = param.List(item_type=ChatEntry, doc="""
         The list of entries in the feed.""")
@@ -830,19 +865,16 @@ class ChatFeed(CompositeWidget):
         if not isinstance(value, (ChatEntry, dict)):
             value = {"value": value}
 
-        new_params = {}
-        if user is not None:
-            new_params["user"] = user
-        if avatar is not None:
-            new_params["avatar"] = avatar
-
         if isinstance(value, dict):
             if "value" not in value:
                 raise ValueError(
                     f"If 'value' is a dict, it must contain a 'value' key, "
                     f"e.g. {{'value': 'Hello World'}}; got {value!r}"
                 )
-            value.update(**new_params)
+            if user:
+                value.update(user=user)
+            if avatar:
+                value.update(avatar=avatar)
             if self.width:
                 entry_params = {"width": int(self.width - 80), **self.entry_params}
             else:
@@ -851,7 +883,12 @@ class ChatFeed(CompositeWidget):
             input_params = {**value, **entry_params}
             entry = ChatEntry(**input_params)
         else:
-            value.param.update(**new_params)
+            # must update one at a time so avatar is not overwritten
+            # by the default avatar
+            if user:
+                value.user = user
+            if avatar:
+                value.avatar = avatar
             entry = value
         return entry
 


### PR DESCRIPTION
I believe it makes sense to move the `user_avatars` to the `ChatEntry` such that if I go low-level and use the `ChatEntry` as well there is still a mechanism for default avatars. I believe its the right place for it to sit.

I've been back and forth but suggest in this PR that

- `user_avatars` are renamed to `default_avatars`.
- We don't also expose `default_avatars` on the `ChatFeed`/ `ChatInterface`. As in `ChatFeed.default_avatars["test"]="X"`. We could. That would avoid an import of `ChatEntry`. But I think there should be "1 way and only 1 way". 
- We don't use the clean up (lower case plus remove space, "-" etc.) functionality originally suggested and implemented. Sorry.
  - I felt it was hard to explain and remember that when configuring the `ChatEntry.default_avatars` you should be using lower cased names without space, "-" etc.
  - Furthermore not using the clean functionality would enable to distinguish between user `AHuang` and `a-huang`.