### PR TITLE
Order Component Gallery alphabetically

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -96,19 +96,21 @@ nbsite_gallery_conf = {
         'reference': {
             'title': 'Component Gallery',
             'sections': [
+                'panes',
+                'widgets',
+                'layouts',
+                # 3 most important by expected usage. Rest alphabetically
                 'chat',
                 'global',
                 'indicators',
-                'layouts',
-                'panes',
                 'templates',
-                'widgets',
             ],
             'titles': {
                 'Vega': 'Altair & Vega',
                 'DeckGL': 'PyDeck & Deck.gl',
                 'ECharts': 'PyEcharts & ECharts',
-                'IPyWidget': 'ipywidgets'
+                'IPyWidget': 'ipywidgets',
+                'PanelCallbackHandler': 'LangChain CallbackHandler',
             },
             'as_pyodide': True,
             'normalize_titles': False

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -96,13 +96,13 @@ nbsite_gallery_conf = {
         'reference': {
             'title': 'Component Gallery',
             'sections': [
-                'panes',
-                'layouts',
-                'templates',
+                'chat',
                 'global',
                 'indicators',
+                'layouts',
+                'panes',
+                'templates',
                 'widgets',
-                'chat',
             ],
             'titles': {
                 'Vega': 'Altair & Vega',


### PR DESCRIPTION
Addresses #5622 by ordering the Component Gallery categories alphabetically.

## Motivation

The Component Gallery has grown big and now contains many categories. 

![image](https://github.com/holoviz/panel/assets/42288570/e380235f-e143-4672-ab6e-015e467f8b1c)

The order of the categories is probably originally motivated by the order in which you should learn or use them ??

But now there are so many categories it takes up some of your muscle memory to remember where they are located. And to new users this order might not be clear at all.

With the addition of the `chat` category this issue has become very clear. Why are they located at the bottom? Where should they really be located?

I suggest solving this and preparing for more future categories by using alphabetical sort.


