### PR TITLE
Add check for None in panel extension extension reload call

### DIFF
--- a/panel/io/resources.py
+++ b/panel/io/resources.py
@@ -372,7 +372,7 @@ def bundle_resources(roots, resources, notebook=False, reloading=False, enable_m
     extensions = _bundle_extensions(None, js_resources)
     if reloading:
         extensions = [
-            ext for ext in extensions if not ext.cdn_url.startswith('https://unpkg.com/@holoviz/panel@')
+            ext for ext in extensions if not (ext.cdn_url is not None and ext.cdn_url.startswith('https://unpkg.com/@holoviz/panel@'))
         ]
     extra_js = []
     if mode == "inline":


### PR DESCRIPTION
This fixes #5563. The basic error is some local extensions can be loaded where `cdn_url is None`, which then fails because the loading code directly trys to call `.startswith` on the object beforehand. See #5563 for more details.