### PR TITLE
`AutocompleteInput`: expose and document `search_strategy`

### DIFF
--- a/examples/reference/widgets/AutocompleteInput.ipynb
+++ b/examples/reference/widgets/AutocompleteInput.ipynb
@@ -3,7 +3,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "import panel as pn\n",
@@ -14,7 +16,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The ``AutocompleteInput`` widget allows selecting a ``value`` from a list or dictionary of ``options`` by entering the value into an auto-completing text field. It falls into the broad category of single-value, option-selection widgets that provide a compatible API and include the [``RadioBoxGroup``](RadioBoxGroup.ipynb), [``Select``](Select.ipynb) and [``DiscreteSlider``](DiscreteSlider.ipynb) widgets.\n",
+    "The `AutocompleteInput` widget allows selecting a `value` from a list or dictionary of `options` by entering the value into an auto-completing text field. It falls into the broad category of single-value, option-selection widgets that provide a compatible API and include the [`RadioBoxGroup`](RadioBoxGroup.ipynb), [`Select`](Select.ipynb) and [`DiscreteSlider`](DiscreteSlider.ipynb) widgets.\n",
     "\n",
     "Discover more on using widgets to add interactivity to your applications in the [how-to guides on interactivity](../how_to/interactivity/index.md). Alternatively, learn [how to set up callbacks and (JS-)links between parameters](../../how_to/links/index.md) or [how to use them as part of declarative UIs with Param](../../how_to/param/index.html).\n",
     "\n",
@@ -24,18 +26,19 @@
     "\n",
     "##### Core\n",
     "\n",
-    "* **``options``** (list): A list of options to select from\n",
-    "* **``restrict``** (boolean): Set to False in order to allow users to enter text that is not present in the options list.\n",
-    "* **``value``** (str): The current value updated when pressing <enter> key; must be one of the option values if restrict=True.\n",
-    "* **``value_input``** (str): The current value updated on every key press.\n",
-    "* **``case_sensitive``** (boolean): Enable or disable case sensitivity for matching completions.\n",
+    "* **`options`** (list): A list of options to select from\n",
+    "* **`restrict`** (boolean, `default=True`): Set to False in order to allow users to enter text that is not present in the options list.\n",
+    "* **`search_strategy`** (str): Define how to search the list of completion strings. The default option `\"starts_with\"` means that the user's text must match the start of a completion string. Using `\"includes\"` means that the user's text can match any substring of a completion string.\n",
+    "* **`value`** (str): The current value updated when pressing <enter> key; must be one of the option values if restrict=True.\n",
+    "* **`value_input`** (str): The current value updated on every key press.\n",
+    "* **`case_sensitive`** (boolean, `default=True`): Enable or disable case sensitivity for matching completions.\n",
     "\n",
     "##### Display\n",
     "\n",
-    "* **``disabled``** (boolean): Whether the widget is editable\n",
-    "* **``name``** (str): The title of the widget\n",
-    "* **``placeholder``** (str): A placeholder string displayed when no option is selected\n",
-    "* **``min_characters``** (int): The number of characters a user must type before completions are presented.\n",
+    "* **`disabled`** (boolean): Whether the widget is editable\n",
+    "* **`name`** (str): The title of the widget\n",
+    "* **`placeholder`** (str): A placeholder string displayed when no option is selected\n",
+    "* **`min_characters`** (int, `default=2`): The number of characters a user must type before completions are presented.\n",
     "\n",
     "___"
    ]
@@ -43,11 +46,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "autocomplete = pn.widgets.AutocompleteInput(\n",
     "    name='Autocomplete Input', options=['Biology', 'Chemistry', 'Physics'],\n",
+    "    case_sensitive=False, search_strategy='includes',\n",
     "    placeholder='Write something here')\n",
     "\n",
     "pn.Row(autocomplete, height=100)"
@@ -57,13 +63,15 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Like most other widgets, ``AutocompleteInput`` has a value parameter that can be accessed or set:"
+    "Like most other widgets, `AutocompleteInput` has a value parameter that can be accessed or set:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "autocomplete.value"
@@ -79,7 +87,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "not_restricted = autocomplete.clone(value='Mathematics', restrict=False)\n",
@@ -89,7 +99,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "not_restricted.value"

--- a/panel/widgets/select.py
+++ b/panel/widgets/select.py
@@ -546,6 +546,13 @@ class AutocompleteInput(Widget):
         Set to False in order to allow users to enter text that is not
         present in the list of completion strings.""")
 
+    search_strategy = param.Selector(default='starts_with',
+        objects=['starts_with', 'includes'], doc="""
+        Define how to search the list of completion strings. The default option
+        `"starts_with"` means that the user's text must match the start of a
+        completion string. Using `"includes"` means that the user's text can
+        match any substring of a completion string.""")
+
     value = param.String(default='', allow_None=True, doc="""
       Initial or entered text value updated when <enter> key is pressed.""")
 


### PR DESCRIPTION
Addresses https://github.com/holoviz/panel/issues/3117

Very very happy to find out that Bokeh added in https://github.com/bokeh/bokeh/pull/13032 a `search_strategy` property to `AutocompleteInput` that when set to `'includes'` allows to to search through the whole string and not just the start.

In https://github.com/holoviz/panel/issues/3117 I was asking specifically for a Search widget but I think I had a too narrow vision of what autocomplete means, I think it can closed as  https://github.com/bokeh/bokeh/pull/13032 implemented the feature I was after.