### PR TITLE
Fix authorization check bug

### DIFF
--- a/panel/io/server.py
+++ b/panel/io/server.py
@@ -519,7 +519,7 @@ class DocHandler(LoginUrlMixin, BkDocHandler, SessionPrefixHandler):
                         raise RuntimeError(
                             'Authorization callback must accept either 1) a single argument '
                             'which is the user name or 2) two arguments which includes the '
-                            'user name and the paths that user name has access to.'
+                            'user name and the url path the user is trying to access.'
                         )
                     auth_error = f'{state.user} is not authorized to access this application.'
                     try:


### PR DESCRIPTION
This commit adds some extra logic, and error messages around user authentication with a user supplied `authorize_callback` method.

- Adds more messaging around the `RuntimeError` when an error occurs during authorization checks.
- Adds messaging to a user attempting access a path they do not have access to.
- Adds logic to ensure if an `authorize_callback` has only 1 parameter, it does not cause a `RuntimeError`.

Resolves #5503