### PR TITLE
Make ChatBox deprecation very clear

### DIFF
--- a/examples/reference/widgets/ChatBox.ipynb
+++ b/examples/reference/widgets/ChatBox.ipynb
@@ -1,6 +1,15 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<div class=\"alert alert-warning\">\n",
+    "The <code>ChatBox</code> is deprecated and will be removed in Panel 1.4. Use the <a href=\"../chat/ChatInterface.ipynb\"><code>ChatInterface</code></a> instead.\n",
+    "</div>"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},


### PR DESCRIPTION
The `ChatBox` is deprecated. This shows up after some time in the output cells when a user reads the `ChatBox` reference notebook.

I want to make it really clear before the user starts reading that the `ChatBox` is deprecated by adding an alert at the top.

![image](https://github.com/holoviz/panel/assets/42288570/6f074723-e3e9-483b-90ba-98ed9d68797e)
