### PR TITLE
Fix increasing number of Cards referenced by the Accordion

### DIFF
--- a/panel/layout/accordion.py
+++ b/panel/layout/accordion.py
@@ -106,6 +106,7 @@ class Accordion(NamedListPanel):
         for obj in old_objects:
             if obj not in self.objects:
                 self._panels[id(obj)]._cleanup(root)
+                del self._panels[id(obj)]
 
         params = {
             k: v for k, v in self.param.values().items()

--- a/panel/tests/layout/test_accordion.py
+++ b/panel/tests/layout/test_accordion.py
@@ -107,6 +107,13 @@ def test_accordion_cleanup_panels(document, comm, accordion):
     assert model.ref['id'] not in card2._models
 
 
+def test_accordion_setitem__panels_udated(document, comm, accordion):
+    accordion.get_root(document, comm=comm)
+    accordion[:] = [('Card1', '1'), ('Card2', '2'), ('Card3', '3')]
+
+    assert len(accordion._panels) == 3
+
+
 def test_accordion_active(document, comm, accordion):
     model = accordion.get_root(document, comm=comm)
 


### PR DESCRIPTION
The issue I'm trying to solve can be reproduced with this app:

- Run the app
- Click on `extend`
- Open the last card
- Check the logs, you will see `debug active [6]`

Getting `[6]` is the problem, there are 5 cards and only the last one is being opened, so we should get `[4]`.

```python
import panel as pn

all_objs = [(f'Title {i}', str(i)) for i in range(5)]

acc = pn.Accordion(*all_objs[:2], toggle=True, active=[0])


def debug_active(event):
    print('debug active', event.new)

acc.param.watch(debug_active, 'active')

b = pn.widgets.Button(name='Extend')

def extend(_):
    print('extend')
    acc[:] = all_objs

b.on_click(extend)

pn.Row(b, acc).servable()
```

I noticed that the length of the `accordion._panels` dictionary was increasing everytime I hit `extend`. I believe this is the cause of the bug I experienced, `_set_active` and `_update_active` relying on `_values` to find out which card(s) are collapsed or not.