### PR TITLE
Update `TextAreaInput` rows on value change when auto_grow

### DIFF
--- a/panel/models/textarea_input.ts
+++ b/panel/models/textarea_input.ts
@@ -9,8 +9,7 @@ export class TextAreaInputView extends BkTextAreaInputView {
 
     const { value, max_rows } = this.model.properties;
 
-    this.on_change(value, () => this.update_rows());  // for manually setting value
-    this.on_change(max_rows, () => this.update_rows());
+    this.on_change([max_rows, value], () => this.update_rows());
   }
 
   update_rows(): void {

--- a/panel/models/textarea_input.ts
+++ b/panel/models/textarea_input.ts
@@ -4,6 +4,15 @@ import * as p from "@bokehjs/core/properties";
 export class TextAreaInputView extends BkTextAreaInputView {
   model: TextAreaInput;
 
+  connect_signals(): void {
+    super.connect_signals();
+
+    const { value, max_rows } = this.model.properties;
+
+    this.on_change(value, () => this.update_rows());  // for manually setting value
+    this.on_change(max_rows, () => this.update_rows());
+  }
+
   update_rows(): void {
     if (!this.model.auto_grow) {
       return;

--- a/panel/tests/ui/widgets/test_input.py
+++ b/panel/tests/ui/widgets/test_input.py
@@ -652,3 +652,20 @@ def test_text_area_auto_grow_min_rows(page):
         input_area.press('Backspace')
 
     expect(page.locator('.bk-input')).to_have_js_property('rows', 3)
+
+
+def test_text_area_auto_grow_shrink_back_on_new_value(page):
+    text_area = TextAreaInput(auto_grow=True, value="1\n2\n3\n4\n", max_rows=5)
+
+    serve_component(page, text_area)
+
+    input_area = page.locator('.bk-input')
+    input_area.click()
+    for _ in range(5):
+        input_area.press('ArrowDown')
+    for _ in range(10):
+        input_area.press('Backspace')
+
+    text_area.value = ""
+
+    expect(page.locator('.bk-input')).to_have_js_property('rows', 2)


### PR DESCRIPTION
Watching `input` events only watches user key strokes, and does not watch `textarea.value = ""`

This PR watches `value` so that rows will also be updated when value is changed programmatically.

