### PR TITLE
Add and clean up utilities for event handling

### DIFF
--- a/panel/io/__init__.py
+++ b/panel/io/__init__.py
@@ -6,7 +6,9 @@ import sys
 
 from .cache import cache  # noqa
 from .callbacks import PeriodicCallback  # noqa
-from .document import init_doc, unlocked, with_lock  # noqa
+from .document import (  # noqa
+    hold, immediate_dispatch, init_doc, unlocked, with_lock,
+)
 from .embed import embed_state  # noqa
 from .logging import panel_logger  # noqa
 from .model import add_to_doc, diff, remove_root  # noqa
@@ -31,6 +33,8 @@ else:
 __all__ = (
     "PeriodicCallback",
     "Resources",
+    "hold",
+    "immediate_dispatch",
     "ipywidget",
     "panel_logger",
     "profile",


### PR DESCRIPTION
Utilities like `hold` and `immediate_dispatch` are incredibly valuable to optimize dispatching of events. I will follow up with a how-to on how to leverage them to get better control over when and how events are dispatched to avoid unnecessary re-rendering.