### PR TITLE
Accordion CSS tweaks

### DIFF
--- a/panel/dist/css/card.css
+++ b/panel/dist/css/card.css
@@ -4,7 +4,8 @@
 }
 
 :host(.accordion) {
-  border: 1px solid rgba(0, 0, 0, 0.125);
+  outline: 1px solid rgba(0, 0, 0, 0.125);
+  width: 100%;
 }
 
 .card-header {
@@ -22,7 +23,8 @@
 .accordion-header {
   align-items: center;
   background-color: rgba(0, 0, 0, 0.03);
-  border: 1px solid;
+  border: none;
+  outline: 1px solid;
   border-radius: 0;
   display: flex;
   justify-content: start;

--- a/panel/dist/css/card.css
+++ b/panel/dist/css/card.css
@@ -11,12 +11,13 @@
 .card-header {
   align-items: center;
   background-color: rgba(0, 0, 0, 0.03);
-  outline: unset;
+  border: unset;
   border-radius: 0.25rem;
   display: inline-flex;
   justify-content: start;
-  position: sticky;
   left: 0;
+  outline: unset;
+  position: sticky;
   width: 100%;
 }
 

--- a/panel/dist/css/card.css
+++ b/panel/dist/css/card.css
@@ -1,5 +1,5 @@
 :host(.card) {
-  border: 1px solid rgba(0, 0, 0, 0.125);
+  outline: 1px solid rgba(0, 0, 0, 0.125);
   border-radius: 0.25rem;
 }
 
@@ -11,7 +11,7 @@
 .card-header {
   align-items: center;
   background-color: rgba(0, 0, 0, 0.03);
-  border: unset;
+  outline: unset;
   border-radius: 0.25rem;
   display: inline-flex;
   justify-content: start;
@@ -23,7 +23,7 @@
 .accordion-header {
   align-items: center;
   background-color: rgba(0, 0, 0, 0.03);
-  border: none;
+  border: unset;
   outline: 1px solid;
   border-radius: 0;
   display: flex;

--- a/panel/theme/css/bootstrap.css
+++ b/panel/theme/css/bootstrap.css
@@ -134,9 +134,9 @@ html {
 
 button.card-header,
 button.accordion-header {
-  outline: unset;
   box-shadow: unset;
   color: var(--bs-body-color);
+  outline: unset;
   padding: 0px 6px;
 }
 

--- a/panel/theme/css/bootstrap.css
+++ b/panel/theme/css/bootstrap.css
@@ -123,7 +123,7 @@ html {
   --bs-card-border-width: var(--bs-border-width);
   --bs-card-border-color: var(--bs-border-color-translucent);
   background-color: var(--bs-body-bg);
-  border: var(--bs-card-border-width) solid var(--bs-card-border-color);
+  outline: var(--bs-card-border-width) solid var(--bs-card-border-color);
   color: var(--bs-body-color);
 }
 
@@ -134,7 +134,7 @@ html {
 
 button.card-header,
 button.accordion-header {
-  border: unset;
+  outline: unset;
   box-shadow: unset;
   color: var(--bs-body-color);
   padding: 0px 6px;

--- a/panel/theme/css/fast.css
+++ b/panel/theme/css/fast.css
@@ -163,7 +163,7 @@ img {
 .accordion-header {
   align-items: center;
   background-color: var(--neutral-fill-rest);
-  border: unset;
+  outline: unset;
   box-shadow: unset;
   color: var(--neutral-foreground-rest);
   display: flex;

--- a/panel/theme/css/fast.css
+++ b/panel/theme/css/fast.css
@@ -163,11 +163,11 @@ img {
 .accordion-header {
   align-items: center;
   background-color: var(--neutral-fill-rest);
-  outline: unset;
   box-shadow: unset;
   color: var(--neutral-foreground-rest);
   display: flex;
   height: unset;
+  outline: unset;
 }
 
 .card-margin {

--- a/panel/theme/css/material.css
+++ b/panel/theme/css/material.css
@@ -49,7 +49,7 @@
 .accordion-header {
   --current-background-color: var(--mdc-theme-surface);
   background-color: var(--current-background-color);
-  border: unset;
+  outline: unset;
   border-radius: 0;
   border-bottom: 0.2px solid var(--current-background-color);
   padding: 0px 6px;

--- a/panel/theme/css/material.css
+++ b/panel/theme/css/material.css
@@ -49,9 +49,9 @@
 .accordion-header {
   --current-background-color: var(--mdc-theme-surface);
   background-color: var(--current-background-color);
-  outline: unset;
   border-radius: 0;
   border-bottom: 0.2px solid var(--current-background-color);
+  outline: unset;
   padding: 0px 6px;
 }
 


### PR DESCRIPTION
- Ensure that all Accordion cards are the same width
- Use `outline` rather than `border` CSS property to avoid doubling up on border.