### PR TITLE
Do no reset Tabulator if DataFrame indexes are unchanged

### DIFF
--- a/panel/models/reactive_html.ts
+++ b/panel/models/reactive_html.ts
@@ -3,10 +3,8 @@ import {useCallback} from 'preact/hooks';
 import {html} from 'htm/preact';
 
 import {div} from "@bokehjs/core/dom"
-import {build_views} from "@bokehjs/core/build_views"
 import {isArray} from "@bokehjs/core/util/types"
 import * as p from "@bokehjs/core/properties"
-import {UIElementView} from "@bokehjs/models/ui/ui_element"
 import {LayoutDOM} from "@bokehjs/models/layouts/layout_dom"
 
 import {dict_to_records} from "./data"

--- a/panel/models/tabulator.ts
+++ b/panel/models/tabulator.ts
@@ -296,7 +296,9 @@ export class DataTabulatorView extends HTMLBoxView {
 
     const p = this.model.properties
     const {configuration, layout, columns, groupby} = p;
-    this.on_change([configuration, layout, groupby], debounce(() => this.invalidate_render(), 20, false))
+    this.on_change([configuration, layout, groupby], debounce(() => {
+      this.invalidate_render()
+    }, 20, false))
 
     this.on_change([columns], () => {
       this.tabulator.setColumns(this.getColumns())


### PR DESCRIPTION
Right now when a user updates the `value` of a table we reset a bunch of settings because effectively anything about the data might have changed. However a) a user can reset these themselves and b) as long as the settings are valid then not resetting shouldn't cause any issues. Here we make an initial conservative change in this direction and avoid resetting the `expanded` property as long as the indexes of the DataFrame being displayed are unchanged.