### PR TITLE
Fix pn.state.onload type hint

### DIFF
--- a/panel/io/state.py
+++ b/panel/io/state.py
@@ -19,7 +19,7 @@ from contextlib import contextmanager
 from contextvars import ContextVar
 from functools import partial, wraps
 from typing import (
-    TYPE_CHECKING, Any, Callable, ClassVar, Coroutine, Dict,
+    TYPE_CHECKING, Any, Awaitable, Callable, ClassVar, Coroutine, Dict,
     Iterator as TIterator, List, Literal, Optional, Tuple, Type, TypeVar,
     Union,
 )
@@ -658,7 +658,7 @@ class _state(param.Parameterized):
             msg = LOG_USER_MSG.format(msg=msg)
         getattr(_state_logger, level.lower())(msg, *args)
 
-    def onload(self, callback: Callable[[], None] | Coroutine[Any, Any, None]):
+    def onload(self, callback: Callable[[], None | Awaitable[None]] | Coroutine[Any, Any, None]):
         """
         Callback that is triggered when a session has been served.
 


### PR DESCRIPTION
My editor was complaining about the typehint for `pn.state.onload` when using an async callable as in 

```python
import panel as pn
from asyncio import sleep
pn.extension()

pn.panel("Hello").servable()

async def run():
    for i in range(10):
        print(i, " I sleep")
        await sleep(0.1)
        
pn.state.onload(run)
```

This PR fixes the issue. See also https://github.com/python/typing/issues/424 for guidance on type annotations for async callables.