### PR TITLE
Clean up skips and imports in tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -165,7 +165,7 @@ jobs:
       - name: build jupyterlite
         run: |
           conda activate test-environment
-          pip install jupyterlite
+          pip install jupyterlite-core jupyterlite-pyodide-kernel
           python ./scripts/build_pyodide_wheels.py lite/pypi
           python ./scripts/panelite/generate_panelite_content.py
           jupyter lite build --lite-dir lite --output-dir lite/dist

--- a/lite/requirements.txt
+++ b/lite/requirements.txt
@@ -4,7 +4,8 @@ ipywidgets
 jupyter_bokeh
 jupyterlab
 jupyterlab-open-url-parameter
-jupyterlite
+jupyterlite-core
+jupyterlite-pyodide-kernel
 nbformat
 pkginfo
 pyviz_comms

--- a/panel/tests/chat/test_langchain.py
+++ b/panel/tests/chat/test_langchain.py
@@ -4,12 +4,11 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-try:
-    from langchain.agents import AgentType, initialize_agent, load_tools
-    from langchain.chat_models.openai import ChatOpenAI
-    from langchain.llms.fake import FakeListLLM
-except ImportError:
-    pytest.skip("langchain not installed", allow_module_level=True)
+pytest.importorskip("langchain", reason="Cannot test PanelCallbackHandler without langchain")
+
+from langchain.agents import AgentType, initialize_agent, load_tools
+from langchain.chat_models.openai import ChatOpenAI
+from langchain.llms.fake import FakeListLLM
 
 from panel.chat import ChatFeed, ChatInterface
 from panel.chat.langchain import PanelCallbackHandler

--- a/panel/tests/test_pipeline.py
+++ b/panel/tests/test_pipeline.py
@@ -1,22 +1,13 @@
 import param
 import pytest
 
-from packaging.version import Version
+hv = pytest.importorskip('holoviews')
 
 from panel.layout import Column, Row
 from panel.pane import HoloViews
 from panel.param import ParamMethod
 from panel.pipeline import Pipeline, find_route
 from panel.widgets import Button, Select
-
-if Version(param.__version__) < Version('1.8.2'):
-    pytestmark = pytest.mark.skip("skipping if param version < 1.8.2", allow_module_level=True)
-
-try:
-    import holoviews as hv
-except Exception:
-    pytestmark = pytest.mark.skip('Pipeline requires HoloViews.')
-
 
 
 class Stage1(param.Parameterized):

--- a/panel/tests/ui/command/test_serve.py
+++ b/panel/tests/ui/command/test_serve.py
@@ -3,15 +3,15 @@ import time
 
 import pytest
 
+pytest.importorskip("playwright")
+
+from playwright.sync_api import expect
+
 from panel.tests.util import (
     run_panel_serve, unix_only, wait_for_port, write_file,
 )
 
-try:
-    from playwright.sync_api import expect
-    pytestmark = pytest.mark.ui
-except ImportError:
-    pytestmark = pytest.mark.skip('playwright not available')
+pytestmark = pytest.mark.ui
 
 
 @unix_only

--- a/panel/tests/ui/io/test_convert.py
+++ b/panel/tests/ui/io/test_convert.py
@@ -9,12 +9,9 @@ from subprocess import PIPE, Popen
 
 import pytest
 
-try:
-    from playwright.sync_api import expect
-except ImportError:
-    pytestmark = pytest.mark.skip('playwright not available')
+pytest.importorskip("playwright")
 
-pytestmark = pytest.mark.ui
+from playwright.sync_api import expect
 
 from panel.config import config
 from panel.io.convert import BOKEH_LOCAL_WHL, PANEL_LOCAL_WHL, convert_apps
@@ -25,6 +22,8 @@ if not (PANEL_LOCAL_WHL.is_file() and BOKEH_LOCAL_WHL.is_file()):
         "version. Build wheels for pyodide using `python scripts/build_pyodide_wheels.py`.",
         allow_module_level=True
     )
+
+pytestmark = pytest.mark.ui
 
 _worker_id = os.environ.get("PYTEST_XDIST_WORKER", "0")
 HTTP_PORT = 5990 + int(re.sub(r"\D", "", _worker_id))

--- a/panel/tests/ui/io/test_jupyter_server_extension.py
+++ b/panel/tests/ui/io/test_jupyter_server_extension.py
@@ -1,13 +1,13 @@
 import pytest
 
-try:
-    from playwright.sync_api import expect
-except ImportError:
-    pytestmark = pytest.mark.skip('playwright not available')
+pytest.importorskip("playwright")
+
+from playwright.sync_api import expect
 
 from panel.tests.util import wait_until
 
-pytestmark = pytest.mark.jupyter
+pytestmark = [pytest.mark.jupyter, pytest.mark.ui]
+
 
 @pytest.mark.flaky(max_runs=3)
 def test_jupyter_server(page, jupyter_preview):

--- a/panel/tests/ui/io/test_jupyterlite.py
+++ b/panel/tests/ui/io/test_jupyterlite.py
@@ -43,6 +43,12 @@ def test_jupyterlite_execution(launch_jupyterlite, page):
     page.goto("http://localhost:8123/index.html")
 
     page.locator('text="Getting_Started.ipynb"').first.dblclick()
+
+    # Select the kernel
+    if page.locator('.jp-Dialog').count() == 1:
+        page.locator('.jp-select-wrapper > select').select_option('Python (Pyodide)')
+        page.locator('.jp-Dialog-footer > button').nth(1).click()
+
     for _ in range(6):
         page.locator('button[data-command="notebook:run-cell-and-select-next"]').click()
         page.wait_for_timeout(500)

--- a/panel/tests/ui/io/test_jupyterlite.py
+++ b/panel/tests/ui/io/test_jupyterlite.py
@@ -5,12 +5,12 @@ from subprocess import PIPE, Popen
 
 import pytest
 
-try:
-    from playwright.sync_api import expect
-except ImportError:
-    pytestmark = pytest.mark.skip('playwright not available')
+pytest.importorskip("playwright")
 
-pytestmark = pytest.mark.ui
+from playwright.sync_api import expect
+
+pytestmark = [pytest.mark.jupyter, pytest.mark.ui]
+
 
 @pytest.fixture()
 def launch_jupyterlite():

--- a/panel/tests/ui/io/test_loading.py
+++ b/panel/tests/ui/io/test_loading.py
@@ -1,14 +1,14 @@
 import pytest
 
-try:
-    from playwright.sync_api import expect
-    pytestmark = pytest.mark.ui
-except ImportError:
-    pytestmark = pytest.mark.skip('playwright not available')
+pytest.importorskip("playwright")
+
+from playwright.sync_api import expect
 
 from panel.config import config
 from panel.pane import Markdown
 from panel.tests.util import serve_component
+
+pytestmark = pytest.mark.ui
 
 
 def test_global_loading_indicator(page):

--- a/panel/tests/ui/io/test_notifications.py
+++ b/panel/tests/ui/io/test_notifications.py
@@ -1,10 +1,8 @@
 import pytest
 
-try:
-    from playwright.sync_api import expect
-    pytestmark = pytest.mark.ui
-except ImportError:
-    pytestmark = pytest.mark.skip('playwright not available')
+pytest.importorskip("playwright")
+
+from playwright.sync_api import expect
 
 from panel.config import config
 from panel.io.state import state
@@ -13,6 +11,7 @@ from panel.template import BootstrapTemplate
 from panel.tests.util import serve_component
 from panel.widgets import Button
 
+pytestmark = pytest.mark.ui
 
 def test_notifications_no_template(page):
     def callback(event):

--- a/panel/tests/ui/io/test_server.py
+++ b/panel/tests/ui/io/test_server.py
@@ -1,14 +1,14 @@
 import pytest
 
-try:
-    from playwright.sync_api import expect
-    pytestmark = pytest.mark.ui
-except ImportError:
-    pytestmark = pytest.mark.skip('playwright not available')
+pytest.importorskip("playwright")
+
+from playwright.sync_api import expect
 
 from panel import config, state
 from panel.template import BootstrapTemplate
 from panel.tests.util import serve_component
+
+pytestmark = pytest.mark.ui
 
 
 def test_server_reuse_sessions(page, reuse_sessions):

--- a/panel/tests/ui/io/test_state.py
+++ b/panel/tests/ui/io/test_state.py
@@ -1,17 +1,14 @@
 import pytest
 
-pytestmark = pytest.mark.ui
+pytest.importorskip("playwright")
 
-try:
-    from playwright.sync_api import expect
-    pytestmark = pytest.mark.ui
-except ImportError:
-    pytestmark = pytest.mark.skip('playwright not available')
+from playwright.sync_api import expect
 
 from panel.io.state import state
 from panel.pane import Markdown
 from panel.tests.util import serve_component
 
+pytestmark = pytest.mark.ui
 
 def test_on_load(page):
     def app():

--- a/panel/tests/ui/layout/test_accordion.py
+++ b/panel/tests/ui/layout/test_accordion.py
@@ -1,14 +1,12 @@
 import pytest
 
+pytest.importorskip("playwright")
+
 from bokeh.models import Div
+from playwright.sync_api import expect
 
 from panel import Accordion
 from panel.tests.util import serve_component
-
-try:
-    from playwright.sync_api import expect
-except ImportError:
-    pytestmark = pytest.mark.skip('playwright not available')
 
 pytestmark = pytest.mark.ui
 

--- a/panel/tests/ui/layout/test_card.py
+++ b/panel/tests/ui/layout/test_card.py
@@ -1,13 +1,12 @@
 import pytest
 
+pytest.importorskip("playwright")
+
+from playwright.sync_api import expect
+
 from panel import Card
 from panel.tests.util import serve_component
 from panel.widgets import FloatSlider, TextInput
-
-try:
-    from playwright.sync_api import expect
-except ImportError:
-    pytestmark = pytest.mark.skip('playwright not available')
 
 pytestmark = pytest.mark.ui
 

--- a/panel/tests/ui/layout/test_column.py
+++ b/panel/tests/ui/layout/test_column.py
@@ -1,14 +1,14 @@
 import pytest
 
-try:
-    from playwright.sync_api import expect
-except ImportError:
-    pytestmark = pytest.mark.skip('playwright not available')
+pytest.importorskip("playwright")
+
+from playwright.sync_api import expect
 
 from panel import Column, Spacer
 from panel.tests.util import serve_component, wait_until
 
 pytestmark = pytest.mark.ui
+
 
 def test_column_scroll(page):
     col = Column(

--- a/panel/tests/ui/layout/test_gridstack.py
+++ b/panel/tests/ui/layout/test_gridstack.py
@@ -1,15 +1,14 @@
 import pytest
 
-try:
-    from playwright.sync_api import expect
-except ImportError:
-    pytestmark = pytest.mark.skip('playwright not available')
+pytest.importorskip("playwright")
 
-pytestmark = pytest.mark.ui
+from playwright.sync_api import expect
 
 from panel import Column, Spacer
 from panel.layout.gridstack import GridStack
 from panel.tests.util import serve_component
+
+pytestmark = pytest.mark.ui
 
 
 def test_gridstack(page):

--- a/panel/tests/ui/pane/test_ipywidget.py
+++ b/panel/tests/ui/pane/test_ipywidget.py
@@ -1,19 +1,16 @@
 import pytest
 
+pytest.importorskip("ipywidgets")
+pytest.importorskip("playwright")
+
+import traitlets
+
 from bokeh.core.has_props import _default_resolver
 from bokeh.model import Model
-
-pytestmark = pytest.mark.ui
 
 from panel.layout import Row
 from panel.pane.ipywidget import Reacton
 from panel.tests.util import serve_component, wait_until
-
-try:
-    import ipywidgets  # noqa
-    import traitlets
-except Exception:
-    pytestmark = pytest.mark.skip('ipywidgets not available')
 
 try:
     import reacton
@@ -26,6 +23,9 @@ try:
 except Exception:
     anywidget = None
 requires_anywidget = pytest.mark.skipif(anywidget is None, reason="requires anywidget")
+
+pytestmark = pytest.mark.ui
+
 
 @pytest.fixture(scope="module", autouse=True)
 def cleanup_ipywidgets():

--- a/panel/tests/ui/pane/test_markup.py
+++ b/panel/tests/ui/pane/test_markup.py
@@ -1,14 +1,13 @@
 import pytest
 
-try:
-    from playwright.sync_api import expect
-except ImportError:
-    pytestmark = pytest.mark.skip('playwright not available')
+pytest.importorskip("playwright")
 
-pytestmark = pytest.mark.ui
+from playwright.sync_api import expect
 
 from panel.pane import Markdown
 from panel.tests.util import serve_component, wait_until
+
+pytestmark = pytest.mark.ui
 
 
 def test_update_markdown_pane(page):

--- a/panel/tests/ui/pane/test_plotly.py
+++ b/panel/tests/ui/pane/test_plotly.py
@@ -1,26 +1,20 @@
 import pytest
 
-try:
-    import plotly
-    import plotly.graph_objs as go
-    import plotly.io as pio
-    pio.templates.default = None
-except Exception:
-    plotly = None
-plotly_available = pytest.mark.skipif(plotly is None, reason="requires plotly")
+pytest.importorskip("playwright")
+pytest.importorskip("plotly")
 
 import numpy as np
+import plotly.graph_objs as go
+import plotly.io as pio
+
+from playwright.sync_api import expect
 
 from panel.pane import Plotly
 from panel.tests.util import serve_component, wait_until
 
-try:
-    from playwright.sync_api import expect
-except ImportError:
-    pytestmark = pytest.mark.skip('playwright not available')
-
 pytestmark = pytest.mark.ui
 
+pio.templates.default = None
 
 @pytest.fixture
 def plotly_2d_plot():
@@ -52,7 +46,6 @@ def plotly_3d_plot():
     return plot_3d, title
 
 
-@plotly_available
 def test_plotly_no_console_errors(page, plotly_2d_plot):
     msgs, _ = serve_component(page, plotly_2d_plot)
 
@@ -61,7 +54,6 @@ def test_plotly_no_console_errors(page, plotly_2d_plot):
     assert [msg for msg in msgs if msg.type == 'error' and 'favicon' not in msg.location['url']] == []
 
 
-@plotly_available
 def test_plotly_2d_plot(page, plotly_2d_plot):
     serve_component(page, plotly_2d_plot)
 
@@ -88,7 +80,6 @@ def test_plotly_2d_plot(page, plotly_2d_plot):
     }, page)
 
 
-@plotly_available
 @pytest.mark.flaky(max_runs=3)
 def test_plotly_3d_plot(page, plotly_3d_plot):
     plot_3d, title = plotly_3d_plot
@@ -114,7 +105,6 @@ def test_plotly_3d_plot(page, plotly_3d_plot):
     expect(modebar).to_have_count(1)
 
 
-@plotly_available
 @pytest.mark.flaky(max_runs=3)
 def test_plotly_hover_data(page, plotly_2d_plot):
     hover_data = []
@@ -146,7 +136,6 @@ def test_plotly_hover_data(page, plotly_2d_plot):
     wait_until(lambda: plotly_2d_plot.hover_data is None, page)
 
 
-@plotly_available
 @pytest.mark.flaky(max_runs=3)
 def test_plotly_click_data(page, plotly_2d_plot):
     serve_component(page, plotly_2d_plot)
@@ -169,7 +158,6 @@ def test_plotly_click_data(page, plotly_2d_plot):
     }, page)
 
 
-@plotly_available
 @pytest.mark.flaky(max_runs=3)
 def test_plotly_select_data(page, plotly_2d_plot):
     serve_component(page, plotly_2d_plot)

--- a/panel/tests/ui/pane/test_vega.py
+++ b/panel/tests/ui/pane/test_vega.py
@@ -1,5 +1,7 @@
 import pytest
 
+pytest.importorskip("playwright")
+
 try:
     import altair as alt
 except Exception:
@@ -7,13 +9,10 @@ except Exception:
 
 altair_available = pytest.mark.skipif(alt is None, reason='Requires altair')
 
+from playwright.sync_api import expect
+
 from panel.pane import Vega
 from panel.tests.util import serve_component, wait_until
-
-try:
-    from playwright.sync_api import expect
-except ImportError:
-    pytestmark = pytest.mark.skip('playwright not available')
 
 pytestmark = pytest.mark.ui
 

--- a/panel/tests/ui/template/test_bootstraptemplate.py
+++ b/panel/tests/ui/template/test_bootstraptemplate.py
@@ -1,14 +1,14 @@
 import pytest
 
-try:
-    from playwright.sync_api import expect
-    pytestmark = pytest.mark.ui
-except ImportError:
-    pytestmark = pytest.mark.skip('playwright not available')
+pytest.importorskip("playwright")
+
+from playwright.sync_api import expect
 
 from panel.pane import Markdown
 from panel.template import BootstrapTemplate
 from panel.tests.util import serve_component
+
+pytestmark = pytest.mark.ui
 
 
 def test_bootstrap_template_no_console_errors(page):

--- a/panel/tests/ui/template/test_fastgridtemplate.py
+++ b/panel/tests/ui/template/test_fastgridtemplate.py
@@ -1,14 +1,14 @@
 import pytest
 
-try:
-    from playwright.sync_api import expect
-    pytestmark = pytest.mark.ui
-except ImportError:
-    pytestmark = pytest.mark.skip('playwright not available')
+pytest.importorskip("playwright")
+
+from playwright.sync_api import expect
 
 from panel.pane import Markdown
 from panel.template import FastGridTemplate
 from panel.tests.util import serve_component
+
+pytestmark = pytest.mark.ui
 
 
 def test_fast_grid_template_no_console_errors(page):

--- a/panel/tests/ui/template/test_materialtemplate.py
+++ b/panel/tests/ui/template/test_materialtemplate.py
@@ -1,14 +1,14 @@
 import pytest
 
-try:
-    from playwright.sync_api import expect
-    pytestmark = pytest.mark.ui
-except ImportError:
-    pytestmark = pytest.mark.skip('playwright not available')
+pytest.importorskip("playwright")
+
+from playwright.sync_api import expect
 
 from panel.pane import Markdown
 from panel.template import MaterialTemplate
 from panel.tests.util import serve_component
+
+pytestmark = pytest.mark.ui
 
 
 def test_material_template_no_console_errors(page):

--- a/panel/tests/ui/template/test_slidestemplate.py
+++ b/panel/tests/ui/template/test_slidestemplate.py
@@ -1,14 +1,14 @@
 import pytest
 
-try:
-    from playwright.sync_api import expect
-    pytestmark = pytest.mark.ui
-except ImportError:
-    pytestmark = pytest.mark.skip('playwright not available')
+pytest.importorskip("playwright")
+
+from playwright.sync_api import expect
 
 from panel.pane import Markdown
 from panel.template import SlidesTemplate
 from panel.tests.util import serve_component
+
+pytestmark = pytest.mark.ui
 
 
 def test_slides_template_no_console_errors(page):

--- a/panel/tests/ui/test_auth.py
+++ b/panel/tests/ui/test_auth.py
@@ -3,17 +3,17 @@ import pathlib
 
 import pytest
 
-try:
-    from playwright.sync_api import expect
-    pytestmark = pytest.mark.ui
-except ImportError:
-    pytestmark = pytest.mark.skip('playwright not available')
+pytest.importorskip("playwright")
+
+from playwright.sync_api import expect
 
 from panel.config import config
 from panel.pane import Markdown
 from panel.tests.util import (
     run_panel_serve, serve_component, unix_only, wait_for_port, write_file,
 )
+
+pytestmark = pytest.mark.ui
 
 
 @unix_only

--- a/panel/tests/ui/test_param.py
+++ b/panel/tests/ui/test_param.py
@@ -2,14 +2,14 @@ import time
 
 import pytest
 
-try:
-    from playwright.sync_api import expect
-    pytestmark = pytest.mark.ui
-except ImportError:
-    pytestmark = pytest.mark.skip('playwright not available')
+pytest.importorskip("playwright")
+
+from playwright.sync_api import expect
 
 from panel.pane import panel
 from panel.tests.util import serve_component
+
+pytestmark = pytest.mark.ui
 
 
 def test_param_defer_load(page):

--- a/panel/tests/ui/test_reactive.py
+++ b/panel/tests/ui/test_reactive.py
@@ -1,14 +1,14 @@
 import param
 import pytest
 
-try:
-    from playwright.sync_api import expect
-    pytestmark = pytest.mark.ui
-except ImportError:
-    pytestmark = pytest.mark.skip('playwright not available')
+pytest.importorskip("playwright")
+
+from playwright.sync_api import expect
 
 from panel.reactive import ReactiveHTML
 from panel.tests.util import serve_component, wait_until
+
+pytestmark = pytest.mark.ui
 
 
 class ReactiveComponent(ReactiveHTML):

--- a/panel/tests/ui/widgets/test_button.py
+++ b/panel/tests/ui/widgets/test_button.py
@@ -1,18 +1,16 @@
 import pytest
 
-pytestmark = pytest.mark.ui
+pytest.importorskip("playwright")
 
 from bokeh.models import Tooltip
+from playwright.sync_api import expect
 
 from panel.tests.util import serve_component, wait_until
 from panel.widgets import (
     Button, CheckButtonGroup, RadioButtonGroup, TooltipIcon,
 )
 
-try:
-    from playwright.sync_api import expect
-except ImportError:
-    pytestmark = pytest.mark.skip("playwright not available")
+pytestmark = pytest.mark.ui
 
 
 def test_button_click(page):

--- a/panel/tests/ui/widgets/test_indicators.py
+++ b/panel/tests/ui/widgets/test_indicators.py
@@ -1,16 +1,14 @@
 import pytest
 
-pytestmark = pytest.mark.ui
+pytest.importorskip("playwright")
 
 from bokeh.models import Tooltip
+from playwright.sync_api import expect
 
 from panel.tests.util import serve_component
 from panel.widgets import TooltipIcon
 
-try:
-    from playwright.sync_api import expect
-except ImportError:
-    pytestmark = pytest.mark.skip("playwright not available")
+pytestmark = pytest.mark.ui
 
 
 @pytest.mark.parametrize(

--- a/panel/tests/ui/widgets/test_input.py
+++ b/panel/tests/ui/widgets/test_input.py
@@ -2,14 +2,14 @@ import datetime
 
 import pytest
 
+pytest.importorskip("playwright")
+
+from playwright.sync_api import expect
+
 from panel.tests.util import serve_component, wait_until
 from panel.widgets import DatetimePicker, DatetimeRangePicker, TextAreaInput
 
-try:
-    from playwright.sync_api import expect
-    pytestmark = pytest.mark.ui
-except ImportError:
-    pytestmark = pytest.mark.skip('playwright not available')
+pytestmark = pytest.mark.ui
 
 
 @pytest.fixture

--- a/panel/tests/ui/widgets/test_tabulator.py
+++ b/panel/tests/ui/widgets/test_tabulator.py
@@ -7,27 +7,24 @@ import pandas as pd
 import param
 import pytest
 
+pytest.importorskip("playwright")
+
 from bokeh.models.widgets.tables import (
     BooleanFormatter, CheckboxEditor, DateEditor, DateFormatter,
     HTMLTemplateFormatter, IntEditor, NumberEditor, NumberFormatter,
     ScientificFormatter, SelectEditor, StringEditor, StringFormatter,
     TextEditor,
 )
+from playwright.sync_api import expect
 
-from panel.layout.base import Column
-
-try:
-    from playwright.sync_api import expect
-except ImportError:
-    pytestmark = pytest.mark.skip('playwright not available')
-
-pytestmark = pytest.mark.ui
-
-from panel import state
 from panel.depends import bind
+from panel.io.state import state
+from panel.layout.base import Column
 from panel.models.tabulator import _TABULATOR_THEMES_MAPPING
 from panel.tests.util import get_ctrl_modifier, serve_component, wait_until
 from panel.widgets import Select, Tabulator
+
+pytestmark = pytest.mark.ui
 
 
 @pytest.fixture

--- a/panel/tests/ui/widgets/test_texteditor.py
+++ b/panel/tests/ui/widgets/test_texteditor.py
@@ -2,16 +2,15 @@ import sys
 
 import pytest
 
+pytest.importorskip("playwright")
+
+from playwright.sync_api import expect
+
 from panel import depends
 from panel.layout import Column
 from panel.pane import HTML
 from panel.tests.util import serve_component, wait_until
 from panel.widgets import RadioButtonGroup, TextEditor
-
-try:
-    from playwright.sync_api import expect
-except ImportError:
-    pytestmark = pytest.mark.skip('playwright not available')
 
 pytestmark = pytest.mark.ui
 

--- a/setup.py
+++ b/setup.py
@@ -130,7 +130,7 @@ _tests_core = [
     'pytest',
     'nbval',
     'flaky',
-    'pytest-asyncio',
+    'pytest-asyncio <0.22',
     'pytest-xdist',
     'pytest-cov',
     'pre-commit',
@@ -229,7 +229,7 @@ extras_require['all_pip'] = sorted(set(extras_require['all']) - set(_conda_only)
 # non-python dependencies). Note that setup_requires isn't used
 # because it doesn't work well with pip.
 extras_require['build'] = [
-    'param >=2.0.0rc6',
+    'param >=2.0.0',
     'setuptools >=42',
     'requests',
     'packaging',


### PR DESCRIPTION
Consistently use `importorskip` when skipping test modules, put `pytestmark` in the right places and remove try/except based skips.