### PR TITLE
Add serialize methods for ChatMessage + ChatFeed

### DIFF
--- a/examples/reference/chat/ChatFeed.ipynb
+++ b/examples/reference/chat/ChatFeed.ipynb
@@ -518,6 +518,22 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "The chat history can be serialized for use with the `transformers` or `openai` packages."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "chat_feed.serialize_for_transformers()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "It can be fun to watch bots talking to each other. Beware of the token usage!\n",
     "\n",
     "```python\n",

--- a/examples/reference/chat/ChatFeed.ipynb
+++ b/examples/reference/chat/ChatFeed.ipynb
@@ -518,7 +518,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The chat history can be serialized for use with the `transformers` or `openai` packages through either `serialize` or `serialize_for_transformers`."
+    "The chat history can be serialized for use with the `transformers` or `openai` packages through either `serialize` with `format=\"transformers\"`."
    ]
   },
   {
@@ -543,7 +543,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "chat_feed.serialize_for_transformers(\n",
+    "chat_feed.serialize(\n",
     "    format=\"transformers\", role_names={\"assistant\": [\"Bot 1\", \"Bot 2\", \"Bot 3\"]}\n",
     ")"
    ]
@@ -563,7 +563,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "chat_feed.serialize_for_transformers(\n",
+    "chat_feed.serialize(\n",
     "    format=\"transformers\",\n",
     "    default_role=\"assistant\"\n",
     ")"

--- a/examples/reference/chat/ChatFeed.ipynb
+++ b/examples/reference/chat/ChatFeed.ipynb
@@ -518,7 +518,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The chat history can be serialized for use with the `transformers` or `openai` packages."
+    "The chat history can be serialized for use with the `transformers` or `openai` packages through either `serialize` or `serialize_for_transformers`."
    ]
   },
   {
@@ -527,7 +527,46 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "chat_feed.serialize_for_transformers()"
+    "chat_feed.serialize(format=\"transformers\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`role_names` can be set to explicitly map the role to the ChatMessage's user name."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "chat_feed.serialize_for_transformers(\n",
+    "    format=\"transformers\", role_names={\"assistant\": [\"Bot 1\", \"Bot 2\", \"Bot 3\"]}\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "A `default_role` can also be set to use if the user name is not found in `role_names`.\n",
+    "\n",
+    "If this is set to None, raises a ValueError if the user name is not found."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "chat_feed.serialize_for_transformers(\n",
+    "    format=\"transformers\",\n",
+    "    default_role=\"assistant\"\n",
+    ")"
    ]
   },
   {

--- a/examples/reference/chat/ChatMessage.ipynb
+++ b/examples/reference/chat/ChatMessage.ipynb
@@ -280,6 +280,23 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "The `ChatMessage` can serialized into a string."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "widget = pn.widgets.FloatSlider(value=3, name=\"Number selected\")\n",
+    "pn.chat.ChatMessage(widget).serialize()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "If you'd like a plain interface with only the `value` displayed, set `show_user`, `show_copy_icon`, `show_avatar`, and `show_timestamp` to `False` and provide an empty `dict` to `reaction_icons`."
    ]
   },

--- a/panel/chat/feed.py
+++ b/panel/chat/feed.py
@@ -591,7 +591,7 @@ class ChatFeed(ListPanel):
         self._chat_log.clear()
         return cleared_entries
 
-    def serialize_for_transformers(
+    def _serialize_for_transformers(
         self,
         role_names: Dict[str, str | List[str]] | None = None,
         default_role: str | None = "assistant",
@@ -599,26 +599,6 @@ class ChatFeed(ListPanel):
     ) -> List[Dict[str, Any]]:
         """
         Exports the chat log for use with transformers.
-
-        Arguments
-        ---------
-        role_names : dict(str, str | list(str)) | None
-            A dictionary mapping the role to the ChatMessage's user name.
-            Defaults to `{"user": ["user"], "assistant": [self.callback_user]}`
-            if not set. The keys and values are case insensitive as the strings
-            will all be lowercased. The values can be a string or a list of strings,
-            e.g. `{"user": "user", "assistant": ["executor", "langchain"]}`.
-        default_role : str
-            The default role to use if the user name is not found in role_names.
-            If this is set to None, raises a ValueError if the user name is not found.
-        custom_serializer : callable
-            A custom function to format the ChatMessage's object. The function must
-            accept one positional argument and return a string. If not provided,
-            uses the serialize method on ChatMessage.
-
-        Returns
-        -------
-        A list of dictionaries with a role and content keys.
         """
         if role_names is None:
             role_names = {
@@ -679,16 +659,26 @@ class ChatFeed(ListPanel):
             accept one positional argument. If not provided,
             uses the serialize method on ChatMessage.
         **serialize_kwargs
-            Additional keyword arguments to use for the specified format;
-            i.e. if the format is "transformers", the kwargs to use for
-            `serialize_for_transformers`: `role_names` and `default_role`.
+            Additional keyword arguments to use for the specified format.
+            Valid keyword arguments for formats are described below.
+
+            - transformers
+            role_names : dict(str, str | list(str)) | None
+                A dictionary mapping the role to the ChatMessage's user name.
+                Defaults to `{"user": ["user"], "assistant": [self.callback_user]}`
+                if not set. The keys and values are case insensitive as the strings
+                will all be lowercased. The values can be a string or a list of strings,
+                e.g. `{"user": "user", "assistant": ["executor", "langchain"]}`.
+            default_role : str
+                The default role to use if the user name is not found in role_names.
+                If this is set to None, raises a ValueError if the user name is not found.
 
         Returns
         -------
         The chat log serialized in the specified format.
         """
         if format == "transformers":
-            return self.serialize_for_transformers(
+            return self._serialize_for_transformers(
                 custom_serializer=custom_serializer, **serialize_kwargs
             )
         raise NotImplementedError(f"Format {format!r} is not supported.")

--- a/panel/chat/feed.py
+++ b/panel/chat/feed.py
@@ -660,18 +660,17 @@ class ChatFeed(ListPanel):
             uses the serialize method on ChatMessage.
         **serialize_kwargs
             Additional keyword arguments to use for the specified format.
-            Valid keyword arguments for formats are described below.
 
-            - transformers
-            role_names : dict(str, str | list(str)) | None
-                A dictionary mapping the role to the ChatMessage's user name.
-                Defaults to `{"user": ["user"], "assistant": [self.callback_user]}`
-                if not set. The keys and values are case insensitive as the strings
-                will all be lowercased. The values can be a string or a list of strings,
-                e.g. `{"user": "user", "assistant": ["executor", "langchain"]}`.
-            default_role : str
-                The default role to use if the user name is not found in role_names.
-                If this is set to None, raises a ValueError if the user name is not found.
+            - format="transformers"
+              role_names : dict(str, str | list(str)) | None
+                  A dictionary mapping the role to the ChatMessage's user name.
+                  Defaults to `{"user": ["user"], "assistant": [self.callback_user]}`
+                  if not set. The keys and values are case insensitive as the strings
+                  will all be lowercased. The values can be a string or a list of strings,
+                  e.g. `{"user": "user", "assistant": ["executor", "langchain"]}`.
+              default_role : str
+                  The default role to use if the user name is not found in role_names.
+                  If this is set to None, raises a ValueError if the user name is not found.
 
         Returns
         -------

--- a/panel/chat/feed.py
+++ b/panel/chat/feed.py
@@ -604,10 +604,10 @@ class ChatFeed(ListPanel):
         ---------
         role_names : dict(str, str | list(str)) | None
             A dictionary mapping the role to the ChatMessage's user name.
-            If not set, defaults to `{"user": ["user"], "assistant": ["assistant"]}`.
-            The keys and values are case insensitive as the strings will all be lowercased.
-            The values can be a string or a list of strings, e.g.
-            `{"user": "user", "assistant": ["executor", "langchain"]}`.
+            Defaults to `{"user": ["user"], "assistant": [self.callback_user]}`
+            if not set. The keys and values are case insensitive as the strings
+            will all be lowercased. The values can be a string or a list of strings,
+            e.g. `{"user": "user", "assistant": ["executor", "langchain"]}`.
         default_role : str
             The default role to use if the user name is not found in role_names.
             If this is set to None, raises a ValueError if the user name is not found.
@@ -623,7 +623,7 @@ class ChatFeed(ListPanel):
         if role_names is None:
             role_names = {
                 "user": ["user"],
-                "assistant": ["assistant"],
+                "assistant": [self.callback_user],
             }
 
         names_role = {}

--- a/panel/chat/interface.py
+++ b/panel/chat/interface.py
@@ -419,7 +419,7 @@ class ChatInterface(ChatFeed):
         if isinstance(self._input_layout, Tabs):
             self._input_layout.active = index
 
-    def serialize_for_transformers(
+    def _serialize_for_transformers(
         self,
         role_names: Dict[str, str | List[str]] | None = None,
         default_role: str | None = "assistant",
@@ -453,4 +453,4 @@ class ChatInterface(ChatFeed):
                 "user": [self.user],
                 "assistant": [self.callback_user],
             }
-        return super().serialize_for_transformers(role_names, default_role, custom_serializer)
+        return super()._serialize_for_transformers(role_names, default_role, custom_serializer)

--- a/panel/chat/interface.py
+++ b/panel/chat/interface.py
@@ -8,7 +8,9 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from io import BytesIO
-from typing import ClassVar, List
+from typing import (
+    Any, Callable, ClassVar, Dict, List,
+)
 
 import param
 
@@ -416,3 +418,39 @@ class ChatInterface(ChatFeed):
         """
         if isinstance(self._input_layout, Tabs):
             self._input_layout.active = index
+
+    def serialize_for_transformers(
+        self,
+        role_names: Dict[str, str | List[str]] | None = None,
+        default_role: str | None = "assistant",
+        format_func: Callable = None
+    ) -> List[Dict[str, Any]]:
+        """
+        Exports the chat log for use with transformers.
+
+        Arguments
+        ---------
+        role_names : dict(str, str | list(str)) | None
+            A dictionary mapping the role to the ChatMessage's user name.
+            Defaults to `{"user": [self.user], "assistant": [self.callback_user]}`
+            if not set. The keys and values are case insensitive as the strings
+            will all be lowercased. The values can be a string or a list of strings,
+            e.g. `{"user": "user", "assistant": ["executor", "langchain"]}`.
+        default_role : str
+            The default role to use if the user name is not found in role_names.
+            If this is set to None, raises a ValueError if the user name is not found.
+        format_func : callable
+            A custom function to format the ChatMessage's object. The function must
+            accept one positional argument and return a string. If not provided,
+            uses the serialize method on ChatMessage.
+
+        Returns
+        -------
+        A list of dictionaries with a role and content keys.
+        """
+        if role_names is None:
+            role_names = {
+                "user": [self.user],
+                "assistant": [self.callback_user],
+            }
+        super().serialize_for_transformers(role_names, default_role, format_func)

--- a/panel/chat/interface.py
+++ b/panel/chat/interface.py
@@ -453,4 +453,4 @@ class ChatInterface(ChatFeed):
                 "user": [self.user],
                 "assistant": [self.callback_user],
             }
-        super().serialize_for_transformers(role_names, default_role, format_func)
+        return super().serialize_for_transformers(role_names, default_role, format_func)

--- a/panel/chat/interface.py
+++ b/panel/chat/interface.py
@@ -423,7 +423,7 @@ class ChatInterface(ChatFeed):
         self,
         role_names: Dict[str, str | List[str]] | None = None,
         default_role: str | None = "assistant",
-        format_func: Callable = None
+        custom_serializer: Callable = None
     ) -> List[Dict[str, Any]]:
         """
         Exports the chat log for use with transformers.
@@ -439,7 +439,7 @@ class ChatInterface(ChatFeed):
         default_role : str
             The default role to use if the user name is not found in role_names.
             If this is set to None, raises a ValueError if the user name is not found.
-        format_func : callable
+        custom_serializer : callable
             A custom function to format the ChatMessage's object. The function must
             accept one positional argument and return a string. If not provided,
             uses the serialize method on ChatMessage.
@@ -453,4 +453,4 @@ class ChatInterface(ChatFeed):
                 "user": [self.user],
                 "assistant": [self.callback_user],
             }
-        return super().serialize_for_transformers(role_names, default_role, format_func)
+        return super().serialize_for_transformers(role_names, default_role, custom_serializer)

--- a/panel/tests/chat/test_feed.py
+++ b/panel/tests/chat/test_feed.py
@@ -706,7 +706,7 @@ class TestChatFeedSerializeForTransformers:
         chat_feed.send("I'm a user", user="user")
         chat_feed.send("I'm the assistant", user="assistant")
         chat_feed.send("I'm a bot", user="bot")
-        assert chat_feed.serialize_for_transformers() == [
+        assert chat_feed.serialize() == [
             {"role": "user", "content": "I'm a user"},
             {"role": "assistant", "content": "I'm the assistant"},
             {"role": "assistant", "content": "I'm a bot"},
@@ -714,14 +714,14 @@ class TestChatFeedSerializeForTransformers:
 
     def test_empty(self):
         chat_feed = ChatFeed()
-        assert chat_feed.serialize_for_transformers() == []
+        assert chat_feed.serialize() == []
 
     def test_case_insensitivity(self):
         chat_feed = ChatFeed()
         chat_feed.send("I'm a user", user="USER")
         chat_feed.send("I'm the assistant", user="ASSISTant")
         chat_feed.send("I'm a bot", user="boT")
-        assert chat_feed.serialize_for_transformers() == [
+        assert chat_feed.serialize() == [
             {"role": "user", "content": "I'm a user"},
             {"role": "assistant", "content": "I'm the assistant"},
             {"role": "assistant", "content": "I'm a bot"},
@@ -732,7 +732,7 @@ class TestChatFeedSerializeForTransformers:
         chat_feed.send("I'm a user", user="user")
         chat_feed.send("I'm the assistant", user="assistant")
         chat_feed.send("I'm a bot", user="bot")
-        assert chat_feed.serialize_for_transformers(default_role="system") == [
+        assert chat_feed.serialize(default_role="system") == [
             {"role": "user", "content": "I'm a user"},
             {"role": "assistant", "content": "I'm the assistant"},
             {"role": "system", "content": "I'm a bot"},
@@ -744,7 +744,7 @@ class TestChatFeedSerializeForTransformers:
         chat_feed.send("I'm the assistant", user="assistant")
         chat_feed.send("I'm a bot", user="bot")
         with pytest.raises(ValueError, match="not found in role_names"):
-            chat_feed.serialize_for_transformers(default_role="")
+            chat_feed.serialize(default_role="")
 
     def test_role_names(self):
         chat_feed = ChatFeed()
@@ -752,7 +752,7 @@ class TestChatFeedSerializeForTransformers:
         chat_feed.send("I'm another user", user="August")
         chat_feed.send("I'm the assistant", user="Bot")
         role_names = {"user": ["Andrew", "August"], "assistant": "Bot"}
-        assert chat_feed.serialize_for_transformers(role_names=role_names) == [
+        assert chat_feed.serialize(role_names=role_names) == [
             {"role": "user", "content": "I'm the user"},
             {"role": "user", "content": "I'm another user"},
             {"role": "assistant", "content": "I'm the assistant"},
@@ -768,7 +768,7 @@ class TestChatFeedSerializeForTransformers:
         chat_feed = ChatFeed()
         chat_feed.send("I'm the user", user="user")
         chat_feed.send(3, user="assistant")
-        assert chat_feed.serialize_for_transformers(custom_serializer=custom_serializer) == [
+        assert chat_feed.serialize(custom_serializer=custom_serializer) == [
             {"role": "user", "content": "new string"},
             {"role": "assistant", "content": "0"},
         ]
@@ -784,9 +784,9 @@ class TestChatFeedSerializeForTransformers:
         chat_feed.send("I'm the user", user="user")
         chat_feed.send(3, user="assistant")
         with pytest.raises(ValueError, match="must return a string"):
-            chat_feed.serialize_for_transformers(custom_serializer=custom_serializer)
+            chat_feed.serialize(custom_serializer=custom_serializer)
 
-class TestChatFeedSerialize:
+class TestChatFeedSerializeBase:
 
     def test_transformers_format(self):
         chat_feed = ChatFeed()


### PR DESCRIPTION
I'm trying to make ChatInterface easy to use to fine tune LLMs. The first step is easy exporting of it, ready to use for transformers.

Kind of addresses https://github.com/holoviz/panel/issues/5567, but specifically for use with fine tuning transformers https://huggingface.co/docs/transformers/main/chat_templating, not ChatInterface.

I was initially thinking of combining these it like in the ChatBox export method https://github.com/holoviz/panel/pull/5178, but decided against it since the logic got long.

There's a lot of ways to serialize the widgets / panes / etc, so I added `format_func` as an escape hatch if users don't agree with the default.

Would like some early thoughts before I add tests.

<img width="1095" alt="image" src="https://github.com/holoviz/panel/assets/15331990/9dd06a12-b9f5-4cc0-93e6-d1efbf410c60">

```python
import panel as pn
import numpy as np
import pandas as pd

pn.extension()

msg = pn.chat.ChatMessage(
    pn.Row(
        pn.widgets.FloatSlider(value=10),
        pn.widgets.Checkbox(name="Check me!"),
        pn.pane.HTML("Hello World!"),
        pn.pane.DataFrame(
            pd.DataFrame(np.random.randn(10, 3), columns=list("ABC"))
        ),
    ),
)
print(str(msg))
```

- [x] Add tests
- [x] Use `user` from ChatInterface in `user_names`