### PR TITLE
Adapt tests to Param 2 changes

### DIFF
--- a/panel/tests/test_param.py
+++ b/panel/tests/test_param.py
@@ -1563,7 +1563,7 @@ def test_set_widget_autocompleteinput(document, comm):
 
     autocompleteinput = model.children[1]
     assert isinstance(autocompleteinput, BkAutocompleteInput)
-    assert autocompleteinput.completions == ['a', 'b']
+    assert autocompleteinput.completions == ['a', 'b', '']
     assert autocompleteinput.value == ''
     assert autocompleteinput.disabled == False
 
@@ -1630,7 +1630,7 @@ def test_param_editablerangeslider_with_bounds():
     t = Test()
     w = EditableRangeSlider.from_param(t.param.i)
 
-    msg = "Range parameter 'value''s lower bound must be in range \[0, 10\]"
+    msg = "Attribute 'bound' of Range parameter 'EditableRangeSlider\.value' must be in range '\[0, 10\]'"
     with pytest.raises(ValueError, match=msg):
         w.value = (-1, 2)
 
@@ -1671,7 +1671,7 @@ def test_param_editablefloatslider_with_bounds():
     t = Test()
     w = EditableFloatSlider.from_param(t.param.i)
 
-    msg = "Parameter 'value' must be at least 0, not -1"
+    msg = "Number parameter 'EditableFloatSlider.value' must be at least 0, not -1"
     with pytest.raises(ValueError, match=msg):
         w.value = -1
 

--- a/panel/tests/test_param.py
+++ b/panel/tests/test_param.py
@@ -11,6 +11,7 @@ from bokeh.models import (
     Row as BkRow, Select, Slider, Tabs as BkTabs, TextInput,
     TextInput as BkTextInput, Toggle,
 )
+from packaging.version import Version
 
 from panel import config
 from panel.depends import bind
@@ -1563,7 +1564,10 @@ def test_set_widget_autocompleteinput(document, comm):
 
     autocompleteinput = model.children[1]
     assert isinstance(autocompleteinput, BkAutocompleteInput)
-    assert autocompleteinput.completions == ['a', 'b', '']
+    if Version(param.__version__) > Version('2.0.0a2'):
+        assert autocompleteinput.completions == ['a', 'b', '']
+    else:
+        assert autocompleteinput.completions == ['a', 'b']
     assert autocompleteinput.value == ''
     assert autocompleteinput.disabled == False
 
@@ -1630,7 +1634,10 @@ def test_param_editablerangeslider_with_bounds():
     t = Test()
     w = EditableRangeSlider.from_param(t.param.i)
 
-    msg = "Attribute 'bound' of Range parameter 'EditableRangeSlider\.value' must be in range '\[0, 10\]'"
+    if Version(param.__version__) > Version('2.0.0a2'):
+        msg = "Attribute 'bound' of Range parameter 'EditableRangeSlider\.value' must be in range '\[0, 10\]'"
+    else:
+        msg = "Range parameter 'value''s lower bound must be in range \[0, 10\]"
     with pytest.raises(ValueError, match=msg):
         w.value = (-1, 2)
 
@@ -1671,7 +1678,10 @@ def test_param_editablefloatslider_with_bounds():
     t = Test()
     w = EditableFloatSlider.from_param(t.param.i)
 
-    msg = "Number parameter 'EditableFloatSlider.value' must be at least 0, not -1"
+    if Version(param.__version__) > Version('2.0.0a2'):
+        msg = "Number parameter 'EditableFloatSlider.value' must be at least 0, not -1"
+    else:
+        msg = "Parameter 'value' must be at least 0, not -1"
     with pytest.raises(ValueError, match=msg):
         w.value = -1
 

--- a/panel/tests/test_viewable.py
+++ b/panel/tests/test_viewable.py
@@ -40,7 +40,7 @@ def test_viewable_ipywidget():
 def test_viewable_signature(viewable):
     from inspect import Parameter, signature
     parameters = signature(viewable).parameters
-    if viewable._param__private.signature:
+    if getattr(getattr(viewable, '_param__private', object), 'signature', None):
         pytest.skip('Signature already set by Param')
     assert 'params' in parameters
     try:

--- a/panel/tests/test_viewable.py
+++ b/panel/tests/test_viewable.py
@@ -40,6 +40,8 @@ def test_viewable_ipywidget():
 def test_viewable_signature(viewable):
     from inspect import Parameter, signature
     parameters = signature(viewable).parameters
+    if viewable._param__private.signature:
+        pytest.skip('Signature already set by Param')
     assert 'params' in parameters
     try:
         assert parameters['params'] == Parameter('params', Parameter.VAR_KEYWORD, annotation='Any')

--- a/panel/tests/widgets/test_base.py
+++ b/panel/tests/widgets/test_base.py
@@ -26,7 +26,7 @@ all_widgets = [
 def test_widget_signature(widget):
     from inspect import signature
     parameters = signature(widget).parameters
-    if widget._param__private.signature:
+    if getattr(getattr(widget, '_param__private', object), 'signature', None):
         pytest.skip('Signature already set by Param')
     assert len(parameters) == 1
 

--- a/panel/tests/widgets/test_base.py
+++ b/panel/tests/widgets/test_base.py
@@ -26,6 +26,8 @@ all_widgets = [
 def test_widget_signature(widget):
     from inspect import signature
     parameters = signature(widget).parameters
+    if widget._param__private.signature:
+        pytest.skip('Signature already set by Param')
     assert len(parameters) == 1
 
 @pytest.mark.parametrize('widget', all_widgets)


### PR DESCRIPTION
Adapting tests to:

- updated validation error messages
- updated signature

`panel_extension._apply_signatures` can't yet be removed as Param only updates the signature of a Parameterized class when its `__init__` signature hasn't changed at all compared to `Parameterized.__init__`, while `_apply_signatures` can handle updating Panel objects (e.g. with `def __init__(self, object, ...)`).