### PR TITLE
Various fixes for rendering of Tabulator and Column

### DIFF
--- a/panel/models/column.ts
+++ b/panel/models/column.ts
@@ -47,28 +47,14 @@ export class ColumnView extends BkColumnView {
 
   render(): void {
     super.render()
-    this.empty()
-    this._update_stylesheets()
-    this._update_css_classes()
-    this._apply_styles()
-    this._apply_visible()
-
-    this.class_list.add(...this.css_classes())
     this.scroll_down_button_el = DOM.createElement('div', { class: 'scroll-button' });
     this.shadow_el.appendChild(this.scroll_down_button_el);
-
     this.el.addEventListener("scroll", () => {
       this.toggle_scroll_button();
     });
     this.scroll_down_button_el.addEventListener("click", () => {
       this.scroll_to_latest();
     });
-
-    for (const child_view of this.child_views) {
-      this.shadow_el.appendChild(child_view.el)
-      child_view.render()
-      child_view.after_render()
-    }
   }
 
   after_render(): void {


### PR DESCRIPTION
The rendering of Tabulator children had a few issues related to race conditions of populating the children property, some issues related to serialization of Map/Object types in Bokeh and JS and then some missing guards to ensure things were waiting for everything to be ready.

Additionally the new `Column` implementation @ahuang11 added had a render method that was wrong in a number of ways:

1. It called `super.render()` resulting in two separate render cycles.
2. It called `after_render` on all the children, something the LayoutDOM model explicitly does not do.

I think by simply calling super and then adding the scroll button we are doing things correctly but @ahuang11 please confirm that the scrolling still works with this change.