### PR TITLE
Param 2: skip custom logic for the private namespace when instantiating the config object

### DIFF
--- a/panel/config.py
+++ b/panel/config.py
@@ -419,6 +419,9 @@ class _config(_base_config):
         """
         from .io.state import state
 
+        if attr == '_param__private':
+            return super().__getattribute__('_param__private')
+
         # _param__private added in Param 2
         try:
             init = super().__getattribute__('_param__private').initialized


### PR DESCRIPTION
Without this change https://github.com/holoviz/param/pull/834 would make Panel fail on import when instantiating its config object.