### PR TITLE
Fix chat interface background

### DIFF
--- a/panel/dist/css/chat_interface.css
+++ b/panel/dist/css/chat_interface.css
@@ -5,5 +5,5 @@
 }
 
 .chat-interface-input-tabs {
-  background: white;
+  background: var(--neutral-fill-rest, var(--background-color, white));
 }

--- a/panel/dist/css/chat_interface.css
+++ b/panel/dist/css/chat_interface.css
@@ -5,5 +5,5 @@
 }
 
 .chat-interface-input-tabs {
-  background: var(--neutral-fill-rest, var(--background-color, white));
+  background: var(--fill-color, var(--background-color, white));
 }


### PR DESCRIPTION
Closes #5705

I've not been able to get Panel to serve this.

But if I change this manually via the browser console in a working app. It works for the below example

```python
import panel as pn

component = pn.chat.ChatInterface(
    widgets=[pn.widgets.FileInput(name="Upload"), pn.widgets.TextInput(name="Message")]
)
pn.template.FastListTemplate(main=[component]).servable()
```

I can manually verify it works for this example

![image](https://github.com/holoviz/panel/assets/42288570/8e9b1880-a608-4280-b034-eeef0789dc2f)
