### PR TITLE
Autofind transformers_js/ transformers-js-py

### DIFF
--- a/panel/io/convert.py
+++ b/panel/io/convert.py
@@ -26,7 +26,7 @@ from .. import __version__, config
 from ..util import base_version, escape
 from .loading import LOADING_INDICATOR_CSS_CLASS
 from .markdown import build_single_handler_application
-from .mime_render import find_imports
+from .mime_render import find_requirements
 from .resources import (
     BASE_TEMPLATE, CDN_DIST, CDN_ROOT, DIST_DIR, INDEX_TEMPLATE, Resources,
     _env as _pn_env, bundle_resources, loading_css, set_resource_mode,
@@ -235,7 +235,7 @@ def script_to_html(
         )
 
     if requirements == 'auto':
-        requirements = find_imports(source)
+        requirements = find_requirements(source)
     elif isinstance(requirements, str) and pathlib.Path(requirements).is_file():
         requirements = pathlib.Path(requirements).read_text(encoding='utf-8').splitlines()
         try:

--- a/panel/io/mime_render.py
+++ b/panel/io/mime_render.py
@@ -45,6 +45,7 @@ def _stdlibs():
 _STDLIBS = _stdlibs()
 _PACKAGE_MAP = {
     'sklearn': 'scikit-learn',
+    'transformers_js': 'transformers-js-py',
 }
 _IGNORED_PKGS = ['js', 'pyodide']
 _PANDAS_AUTODETECT = ['bokeh.sampledata', 'as_frame']

--- a/panel/io/mime_render.py
+++ b/panel/io/mime_render.py
@@ -50,9 +50,9 @@ _PACKAGE_MAP = {
 _IGNORED_PKGS = ['js', 'pyodide']
 _PANDAS_AUTODETECT = ['bokeh.sampledata', 'as_frame']
 
-def find_imports(code: str) -> List[str]:
+def find_requirements(code: str) -> List[str]:
     """
-    Finds the imports in a string of code.
+    Finds the packages required in a string of code.
 
     Parameters
     ----------
@@ -62,7 +62,7 @@ def find_imports(code: str) -> List[str]:
     Returns
     -------
     ``List[str]``
-        A list of module names that are imported in the code.
+        A list of package names that are to be installed for the code to be able to run.
 
     Examples
     --------

--- a/panel/tests/io/test_mime_render.py
+++ b/panel/tests/io/test_mime_render.py
@@ -48,6 +48,12 @@ def test_find_import_imports_multiline():
     """
     assert find_imports(code) == ['numpy', 'scipy']
 
+def test_find_import_replacement():
+    code = """
+    import transformers_js
+    """
+    assert find_imports(code) == ['transformers-js-py']
+
 def test_exec_with_return_multi_line():
     assert exec_with_return('a = 1\nb = 2\na + b') == 3
 

--- a/panel/tests/io/test_mime_render.py
+++ b/panel/tests/io/test_mime_render.py
@@ -1,7 +1,7 @@
 import pathlib
 
 from panel.io.mime_render import (
-    WriteCallbackStream, exec_with_return, find_imports, format_mime,
+    WriteCallbackStream, exec_with_return, find_requirements, format_mime,
 )
 
 
@@ -34,25 +34,25 @@ def test_find_imports_stdlibs():
     import base64
     import pathlib
     """
-    assert find_imports(code) == []
+    assert find_requirements(code) == []
 
 def test_find_import_stdlibs_multiline():
     code = """
     import re, io, time
     """
-    assert find_imports(code) == []
+    assert find_requirements(code) == []
 
 def test_find_import_imports_multiline():
     code = """
     import numpy, scipy
     """
-    assert find_imports(code) == ['numpy', 'scipy']
+    assert find_requirements(code) == ['numpy', 'scipy']
 
 def test_find_import_replacement():
     code = """
     import transformers_js
     """
-    assert find_imports(code) == ['transformers-js-py']
+    assert find_requirements(code) == ['transformers-js-py']
 
 def test_exec_with_return_multi_line():
     assert exec_with_return('a = 1\nb = 2\na + b') == 3


### PR DESCRIPTION
Addresses https://github.com/whitphx/transformers.js.py/issues/26 as discussed in https://github.com/whitphx/transformers.js.py/pull/23#discussion_r1372601075

I renamed from `find_imports` to `find_requirements` because it find the package requirements and not the *imports* (?) as previously described by the docstring.