### PR TITLE
Fix from_param type annotation

### DIFF
--- a/panel/widgets/base.py
+++ b/panel/widgets/base.py
@@ -30,7 +30,7 @@ if TYPE_CHECKING:
 
     from ..layout.base import ListPanel
 
-    T = TypeVar('T', bound='Widget')
+    T = TypeVar('T')
 
 
 class Widget(Reactive):
@@ -75,7 +75,7 @@ class Widget(Reactive):
         super().__init__(**params)
 
     @classmethod
-    def from_param(cls, parameter: param.Parameter, **params) -> T:
+    def from_param(cls: Type[T], parameter: param.Parameter, **params) -> T:
         """
         Construct a widget from a Parameter and link the two
         bi-directionally.


### PR DESCRIPTION
In one of my applications `mypy` was complaining that `_table` in `self._table = pn.widgets.Tabulator.from_param` needed a type annotation.

I believe its because the `cls` needs the type annotation as described in https://stackoverflow.com/questions/46007544/python-3-type-hint-for-a-factory-method-on-a-base-class-returning-a-child-class.

Furthermore I think `T` should not be bound to `'Widget'`.

When I applied these changes mypy no longer complained.