### PR TITLE
Param 2: adapt one test to updated error message

### DIFF
--- a/panel/tests/test_param.py
+++ b/panel/tests/test_param.py
@@ -1634,10 +1634,12 @@ def test_param_editablerangeslider_with_bounds():
     t = Test()
     w = EditableRangeSlider.from_param(t.param.i)
 
-    if Version(param.__version__) > Version('2.0.0a2'):
-        msg = "Attribute 'bound' of Range parameter 'EditableRangeSlider\.value' must be in range '\[0, 10\]'"
+    if Version(param.__version__) > Version('2.0.0a3'):
+        msg = r"Range parameter 'EditableRangeSlider\.value' lower bound must be in range \[0, 10\], not -1\."
+    elif Version(param.__version__) > Version('2.0.0a2'):
+        msg = r"Attribute 'bound' of Range parameter 'EditableRangeSlider\.value' must be in range '\[0, 10\]'"
     else:
-        msg = "Range parameter 'value''s lower bound must be in range \[0, 10\]"
+        msg = r"Range parameter 'value''s lower bound must be in range \[0, 10\]"
     with pytest.raises(ValueError, match=msg):
         w.value = (-1, 2)
 


### PR DESCRIPTION
Adapting one test to an improved error message changed in https://github.com/holoviz/param/pull/824 that will be in Param 2.0.0a3 (not yet release)