### PR TITLE
Return `None` user info if no `id_token`

### DIFF
--- a/panel/io/state.py
+++ b/panel/io/state.py
@@ -1094,6 +1094,8 @@ class _state(param.Parameterized):
         Returns the OAuth user information if enabled.
         """
         id_token = self._decode_cookie('id_token')
+        if id_token is None:
+            return None
         return decode_token(id_token)
 
 state = _state()

--- a/panel/util/__init__.py
+++ b/panel/util/__init__.py
@@ -275,7 +275,7 @@ def base64url_decode(input):
     return base64.urlsafe_b64decode(input)
 
 
-def decode_token(token, signed=True):
+def decode_token(token: str, signed: bool = True) -> dict[str, Any]:
     """
     Decodes a signed or unsigned JWT token.
     """


### PR DESCRIPTION
To fix an error I've seen in a test suite after upgrading to Panel 1.3.0

```
[2023-10-26T10:12:07.721Z] /usr/local/lib/python3.10/site-packages/panel/util/__init__.py:282: in decode_token
[2023-10-26T10:12:07.721Z]     if signed and "." in token:
[2023-10-26T10:12:07.721Z] E   TypeError: argument of type 'NoneType' is not iterable
```