### PR TITLE
Add examples/conftest.py

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -54,10 +54,10 @@ jobs:
           python-version: ${{ matrix.python-version }}
           channels: pyviz/label/dev,numba,bokeh,conda-forge,nodefaults
           # Remove when Python 3.11 is well supported on latest conda/conda-forge.
-          conda-update: ${{ matrix.python-version == '3.11' && 'false' || 'true' }}
+          conda-update: true
           nodejs: true
           # Remove when all examples tools can be installed on 3.10
-          envs: ${{ !contains(matrix.python-version, '3.1') && '-o examples -o recommended -o tests -o build' || '-o recommended -o tests -o build' }}
+          envs: -o examples -o recommended -o tests -o build
           cache: true
           opengl: true
         id: install
@@ -89,8 +89,6 @@ jobs:
           conda activate test-environment
           doit test_subprocess
       - name: test examples
-        # Remove when all examples tools can be installed on 3.10
-        if: (!(contains(matrix.python-version, '3.1')))
         run: |
           conda activate test-environment
           doit test_examples

--- a/examples/conftest.py
+++ b/examples/conftest.py
@@ -2,10 +2,8 @@ collect_ignore_glob = [
     "apps/",
     "developer_guide/",
     "homepage.ipynb",
-    "*VTK*",
-    "*vtk*",
+    "*VTK*.ipynb",
     "*Vega.ipynb",
-    "*DeckGL*",
-    "*deckgl*",
-    "reference/widgets/Terminal.ipynb",
- ]
+    "*DeckGL*.ipynb",
+    "*Terminal.ipynb",
+]

--- a/examples/conftest.py
+++ b/examples/conftest.py
@@ -1,0 +1,11 @@
+collect_ignore_glob = [
+    "apps/",
+    "developer_guide/",
+    "homepage.ipynb",
+    "*VTK*",
+    "*vtk*",
+    "*Vega.ipynb",
+    "*DeckGL*",
+    "*deckgl*",
+    "reference/widgets/Terminal.ipynb",
+ ]

--- a/tox.ini
+++ b/tox.ini
@@ -37,10 +37,8 @@ commands = pytest panel --cov=./panel --cov-report=xml --subprocess
 [_examples]
 description = Test that default examples run
 deps = .[recommended, tests]
-; Not running clifford_interact as h5py install was corrupted on Python 3.7, see https://github.com/h5py/h5py/issues/1880.
-; To remove when Python 3.7 is dropped or the issue is fixed upstream.
 commands = pytest panel --docs
-           pytest -n logical --dist loadscope --nbval-lax examples/reference examples/gallery --ignore-glob="*VTK*.ipynb" --ignore-glob="*Vega.ipynb" --ignore-glob="*DeckGL.ipynb" --ignore-glob="*Terminal.ipynb"  --ignore-glob="*DatePicker.ipynb"  --ignore-glob="*hvplot_explorer.ipynb"
+           pytest -n logical --dist loadscope --nbval-lax examples
 
 [_all_recommended]
 description = Run all recommended tests


### PR DESCRIPTION
This is just moving the `ignore_glob` into a file.  

But this will give the option to selectively ignore files based on the Python version, a package version or the OS instead of removing it from all. 