### PR TITLE
Fix authorize_info in user_info.md

### DIFF
--- a/doc/how_to/authentication/user_info.md
+++ b/doc/how_to/authentication/user_info.md
@@ -11,9 +11,9 @@ Once a user is authorized with the chosen OAuth provider certain user informatio
 
 ## Authorization callbacks
 
-The OAuth providers integrated with Panel provide an easy way to enable authentication on your applications. This verifies the identity of a user and also provides some level of access control (i.e. authorization). However often times the OAuth configuration is controlled by a corporate IT department or is otherwise difficult to manage so its often easier to grant permissions to use the OAuth provider freely but then restrict access controls in the application itself. To manage access you can provide an `authorization_callback` as part of your applications.
+The OAuth providers integrated with Panel provide an easy way to enable authentication on your applications. This verifies the identity of a user and also provides some level of access control (i.e. authorization). However often times the OAuth configuration is controlled by a corporate IT department or is otherwise difficult to manage so its often easier to grant permissions to use the OAuth provider freely but then restrict access controls in the application itself. To manage access you can provide an `authorize_callback` as part of your applications.
 
-The `authorization_callback` can be configured on `pn.config` or via the `pn.extension`:
+The `authorize_callback` can be configured on `pn.config` or via the `pn.extension`:
 
 ```python
 import panel as pn

--- a/doc/how_to/authentication/user_info.md
+++ b/doc/how_to/authentication/user_info.md
@@ -39,7 +39,7 @@ The auth template must be a valid Jinja2 template and accepts a number of argume
 - `{{ error }}`: A short description of the error.
 - `{{ error_msg }}`: A full description of the error.
 
-The `authorization_callback` may also contain a second parameter, which is set by the
+The `authorize_callback` may also contain a second parameter, which is set by the
 requested application path. You can use this extra parameter to check if a user is
 authenticated _and_ has access to the application at the given path.
 


### PR DESCRIPTION
Fix docs typo: `authorization_callback` -> `authorize_callback`.

Also the docs say it can be configured via `pn.config`  and `pn.extension`, but that's not mentioned in their docs:

* https://holoviz-dev.github.io/panel/api/config.html
* https://holoviz-dev.github.io/panel/api/panel.config.html#panel.config.panel_extension

If someone knows how to add document the option there, please do.
