### PR TITLE
Make `_display_globals` a staticmethod

### DIFF
--- a/panel/config.py
+++ b/panel/config.py
@@ -834,8 +834,8 @@ class panel_extension(_pyviz_extension):
         if not published:
             self._display_globals()
 
-    @classmethod
-    def _display_globals(self):
+    @staticmethod
+    def _display_globals():
         if config.browser_info and state.browser_info:
             doc = Document()
             comm = state._comm_manager.get_server_comm()

--- a/panel/config.py
+++ b/panel/config.py
@@ -834,6 +834,7 @@ class panel_extension(_pyviz_extension):
         if not published:
             self._display_globals()
 
+    @classmethod
     def _display_globals(self):
         if config.browser_info and state.browser_info:
             doc = Document()


### PR DESCRIPTION
This will make it possible to call it in HoloViews without initializing `pn.extension`. 