### PR TITLE
Update commandline.md

### DIFF
--- a/doc/how_to/server/commandline.md
+++ b/doc/how_to/server/commandline.md
@@ -109,7 +109,7 @@ options:
                         A random string used to encode the user information.
   --oauth-expiry-days OAUTH_EXPIRY_DAYS
                         Expiry off the OAuth cookie in number of days.
-  --oauth-refresh_tokens OAUTH_REFRESH_TOKEN
+  --oauth-refresh-tokens OAUTH_REFRESH_TOKENS
                         Whether to automatically refresh OAuth access tokens when they expire.
   --auth-template AUTH_TEMPLATE
                         Template to serve when user is unauthenticated.


### PR DESCRIPTION
Follow-up to #5648 fixing a docs typo.

What else needs to be edited to make the env var show up in the help output?

It's currently not there:
```
$ panel serve --help

...
  --oauth-expiry-days OAUTH_EXPIRY_DAYS
                        Expiry off the OAuth cookie in number of days.
  --oauth-refresh-tokens
                        Whether to automatically OAuth access tokens when they expire.
  --login-endpoint LOGIN_ENDPOINT
                        Endpoint to serve the authentication login page on.
...
````