### PR TITLE
Make scroll button more robust

### DIFF
--- a/panel/dist/css/listpanel.css
+++ b/panel/dist/css/listpanel.css
@@ -45,7 +45,7 @@
 }
 
 .scroll-button.visible:before {
-  content: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-arrow-big-down-filled" width="20" height="20" viewBox="0 0 24 24" stroke-width="2" stroke="white" fill="white" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"></path><path d="M10 2l-.15 .005a2 2 0 0 0 -1.85 1.995v6.999l-2.586 .001a2 2 0 0 0 -1.414 3.414l6.586 6.586a2 2 0 0 0 2.828 0l6.586 -6.586a2 2 0 0 0 .434 -2.18l-.068 -.145a2 2 0 0 0 -1.78 -1.089l-2.586 -.001v-6.999a2 2 0 0 0 -2 -2h-4z" stroke-width="0" fill="currentColor"></path></svg>');
+  content: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGNsYXNzPSJpY29uIGljb24tdGFibGVyIGljb24tdGFibGVyLWFycm93LWJpZy1kb3duLWZpbGxlZCIgd2lkdGg9IjIwIiBoZWlnaHQ9IjIwIiB2aWV3Qm94PSIwIDAgMjQgMjQiIHN0cm9rZS13aWR0aD0iMiIgc3Ryb2tlPSJjdXJyZW50Q29sb3IiIGZpbGw9Im5vbmUiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCI+CiAgIDxwYXRoIHN0cm9rZT0ibm9uZSIgZD0iTTAgMGgyNHYyNEgweiIgZmlsbD0ibm9uZSI+PC9wYXRoPgogICA8cGF0aCBkPSJNMTAgMmwtLjE1IC4wMDVhMiAyIDAgMCAwIC0xLjg1IDEuOTk1djYuOTk5bC0yLjU4NiAuMDAxYTIgMiAwIDAgMCAtMS40MTQgMy40MTRsNi41ODYgNi41ODZhMiAyIDAgMCAwIDIuODI4IDBsNi41ODYgLTYuNTg2YTIgMiAwIDAgMCAuNDM0IC0yLjE4bC0uMDY4IC0uMTQ1YTIgMiAwIDAgMCAtMS43OCAtMS4wODlsLTIuNTg2IC0uMDAxdi02Ljk5OWEyIDIgMCAwIDAgLTIgLTJoLTR6IiBzdHJva2Utd2lkdGg9IjAiIGZpbGw9ImN1cnJlbnRDb2xvciI+PC9wYXRoPgo8L3N2Zz4=');
   margin-top: 10px;
   filter: invert();
 }

--- a/panel/dist/css/listpanel.css
+++ b/panel/dist/css/listpanel.css
@@ -13,7 +13,7 @@
 .scroll-button {
   /* For location */
   position: sticky;
-  top: calc(100% - 38px);
+  bottom: 10px;
   left: calc(100% - 45px);
   /* For icon */
   cursor: pointer;
@@ -45,5 +45,7 @@
 }
 
 .scroll-button.visible:before {
-  content: '⬇';
+  content: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-arrow-big-down-filled" width="20" height="20" viewBox="0 0 24 24" stroke-width="2" stroke="white" fill="white" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"></path><path d="M10 2l-.15 .005a2 2 0 0 0 -1.85 1.995v6.999l-2.586 .001a2 2 0 0 0 -1.414 3.414l6.586 6.586a2 2 0 0 0 2.828 0l6.586 -6.586a2 2 0 0 0 .434 -2.18l-.068 -.145a2 2 0 0 0 -1.78 -1.089l-2.586 -.001v-6.999a2 2 0 0 0 -2 -2h-4z" stroke-width="0" fill="currentColor"></path></svg>');
+  margin-top: 10px;
+  filter: invert();
 }

--- a/panel/dist/css/listpanel.css
+++ b/panel/dist/css/listpanel.css
@@ -13,7 +13,7 @@
 .scroll-button {
   /* For location */
   position: sticky;
-  bottom: 0;
+  top: calc(100% - 38px);
   left: calc(100% - 45px);
   /* For icon */
   cursor: pointer;

--- a/panel/models/column.ts
+++ b/panel/models/column.ts
@@ -49,7 +49,6 @@ export class ColumnView extends BkColumnView {
   toggle_scroll_button(): void {
     const threshold = this.model.scroll_button_threshold
     const exceeds_threshold = this.distance_from_latest >= threshold
-    // if scroll_down_button_el is not null
     if (this.scroll_down_button_el) {
       this.scroll_down_button_el.classList.toggle(
         "visible", threshold !== 0 && exceeds_threshold

--- a/panel/models/column.ts
+++ b/panel/models/column.ts
@@ -43,7 +43,7 @@ export class ColumnView extends BkColumnView {
   }
 
   record_scroll_position(): void {
-    this.model.scroll_position = this.el.scrollTop;
+    this.model.scroll_position = Math.round(this.el.scrollTop);
   }
 
   toggle_scroll_button(): void {

--- a/panel/models/column.ts
+++ b/panel/models/column.ts
@@ -49,9 +49,12 @@ export class ColumnView extends BkColumnView {
   toggle_scroll_button(): void {
     const threshold = this.model.scroll_button_threshold
     const exceeds_threshold = this.distance_from_latest >= threshold
-    this.scroll_down_button_el.classList.toggle(
-      "visible", threshold !== 0 && exceeds_threshold
-    )
+    // if scroll_down_button_el is not null
+    if (this.scroll_down_button_el) {
+      this.scroll_down_button_el.classList.toggle(
+        "visible", threshold !== 0 && exceeds_threshold
+      )
+    }
   }
 
   render(): void {


### PR DESCRIPTION
Patches https://github.com/holoviz/panel/pull/5532 where the scroll_button landed on top right:
![image](https://github.com/holoviz/panel/assets/15331990/57e9892f-d3a7-40a9-8a48-98b09f202615)

Now:
<img width="511" alt="image" src="https://github.com/holoviz/panel/assets/15331990/1d8fb7b7-e410-4240-bfb0-2659ee6d924d">

Also, it still fixes https://github.com/holoviz/panel/issues/5544
<img width="1135" alt="image" src="https://github.com/holoviz/panel/assets/15331990/44f378d4-c147-4f6e-b1f3-8392978abbcd">
