### PR TITLE
FileInput seek 0

### DIFF
--- a/examples/reference/widgets/FileInput.ipynb
+++ b/examples/reference/widgets/FileInput.ipynb
@@ -138,6 +138,47 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### Reference Example\n",
+    "\n",
+    "Try uploading a `.csv` file."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import panel as pn\n",
+    "import pandas as pd\n",
+    "import io\n",
+    "\n",
+    "pn.extension()\n",
+    "\n",
+    "file_input = pn.widgets.FileInput(accept=\".csv\")\n",
+    "\n",
+    "\n",
+    "def get_rows(value):\n",
+    "    if file_input.value:\n",
+    "        out = io.BytesIO()\n",
+    "        file_input.save(out)\n",
+    "        df = pd.read_csv(out)\n",
+    "        return df.describe()\n",
+    "\n",
+    "    return \"Please upload data\"\n",
+    "\n",
+    "\n",
+    "pn.Column(\n",
+    "    \"## CSV File Upload\",\n",
+    "    file_input,\n",
+    "    pn.panel(pn.bind(get_rows, file_input), loading_indicator=True),\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### Upload size limits\n",
     "\n",
     "While the `FileInput` widget doesn't set any limit on the size of a file that can be selected by a user, the infrastructure onto which Panel relies (web browsers, Bokeh, Tornado, notebooks, etc.) limits significantly what is actually possible. By default the `FileInput` widget allows to upload data that is in the order of 10 MB. Even if it is possible to increase this limit by setting some parameters (described below), bear in mind that the `FileInput` widget is not meant to upload large files.\n",

--- a/panel/widgets/input.py
+++ b/panel/widgets/input.py
@@ -227,8 +227,8 @@ class FileInput(Widget):
                     f.write(val)
             else:
                 fn.write(val)
-                if hasattr(val, "seek"):
-                    val.seek(0)
+                if hasattr(fn, "seek"):
+                    fn.seek(0)
 
 
 class StaticText(Widget):

--- a/panel/widgets/input.py
+++ b/panel/widgets/input.py
@@ -227,6 +227,8 @@ class FileInput(Widget):
                     f.write(val)
             else:
                 fn.write(val)
+                if hasattr(val, "seek"):
+                    val.seek(0)
 
 
 class StaticText(Widget):


### PR DESCRIPTION
The documentation states

![image](https://github.com/holoviz/panel/assets/42288570/20fe8ee6-a7cc-4489-977b-e604d4d76aff)

It does not mention that every user has to run `.seek(0)`. This is a major pain and friction.

This PR tries to address this.