### PR TITLE
Add support for Path object in FileDownload

### DIFF
--- a/examples/reference/widgets/FileDownload.ipynb
+++ b/examples/reference/widgets/FileDownload.ipynb
@@ -29,7 +29,7 @@
     "* **`auto`** (boolean):  Whether to download the file the initial click (if `True`) or when clicking a second time (or via the right-click Save file menu).\n",
     "* **`callback`** (callable): A callable that returns a file or file-like object (takes precedence over `file` if set). \n",
     "* **`embed`** (boolean):  Whether to embed the data on initialization.\n",
-    "* **`file`** (str or file-like object):  A path to a file or a file-like object.\n",
+    "* **`file`** (str, Path or file-like object):  A path to a file or a file-like object.\n",
     "* **`filename`** (str): The filename to save the file as.\n",
     "\n",
     "##### Display\n",

--- a/panel/tests/widgets/test_misc.py
+++ b/panel/tests/widgets/test_misc.py
@@ -1,4 +1,5 @@
 from io import StringIO
+from pathlib import Path
 
 import pytest
 
@@ -78,10 +79,8 @@ def test_file_download_file():
 
 
 def test_file_download_callback():
-    file_download = FileDownload(callback=lambda: StringIO("data"), file="abc")
-
     with pytest.raises(ValueError):
-        file_download._clicks += 1
+        FileDownload(callback=lambda: StringIO("data"))
 
     file_download = FileDownload(callback=lambda: StringIO("data"), filename="abc.py")
 
@@ -131,3 +130,14 @@ def test_file_download_data():
     file_download.data = None
     file_download._clicks += 1
     assert file_download.data is not None
+
+def test_file_path_download():
+    path = Path(__file__)
+
+    file_download = FileDownload(path)
+
+    assert file_download.filename == "test_misc.py"
+    assert file_download.label == "Download test_misc.py"
+    file_download._clicks += 1
+    assert file_download.data
+    assert file_download._transfers == 1


### PR DESCRIPTION
I was trying to add a FileDownload to one of the examples in panel-chat-examples. But i got an exception because I provided a `Path` object. This PR adds support for `Path` objects to the `FileDownload`.