### PR TITLE
Move API removals from version 1.3 to 1.4

### DIFF
--- a/panel/pane/markup.py
+++ b/panel/pane/markup.py
@@ -44,7 +44,7 @@ class HTMLBasePane(ModelPane):
         if "style" in params:
             # In Bokeh 3 'style' was changed to 'styles'.
             params["styles"] = params.pop("style")
-            deprecated("1.3", "style",  "styles")
+            deprecated("1.4", "style",  "styles")
         super().__init__(object=object, **params)
 
 

--- a/panel/viewable.py
+++ b/panel/viewable.py
@@ -726,7 +726,7 @@ class Viewable(Renderable, Layoutable, ServableMixin):
         # Warning
         prev = f'{type(self).name}(..., background={self.background!r})'
         new = f"{type(self).name}(..., styles={{'background': {self.background!r}}})"
-        deprecated("1.3", prev, new)
+        deprecated("1.4", prev, new)
 
         self.styles = dict(self.styles, background=self.background)
 
@@ -862,7 +862,7 @@ class Viewable(Renderable, Layoutable, ServableMixin):
         """
         Prints a compositional repr of the class.
         """
-        deprecated('1.3', f'{type(self).__name__}.pprint', 'print')
+        deprecated('1.4', f'{type(self).__name__}.pprint', 'print')
         print(self)
 
     def select(
@@ -900,7 +900,7 @@ class Viewable(Renderable, Layoutable, ServableMixin):
         port: int (optional, default=0)
           Allows specifying a specific port
         """
-        deprecated('1.3', f'{type(self).__name__}.app', 'panel.io.notebook.show_server')
+        deprecated('1.4', f'{type(self).__name__}.app', 'panel.io.notebook.show_server')
         return show_server(self, notebook_url, port)
 
     def embed(

--- a/panel/widgets/codeeditor.py
+++ b/panel/widgets/codeeditor.py
@@ -86,5 +86,5 @@ class CodeEditor(Widget):
 
 class Ace(CodeEditor):
     def __init__(self, **params):
-        deprecated("1.3", "Ace", "CodeEditor")
+        deprecated("1.4", "Ace", "CodeEditor")
         super().__init__(**params)

--- a/panel/widgets/indicators.py
+++ b/panel/widgets/indicators.py
@@ -1088,7 +1088,7 @@ class Trend(SyncableData, Indicator):
     def __init__(self, **params):
         if "title" in params:
             params["name"] = params.pop("title")
-            deprecated("1.3", "title",  "name")
+            deprecated("1.4", "title",  "name")
         super().__init__(**params)
 
     def _get_data(self):


### PR DESCRIPTION
The CI is currently failing as `deprecated` raises an error if the version announced for the removal has a beta or RC release.

I checked some of these deprecations and believe they were set before Panel 1.1.1 was released, on the 21th of June. In my opinion 4 months is too tight, so I bumped it arbitrarily to 1.4. Feel free to discard this PR and resolve the issue in another manner.