### PR TITLE
Workaround ChatMessage Matplotlib Pyodide issue

### DIFF
--- a/examples/reference/chat/ChatMessage.ipynb
+++ b/examples/reference/chat/ChatMessage.ipynb
@@ -11,7 +11,7 @@
     "\n",
     "from panel.chat import ChatMessage\n",
     "\n",
-    "pn.extension()"
+    "pn.extension(\"vega\")"
    ]
   },
   {
@@ -85,19 +85,27 @@
    "outputs": [],
    "source": [
     "import pandas as pd\n",
-    "import matplotlib.pyplot as plt\n",
     "\n",
     "df = pd.DataFrame({\"x\": [1, 2, 3], \"y\": [4, 5, 6]})\n",
     "\n",
-    "fig, axes = plt.subplots()\n",
-    "axes.plot(df[\"x\"], df[\"y\"])\n",
-    "plt.close(fig)\n",
+    "vegalite = {\n",
+    "  \"$schema\": \"https://vega.github.io/schema/vega-lite/v5.json\",\n",
+    "  \"data\": {\"url\": \"https://raw.githubusercontent.com/vega/vega/master/docs/data/barley.json\"},\n",
+    "  \"mark\": \"bar\",\n",
+    "  \"encoding\": {\n",
+    "    \"x\": {\"aggregate\": \"sum\", \"field\": \"yield\", \"type\": \"quantitative\"},\n",
+    "    \"y\": {\"field\": \"variety\", \"type\": \"nominal\"},\n",
+    "    \"color\": {\"field\": \"site\", \"type\": \"nominal\"}\n",
+    "  },\n",
+    "  \"width\": \"container\",\n",
+    "}\n",
+    "vgl_pane = pn.pane.Vega(vegalite, height=240)\n",
     "\n",
     "pn.Column(\n",
     "    ChatMessage(pn.widgets.Button(name=\"Click\")),\n",
     "    ChatMessage(df),\n",
-    "    ChatMessage(fig),\n",
-    ")"
+    "    ChatMessage(vgl_pane),\n",
+    ").servable()"
    ]
   },
   {

--- a/examples/reference/chat/ChatMessage.ipynb
+++ b/examples/reference/chat/ChatMessage.ipynb
@@ -7,6 +7,7 @@
    "outputs": [],
    "source": [
     "import asyncio\n",
+    "import pandas as pd\n",
     "import panel as pn\n",
     "\n",
     "from panel.chat import ChatMessage\n",
@@ -84,8 +85,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import pandas as pd\n",
-    "\n",
     "df = pd.DataFrame({\"x\": [1, 2, 3], \"y\": [4, 5, 6]})\n",
     "\n",
     "vegalite = {\n",
@@ -105,7 +104,7 @@
     "    ChatMessage(pn.widgets.Button(name=\"Click\")),\n",
     "    ChatMessage(df),\n",
     "    ChatMessage(vgl_pane),\n",
-    ").servable()"
+    ")"
    ]
   },
   {


### PR DESCRIPTION
Addresses #5622

The `ChatMessage` reference notebook does not work in Pyodide because Matplotlib cannot run in Pyodide with service workers. See https://github.com/pyodide/pyodide/issues/561.

I work around the issue by replacing Matplotlib with Vega.

The result looks like

![image](https://github.com/holoviz/panel/assets/42288570/78c20447-396d-42dd-8e41-346567a11374)
