### PR TITLE
Fix thumbnails and use Panel design on index page

### DIFF
--- a/panel/_templates/index.html
+++ b/panel/_templates/index.html
@@ -124,7 +124,7 @@
 	text-align: center;
     }
     .header {
-  background-image: linear-gradient(to top, rgba(0, 0, 0, 0.6), rgba(0, 0, 0, 0) ),url('{{ PANEL_CDN }}images/index_background.png');
+         background-image: linear-gradient(to top, rgba(0, 0, 0, 0.6), rgba(0, 0, 0, 0) ),url('{{ PANEL_CDN }}images/index_background.png');
 	background-size: cover;
 	background-repeat: space;
 	background-position: center;
@@ -207,10 +207,10 @@
 	margin-top: 25px;
     }
     object {
-  height: 175px;
+        height: 175px;
 	max-width: calc(100% - 50px);
 	margin-top: 25px;
-  border-radius: calc(var(--control-corner-radius) * 1px);
+        border-radius: calc(var(--control-corner-radius) * 1px);
     }
     .card-content {
 	padding: 10px 10px 10px;

--- a/panel/_templates/index.html
+++ b/panel/_templates/index.html
@@ -124,7 +124,7 @@
 	text-align: center;
     }
     .header {
-         background-image: linear-gradient(to top, rgba(0, 0, 0, 0.6), rgba(0, 0, 0, 0) ),url('{{ PANEL_CDN }}images/index_background.png');
+        background-image: linear-gradient(to top, rgba(0, 0, 0, 0.6), rgba(0, 0, 0, 0) ),url('{{ PANEL_CDN }}images/index_background.png');
 	background-size: cover;
 	background-repeat: space;
 	background-position: center;

--- a/panel/_templates/index.html
+++ b/panel/_templates/index.html
@@ -124,7 +124,7 @@
 	text-align: center;
     }
     .header {
-  background-image: linear-gradient(to top, rgba(0, 0, 0, 0.6), rgba(0, 0, 0, 0) ),url('{{ PANEL_CDN }}images/index_background.png');
+  background-image: linear-gradient(to top, rgba(0, 0, 0, 0.6), rgba(0, 0, 0, 0) ),url('https://user-images.githubusercontent.com/42288570/273394530-d49f47e4-0ce3-46d9-9639-38cff4966baf.png');
 	background-size: cover;
 	background-repeat: space;
 	background-position: center;
@@ -203,7 +203,7 @@
     }
     .card-image {
 	height: 175px;
-	max-width: calc(100% - 50px);
+	width: 100%;
 	margin-top: 25px;
     }
     object {

--- a/panel/_templates/index.html
+++ b/panel/_templates/index.html
@@ -124,9 +124,9 @@
 	text-align: center;
     }
     .header {
-	background-image: linear-gradient(to top, rgba(0, 0, 0, 0.6), rgba(0, 0, 0, 0) ),url('{{ PANEL_CDN }}images/index_background.png');
+  background-image: linear-gradient(to top, rgba(0, 0, 0, 0.6), rgba(0, 0, 0, 0) ),url('{{ PANEL_CDN }}images/index_background.png');
 	background-size: cover;
-	background-repeat: no-repeat;
+	background-repeat: space;
 	background-position: center;
     }
     .header-content {
@@ -202,12 +202,15 @@
 	fill: var(--neutral-foreground-rest);
     }
     .card-image {
-	height: 100px;
-	width: 100%;
+	height: 175px;
+	max-width: calc(100% - 50px);
 	margin-top: 25px;
     }
     object {
-	height: 125px;
+  height: 175px;
+	max-width: calc(100% - 50px);
+	margin-top: 25px;
+  border-radius: calc(var(--control-corner-radius) * 1px);
     }
     .card-content {
 	padding: 10px 10px 10px;
@@ -292,6 +295,7 @@
       const header_design = new window.fastDesignProvider("#header-design-provider");
       header_design.setBackgroundColor('#ffffff')
       const body_design = window.bodyDesign = new window.fastDesignProvider("#body-design-provider");
+      body_design.setAccentColor("#0072B5")
       setSwitchFromParams()
       setSearchFromParams()
     })

--- a/panel/_templates/index.html
+++ b/panel/_templates/index.html
@@ -124,7 +124,7 @@
 	text-align: center;
     }
     .header {
-  background-image: linear-gradient(to top, rgba(0, 0, 0, 0.6), rgba(0, 0, 0, 0) ),url('https://user-images.githubusercontent.com/42288570/273394530-d49f47e4-0ce3-46d9-9639-38cff4966baf.png');
+  background-image: linear-gradient(to top, rgba(0, 0, 0, 0.6), rgba(0, 0, 0, 0) ),url('{{ PANEL_CDN }}images/index_background.png');
 	background-size: cover;
 	background-repeat: space;
 	background-position: center;


### PR DESCRIPTION
For the panel-chat-examples we are using the index page with thumbnails. The index page could need a make over because

- Its not using the Panel blue
- Thumbnails are not positioned well (Also reported in #5128)
- The header background could be more Panel specific as well as work better with Panel blue.

This fixes the issues

## Before

```bash
panel serve app1.py app2.py --autoreload --static thumbnails=thumbnails
```

![before](https://github.com/holoviz/panel/assets/42288570/1f11f531-c833-44e8-b759-365cf8faf6a0)

## After

![image](https://github.com/holoviz/panel/assets/42288570/292236ea-13ea-47c1-bd3d-089a34cd53cb)

![image](https://github.com/holoviz/panel/assets/42288570/6792bd55-bca0-425a-ab3f-78b23600a232)

## Todo

[ ] @philippjfr should consider replacing the existing `index_background.png` image with the below in the CDN. (see discussion below).

![index_background](https://github.com/holoviz/panel/assets/42288570/d49f47e4-0ce3-46d9-9639-38cff4966baf)

FYI. @ahuang11 