### PR TITLE
Ensure that parameters set on the frontend are not dereferenced

### DIFF
--- a/panel/param.py
+++ b/panel/param.py
@@ -235,7 +235,6 @@ class Param(PaneBase):
         else:
             self._explicit_parameters = object is not None
 
-        print(object)
         if object and 'name' not in params:
             params['name'] = param_name(object.name)
         super().__init__(object, **params)


### PR DESCRIPTION
Since references set up on a Parameter are now dynamic we need to be careful that setting something on the frontend doesn't end up de-referencing it causing it to become unlinked.