### PR TITLE
Allow ListPanel objects to be a reference

### DIFF
--- a/panel/layout/base.py
+++ b/panel/layout/base.py
@@ -13,6 +13,7 @@ from typing import (
 import param
 
 from bokeh.models import Row as BkRow
+from param.parameterized import iscoroutinefunction, resolve_ref
 
 from ..io.model import hold
 from ..io.resources import CDN_DIST
@@ -801,8 +802,9 @@ class ListPanel(ListLike, Panel):
                                  "not both." % type(self).__name__)
             params['objects'] = [panel(pane) for pane in objects]
         elif 'objects' in params:
-            if not hasattr(params['objects'], '_dinfo'):
-                params['objects'] = [panel(pane) for pane in params['objects']]
+            objects = params['objects']
+            if not resolve_ref(objects) or iscoroutinefunction(objects):
+                params['objects'] = [panel(pane) for pane in objects]
         super(Panel, self).__init__(**params)
 
     @property

--- a/panel/tests/layout/test_base.py
+++ b/panel/tests/layout/test_base.py
@@ -8,10 +8,10 @@ from panel.layout import (
     Accordion, Card, Column, Row, Spacer, Tabs, WidgetBox,
 )
 from panel.layout.base import ListPanel, NamedListPanel
-from panel.pane import Bokeh
+from panel.pane import Bokeh, Markdown
 from panel.param import Param
 from panel.tests.util import check_layoutable_properties
-from panel.widgets import Debugger
+from panel.widgets import Debugger, MultiSelect
 
 excluded = (NamedListPanel, Debugger, ChatInterface)
 all_panels = [w for w in param.concrete_descendents(ListPanel).values()
@@ -579,3 +579,22 @@ def test_column_scroll_params_sets_scroll(scroll_param, document, comm):
     col = Column(**params)
     assert getattr(col, scroll_param)
     assert col.scroll
+
+def test_pass_objects_ref(document, comm):
+    multi_select = MultiSelect(options=['foo', 'bar', 'baz'], value=['bar', 'baz'])
+    col = Column(objects=multi_select)
+    col.get_root(document, comm=comm)
+
+    assert len(col.objects) == 2
+    md1, md2 = col.objects
+    assert isinstance(md1, Markdown)
+    assert md1.object == 'bar'
+    assert isinstance(md2, Markdown)
+    assert md2.object == 'baz'
+
+    multi_select.value = ['foo']
+
+    assert len(col.objects) == 1
+    md3 = col.objects[0]
+    assert isinstance(md3, Markdown)
+    assert md3.object == 'foo'


### PR DESCRIPTION
`ListPanel` had logic in its constructor that meant you could not pass a reference to the `objects` parameter, e.g. `Column(objects=multi_select)` would not display the contents of the multi-select as individual items.