### PR TITLE
Fix autoreload

### DIFF
--- a/panel/io/callbacks.py
+++ b/panel/io/callbacks.py
@@ -84,7 +84,7 @@ class PeriodicCallback(param.Parameterized):
             with set_curdoc(self._doc):
                 if self.running:
                     self.counter += 1
-                    if self.counter > self.count:
+                    if self.count is not None and self.counter > self.count:
                         self.stop()
                 cb = self.callback() if self.running else None
         except Exception:

--- a/panel/tests/ui/command/test_serve.py
+++ b/panel/tests/ui/command/test_serve.py
@@ -29,7 +29,8 @@ def test_autoreload_app(py_file, port, page):
         page.goto(f"http://localhost:{port}/{app_name}")
         expect(page.locator(".markdown")).to_have_text("Example 1")
 
-        time.sleep(0.5)
+        # Timeout to ensure websocket is initialized
+        time.sleep(1.0)
 
         write_file(app2, py_file.file)
         expect(page.locator(".markdown")).to_have_text('Example 2')

--- a/panel/tests/ui/command/test_serve.py
+++ b/panel/tests/ui/command/test_serve.py
@@ -1,0 +1,33 @@
+import os
+import time
+
+import pytest
+
+from panel.tests.util import (
+    run_panel_serve, unix_only, wait_for_port, write_file,
+)
+
+try:
+    from playwright.sync_api import expect
+    pytestmark = pytest.mark.ui
+except ImportError:
+    pytestmark = pytest.mark.skip('playwright not available')
+
+
+@unix_only
+def test_autoreload_app(py_file, port, page):
+    app = "import panel as pn; pn.Row('Example 1').servable()"
+    app2 = "import panel as pn; pn.Row('Example 2').servable()"
+    write_file(app, py_file.file)
+
+    app_name = os.path.basename(py_file.name)[:-3]
+
+    with run_panel_serve(["--port", str(port), '--autoreload', py_file.name]) as p:
+        port = wait_for_port(p.stdout)
+        time.sleep(0.2)
+
+        page.goto(f"http://localhost:{port}/{app_name}")
+        expect(page.locator(".markdown")).to_have_text("Example 1")
+
+        write_file(app2, py_file.file)
+        expect(page.locator(".markdown")).to_have_text('Example 2')

--- a/panel/tests/ui/command/test_serve.py
+++ b/panel/tests/ui/command/test_serve.py
@@ -29,5 +29,7 @@ def test_autoreload_app(py_file, port, page):
         page.goto(f"http://localhost:{port}/{app_name}")
         expect(page.locator(".markdown")).to_have_text("Example 1")
 
+        time.sleep(0.5)
+
         write_file(app2, py_file.file)
         expect(page.locator(".markdown")).to_have_text('Example 2')


### PR DESCRIPTION
Fixes  #5489

`self.count` has a default of None (meaning unlimited), which will always give an exception out when comparing to `self.counter`