### PR TITLE
Enhance extension and config docs

### DIFF
--- a/doc/api/config.md
+++ b/doc/api/config.md
@@ -1,68 +1,93 @@
 # Config
 
-The `pn.config` object allows setting various configuration variables, the config variables can also be set as environment variables or passed through the [`pn.extension`](cheatsheet#pn-extension):
+The `pn.config` object holds global configuration options for Panel.
 
-### Python only
+The options can be set directly on the global config instance, via
+keyword arguments to [`pn.extension`](cheatsheet#pn-extension) or via environment variables.
+
+For example to set the `embed` option the following approaches can be used:
+
+```python
+pn.config.embed = True
+pn.extension(embed=True)
+os.environ['PANEL_EMBED'] = 'True'
+```
+
+## Options Summary
+
+`admin`
+: Whether the admin panel was enabled.
+
+`admin_endpoint` (`PANEL_ADMIN_ENDPOINT`)
+: Name to use for the admin endpoint.
+
+`admin_log_level` (`PANEL_ADMIN_LOG_LEVEL`)
+: Log level of the Admin Panel logger
+
+`admin_plugins`
+: A list of tuples containing a title and a function that returns
+        an additional panel to be rendered into the admin page.
+
+`apply_signatures`
+: Whether to set custom Signature which allows tab-completion
+        in some IDEs and environments.
+
+`auth_template`
+: A jinja2 template rendered when the authorize_callback determines
+        that a user in not authorized to access the application.
+
+`authorize_callback`
+: Authorization callback that is invoked when authentication
+        is enabled. The callback is given the user information returned
+        by the configured Auth provider and should return True or False
+        depending on whether the user is authorized to access the
+        application. The callback may also contain a second parameter,
+        which is the requested path the user is making. If the user
+        is authenticated and has explicit access to the path, then
+        the callback should return True otherwise it should return
+        False.
+
+`autoreload`
+: Whether to autoreload server when script changes.
+
+`basic_auth` (`PANEL_BASIC_AUTH`)
+: Password, dictionary with a mapping from username to password
+        or filepath containing JSON to use with the basic auth
+        provider.
+
+`basic_auth_template`
+: A jinja2 template to override the default Basic Authentication
+        login page.
+
+`browser_info`
+: Whether to request browser info from the frontend.
+
+`comms` (`PANEL_COMMS`)
+: Whether to render output in Jupyter with the default Jupyter
+        extension or use the jupyter_bokeh ipywidget model.
+
+`console_output` (`PANEL_CONSOLE_OUTPUT`)
+: How to log errors and stdout output triggered by callbacks
+        from Javascript in the notebook.
+
+`cookie_secret` (`PANEL_COOKIE_SECRET`)
+: Configure to enable getting/setting secure cookies.
 
 `css_files`
 : External CSS files to load.
 
-`js_files`
-: External JS files to load. Dictionary should map from exported name to the URL of the JS file.
-
-`loading_spinner`
-: The style of the global loading indicator, e.g. 'arcs', 'bars', 'dots', 'petals'.
-
-`loading_color`
-: The color of the global loading indicator as a hex color, e.g. #6a6a6a
-
 `defer_load`
-: Whether reactive function evaluation is deferred until the page is rendered.
+: Whether to defer load of rendered functions.
 
-`exception_handler`
-: A custom exception handler can be defined which should accept any exceptions raised while processing events originating from the frontend and onload callbacks.
+`design`
+: The design system to use to style components.
 
-`loading_indicator`
-: Whether a loading indicator is shown by default when panes are updating.
-
-`nthreads`
-: If set will start a `ThreadPoolExecutor` to dispatch events to for concurrent execution on separate cores. By default no thread pool is launched, while setting nthreads=0 launches `min(32, os.cpu_count() + 4)` threads.
-
-`raw_css`
-: List of raw CSS strings to add to load.
-
-`reuse_sessions`
-: Whether to reuse a session for the initial request to speed up the initial page render. Note that if the initial page differs between sessions, e.g. because it uses query parameters to modify the rendered content, then this option will result in the wrong content being rendered. See the corresponding [how-to guide](../how_to/performance/reuse_sessions.md) for more information.
-
-`safe_embed`
-: Whether to record all set events when embedding rather than just those that are changed
-
-`session_history`
-: If set to a non-zero value this determines the maximum length of the pn.state.session_info dictionary, which tracks information about user sessions. A value of -1 indicates an unlimited history.
-`sizing_mode`
-:  Specify the default sizing mode behavior of panels.
-
-`template`
-: The template to render the served application into, e.g. `'bootstrap'` or `'material'`.
-
-`theme`
-: The theme to apply to the selected template (no effect unless `template` is set)
-
-`throttled`
-: Whether sliders and inputs should be throttled until release of mouse.
-
-### Python and Environment variables
-
-`admin_log_level` (`PANEL_ADMIN_LOG_LEVEL`):
-Log level of Panel admin's logger (default=DEBUG).
-
-`comms` (`PANEL_COMMS`)
-: Whether to render output in Jupyter with the default Jupyter extension or use the `jupyter_bokeh` ipywidget model.
-
-`console_output` (`PANEL_CONSOLE_OUTPUT`): How to log errors and stdout output triggered by callbacks from Javascript in the notebook. Options include `'accumulate'`, `'replace'` and `'disable'`.
+`disconnect_notification`
+: The notification to display to the user when the connection
+        to the server is dropped.
 
 `embed` (`PANEL_EMBED`)
-: Whether plot data will be [embedded](./Deploy_and_Export.rst#Embedding).
+: Whether plot data will be embedded.
 
 `embed_json` (`PANEL_EMBED_JSON`)
 : Whether to save embedded state to json files.
@@ -76,11 +101,146 @@ Log level of Panel admin's logger (default=DEBUG).
 `embed_save_path` (`PANEL_EMBED_SAVE_PATH`)
 : Where to save json files for embedded state.
 
+`exception_handler`
+: General exception handler for events.
+
+`global_css`
+: List of raw CSS to be added to the header.
+
+`global_loading_spinner`
+: Whether to add a global loading spinner for the whole application.
+
 `inline` (`PANEL_INLINE`)
-: Whether to inline JS and CSS resources. If disabled, resources are loaded from CDN if one is available.
+: Whether to inline JS and CSS resources. If disabled, resources
+        are loaded from CDN if one is available.
+
+`js_files`
+: External JS files to load. Dictionary should map from exported
+        name to the URL of the JS file.
+
+`js_modules`
+: External JS files to load as modules. Dictionary should map from
+        exported name to the URL of the JS file.
+
+`layout_compatibility`
+: Provide compatibility for older layout specifications. Incompatible
+        specifications will trigger warnings by default but can be set to error.
+        Compatibility to be set to error by default in Panel 1.1.
+
+`load_entry_points`
+: Load entry points from external packages.
+
+`loading_color`
+: Color of the loading indicator.
+
+`loading_indicator`
+: Whether a loading indicator is shown by default while panes are updating.
+
+`loading_max_height`
+: Maximum height of the loading indicator.
+
+`loading_spinner`
+: Loading indicator to use when component loading parameter is set.
 
 `log_level` (`PANEL_LOG_LEVEL`)
-: Log level of Panel's logger (default=WARNING).
+: Log level of Panel loggers
+
+`name`
+: String identifier for this object.
+
+`notifications`
+: Whether to enable notifications functionality.
 
 `npm_cdn` (`PANEL_NPM_CDN`)
-: The CDN to load NPM packages from if resources are served from CDN. Allows switching between 'https://unpkg.com' (default) and 'https://cdn.jsdelivr.net/npm' for most resources.
+: The CDN to load NPM packages from if resources are served from
+        CDN. Allows switching between [https://unpkg.com](https://unpkg.com) and
+        [https://cdn.jsdelivr.net/npm(https://cdn.jsdelivr.net/npm) for most resources.
+
+`nthreads` (`PANEL_NUM_THREADS`)
+: When set to a non-None value a thread pool will be started.
+        Whenever an event arrives from the frontend it will be
+        dispatched to the thread pool to be processed.
+
+`oauth_encryption_key` (`PANEL_OAUTH_ENCRYPTION`)
+: A random string used to encode OAuth related user information.
+
+`oauth_expiry` (`PANEL_OAUTH_EXPIRY`)
+: Expiry of the OAuth cookie in number of days.
+
+`oauth_extra_params` (`PANEL_OAUTH_EXTRA_PARAMS`)
+: Additional parameters required for OAuth provider.
+
+`oauth_guest_endpoints` (`PANEL_OAUTH_GUEST_ENDPOINTS`)
+: List of endpoints that can be accessed as a guest without authenticating.
+
+`oauth_jwt_user` (`PANEL_OAUTH_JWT_USER`)
+: The key in the ID JWT token to consider the user.
+
+`oauth_key` (`PANEL_OAUTH_KEY`)
+: A client key to provide to the OAuth provider.
+
+`oauth_optional` (`PANEL_OAUTH_OPTIONAL`)
+: Whether the user will be forced to go through login flow or if
+        they can access all applications as a guest.
+
+`oauth_provider` (`PANEL_OAUTH_PROVIDER`)
+: Select between a list of authentication providers.
+
+`oauth_redirect_uri` (`PANEL_OAUTH_REDIRECT_URI`)
+: A redirect URI to provide to the OAuth provider.
+
+`oauth_refresh_tokens` (`PANEL_OAUTH_REFRESH_TOKENS`)
+: Whether to automatically refresh access tokens in the background.
+
+`oauth_secret` (`PANEL_OAUTH_SECRET`)
+: A client secret to provide to the OAuth provider.
+
+`profiler`
+: The profiler engine to enable.
+
+`raw_css`
+: List of raw CSS strings to add to load.
+
+`ready_notification`
+: The notification to display when the application is ready and
+        fully loaded.
+
+`reuse_sessions`
+: Whether to reuse a session for the initial request to speed up
+        the initial page render. Note that if the initial page differs
+        between sessions, e.g. because it uses query parameters to modify
+        the rendered content, then this option will result in the wrong
+        content being rendered. Define a session_key_func to ensure that
+        reused sessions are only reused when appropriate.
+
+`safe_embed`
+: Ensure all bokeh property changes trigger events which are
+        embedded. Useful when only partial updates are made in an
+        app, e.g. when working with HoloViews.
+
+`session_history`
+: If set to a non-negative value this determines the maximum length
+        of the pn.state.session_info dictionary, which tracks
+        information about user sessions. A value of -1 indicates an
+        unlimited history.
+
+`session_key_func`
+: Used in conjunction with the reuse_sessions option, the
+        session_key_func is given a tornado.httputil.HTTPServerRequest
+        and should return a key that uniquely captures a session.
+
+`sizing_mode`
+: Specify the default sizing mode behavior of panels.
+
+`template`
+: The default template to render served applications into.
+
+`theme`
+: The theme to apply to components.
+
+`throttled`
+: If sliders and inputs should be throttled until release of mouse.
+
+## Full Details
+
+To see the full details including types and default values run `?pn.config` in an ipython terminal or Notebook.

--- a/doc/api/config.md
+++ b/doc/api/config.md
@@ -2,8 +2,6 @@
 
 The `pn.config` object holds global configuration options for Panel.
 
-To see the current configuration run `?pn.config` in an ipython terminal or Notebook.
-
 The options can be set directly on the global config instance, via
 keyword arguments to [`pn.extension`](cheatsheet#pn-extension) or via environment variables.
 

--- a/doc/api/config.md
+++ b/doc/api/config.md
@@ -241,6 +241,6 @@ os.environ['PANEL_EMBED'] = 'True'
 `throttled`
 : If sliders and inputs should be throttled until release of mouse.
 
-## Full Details
+## Options Details
 
 To see the full details including types and default values run `?pn.config` in an ipython terminal or Notebook.

--- a/doc/api/config.md
+++ b/doc/api/config.md
@@ -2,6 +2,8 @@
 
 The `pn.config` object holds global configuration options for Panel.
 
+To see the current configuration run `?pn.config` in an ipython terminal or Notebook.
+
 The options can be set directly on the global config instance, via
 keyword arguments to [`pn.extension`](cheatsheet#pn-extension) or via environment variables.
 
@@ -13,232 +15,410 @@ pn.extension(embed=True)
 os.environ['PANEL_EMBED'] = 'True'
 ```
 
-To see the fual details and current configuration run `?pn.config` in an ipython terminal or Notebook.
-
 ## Options Summary
 
-`admin`
-: Whether the admin panel was enabled.
+### `admin`
 
-`admin_endpoint` (`PANEL_ADMIN_ENDPOINT`)
-: Name to use for the admin endpoint.
+Whether the admin panel is enabled.
 
-`admin_log_level` (`PANEL_ADMIN_LOG_LEVEL`)
-: Log level of the Admin Panel logger
+Default: False | Type: Boolean
 
-`admin_plugins`
-: A list of tuples containing a title and a function that returns
-        an additional panel to be rendered into the admin page.
+### `admin_endpoint` (`PANEL_ADMIN_ENDPOINT`)
 
-`apply_signatures`
-: Whether to set custom Signature which allows tab-completion
-        in some IDEs and environments.
+Name to use for the admin endpoint.
 
-`auth_template`
-: A jinja2 template rendered when the authorize_callback determines
-        that a user in not authorized to access the application.
+Default: None | Type: String
 
-`authorize_callback`
-: Authorization callback that is invoked when authentication
-        is enabled. The callback is given the user information returned
-        by the configured Auth provider and should return True or False
-        depending on whether the user is authorized to access the
-        application. The callback may also contain a second parameter,
-        which is the requested path the user is making. If the user
-        is authenticated and has explicit access to the path, then
-        the callback should return True otherwise it should return
-        False.
+### `admin_log_level` (`PANEL_ADMIN_LOG_LEVEL`)
 
-`autoreload`
-: Whether to autoreload server when script changes.
+Log level of the Admin Panel logger
 
-`basic_auth` (`PANEL_BASIC_AUTH`)
-: Password, dictionary with a mapping from username to password
-        or filepath containing JSON to use with the basic auth
-        provider.
+Default: 'DEBUG' | Type: Literal | Options: 'DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'
 
-`basic_auth_template`
-: A jinja2 template to override the default Basic Authentication
-        login page.
+### `admin_plugins`
 
-`browser_info`
-: Whether to request browser info from the frontend.
+A list of tuples containing a title and a function that returns
+an additional panel to be rendered into the admin page.
 
-`comms` (`PANEL_COMMS`)
-: Whether to render output in Jupyter with the default Jupyter
-        extension or use the jupyter_bokeh ipywidget model.
+Default: [] | Type: List
 
-`console_output` (`PANEL_CONSOLE_OUTPUT`)
-: How to log errors and stdout output triggered by callbacks
-        from Javascript in the notebook.
+### `apply_signatures`
 
-`cookie_secret` (`PANEL_COOKIE_SECRET`)
-: Configure to enable getting/setting secure cookies.
+Whether to set custom Signature which allows tab-completion
+in some IDEs and environments.
 
-`css_files`
-: External CSS files to load.
+Default: True | Type: Boolean
 
-`defer_load`
-: Whether to defer load of rendered functions.
+### `auth_template`
 
-`design`
-: The design system to use to style components.
+A jinja2 template rendered when the authorize_callback determines
+that a user in not authorized to access the application.
 
-`disconnect_notification`
-: The notification to display to the user when the connection
-        to the server is dropped.
+Default: None | Type: Path
 
-`embed` (`PANEL_EMBED`)
-: Whether plot data will be embedded.
+### `authorize_callback`
 
-`embed_json` (`PANEL_EMBED_JSON`)
-: Whether to save embedded state to json files.
+Authorization callback that is invoked when authentication
+is enabled. The callback is given the user information returned
+by the configured Auth provider and should return True or False
+depending on whether the user is authorized to access the
+application. The callback may also contain a second parameter,
+which is the requested path the user is making. If the user
+is authenticated and has explicit access to the path, then
+the callback should return True otherwise it should return
+False.
 
-`embed_json_prefix` (`PANEL_EMBED_JSON_PREFIX`)
-: Prefix for randomly generated json directories.
+Default: None | Type: Callable
 
-`embed_load_path` (`PANEL_EMBED_LOAD_PATH`)
-: Where to load json files for embedded state.
+### `autoreload`
 
-`embed_save_path` (`PANEL_EMBED_SAVE_PATH`)
-: Where to save json files for embedded state.
+Whether to autoreload server when script changes.
 
-`exception_handler`
-: General exception handler for events.
+Default: False | Type: Boolean
 
-`global_css`
-: List of raw CSS to be added to the header.
+### `basic_auth` (`PANEL_BASIC_AUTH`)
 
-`global_loading_spinner`
-: Whether to add a global loading spinner for the whole application.
+Password, dictionary with a mapping from username to password
+or filepath containing JSON to use with the basic auth
+provider.
 
-`inline` (`PANEL_INLINE`)
-: Whether to inline JS and CSS resources. If disabled, resources
-        are loaded from CDN if one is available.
+Default: None | Type: ClassSelector
 
-`js_files`
-: External JS files to load. Dictionary should map from exported
-        name to the URL of the JS file.
+### `basic_auth_template`
 
-`js_modules`
-: External JS files to load as modules. Dictionary should map from
-        exported name to the URL of the JS file.
+A jinja2 template to override the default Basic Authentication
+login page.
 
-`layout_compatibility`
-: Provide compatibility for older layout specifications. Incompatible
-        specifications will trigger warnings by default but can be set to error.
-        Compatibility to be set to error by default in Panel 1.1.
+Default: None | Type: Path
 
-`load_entry_points`
-: Load entry points from external packages.
+### `browser_info`
 
-`loading_color`
-: Color of the loading indicator.
+Whether to request browser info from the frontend.
 
-`loading_indicator`
-: Whether a loading indicator is shown by default while panes are updating.
+Default: True | Type: Boolean
 
-`loading_max_height`
-: Maximum height of the loading indicator.
+### `comms` (`PANEL_COMMS`)
 
-`loading_spinner`
-: Loading indicator to use when component loading parameter is set.
+Whether to render output in Jupyter with the default Jupyter
+extension or use the jupyter_bokeh ipywidget model.
 
-`log_level` (`PANEL_LOG_LEVEL`)
-: Log level of Panel loggers
+Default: 'default' | Type: Literal | Options: 'default', 'ipywidgets', 'vscode', 'colab'
 
-`name`
-: String identifier for this object.
+### `console_output` (`PANEL_CONSOLE_OUTPUT`)
 
-`notifications`
-: Whether to enable notifications functionality.
+How to log errors and stdout output triggered by callbacks
+from Javascript in the notebook.
 
-`npm_cdn` (`PANEL_NPM_CDN`)
-: The CDN to load NPM packages from if resources are served from
-        CDN. Allows switching between [https://unpkg.com](https://unpkg.com) and
-        [https://cdn.jsdelivr.net/npm(https://cdn.jsdelivr.net/npm) for most resources.
+Default: 'accumulate' | Type: Literal | Options: 'accumulate', 'replace', 'disable', 'False'
 
-`nthreads` (`PANEL_NUM_THREADS`)
-: When set to a non-None value a thread pool will be started.
-        Whenever an event arrives from the frontend it will be
-        dispatched to the thread pool to be processed.
+### `cookie_secret` (`PANEL_COOKIE_SECRET`)
 
-`oauth_encryption_key` (`PANEL_OAUTH_ENCRYPTION`)
-: A random string used to encode OAuth related user information.
+Configure to enable getting/setting secure cookies.
 
-`oauth_expiry` (`PANEL_OAUTH_EXPIRY`)
-: Expiry of the OAuth cookie in number of days.
+Default: None | Type: String
 
-`oauth_extra_params` (`PANEL_OAUTH_EXTRA_PARAMS`)
-: Additional parameters required for OAuth provider.
+### `css_files`
 
-`oauth_guest_endpoints` (`PANEL_OAUTH_GUEST_ENDPOINTS`)
-: List of endpoints that can be accessed as a guest without authenticating.
+External CSS files to load.
 
-`oauth_jwt_user` (`PANEL_OAUTH_JWT_USER`)
-: The key in the ID JWT token to consider the user.
+Default: [] | Type: List
 
-`oauth_key` (`PANEL_OAUTH_KEY`)
-: A client key to provide to the OAuth provider.
+### `defer_load`
 
-`oauth_optional` (`PANEL_OAUTH_OPTIONAL`)
-: Whether the user will be forced to go through login flow or if
-        they can access all applications as a guest.
+Whether to defer load of rendered functions.
 
-`oauth_provider` (`PANEL_OAUTH_PROVIDER`)
-: Select between a list of authentication providers.
+Default: False | Type: Boolean
 
-`oauth_redirect_uri` (`PANEL_OAUTH_REDIRECT_URI`)
-: A redirect URI to provide to the OAuth provider.
+### `design`
 
-`oauth_refresh_tokens` (`PANEL_OAUTH_REFRESH_TOKENS`)
-: Whether to automatically refresh access tokens in the background.
+The design system to use to style components.
 
-`oauth_secret` (`PANEL_OAUTH_SECRET`)
-: A client secret to provide to the OAuth provider.
+Default: None | Type: ClassSelector
 
-`profiler`
-: The profiler engine to enable.
+### `disconnect_notification`
 
-`raw_css`
-: List of raw CSS strings to add to load.
+The notification to display to the user when the connection
+to the server is dropped.
 
-`ready_notification`
-: The notification to display when the application is ready and
-        fully loaded.
+Default: '' | Type: String
 
-`reuse_sessions`
-: Whether to reuse a session for the initial request to speed up
-        the initial page render. Note that if the initial page differs
-        between sessions, e.g. because it uses query parameters to modify
-        the rendered content, then this option will result in the wrong
-        content being rendered. Define a session_key_func to ensure that
-        reused sessions are only reused when appropriate.
+### `embed` (`PANEL_EMBED`)
 
-`safe_embed`
-: Ensure all bokeh property changes trigger events which are
-        embedded. Useful when only partial updates are made in an
-        app, e.g. when working with HoloViews.
+Whether plot data will be embedded.
 
-`session_history`
-: If set to a non-negative value this determines the maximum length
-        of the pn.state.session_info dictionary, which tracks
-        information about user sessions. A value of -1 indicates an
-        unlimited history.
+Default: False | Type: Boolean
 
-`session_key_func`
-: Used in conjunction with the reuse_sessions option, the
-        session_key_func is given a tornado.httputil.HTTPServerRequest
-        and should return a key that uniquely captures a session.
+### `embed_json` (`PANEL_EMBED_JSON`)
 
-`sizing_mode`
-: Specify the default sizing mode behavior of panels.
+Whether to save embedded state to json files.
 
-`template`
-: The default template to render served applications into.
+Default: False | Type: Boolean
 
-`theme`
-: The theme to apply to components.
+### `embed_json_prefix` (`PANEL_EMBED_JSON_PREFIX`)
 
-`throttled`
-: If sliders and inputs should be throttled until release of mouse.
+Prefix for randomly generated json directories.
+
+Default: '' | Type: String
+
+### `embed_load_path` (`PANEL_EMBED_LOAD_PATH`)
+
+Where to load json files for embedded state.
+
+Default: None | Type: String
+
+### `embed_save_path` (`PANEL_EMBED_SAVE_PATH`)
+
+Where to save json files for embedded state.
+
+Default: './' | Type: String
+
+### `exception_handler`
+
+General exception handler for events.
+
+Default: None | Type: Callable
+
+### `global_css`
+
+List of raw CSS to be added to the header.
+
+Default: [] | Type: List
+
+### `global_loading_spinner`
+
+Whether to add a global loading spinner for the whole application.
+
+Default: False | Type: Boolean
+
+### `inline` (`PANEL_INLINE`)
+
+Whether to inline JS and CSS resources. If disabled, resources
+are loaded from CDN if one is available.
+
+Default: True | Type: Boolean
+
+### `js_files`
+
+External JS files to load. Dictionary should map from exported
+name to the URL of the JS file.
+
+Default: {} | Type: Dict
+
+### `js_modules`
+
+External JS files to load as modules. Dictionary should map from
+exported name to the URL of the JS file.
+
+Default: {} | Type: Dict
+
+### `layout_compatibility`
+
+Provide compatibility for older layout specifications. Incompatible
+specifications will trigger warnings by default but can be set to error.
+Compatibility to be set to error by default in Panel 1.1.
+
+Default: 'warn' | Type: Literal | Options: 'warn', 'error'
+
+### `load_entry_points`
+
+Load entry points from external packages.
+
+Default: True | Type: Boolean
+
+### `loading_color`
+
+Color of the loading indicator.
+
+Default: '#c3c3c3' | Type: Color
+
+### `loading_indicator`
+
+Whether a loading indicator is shown by default while panes are updating.
+
+Default: False | Type: Boolean
+
+### `loading_max_height`
+
+Maximum height of the loading indicator.
+
+Default: 400 | Type: Integer
+
+### `loading_spinner`
+
+Loading indicator to use when component loading parameter is set.
+
+Default: 'arc' | Type: Literal | Options: 'arc', 'arcs', 'bar', 'dots', 'petal'
+
+### `log_level` (`PANEL_LOG_LEVEL`)
+
+Log level of Panel loggers
+
+Default: 'WARNING' | Type: Literal | Options: 'DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'
+
+### `notifications`
+
+Whether to enable notifications functionality.
+
+Default: False | Type: Boolean
+
+### `npm_cdn` (`PANEL_NPM_CDN`)
+
+The CDN to load NPM packages from if resources are served from
+CDN. Allows switching between [https://unpkg.com](https://unpkg.com) and
+[https://cdn.jsdelivr.net/npm](https://cdn.jsdelivr.net/npm) for most resources.
+
+Default: 'https://cdn.jsdelivr.net/npm' | Type: Literal | Options: 'https://unpkg.com', 'https://cdn.jsdelivr.net/npm'
+
+### `nthreads` (`PANEL_NTHREADS`)
+
+When set to a non-None value a thread pool will be started.
+Whenever an event arrives from the frontend it will be
+dispatched to the thread pool to be processed.
+
+Default: None | Type: Integer
+
+### `oauth_encryption_key` (`PANEL_OAUTH_ENCRYPTION`)
+
+A random string used to encode OAuth related user information.
+
+Default: None | Type: ClassSelector
+
+### `oauth_expiry` (`PANEL_OAUTH_EXPIRY`)
+
+Expiry of the OAuth cookie in number of days.
+
+Default: 1 | Type: Number
+
+### `oauth_extra_params` (`PANEL_OAUTH_EXTRA_PARAMS`)
+
+Additional parameters required for OAuth provider.
+
+Default: {} | Type: Dict
+
+### `oauth_guest_endpoints` (`PANEL_OAUTH_GUEST_ENDPOINTS`)
+
+List of endpoints that can be accessed as a guest without authenticating.
+
+Default: None | Type: List
+
+### `oauth_jwt_user` (`PANEL_OAUTH_JWT_USER`)
+
+The key in the ID JWT token to consider the user.
+
+Default: None | Type: String
+
+### `oauth_key` (`PANEL_OAUTH_KEY`)
+
+A client key to provide to the OAuth provider.
+
+Default: None | Type: String
+
+### `oauth_optional` (`PANEL_OAUTH_OPTIONAL`)
+
+Whether the user will be forced to go through login flow or if
+they can access all applications as a guest.
+
+Default: False | Type: Boolean
+
+### `oauth_provider` (`PANEL_OAUTH_PROVIDER`)
+
+Select between a list of authentication providers.
+
+Default: None | Type: Literal | Options: 'None'
+
+### `oauth_redirect_uri` (`PANEL_OAUTH_REDIRECT_URI`)
+
+A redirect URI to provide to the OAuth provider.
+
+Default: None | Type: String
+
+### `oauth_refresh_tokens` (`PANEL_OAUTH_REFRESH_TOKENS`)
+
+Whether to automatically refresh access tokens in the background.
+
+Default: False | Type: Boolean
+
+### `oauth_secret` (`PANEL_OAUTH_SECRET`)
+
+A client secret to provide to the OAuth provider.
+
+Default: None | Type: String
+
+### `profiler`
+
+The profiler engine to enable.
+
+Default: None | Type: Literal | Options: 'pyinstrument', 'snakeviz', 'memray'
+
+### `raw_css`
+
+List of raw CSS strings to add to load.
+
+Default: [] | Type: List
+
+### `ready_notification`
+
+The notification to display when the application is ready and
+fully loaded.
+
+Default: '' | Type: String
+
+### `reuse_sessions`
+
+Whether to reuse a session for the initial request to speed up
+the initial page render. Note that if the initial page differs
+between sessions, e.g. because it uses query parameters to modify
+the rendered content, then this option will result in the wrong
+content being rendered. Define a session_key_func to ensure that
+reused sessions are only reused when appropriate.
+
+Default: False | Type: Boolean
+
+### `safe_embed`
+
+Ensure all bokeh property changes trigger events which are
+embedded. Useful when only partial updates are made in an
+app, e.g. when working with HoloViews.
+
+Default: False | Type: Boolean
+
+### `session_history`
+
+If set to a non-negative value this determines the maximum length
+of the pn.state.session_info dictionary, which tracks
+information about user sessions. A value of -1 indicates an
+unlimited history.
+
+Default: 0 | Type: Integer
+
+### `session_key_func`
+
+Used in conjunction with the reuse_sessions option, the
+session_key_func is given a tornado.httputil.HTTPServerRequest
+and should return a key that uniquely captures a session.
+
+Default: None | Type: Callable
+
+### `sizing_mode`
+
+Specify the default sizing mode behavior of panels.
+
+Default: None | Type: Literal | Options: 'fixed', 'stretch_width', 'stretch_height', 'stretch_both', 'scale_width', 'scale_height', 'scale_both', 'None'
+
+### `template`
+
+The default template to render served applications into.
+
+Default: None | Type: Literal | Options: 'bootstrap', 'fast', 'fast-list', 'material', 'golden', 'slides', 'vanilla'
+
+### `theme`
+
+The theme to apply to components.
+
+Default: None | Type: Literal | Options: 'default', 'dark'
+
+### `throttled`
+
+If sliders and inputs should be throttled until release of mouse.
+
+Default: False | Type: Boolean

--- a/doc/api/config.md
+++ b/doc/api/config.md
@@ -13,6 +13,8 @@ pn.extension(embed=True)
 os.environ['PANEL_EMBED'] = 'True'
 ```
 
+To see the fual details and current configuration run `?pn.config` in an ipython terminal or Notebook.
+
 ## Options Summary
 
 `admin`
@@ -240,7 +242,3 @@ os.environ['PANEL_EMBED'] = 'True'
 
 `throttled`
 : If sliders and inputs should be throttled until release of mouse.
-
-## Options Details
-
-To see the full details including types and default values run `?pn.config` in an ipython terminal or Notebook.

--- a/panel/config.py
+++ b/panel/config.py
@@ -635,7 +635,14 @@ class panel_extension(_pyviz_extension):
     - Update the global configuration `pn.config`
     (keyword arguments).
 
-    Reference: https://github.com/holoviz/panel/issues/3404
+    Parameters
+    ----------
+    *args : list[str]
+        Positional arguments listing the extension to load. For example "plotly",
+        "tabulator".
+    **params : dict[str,Any]
+        Keyword arguments to be set on the `pn.config` element. See
+        https://panel.holoviz.org/api/config.html
 
     :Example:
 

--- a/panel/config.py
+++ b/panel/config.py
@@ -219,7 +219,7 @@ class _config(_base_config):
     throttled = param.Boolean(default=False, doc="""
         If sliders and inputs should be throttled until release of mouse.""")
 
-    _admin = param.Boolean(default=False, doc="Whether the admin panel was enabled.")
+    _admin = param.Boolean(default=False, doc="Whether the admin panel is enabled.")
 
     _admin_endpoint = param.String(default=None, doc="Name to use for the admin endpoint.")
 
@@ -263,8 +263,8 @@ class _config(_base_config):
     _npm_cdn = param.Selector(default='https://cdn.jsdelivr.net/npm',
         objects=['https://unpkg.com', 'https://cdn.jsdelivr.net/npm'],  doc="""
         The CDN to load NPM packages from if resources are served from
-        CDN. Allows switching between https://unpkg.com and
-        https://cdn.jsdelivr.net/npm for most resources.""")
+        CDN. Allows switching between [https://unpkg.com](https://unpkg.com) and
+        [https://cdn.jsdelivr.net/npm](https://cdn.jsdelivr.net/npm) for most resources.""")
 
     _nthreads = param.Integer(default=None, doc="""
         When set to a non-None value a thread pool will be started.
@@ -473,6 +473,10 @@ class _config(_base_config):
     @property
     def _doc_build(self):
         return os.environ.get('PANEL_DOC_BUILD')
+
+    @property
+    def admin(self):
+        return self._admin
 
     @property
     def admin_endpoint(self):


### PR DESCRIPTION
Closes #3404

You can preview the docs [here](https://github.com/holoviz/panel/blob/enhancement/docs-extension-config/doc/api/config.md)

I've used the script below to generate the *options summary* section.

```python
import panel as pn
from textwrap import dedent
import textwrap

NO_ENVIRONMENT_VARIABLE=[
    '_admin', '_theme'
]

ENVIRONMENT_VARIABLE_NAME={
    "_oauth_encryption_key": "PANEL_OAUTH_ENCRYPTION",
    "_nthreads": "PANEL_NTHREADS",
}

def nice_name(key):
    if key.startswith("_"):
        return key[1:]
    return key

def environment_variable(key):
    if key in NO_ENVIRONMENT_VARIABLE:
        return ""
    if key in ENVIRONMENT_VARIABLE_NAME:
        return f" (`{ENVIRONMENT_VARIABLE_NAME[key]}`)" 
    if key.startswith("_"):
        return f" (`PANEL{key.upper()}`)"
    return ""

def nice_default_value(parameter):
    default=parameter.default
    if isinstance(default, str):
        return f"'{default}'"
    return str(default)

def nice_type(parameter):
    if parameter.__class__.__name__ in ["Selector", "ObjectSelector"]:
        return f"""Literal | Options: '{"', '".join([str(object) for object in parameter.objects])}'"""
    return parameter.__class__.__name__

def is_readonly(parameter):
    original = parameter.name.startswith("_") or parameter.constant or parameter.readonly
    new = False
    try:
         setattr(pn.config, parameter.name, getattr(pn.config, parameter.name))
    except:
        new = True
    return new

keys_and_parameters = [(key, pn.config.param[key]) for key in pn.config.param.values() if key!="name"]
keys_and_parameters = sorted(keys_and_parameters, key=lambda x: nice_name(x[0]))

def print_parameters(parameters):
    for key, parameter in parameters:    
        text = f"""\
### `{nice_name(key)}`{environment_variable(key)}

{dedent(pn.config.param[key].doc)}

Default: {nice_default_value(parameter)} | Type: {nice_type(parameter)}
"""
        text = text.replace("`\n\n", "`\n").replace("`)\n\n\n", "`)\n\n")
        print(text)

print("## Options Summary\n")

print_parameters(keys_and_parameters)
```