### PR TITLE
Explain "slim" better

### DIFF
--- a/examples/reference/chat/ChatInterface.ipynb
+++ b/examples/reference/chat/ChatInterface.ipynb
@@ -388,7 +388,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If you want a slimmer `ChatInterface`, use `show_button_name=False` to hide the labels of the buttons."
+    "If you want a slimmer `ChatInterface`, use `show_button_name=False` to hide the labels of the buttons and/ or `width` to set the total width of the component."
    ]
   },
   {


### PR DESCRIPTION
Addresses #5622. I was confused by the "slim" example. Only the `show_button_name=False` setting was mentioned, so I thought it also caused that the input widget did not stretch while it was the `width` setting.

This PR makes this more clear.

![image](https://github.com/holoviz/panel/assets/42288570/c5186fa2-ccd3-4bfc-8ccc-55abb3047a9b)
