### PR TITLE
Ensure notifications and browser_info are loaded in the extension

### DIFF
--- a/panel/config.py
+++ b/panel/config.py
@@ -813,7 +813,7 @@ class panel_extension(_pyviz_extension):
             # In embedded mode the ipywidgets_bokeh model must be loaded
             __import__(self._imports['ipywidgets'])
 
-        nb_loaded = getattr(self, '_repeat_execution_in_cell', False)
+        nb_loaded = published = getattr(self, '_repeat_execution_in_cell', False)
         if 'holoviews' in sys.modules:
             if getattr(hv.extension, '_loaded', False):
                 nb_loaded = True
@@ -831,13 +831,13 @@ class panel_extension(_pyviz_extension):
                 config.inline, reloading=nb_loaded
             )
 
-        if not nb_loaded and config.browser_info and state.browser_info:
+        if not published and config.browser_info and state.browser_info:
             doc = Document()
             comm = state._comm_manager.get_server_comm()
             model = state.browser_info._render_model(doc, comm)
             bundle, meta = state.browser_info._render_mimebundle(model, doc, comm)
             display(bundle, metadata=meta, raw=True)  # noqa
-        if not nb_loaded and config.notifications:
+        if not published and config.notifications:
             display(state.notifications)  # noqa
 
     def _detect_comms(self, params):


### PR DESCRIPTION
Load notifications and browser_info even when HoloViews is in `sys.modules`. Previously Holoviews being available would always force `nb_loaded` to True meaning that browser_info and notifications would never get displayed.