### PR TITLE
Allow refs on Matplotlib and PaneBase

### DIFF
--- a/panel/pane/base.py
+++ b/panel/pane/base.py
@@ -125,7 +125,7 @@ class PaneBase(Reactive):
         be specified as a two-tuple of the form (vertical, horizontal)
         or a four-tuple (top, right, bottom, left).""")
 
-    object = param.Parameter(default=None, doc="""
+    object = param.Parameter(default=None, allow_refs=True, doc="""
         The object being wrapped, which will be converted to a
         Bokeh model.""")
 

--- a/panel/pane/plot.py
+++ b/panel/pane/plot.py
@@ -222,7 +222,7 @@ class Matplotlib(Image, IPyWidget):
     interactive = param.Boolean(default=False, constant=True, doc="""
         Whether to render interactive matplotlib plot with ipympl.""")
 
-    object = param.Parameter(default=None, allow_refs=False, doc="""
+    object = param.Parameter(default=None, allow_refs=True, doc="""
         The Matplotlib Figure being wrapped, which will be rendered as a
         Bokeh model.""")
 


### PR DESCRIPTION
I can see the Gaminder example fails because they are False. 

https://github.com/holoviz/panel/actions/runs/6403251613/job/17381429742?pr=5572