### PR TITLE
Param 2: temporarily ignore testing the `hvplot_explorer` example

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -40,7 +40,7 @@ deps = .[recommended, tests]
 ; Not running clifford_interact as h5py install was corrupted on Python 3.7, see https://github.com/h5py/h5py/issues/1880.
 ; To remove when Python 3.7 is dropped or the issue is fixed upstream.
 commands = pytest panel --docs
-           pytest -n logical --dist loadscope --nbval-lax examples/reference examples/gallery --ignore-glob="*VTK*.ipynb" --ignore-glob="*Vega.ipynb" --ignore-glob="*DeckGL.ipynb" --ignore-glob="*Terminal.ipynb"  --ignore-glob="*DatePicker.ipynb"
+           pytest -n logical --dist loadscope --nbval-lax examples/reference examples/gallery --ignore-glob="*VTK*.ipynb" --ignore-glob="*Vega.ipynb" --ignore-glob="*DeckGL.ipynb" --ignore-glob="*Terminal.ipynb"  --ignore-glob="*DatePicker.ipynb"  --ignore-glob="*hvplot_explorer.ipynb"
 
 [_all_recommended]
 description = Run all recommended tests


### PR DESCRIPTION
To be reverted when https://github.com/holoviz/hvplot/pull/1146 is merged and released.