### PR TITLE
Add reference example to set needle color in `Gauge`

### DIFF
--- a/examples/reference/indicators/Gauge.ipynb
+++ b/examples/reference/indicators/Gauge.ipynb
@@ -72,6 +72,26 @@
     "    colors=[(0.2, 'green'), (0.8, 'gold'), (1, 'red')]\n",
     ")"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "You can also change the color of the needle by passing custom options:"
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "pn.indicators.Gauge(\n",
+    "    name=\"Engine\", value=2500, bounds=(0, 3000), format='{value} rpm',\n",
+    "    colors=[(0.2, 'green'), (0.8, 'gold'), (1, 'red')],\n",
+    "    custom_opts={\"pointer\": {\"itemStyle\": {\"color\": 'red'}}}\n",
+    ")\n"
+   ],
+   "metadata": {}
   }
  ],
  "metadata": {


### PR DESCRIPTION
Fixes #3357

Adds an examples to set needle color in Gauge.

Docs Preview:

<img width="1107" alt="Screenshot 2023-09-27 at 12 05 02 pm" src="https://github.com/holoviz/panel/assets/5647941/3003a2ea-8e2c-4d32-b5c0-965973226715">


ping @MarcSkovMadsen 