### PR TITLE
Fix race conditions when initializing and rendering IPyWidgets

### DIFF
--- a/panel/models/ipywidget.ts
+++ b/panel/models/ipywidget.ts
@@ -11,8 +11,9 @@ export class IPyWidgetView extends HTMLBoxView {
   private ipychildren: any[]
   private manager: any
 
-  override async lazy_initialize(): Promise<void> {
-    await super.lazy_initialize()
+
+  initialize(): void {
+    super.initialize()
     let manager: any
     if ((Jupyter != null) && (Jupyter.notebook != null))
       manager = Jupyter.notebook.kernel.widget_manager
@@ -24,17 +25,11 @@ export class IPyWidgetView extends HTMLBoxView {
     }
     this.manager = manager
     this.ipychildren = []
-    const {spec, state} = this.model.bundle
-    const models = await manager.set_state(state)
-    const model = models.find((item: any) => item.model_id == spec.model_id)
-    if (model != null) {
-      const view = await this.manager.create_view(model, {el: this.el})
-      this.ipyview = view
-      if (view.children_views) {
-        for (const child of view.children_views.views)
-          this.ipychildren.push(await child)
-      }
-    }
+  }
+
+  override remove(): void {
+    this.ipyview.remove()
+    super.remove()
   }
 
   protected _ipy_stylesheets(): StyleSheetLike[] {
@@ -59,13 +54,26 @@ export class IPyWidgetView extends HTMLBoxView {
 
   render(): void {
     super.render()
-    if (this.ipyview != null) {
-      this.shadow_el.appendChild(this.ipyview.el)
-      this.ipyview.trigger('displayed', this.ipyview)
-      for (const child of this.ipychildren)
-        child.trigger('displayed', child)
-      this.invalidate_layout()
-    }
+    const {spec, state} = this.model.bundle
+    this.manager.set_state(state).then(async (models: any) => {
+      const model = models.find((item: any) => item.model_id == spec.model_id)
+      if (model == null)
+	return
+
+      this.manager.create_view(model, {el: this.el}).then(async (view: any) => {
+	this.ipyview = view
+	this.ipychildren = []
+	if (view.children_views) {
+          for (const child of view.children_views.views)
+            this.ipychildren.push(await child)
+	}
+	this.shadow_el.appendChild(this.ipyview.el)
+	this.ipyview.trigger('displayed', this.ipyview)
+	for (const child of this.ipychildren)
+          child.trigger('displayed', child)
+	this.invalidate_layout()
+      })
+    })
   }
 }
 

--- a/panel/models/ipywidget.ts
+++ b/panel/models/ipywidget.ts
@@ -11,7 +11,6 @@ export class IPyWidgetView extends HTMLBoxView {
   private ipychildren: any[]
   private manager: any
 
-
   initialize(): void {
     super.initialize()
     let manager: any
@@ -60,19 +59,18 @@ export class IPyWidgetView extends HTMLBoxView {
       if (model == null)
 	return
 
-      this.manager.create_view(model, {el: this.el}).then(async (view: any) => {
-	this.ipyview = view
-	this.ipychildren = []
-	if (view.children_views) {
-          for (const child of view.children_views.views)
-            this.ipychildren.push(await child)
-	}
-	this.shadow_el.appendChild(this.ipyview.el)
-	this.ipyview.trigger('displayed', this.ipyview)
-	for (const child of this.ipychildren)
-          child.trigger('displayed', child)
-	this.invalidate_layout()
-      })
+      const view = await this.manager.create_view(model, {el: this.el})
+      this.ipyview = view
+      this.ipychildren = []
+      if (view.children_views) {
+        for (const child of view.children_views.views)
+          this.ipychildren.push(await child)
+      }
+      this.shadow_el.appendChild(this.ipyview.el)
+      this.ipyview.trigger('displayed', this.ipyview)
+      for (const child of this.ipychildren)
+        child.trigger('displayed', child)
+      this.invalidate_layout()
     })
   }
 }


### PR DESCRIPTION
When rendering IPyWidgets in a notebook there was a race condition which meant that because lazy_initialize was slow you could end up with multiple Views for the same model.

@mattpap While I realize I was inappropriately using lazy_initialize here I think this revealed a bokeh bug where there could be a race condition where `this._child_views` was reset while a view was still initializing meaning that it was never cleaned up (or reused).  

Fixes https://github.com/holoviz/panel/issues/5459