### PR TITLE
Ensure global authorization callbacks are run before session creation

### DIFF
--- a/panel/io/server.py
+++ b/panel/io/server.py
@@ -86,6 +86,7 @@ from .resources import (
     BASE_TEMPLATE, CDN_DIST, COMPONENT_PATH, ERROR_TEMPLATE, LOCAL_DIST,
     Resources, _env, bundle_resources, patch_model_css, resolve_custom_path,
 )
+from .session import generate_session
 from .state import set_curdoc, state
 
 logger = logging.getLogger(__name__)
@@ -481,7 +482,7 @@ class DocHandler(LoginUrlMixin, BkDocHandler, SessionPrefixHandler):
                     session.block_expiration()
         return session
 
-    def _token_payload(self):
+    def _generate_token_payload(self):
         app = self.application
         if app.include_headers is None:
             excluded_headers = (app.exclude_headers or [])
@@ -510,8 +511,76 @@ class DocHandler(LoginUrlMixin, BkDocHandler, SessionPrefixHandler):
         payload.update(self.application_context.application.process_request(self.request))
         return payload
 
+    def _authorize(self, session=False):
+        """
+        """
+        auth_cb = config.authorize_callback
+        # If inside a session ensure the authorize callback is not global
+        if not auth_cb or (session and auth_cb is config._param__private.values['authorize_callback']):
+            return True, None
+        authorized = False
+        auth_params = inspect.signature(auth_cb).parameters
+        if len(auth_params) == 1:
+            auth_args = (state.user_info,)
+        elif len(auth_params) == 2:
+            auth_args = (state.user_info, self.request.path,)
+        else:
+            raise RuntimeError(
+                'Authorization callback must accept either 1) a single argument '
+                'which is the user name or 2) two arguments which includes the '
+                'user name and the url path the user is trying to access.'
+            )
+        auth_error = f'{state.user} is not authorized to access this application.'
+        try:
+            authorized = auth_cb(*auth_args)
+            if isinstance(authorized, str):
+                self.redirect(authorized)
+                return None, None
+            elif not authorized:
+                auth_error = (
+                    f'Authorization callback errored. Could not validate user name "{state.user}" '
+                    f'for the given app "{self.request.path}".'
+                )
+                if authorized:
+                    auth_error = None
+        except Exception:
+            auth_error = f'Authorization callback errored. Could not validate user {state.user}.'
+        else:
+            authorized = True
+        return authorized, auth_error
+
+    def _render_auth_error(self, auth_error):
+        if config.auth_template:
+            with open(config.auth_template) as f:
+                template = _env.from_string(f.read())
+        else:
+            template = ERROR_TEMPLATE
+        return template.render(
+            npm_cdn=config.npm_cdn,
+            title='Panel: Authorization Error',
+            error_type='Authorization Error',
+            error='User is not authorized.',
+            error_msg=auth_error
+        )
+
     @authenticated
     async def get(self, *args, **kwargs):
+        # Run global authorization callback
+        payload = self._generate_token_payload()
+        print('!!!!!!!')
+        if config.authorize_callback:
+            temp_session = generate_session(
+                self.application, self.request, payload, initialize=False
+            )
+            with set_curdoc(temp_session.document):
+                authorized, auth_error = self._authorize()
+            if authorized is None:
+                return
+            elif not authorized:
+                self._render_auth_error(auth_error)
+                page = self.set_header("Content-Type", 'text/html')
+                self.write(page)
+
         app = self.application
         with self._session_prefix():
             key_func = state._session_key_funcs.get(self.request.path, lambda r: r.path)
@@ -523,7 +592,7 @@ class DocHandler(LoginUrlMixin, BkDocHandler, SessionPrefixHandler):
                     signed=self.application.sign_sessions
                 )
                 payload = get_token_payload(session.token)
-                payload.update(self._token_payload())
+                payload.update(payload)
                 del payload['session_expiry']
                 token = generate_jwt_token(
                     session_id,
@@ -537,58 +606,19 @@ class DocHandler(LoginUrlMixin, BkDocHandler, SessionPrefixHandler):
             logger.info(LOG_SESSION_CREATED, id(session.document))
             with set_curdoc(session.document):
                 resources = Resources.from_bokeh(self.application.resources())
-                auth_cb = config.authorize_callback
-                authorized = False
-                if auth_cb:
-                    auth_cb = config.authorize_callback
-                    auth_params = inspect.signature(auth_cb).parameters
-                    if len(auth_params) == 1:
-                        auth_args = (state.user_info,)
-                    elif len(auth_params) == 2:
-                        auth_args = (state.user_info, self.request.path,)
-                    else:
-                        raise RuntimeError(
-                            'Authorization callback must accept either 1) a single argument '
-                            'which is the user name or 2) two arguments which includes the '
-                            'user name and the url path the user is trying to access.'
-                        )
-                    auth_error = f'{state.user} is not authorized to access this application.'
-                    try:
-                        authorized = auth_cb(*auth_args)
-                        if isinstance(authorized, str):
-                            self.redirect(authorized)
-                            return
-                        elif not authorized:
-                            auth_error = (
-                                f'Authorization callback errored. Could not validate user name "{state.user}" '
-                                f'for the given app "{self.request.path}".'
-                            )
-                        if authorized:
-                            auth_error = None
-                    except Exception:
-                        auth_error = f'Authorization callback errored. Could not validate user {state.user}.'
-                else:
-                    authorized = True
-
+                # Session authorization callback
+                authorized, auth_error = self._authorize(session=True)
                 if authorized:
                     page = server_html_page_for_session(
                         session, resources=resources, title=session.document.title,
                         token=token, template=session.document.template,
                         template_variables=session.document.template_variables,
                     )
+                elif authorized is None:
+                    return
                 else:
-                    if config.auth_template:
-                        with open(config.auth_template) as f:
-                            template = _env.from_string(f.read())
-                    else:
-                        template = ERROR_TEMPLATE
-                    page = template.render(
-                        npm_cdn=config.npm_cdn,
-                        title='Panel: Authorization Error',
-                        error_type='Authorization Error',
-                        error='User is not authorized.',
-                        error_msg=auth_error
-                    )
+                    page = self._render_auth_error(auth_error)
+
         self.set_header("Content-Type", 'text/html')
         self.write(page)
 

--- a/panel/io/server.py
+++ b/panel/io/server.py
@@ -571,7 +571,6 @@ class DocHandler(LoginUrlMixin, BkDocHandler, SessionPrefixHandler):
             )
             with set_curdoc(temp_session.document):
                 authorized, auth_error = self._authorize()
-            print('>>>>', authorized)
             if authorized is None:
                 return
             elif not authorized:

--- a/panel/tests/ui/test_auth.py
+++ b/panel/tests/ui/test_auth.py
@@ -8,9 +8,11 @@ pytest.importorskip("playwright")
 from playwright.sync_api import expect
 
 from panel.config import config
+from panel.io.state import state
 from panel.pane import Markdown
 from panel.tests.util import (
-    run_panel_serve, serve_component, unix_only, wait_for_port, write_file,
+    run_panel_serve, serve_component, unix_only, wait_for_port,
+    wait_until, write_file,
 )
 
 pytestmark = pytest.mark.ui
@@ -204,3 +206,26 @@ def test_authorize_callback_redirect(page):
         page.get_by_role("button").click(force=True)
 
         expect(page.locator(".markdown").locator("div")).to_have_text('Page B\n')
+
+
+@unix_only
+def test_global_authorize_callback(page):
+    users, sessions = [], []
+    def authorize(user_info, uri):
+        users.append(user_info['user'])
+        return False
+
+    def app():
+        sessions.append(state.user)
+        return Markdown('Page A')
+
+    with config.set(authorize_callback=authorize):
+        _, port = serve_component(page, app, basic_auth='my_password', cookie_secret='my_secret', wait=False)
+
+        page.locator('input[name="username"]').fill("A")
+        page.locator('input[name="password"]').fill("my_password")
+        page.get_by_role("button").click(force=True)
+
+        wait_until(lambda: len(users) == 1, page)
+        assert users[0] == 'A'
+        assert len(sessions) == 0

--- a/panel/tests/ui/test_auth.py
+++ b/panel/tests/ui/test_auth.py
@@ -11,8 +11,8 @@ from panel.config import config
 from panel.io.state import state
 from panel.pane import Markdown
 from panel.tests.util import (
-    run_panel_serve, serve_component, unix_only, wait_for_port,
-    wait_until, write_file,
+    run_panel_serve, serve_component, unix_only, wait_for_port, wait_until,
+    write_file,
 )
 
 pytestmark = pytest.mark.ui


### PR DESCRIPTION
Previously the `authorize_callback` was always run **after** a session was created. This is required when the user configures the `authorize_callback` inside their app, but you can also set a global `authorize_callback`, e.g. as part of a `--setup` script or when dynamically starting a server with `pn.serve`. In this scenario we can run the `authorize_callback` without running the session and therefore avoid pointless computation.

Fixes https://github.com/holoviz/panel/issues/5801