### PR TITLE
Prevent `TextAreaInput` from auto sending messages in ChatInterface unless specified

### DIFF
--- a/panel/chat/interface.py
+++ b/panel/chat/interface.py
@@ -210,8 +210,13 @@ class ChatInterface(ChatFeed):
             # for longer form messages, like TextArea / Ace, don't
             # submit when clicking away; only if they manually click
             # the send button
-            auto_send_types = tuple(self.auto_send_types) or (TextInput,)
-            if isinstance(widget, auto_send_types) and widget in new_widgets:
+            # note, explicitly not isinstance because
+            # TextAreaInput will trigger auto send!
+            auto_send = (
+                isinstance(widget, tuple(self.auto_send_types)) or
+                type(widget) is TextInput
+            )
+            if auto_send and widget in new_widgets:
                 widget.param.watch(self._click_send, "value")
             widget.param.update(
                 sizing_mode="stretch_width",

--- a/panel/tests/chat/test_interface.py
+++ b/panel/tests/chat/test_interface.py
@@ -67,6 +67,17 @@ class TestChatInterface:
     def test_click_send(self, chat_interface: ChatInterface):
         chat_interface.widgets = [TextAreaInput()]
         chat_interface.active_widget.value = "Message"
+        # since it's TextAreaInput and NOT TextInput, need to manually send
+        assert len(chat_interface.objects) == 0
+        chat_interface._click_send(None)
+        assert len(chat_interface.objects) == 1
+        assert chat_interface.objects[0].object == "Message"
+
+    @pytest.mark.parametrize("widget", [TextInput(), TextAreaInput()])
+    def test_auto_send_types(self, chat_interface: ChatInterface, widget):
+        chat_interface.auto_send_types = [TextAreaInput]
+        chat_interface.widgets = [widget]
+        chat_interface.active_widget.value = "Message"
         assert len(chat_interface.objects) == 1
         assert chat_interface.objects[0].object == "Message"
 


### PR DESCRIPTION
I don't think `TextAreaInput` should auto send by default because users need to usually gather info from other browser tabs.

At the moment, if the user copies text from another browser tab, it sends the existing, unfinished message which can be irritating.

The prior logic uses `isinstance()` which makes `TextAreaInput` always auto send since `TextAreaInput` is a subclass of `TextInput` 

A workaround is to have `auto_send_types` set to some arbitrary value.