### PR TITLE
Fix Tabulator container scrolling up when patching

### DIFF
--- a/panel/models/tabulator.ts
+++ b/panel/models/tabulator.ts
@@ -911,8 +911,16 @@ export class DataTabulatorView extends HTMLBoxView {
     if (this._tabulator_cell_updating)
       return
 
+    // Temporarily set minHeight to avoid "scroll-to-top" issues caused
+    // by Tabulator JS entirely destroying the table when .setData is called.
+    // Inspired by https://github.com/olifolkerd/tabulator/issues/4155
+    const prev_minheight = this.tabulator.element.style.minHeight
+    this.tabulator.element.style.minHeight = this.tabulator.element.offsetHeight + "px"
+
     let data = transform_cds_to_records(this.model.source, true)
-    this.tabulator.setData(data)
+    this.tabulator.setData(data).then(() => {
+      this.tabulator.element.style.minHeight = prev_minheight
+    })
   }
 
   setFrozen(): void {

--- a/panel/tests/ui/widgets/test_tabulator.py
+++ b/panel/tests/ui/widgets/test_tabulator.py
@@ -975,6 +975,28 @@ def test_tabulator_patch_no_vertical_rescroll(page):
     assert bb == page.locator(f'text="{new_val}"').bounding_box()
 
 
+def test_tabulator_patch_no_height_resize(page):
+    header = Column('Text', height=1000)
+    df = pd.DataFrame(np.random.random((150, 1)), columns=['a'])
+    widget = Tabulator(df)
+    app = Column(header, widget)
+
+    serve_component(page, app)
+
+    page.mouse.wheel(delta_x=0, delta_y=10000)
+    at_bottom_script = """
+    isAtBottom => (window.innerHeight + window.scrollY) >= document.body.scrollHeight;
+    """
+    wait_until(lambda: page.evaluate(at_bottom_script), page)
+
+    widget.patch({'a': [(len(df)-1, 100)]})
+
+    # Give it some time to potentially "re-scroll"
+    page.wait_for_timeout(400)
+
+    wait_until(lambda: page.evaluate(at_bottom_script), page)
+
+
 @pytest.mark.parametrize(
     'pagination',
     (


### PR DESCRIPTION
Addresses https://github.com/holoviz/panel/issues/5673

While looking into fixing this issue, I found this issue https://github.com/olifolkerd/tabulator/issues/4155 where some Tabulator JS users reported the same problem and dealt with it setting minHeight on the table. This is the approach I chose and that works in the test I've added.

TabulatorJS offers two APIs to replace data (`replaceData`, `updateData`) but I don't think swapping `setData` for one of them would resolve this issue. It can however help fixing some of the other scrolling issues users have reported when `.patch` is called and a height is set (in which case I believe `replaceData` is the correct API to use per this comment https://github.com/olifolkerd/tabulator/issues/4056#issuecomment-1343330186 and the [docs](https://tabulator.info/docs/5.5/update#alter-replace)).