### PR TITLE
Add verbose to ChatFeed example

### DIFF
--- a/examples/reference/chat/ChatFeed.ipynb
+++ b/examples/reference/chat/ChatFeed.ipynb
@@ -3,7 +3,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "import time\n",
@@ -312,20 +314,24 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "def bad_callback(contents, user, instance):\n",
     "    return 1 / 0\n",
     "\n",
-    "chat_feed = pn.chat.ChatFeed(callback=bad_callback, callback_exception=\"summary\")\n",
+    "chat_feed = pn.chat.ChatFeed(callback=bad_callback, callback_exception=\"verbose\")\n",
     "chat_feed"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "chat_feed.send(\"This will fail...\")"


### PR DESCRIPTION
Addresses #5690 by setting `callback_exception="verbose"` as mentioned in the text.

# Before

![image](https://github.com/holoviz/panel/assets/42288570/9445541e-3078-4924-a1b2-10a637cffdd6)

# After

![image](https://github.com/holoviz/panel/assets/42288570/53148eda-4a3a-42a2-b79f-591972935ca4)