### PR TITLE
Fix Beatboxing

### DIFF
--- a/examples/reference/chat/ChatMessage.ipynb
+++ b/examples/reference/chat/ChatMessage.ipynb
@@ -153,7 +153,7 @@
     "        pn.Column(\n",
     "            \"Here goes. Hope you like this one?\",\n",
     "            pn.pane.Audio(\n",
-    "                \"https://upload.wikimedia.org/wikipedia/commons/d/d3/Beatboxset1_pepouni.ogg\"\n",
+    "                \"https://github.com/holoviz/panel/raw/fi/beatboxing-ogg/examples/assets/Beatboxset1_pepouni.mp3\"\n",
     "            ),\n",
     "        ),\n",
     "        user=\"Beat Boxer\",\n",

--- a/examples/reference/chat/ChatMessage.ipynb
+++ b/examples/reference/chat/ChatMessage.ipynb
@@ -153,7 +153,7 @@
     "        pn.Column(\n",
     "            \"Here goes. Hope you like this one?\",\n",
     "            pn.pane.Audio(\n",
-    "                \"https://github.com/holoviz/panel/raw/fi/beatboxing-ogg/examples/assets/Beatboxset1_pepouni.mp3\"\n",
+    "                \"https://assets.holoviz.org/panel/samples/beatboxing.mp3\"\n",
     "            ),\n",
     "        ),\n",
     "        user=\"Beat Boxer\",\n",


### PR DESCRIPTION
This PR will fix the `.ogg` beat boxing example in the ChatMessage reference notebook as mentioned in #5622.

I've fixed the issue by converting the `.ogg` file to `.mp3` and hosting it elsewhere than wikipedia. I guess the conversion is really the solution.

I've tested manually by replacing the link in the source document. It works with the `.mp3` file. It does not work if I switch back to the `.ogg` file.

![image](https://github.com/holoviz/panel/assets/42288570/926fb666-f891-4cff-a950-0eee21074f31)

# Todo

- [ ] Upload [Beatboxset1_pepouni.mp3](https://github.com/holoviz/panel/raw/fi/beatboxing-ogg/examples/assets/Beatboxset1_pepouni.mp3) file to CDN and replace link