### PR TITLE
Use `sys.stdlib_module_names` for Python 3.10 and greater

### DIFF
--- a/panel/io/mime_render.py
+++ b/panel/io/mime_render.py
@@ -34,6 +34,8 @@ import markdown
 #---------------------------------------------------------------------
 
 def _stdlibs():
+    if sys.version_info[:2] >= (3, 10):
+        return sys.stdlib_module_names
     env_dir = str(pathlib.Path(sys.executable).parent.parent)
     modules = list(sys.builtin_module_names)
     for m in pkgutil.iter_modules():

--- a/panel/tests/io/test_mime_render.py
+++ b/panel/tests/io/test_mime_render.py
@@ -33,6 +33,8 @@ def test_find_imports_stdlibs():
     import os
     import base64
     import pathlib
+    import random
+    from datetime import datetime, timedelta
     """
     assert find_requirements(code) == []
 


### PR DESCRIPTION
Fixes #5811

I still need to look into Python 3.9