### PR TITLE
Add unit to widget in HoloViews pane if provided

### DIFF
--- a/panel/pane/holoviews.py
+++ b/panel/pane/holoviews.py
@@ -648,7 +648,8 @@ class HoloViews(PaneBase):
                     options = list(vals)
                     widget_type = widget_type or Select
                 default = vals[0] if dim.default is None else dim.default
-                widget_kwargs = dict(dict(name=dim.label, options=options, value=default), **widget_kwargs)
+                widget_name = dim.pprint_label
+                widget_kwargs = dict(dict(name=widget_name, options=options, value=default), **widget_kwargs)
                 widget = widget_type(**widget_kwargs)
             elif dim.range != (None, None):
                 start, end = dim.range


### PR DESCRIPTION
This PR adds the dimension units, if provided, to widget labels in dimensioned HoloViews containers.

Discussed [here](https://github.com/holoviz/holoviews/issues/5876)