### PR TITLE
Fix ChatInterface Perspective examples

### DIFF
--- a/examples/reference/chat/ChatInterface.ipynb
+++ b/examples/reference/chat/ChatInterface.ipynb
@@ -9,7 +9,7 @@
     "import panel as pn\n",
     "from panel.chat import ChatInterface\n",
     "\n",
-    "pn.extension()"
+    "pn.extension(\"perspective\")"
    ]
   },
   {
@@ -211,7 +211,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Note, if you don't like the default renderer, `pn.pane.DataFrame` for CSVs, you can specify `renderers` to use `pn.pane.Perspective`; just be sure you have the extension added!"
+    "Note, if you don't like the default renderer, `pn.pane.DataFrame` for CSVs, you can specify `renderers` to use `pn.pane.Perspective`; just be sure you have the `\"perspective\"` extension added to `pn.extension(...)` at the top of your file!"
    ]
   },
   {
@@ -220,8 +220,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "pn.extension(\"perspective\")\n",
-    "\n",
     "ChatInterface(\n",
     "    widgets=pn.widgets.FileInput(name=\"CSV File\", accept=\".csv\"),\n",
     "    renderers=pn.pane.Perspective\n",


### PR DESCRIPTION
As reported in #5622 the Perspective examples do not work in the ChatInterface reference notebook on the `dev` site. The output cell just displays as blank.

![image](https://github.com/holoviz/panel/assets/42288570/b10c7933-664d-494b-b1d5-a76f4e2e1159)

I believe the issue is that the `"perspective"` extension is not loaded at the top of the notebook.

I've manually changed the code in the docs to test out the hypothesis and then 1) clicked the run pyodide button 2) tested the example. It works 👍 

![image](https://github.com/holoviz/panel/assets/42288570/18fca313-e5f2-413f-8064-86897f8d2e90)


