### PR TITLE
Error if trailing slash used in pn.Serve

### DIFF
--- a/panel/io/server.py
+++ b/panel/io/server.py
@@ -1080,6 +1080,8 @@ def get_server(
     if isinstance(panel, dict):
         apps = {}
         for slug, app in panel.items():
+            if slug.endswith('/'):
+                raise ValueError(f"Invalid URL: trailing slash '/' used for {slug!r} not supported.")
             if isinstance(title, dict):
                 try:
                     title_ = title[slug]

--- a/panel/io/server.py
+++ b/panel/io/server.py
@@ -1080,7 +1080,7 @@ def get_server(
     if isinstance(panel, dict):
         apps = {}
         for slug, app in panel.items():
-            if slug.endswith('/'):
+            if slug.endswith('/') and not slug == '/':
                 raise ValueError(f"Invalid URL: trailing slash '/' used for {slug!r} not supported.")
             if isinstance(title, dict):
                 try:


### PR DESCRIPTION
Fixes #5603

Alternatively, we can just remove the trailing slash. 