### PR TITLE
Allow to pass 'basic_login_template' argument to panel server

### DIFF
--- a/panel/io/server.py
+++ b/panel/io/server.py
@@ -1139,7 +1139,8 @@ def get_server(
     if basic_auth:
         from ..auth import BasicProvider
         server_config['basic_auth'] = basic_auth
-        opts['auth_provider'] = BasicProvider()
+        basic_login_template = kwargs.pop('basic_login_template', None)
+        opts['auth_provider'] = BasicProvider(basic_login_template)
     elif oauth_provider:
         from ..auth import OAuthProvider
         config.oauth_provider = oauth_provider # type: ignore


### PR DESCRIPTION
BasicProvider() class allows to pass custom login template to its constructor. 
This change allows to pass the argument 'basic_login_template' to panel.serve() function to be used by BasicProvider class. 
In my PR the argument is read from **kwargs, but this could be changed to function argument directly in get_server() function. I am not sure what is a preferable way.