### PR TITLE
POC of Panel Playground

### DIFF
--- a/examples/gallery/playground/playground.py
+++ b/examples/gallery/playground/playground.py
@@ -1,0 +1,183 @@
+import param
+
+import panel as pn
+
+from panel.reactive import ReactiveHTML
+
+pn.extension("codeeditor", "terminal", design="bootstrap")
+
+HELLO_WORLD_EXAMPLE = """\
+import panel as pn
+
+pn.extension("terminal")
+
+pn.panel("Hello World").servable()
+"""
+
+EXAMPLES = {
+    "Hello World": HELLO_WORLD_EXAMPLE,
+    "Reactive Expressions": """
+import panel as pn
+import param
+
+pn.extension()
+
+
+count = pn.widgets.IntSlider(value=1, start=0, end=10, name="Count")
+expr = count.rx() * "⭐"
+
+pn.panel(expr).servable()
+""",
+    "Matplotlib": """\
+import numpy as np
+
+from matplotlib.figure import Figure
+from matplotlib import cm
+from matplotlib.backends.backend_agg import FigureCanvas  # not needed for mpl >= 3.1
+
+import panel as pn
+pn.extension()
+
+Y, X = np.mgrid[-3:3:100j, -3:3:100j]
+U = -1 - X**2 + Y
+V = 1 + X - Y**2
+speed = np.sqrt(U*U + V*V)
+
+fig0 = Figure(figsize=(8, 6))
+ax0 = fig0.subplots()
+FigureCanvas(fig0)  # not needed for mpl >= 3.1
+
+strm = ax0.streamplot(X, Y, U, V, color=U, linewidth=2, cmap=cm.autumn)
+fig0.colorbar(strm.lines)
+
+pn.pane.Matplotlib(fig0, dpi=144).servable()
+""",
+}
+EXAMPLES = {key: EXAMPLES[key] for key in sorted(EXAMPLES)}
+
+TEMPLATE = """
+<div id="pn-container" style="height:100%;width:100%;border: 1px solid black"></div>
+"""
+
+
+class PanelPlayground(ReactiveHTML):
+    code = param.String(HELLO_WORLD_EXAMPLE)
+    timeout = param.Integer(25, bounds=(1, 1000))
+    examples = param.Dict(EXAMPLES)
+
+    log_message = param.String(label="Status")
+    running = param.Boolean()
+
+    _template = TEMPLATE
+
+    __javascript__ = [
+        "https://cdn.jsdelivr.net/pyodide/v0.23.4/full/pyodide.js",
+        "https://cdn.bokeh.org/bokeh/release/bokeh-3.3.0.min.js",
+        "https://cdn.bokeh.org/bokeh/release/bokeh-gl-3.3.0.min.js",
+        "https://cdn.bokeh.org/bokeh/release/bokeh-widgets-3.3.0.min.js",
+        "https://cdn.bokeh.org/bokeh/release/bokeh-tables-3.3.0.min.js",
+        "https://cdn.holoviz.org/panel/1.3.0/dist/panel.min.js",
+    ]
+
+    _scripts = {
+        "render": """
+state.main = document.createElement('div');
+state.code=""
+state.ready=false;
+data.running=true;
+
+state.log = (message)=>{
+    console.log(message);
+    data.log_message = "\\n"
+    data.log_message = message
+}
+
+async function main() {
+    state.log("Loading pyodide")
+    let pyodide = await loadPyodide();
+    state.pyodide = pyodide
+    state.log("Loading micropip")
+    await pyodide.loadPackage("micropip");
+    state.log("Loading packages")
+    await pyodide.runPythonAsync(`
+    import micropip
+    await micropip.install(['https://cdn.holoviz.org/panel/wheels/bokeh-3.3.0-py3-none-any.whl', 'https://cdn.holoviz.org/panel/1.3.0/dist/wheels/panel-1.3.0-py3-none-any.whl', 'pyodide-http==0.2.1', 'param', "matplotlib"]);
+    `);
+}
+main().then(()=>{self.runCode()})
+""",
+        "preCode": """
+    data.running=true;
+    state.log("Started running the code")
+    state.code=data.code;
+    const body = document.querySelector('body');
+    state.main.innerHTML=""
+    state.main.id = 'main';
+    body.appendChild(state.main);
+    """,
+        "postCode": """
+    const checkDiv = setInterval(() => {
+    if (state.main.hasChildNodes()) {
+        clearInterval(checkDiv);
+        pn_container.appendChild(state.main);
+        data.running=false;
+        if (state.code!=data.code){
+            state.log("Code changed. I will run the code again")
+            self.runCode()
+        } else {
+            state.log("Finished Running Code")
+        }
+    } else {
+        state.log('Waiting. The code has not been executed yet');
+    }
+    }, data.timeout);
+    """,
+        "runCode": """
+    self.preCode()
+    const cleanCode=data.code.replace(".servable()", '.servable(target="main")')
+    state.pyodide.runPythonAsync(cleanCode).then(()=>{
+        self.postCode()
+    })
+    .catch((error) => {
+        state.log('An error occurred:' + error.toString());
+        pn_container.appendChild(state.main);
+        data.running=false;
+        state.main.innerText=error.toString();
+        if (state.code!=data.code){
+            state.log("Code changed. I will run the code again")
+            self.runCode()
+        }
+    });
+
+    """,
+        "code": """
+    if (!data.running){self.runCode()}else{state.log("The code is already running.")}
+    """,
+    }
+
+
+playground = PanelPlayground(sizing_mode="stretch_both")
+examples = pn.widgets.RadioButtonGroup(
+    options=EXAMPLES,
+    name="Examples",
+    orientation="vertical",
+    sizing_mode="stretch_width",
+    button_style="outline",
+)
+
+@pn.depends(examples, watch=True)
+def _apply_example(value):
+    playground.code = value
+
+pn.Row(
+    pn.Column(
+        "#### Examples",
+        examples,
+        "#### Status",
+        playground.param.running,
+        pn.pane.Str(playground.param.log_message, name="Status"),
+        width=300,
+    ),
+    pn.widgets.CodeEditor.from_param(playground.param.code, sizing_mode="stretch_both"),
+    playground,
+).servable()

--- a/examples/gallery/playground/playground.py
+++ b/examples/gallery/playground/playground.py
@@ -55,8 +55,23 @@ pn.pane.Matplotlib(fig0, dpi=144).servable()
 }
 EXAMPLES = {key: EXAMPLES[key] for key in sorted(EXAMPLES)}
 
-TEMPLATE = """
-<div id="pn-container" style="height:100%;width:100%;border: 1px solid black"></div>
+LOADING_SPINNER = """
+<svg id="loading" xmlns="http://www.w3.org/2000/svg" style="margin: auto; background: none; display: block; shape-rendering: auto;" viewBox="0 0 100 100" preserveAspectRatio="xMidYMid">
+<rect x="15" y="30" width="10" height="40" fill="#424242">
+  <animate attributeName="opacity" dur="1s" repeatCount="indefinite" calcMode="spline" keyTimes="0;0.5;1" keySplines="0.5 0 0.5 1;0.5 0 0.5 1" values="1;0.2;1" begin="-0.6"/>
+</rect><rect x="35" y="30" width="10" height="40" fill="#424242">
+  <animate attributeName="opacity" dur="1s" repeatCount="indefinite" calcMode="spline" keyTimes="0;0.5;1" keySplines="0.5 0 0.5 1;0.5 0 0.5 1" values="1;0.2;1" begin="-0.4"/>
+</rect><rect x="55" y="30" width="10" height="40" fill="#424242">
+  <animate attributeName="opacity" dur="1s" repeatCount="indefinite" calcMode="spline" keyTimes="0;0.5;1" keySplines="0.5 0 0.5 1;0.5 0 0.5 1" values="1;0.2;1" begin="-0.2"/>
+</rect><rect x="75" y="30" width="10" height="40" fill="#424242">
+  <animate attributeName="opacity" dur="1s" repeatCount="indefinite" calcMode="spline" keyTimes="0;0.5;1" keySplines="0.5 0 0.5 1;0.5 0 0.5 1" values="1;0.2;1" begin="-1"/>
+</rect></svg>
+"""
+
+TEMPLATE = f"""
+<div id="pn-container" style="height:100%;width:100%;border: 1px solid black">
+    {LOADING_SPINNER}
+</div>
 """
 
 
@@ -81,14 +96,12 @@ class PanelPlayground(ReactiveHTML):
 
     _scripts = {
         "render": """
+data.running=true;
 state.main = document.createElement('div');
 state.code=""
 state.ready=false;
-data.running=true;
 
 state.log = (message)=>{
-    console.log(message);
-    data.log_message = "\\n"
     data.log_message = message
 }
 
@@ -153,6 +166,13 @@ main().then(()=>{self.runCode()})
         "code": """
     if (!data.running){self.runCode()}else{state.log("The code is already running.")}
     """,
+        "running": """
+    if (data.running==true){
+        setTimeout(() => {
+            if (data.running){loading.style.display="block";}
+        }, "200");
+    } else {loading.style.display="none"}
+    """
     }
 
 

--- a/panel/io/convert.py
+++ b/panel/io/convert.py
@@ -26,7 +26,7 @@ from .. import __version__, config
 from ..util import base_version, escape
 from .loading import LOADING_INDICATOR_CSS_CLASS
 from .markdown import build_single_handler_application
-from .mime_render import find_imports
+from .mime_render import find_requirements
 from .resources import (
     BASE_TEMPLATE, CDN_DIST, CDN_ROOT, DIST_DIR, INDEX_TEMPLATE, Resources,
     _env as _pn_env, bundle_resources, loading_css, set_resource_mode,
@@ -235,7 +235,7 @@ def script_to_html(
         )
 
     if requirements == 'auto':
-        requirements = find_imports(source)
+        requirements = find_requirements(source)
     elif isinstance(requirements, str) and pathlib.Path(requirements).is_file():
         requirements = pathlib.Path(requirements).read_text(encoding='utf-8').splitlines()
         try:

--- a/panel/io/mime_render.py
+++ b/panel/io/mime_render.py
@@ -45,13 +45,14 @@ def _stdlibs():
 _STDLIBS = _stdlibs()
 _PACKAGE_MAP = {
     'sklearn': 'scikit-learn',
+    'transformers_js': 'transformers-js-py',
 }
 _IGNORED_PKGS = ['js', 'pyodide']
 _PANDAS_AUTODETECT = ['bokeh.sampledata', 'as_frame']
 
-def find_imports(code: str) -> List[str]:
+def find_requirements(code: str) -> List[str]:
     """
-    Finds the imports in a string of code.
+    Finds the packages required in a string of code.
 
     Parameters
     ----------
@@ -61,7 +62,7 @@ def find_imports(code: str) -> List[str]:
     Returns
     -------
     ``List[str]``
-        A list of module names that are imported in the code.
+        A list of package names that are to be installed for the code to be able to run.
 
     Examples
     --------

--- a/panel/tests/io/test_mime_render.py
+++ b/panel/tests/io/test_mime_render.py
@@ -1,7 +1,7 @@
 import pathlib
 
 from panel.io.mime_render import (
-    WriteCallbackStream, exec_with_return, find_imports, format_mime,
+    WriteCallbackStream, exec_with_return, find_requirements, format_mime,
 )
 
 
@@ -34,19 +34,25 @@ def test_find_imports_stdlibs():
     import base64
     import pathlib
     """
-    assert find_imports(code) == []
+    assert find_requirements(code) == []
 
 def test_find_import_stdlibs_multiline():
     code = """
     import re, io, time
     """
-    assert find_imports(code) == []
+    assert find_requirements(code) == []
 
 def test_find_import_imports_multiline():
     code = """
     import numpy, scipy
     """
-    assert find_imports(code) == ['numpy', 'scipy']
+    assert find_requirements(code) == ['numpy', 'scipy']
+
+def test_find_import_replacement():
+    code = """
+    import transformers_js
+    """
+    assert find_requirements(code) == ['transformers-js-py']
 
 def test_exec_with_return_multi_line():
     assert exec_with_return('a = 1\nb = 2\na + b') == 3


### PR DESCRIPTION
Proof of concept for #5768 to aid the discussion.

This code shows that its doable to build a simple Panel Playground using Panel and Pyodide.

Is this something for Panel to build and manage or should I build on my own @philippjfr ?

**THE APPS ON THE RIGHT ARE RUN IN PYODIDE. THEY RUN SMOOTHLY, FAST. AND THE LIVE RELOAD IS VERY FAST.**

https://github.com/holoviz/panel/assets/42288570/62703adb-e633-44f8-9cd7-9d51660e6256

![image](https://github.com/holoviz/panel/assets/42288570/ae7affa8-8f67-45f0-acbd-2bc61717155d)

THERE ARE PROBABLY LOTS OF ISSUES TO SOLVE FOR A REAL APPLICATION THAT CAN SERVE USERS

## Requirements

- [ ] Standalone js or webcomponents that can easily be embedded on website
  - [ ] web component to easily display panel app also inside `ReactiveHTML` and with *hot reload*.
    - [ ] Custom `<panel-lite>` like `<gradio-lite>` or
    - [ ] `<py-script>` if below was solved
      - [ ] https://github.com/pyscript/pyscript/issues/1820
      - [ ] https://github.com/pyscript/pyscript/discussions/1822
  - [ ] web component playground to easily edit and show Panel apps with hot reload of packages and code
    - [ ] Custom `<panel-lite-editor>` like the Gradio Lite Playground or
    - [ ] General `<py-script-editor>` as requested here https://github.com/pyscript/pyscript/discussions/1823

## Roadmap

- [ ] Figure out if we should build on Panel or make a standalone playground in JS?
- [ ] Figure out if I can use panel convert to generate the *template* and embed that inside an iframe
  - [x] https://github.com/holoviz/panel/issues/5506
- [ ] Figure out if this can run safely outside iframe (as now) or should run inside iframe
- [ ] Add support for `async` javascript to the `ReactiveHTML` `_script` such that this can run properly using async/ await syntax.
- [ ] Carve our `Pyodide` pane and make it generally available. We really want two versions. One that can display Panel components. Another that can run Python code in a safe sandbox environment and return the result - for example code generate generated by llms.
- [ ] Support optional packages (via requirements.txt tab)
- [ ] Support optional template (via index.html tab)
- [ ] Support extension that the user provides in `pn.extension`
- [ ] Support design that the user provides in `pn.extension`
- [ ] Support writing to multiple `target`s
- [ ] Support export/ download
- [ ] Maybe use service workers.
- [ ] Wrap this in a nice template with "splitters" or similar inspired by for example Gradio Playground.
- [ ] Add examples
- [ ] Add optional (github?) auth for users such that apps can be persisted under that user
- [ ] Enable users to share their apps
- [ ] Enable users to update their apps
- [ ] Enable users to easily share at pyscript.com, Hugging Face spaces or similar.
- [ ] Add a gallery for discovery and appraisal of apps
- [ ] Add functionality to take screenshots of apps to show in gallery
- [ ] Figure out how *versions* of Panel, Bokeh, Tabulator etc. should be managed.
- [ ] Figure out what it requires to main this. Should some code run automatically once in a while to rebuild apps using latest versions of Panel, Bokeh etc.?
- [ ] Lots of testing of real world application development. How does the live reload work when we start to develop larger applications that load a lot of data.
- [ ] Should we actually enable developing in the (jupyterlite) notebook with live reload rendering on the right?
- [ ] Fix workaround where `#main` div is moved outside shadowroot and then back in after panel app has rendered.