### PR TITLE
Ensure Tabulator.style applies correctly with changing data

### DIFF
--- a/panel/tests/test_util.py
+++ b/panel/tests/test_util.py
@@ -11,6 +11,7 @@ from panel.io.notebook import render_mimebundle
 from panel.pane import PaneBase
 from panel.util import (
     abbreviated_repr, extract_dependencies, get_method_owner, parse_query,
+    styler_update,
 )
 
 
@@ -115,3 +116,19 @@ def test_parse_query_singe_quoted():
     }
     results = parse_query(query)
     assert expected_results == results
+
+
+def test_styler_update(dataframe):
+    styler = dataframe.style.background_gradient('Reds')
+    new_df = dataframe.iloc[:, :2]
+    new_style = new_df.style
+    new_style._todo = styler_update(styler, new_df)
+    new_style._compute()
+    assert dict(new_style.ctx) == {
+        (0, 0): [('background-color', '#fff5f0'), ('color', '#000000')],
+        (0, 1): [('background-color', '#fff5f0'), ('color', '#000000')],
+        (1, 0): [('background-color', '#fb694a'), ('color', '#f1f1f1')],
+        (1, 1): [('background-color', '#fb694a'), ('color', '#f1f1f1')],
+        (2, 0): [('background-color', '#67000d'), ('color', '#f1f1f1')],
+        (2, 1): [('background-color', '#67000d'), ('color', '#f1f1f1')]
+    }

--- a/panel/util/__init__.py
+++ b/panel/util/__init__.py
@@ -501,3 +501,41 @@ def flatten(line):
             yield from flatten(element)
         else:
             yield element
+
+
+def styler_update(styler, new_df):
+    """
+    Updates the todo items on a pandas Styler object to apply to a new
+    DataFrame.
+
+    Arguments
+    ---------
+    styler: pandas.io.formats.style.Styler
+      Styler objects
+    new_df: pd.DataFrame
+      New DataFrame to update the styler to do items
+
+    Returns
+    -------
+    todos: list
+    """
+    todos = []
+    for todo in styler._todo:
+        if not isinstance(todo, tuple):
+            todos.append(todo)
+            continue
+        ops = []
+        for op in todo:
+            if not isinstance(op, tuple):
+                ops.append(op)
+                continue
+            op_fn = str(op[0])
+            if ('_background_gradient' in op_fn or '_bar' in op_fn) and op[1] in (0, 1):
+                applies = np.array([
+                    new_df[col].dtype.kind in 'uif' for col in new_df.columns
+                ])
+                op = (op[0], op[1], applies)
+            ops.append(op)
+        todo = tuple(ops)
+        todos.append(todo)
+    return todos

--- a/panel/widgets/tables.py
+++ b/panel/widgets/tables.py
@@ -30,7 +30,7 @@ from ..io.state import state
 from ..reactive import Reactive, ReactiveData
 from ..util import (
     BOKEH_JS_NAT, clone_model, datetime_as_utctimestamp, isdatetime, lazy_load,
-    updating,
+    styler_update, updating,
 )
 from .base import Widget
 from .button import Button
@@ -1337,8 +1337,11 @@ class Tabulator(BaseTable):
                 return {}
             if styler is None:
                 return {}
-            styler._todo = self.style._todo
-            styler._compute()
+            styler._todo = styler_update(self.style, df)
+            try:
+                styler._compute()
+            except Exception:
+                styler._todo = []
         else:
             styler = self._computed_styler
         if styler is None:


### PR DESCRIPTION
The `Tabulator.style.background_gradient` and `Tabulator.style.bar` methods keep track of the columns that it can apply these styling options too, which means that if the data changes the styles will no longer correctly apply. Therefore we introduce a utility that will update the boolean index of column inside the `Styler._todo` list.

- [x] Add tests