### PR TITLE
Implement chat exception

### DIFF
--- a/examples/reference/widgets/ChatFeed.ipynb
+++ b/examples/reference/widgets/ChatFeed.ipynb
@@ -275,6 +275,37 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "You can surface exceptions by setting `callback_exception` to `\"summary\"`.\n",
+    "\n",
+    "To see the entire traceback, you can set it to `\"verbose\"`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def bad_callback(contents, user, instance):\n",
+    "    return 1 / 0\n",
+    "\n",
+    "chat_feed = pn.widgets.ChatFeed(callback=bad_callback, callback_exception=\"summary\")\n",
+    "chat_feed"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "chat_feed.send(\"This will fail...\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "The `ChatFeed` also support *async* `callback`s.\n",
     "\n",
     "In fact, we recommend using *async* `callback`s whenever possible to keep your app fast and responsive."

--- a/panel/tests/widgets/test_chat.py
+++ b/panel/tests/widgets/test_chat.py
@@ -1099,3 +1099,9 @@ class TestChatInterface:
     def test_widgets_supports_list_and_widget(self, chat_interface):
         chat_interface.widgets = TextAreaInput()
         chat_interface.widgets = [TextAreaInput(), FileInput]
+
+    def test_show_button_name_width(self, chat_interface):
+        assert chat_interface.show_button_name
+        assert chat_interface.width is None
+        chat_interface.width = 200
+        assert not chat_interface.show_button_name

--- a/panel/tests/widgets/test_chat.py
+++ b/panel/tests/widgets/test_chat.py
@@ -870,6 +870,45 @@ class TestChatFeedCallback:
         assert gauge.width == 100
         assert gauge.sizing_mode == "fixed"
 
+    def test_callback_exception(self, chat_feed):
+        def callback(msg, user, instance):
+            return 1 / 0
+
+        chat_feed.callback = callback
+        chat_feed.callback_exception = "summary"
+        chat_feed.send("Message", respond=True)
+        assert chat_feed.value[-1].value == "division by zero"
+        assert chat_feed.value[-1].user == "Exception"
+
+    def test_callback_exception_traceback(self, chat_feed):
+        def callback(msg, user, instance):
+            return 1 / 0
+
+        chat_feed.callback = callback
+        chat_feed.callback_exception = "verbose"
+        chat_feed.send("Message", respond=True)
+        assert chat_feed.value[-1].value.startswith("```python\nTraceback (most recent call last):")
+        assert chat_feed.value[-1].user == "Exception"
+
+    def test_callback_exception_ignore(self, chat_feed):
+        def callback(msg, user, instance):
+            return 1 / 0
+
+        chat_feed.callback = callback
+        chat_feed.callback_exception = "ignore"
+        chat_feed.send("Message", respond=True)
+        assert len(chat_feed.value) == 1
+
+    def test_callback_exception_raise(self, chat_feed):
+        def callback(msg, user, instance):
+            return 1 / 0
+
+        chat_feed.callback = callback
+        chat_feed.callback_exception = "raise"
+        with pytest.raises(ZeroDivisionError, match="division by zero"):
+            chat_feed.send("Message", respond=True)
+        assert len(chat_feed.value) == 1
+
 
 class TestChatInterfaceWidgetsSizingMode:
     def test_none(self):

--- a/panel/tests/widgets/test_chat.py
+++ b/panel/tests/widgets/test_chat.py
@@ -808,9 +808,7 @@ class TestChatFeedCallback:
 
         chat_feed.placeholder_threshold = 0.1
         chat_log_mock = MagicMock()
-        chat_log_mock.__getitem__.return_value = ChatEntry(
-            value="Message", placeholder_threshold=0.1
-        )
+        chat_log_mock.__getitem__.return_value = ChatEntry(value="Message")
         chat_feed.callback = echo
         chat_feed._chat_log = chat_log_mock
         chat_feed.send("Message", respond=True)
@@ -887,7 +885,9 @@ class TestChatFeedCallback:
         chat_feed.callback = callback
         chat_feed.callback_exception = "verbose"
         chat_feed.send("Message", respond=True)
-        assert chat_feed.value[-1].value.startswith("```python\nTraceback (most recent call last):")
+        assert chat_feed.value[-1].value.startswith(
+            "```python\nTraceback (most recent call last):"
+        )
         assert chat_feed.value[-1].user == "Exception"
 
     def test_callback_exception_ignore(self, chat_feed):

--- a/panel/widgets/chat.py
+++ b/panel/widgets/chat.py
@@ -776,7 +776,7 @@ class ChatFeed(CompositeWidget):
         The default user name to use for the entry provided by the callback.""")
 
     callback_exception = param.ObjectSelector(
-        default="raise",
+        default="summary",
         objects=["raise", "summary", "verbose", "ignore"],
         doc="""
         How to handle exceptions raised by the callback.

--- a/panel/widgets/chat.py
+++ b/panel/widgets/chat.py
@@ -541,7 +541,7 @@ class ChatEntry(CompositeWidget):
             not isinstance(obj, FileBase)
         )
         if is_markup:
-            if len(obj.object) > 0:  # only show a background if there is content
+            if len(str(obj.object)) > 0:  # only show a background if there is content
                 obj.css_classes = [*obj.css_classes, "message"]
         else:
             if obj.sizing_mode is None and not obj.width:
@@ -631,7 +631,7 @@ class ChatEntry(CompositeWidget):
         return HTML(self.user, height=20, css_classes=["name"], visible=self.show_user)
 
     @param.depends("value")
-    async def _render_value(self) -> Viewable:
+    def _render_value(self) -> Viewable:
         """
         Renders value as a panel object.
         """
@@ -1364,15 +1364,15 @@ class ChatInterface(ChatFeed):
             setattr(obj, attr, getattr(self, attr))
             self.link(obj, **{attr: attr})
 
-    @param.depends("width", on_init=True)
+    @param.depends("width", on_init=True, watch=True)
     def _update_input_width(self):
         """
         Update the input width.
         """
-        if self.show_button_name is None:
-            self.show_button_name = self.width >= 400
+        self.show_button_name = self.width is None or self.width >= 400
 
     @param.depends(
+        "width",
         "widgets",
         "show_send",
         "show_rerun",
@@ -1432,8 +1432,8 @@ class ChatInterface(ChatFeed):
                     icon=button_data.icon,
                     sizing_mode="fixed",
                     width=90 if self.show_button_name else 45,
-                    height=35,
-                    margin=(5, 5),
+                    height=30,
+                    margin=(5, 5, 5, 0),
                     align="center",
                 )
                 self._link_disabled_loading(button)


### PR DESCRIPTION
Surfaces exceptions to the chat interface/feed

```
import panel as pn
from panel.widgets import ChatInterface

def callback(msg, user, instance):
    return 1 / 0

ChatInterface(callback=callback, callback_exception="verbose").servable()
```

<img width="1153" alt="image" src="https://github.com/holoviz/panel/assets/15331990/49f6024a-2c51-4a77-a046-890ebe7088f6">
