### PR TITLE
Speed up Pane.clone with 50%

### DIFF
--- a/panel/pane/base.py
+++ b/panel/pane/base.py
@@ -40,9 +40,9 @@ if TYPE_CHECKING:
     from bokeh.model import Model
     from pyviz_comms import Comm
 
-def _should_inherit(self, p, v):
+def _clone_should_inherit(self, p, v):
         _p = self.param[p]
-        return not _p.readonly and v is not _p.default and (v is not None or _p.allow_None)
+        return v is not _p.default and not _p.readonly and (v is not None or _p.allow_None)
 
 def panel(obj: Any, **kwargs) -> Viewable:
     """
@@ -386,7 +386,7 @@ class PaneBase(Reactive):
         Cloned Pane object
         """
         inherited = {
-            p: v for p, v in self.param.values().items() if _should_inherit(self, p, v)
+            p: v for p, v in self.param.values().items() if _clone_should_inherit(self, p, v)
         }
         params = dict(inherited, **params)
         old_object = params.pop('object', None)

--- a/panel/pane/base.py
+++ b/panel/pane/base.py
@@ -40,6 +40,9 @@ if TYPE_CHECKING:
     from bokeh.model import Model
     from pyviz_comms import Comm
 
+def _should_inherit(self, p, v):
+        _p = self.param[p]
+        return not _p.readonly and v is not _p.default and (v is not None or _p.allow_None)
 
 def panel(obj: Any, **kwargs) -> Viewable:
     """
@@ -369,10 +372,6 @@ class PaneBase(Reactive):
         """
         return None
 
-    def _should_inherit(self, p, v):
-        _p = self.param[p]
-        return not _p.readonly and v is not _p.default and (v is not None or _p.allow_None)
-
     def clone(self: T, object: Optional[Any] = None, **params) -> T:
         """
         Makes a copy of the Pane sharing the same parameters.
@@ -387,7 +386,7 @@ class PaneBase(Reactive):
         Cloned Pane object
         """
         inherited = {
-            p: v for p, v in self.param.values().items() if self._should_inherit(p, v)
+            p: v for p, v in self.param.values().items() if _should_inherit(self, p, v)
         }
         params = dict(inherited, **params)
         old_object = params.pop('object', None)

--- a/panel/pane/base.py
+++ b/panel/pane/base.py
@@ -31,7 +31,7 @@ from ..models import ReactiveHTML as _BkReactiveHTML
 from ..reactive import Reactive
 from ..util import param_reprs, param_watchers
 from ..util.checks import is_dataframe, is_series
-from ..util.param import get_params_to_inherit
+from ..util.parameters import get_params_to_inherit
 from ..viewable import (
     Layoutable, ServableMixin, Viewable, Viewer,
 )

--- a/panel/pane/base.py
+++ b/panel/pane/base.py
@@ -369,6 +369,10 @@ class PaneBase(Reactive):
         """
         return None
 
+    def _should_inherit(self, p, v):
+        _p = self.param[p]
+        return not _p.readonly and v is not _p.default and (v is not None or _p.allow_None)
+
     def clone(self: T, object: Optional[Any] = None, **params) -> T:
         """
         Makes a copy of the Pane sharing the same parameters.
@@ -383,9 +387,7 @@ class PaneBase(Reactive):
         Cloned Pane object
         """
         inherited = {
-            p: v for p, v in self.param.values().items()
-            if not self.param[p].readonly and v is not self.param[p].default
-            and not (v is None and not self.param[p].allow_None)
+            p: v for p, v in self.param.values().items() if self._should_inherit(p, v)
         }
         params = dict(inherited, **params)
         old_object = params.pop('object', None)

--- a/panel/pane/base.py
+++ b/panel/pane/base.py
@@ -32,17 +32,13 @@ from ..reactive import Reactive
 from ..util import param_reprs, param_watchers
 from ..util.checks import is_dataframe, is_series
 from ..viewable import (
-    Layoutable, ServableMixin, Viewable, Viewer,
+    Layoutable, ServableMixin, Viewable, Viewer, _get_items_to_inherit,
 )
 
 if TYPE_CHECKING:
     from bokeh.document import Document
     from bokeh.model import Model
     from pyviz_comms import Comm
-
-def _clone_should_inherit(self, p, v):
-        _p = self.param[p]
-        return v is not _p.default and not _p.readonly and (v is not None or _p.allow_None)
 
 def panel(obj: Any, **kwargs) -> Viewable:
     """
@@ -385,9 +381,7 @@ class PaneBase(Reactive):
         -------
         Cloned Pane object
         """
-        inherited = {
-            p: v for p, v in self.param.values().items() if _clone_should_inherit(self, p, v)
-        }
+        inherited = _get_items_to_inherit(self)
         params = dict(inherited, **params)
         old_object = params.pop('object', None)
         if object is None:

--- a/panel/pane/base.py
+++ b/panel/pane/base.py
@@ -31,8 +31,9 @@ from ..models import ReactiveHTML as _BkReactiveHTML
 from ..reactive import Reactive
 from ..util import param_reprs, param_watchers
 from ..util.checks import is_dataframe, is_series
+from ..util.param import get_params_to_inherit
 from ..viewable import (
-    Layoutable, ServableMixin, Viewable, Viewer, _get_items_to_inherit,
+    Layoutable, ServableMixin, Viewable, Viewer,
 )
 
 if TYPE_CHECKING:
@@ -381,7 +382,7 @@ class PaneBase(Reactive):
         -------
         Cloned Pane object
         """
-        inherited = _get_items_to_inherit(self)
+        inherited = get_params_to_inherit(self)
         params = dict(inherited, **params)
         old_object = params.pop('object', None)
         if object is None:

--- a/panel/tests/pane/test_base.py
+++ b/panel/tests/pane/test_base.py
@@ -103,6 +103,13 @@ def test_pane_clone(pane):
     assert ([(k, v) for k, v in sorted(p.param.values().items()) if k not in ('name', '_pane')] ==
             [(k, v) for k, v in sorted(clone.param.values().items()) if k not in ('name', '_pane')])
 
+def test_pane_with_non_defaults_clone():
+    p = Markdown("Hello World", sizing_mode="stretch_width")
+    clone = p.clone()
+
+    assert ([(k, v) for k, v in sorted(p.param.values().items()) if k not in ('name', '_pane')] ==
+            [(k, v) for k, v in sorted(clone.param.values().items()) if k not in ('name', '_pane')])
+
 
 @pytest.mark.parametrize('pane', all_panes)
 def test_pane_signature(pane):

--- a/panel/tests/test_viewable.py
+++ b/panel/tests/test_viewable.py
@@ -100,3 +100,18 @@ def test_non_viewer_class():
             return 42
 
     panel(Example())
+
+@pytest.mark.parametrize('viewable', all_viewables)
+def test_clone(viewable):
+    v = Viewable()
+    clone = v.clone()
+
+    assert ([(k, v) for k, v in sorted(v.param.values().items()) if k not in ('name')] ==
+            [(k, v) for k, v in sorted(clone.param.values().items()) if k not in ('name')])
+
+def test_clone_with_non_defaults():
+    v= Viewable(loading=True)
+    clone = v.clone()
+
+    assert ([(k, v) for k, v in sorted(v.param.values().items()) if k not in ('name')] ==
+            [(k, v) for k, v in sorted(clone.param.values().items()) if k not in ('name')])

--- a/panel/util/__init__.py
+++ b/panel/util/__init__.py
@@ -36,8 +36,9 @@ from .checks import (  # noqa
     datetime_types, is_dataframe, is_holoviews, is_number, is_parameterized,
     is_series, isdatetime, isfile, isIn, isurl,
 )
-from .param import (  # noqa
+from .parameters import (  # noqa
     edit_readonly, extract_dependencies, get_method_owner, param_watchers,
+    recursive_parameterized,
 )
 
 log = logging.getLogger('panel.util')
@@ -86,17 +87,6 @@ def param_name(name: str) -> str:
     return name[:name.index(match[0])] if match else name
 
 
-def recursive_parameterized(parameterized: param.Parameterized, objects=None) -> list[param.Parameterized]:
-    """
-    Recursively searches a Parameterized object for other Parmeterized
-    objects.
-    """
-    objects = [] if objects is None else objects
-    objects.append(parameterized)
-    for p in parameterized.param.values().values():
-        if isinstance(p, param.Parameterized) and not any(p is o for o in objects):
-            recursive_parameterized(p, objects)
-    return objects
 
 
 def abbreviated_repr(value, max_length=25, natural_breaks=(',', ' ')):

--- a/panel/util/__init__.py
+++ b/panel/util/__init__.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 import ast
 import base64
 import datetime as dt
-import inspect
 import json
 import logging
 import numbers
@@ -18,12 +17,11 @@ import urllib.parse as urlparse
 
 from collections import OrderedDict, defaultdict
 from collections.abc import MutableMapping, MutableSequence
-from contextlib import contextmanager
 from datetime import datetime
 from functools import partial
 from html import escape  # noqa
 from importlib import import_module
-from typing import Any, AnyStr, Iterator
+from typing import Any, AnyStr
 
 import bleach
 import bokeh
@@ -37,6 +35,9 @@ from packaging.version import Version
 from .checks import (  # noqa
     datetime_types, is_dataframe, is_holoviews, is_number, is_parameterized,
     is_series, isdatetime, isfile, isIn, isurl,
+)
+from .param import (  # noqa
+    edit_readonly, extract_dependencies, get_method_owner, param_watchers,
 )
 
 log = logging.getLogger('panel.util')
@@ -174,42 +175,6 @@ def full_groupby(l, key=lambda x: x):
     return d.items()
 
 
-def get_method_owner(meth):
-    """
-    Returns the instance owning the supplied instancemethod or
-    the class owning the supplied classmethod.
-    """
-    if inspect.ismethod(meth):
-        return meth.__self__
-
-
-def extract_dependencies(function):
-    """
-    Extract references from a method or function that declares the references.
-    """
-    subparameters = list(function._dinfo['dependencies'])+list(function._dinfo['kw'].values())
-    params = []
-    for p in subparameters:
-        if isinstance(p, str):
-            owner = get_method_owner(function)
-            *subps, p = p.split('.')
-            for subp in subps:
-                owner = getattr(owner, subp, None)
-                if owner is None:
-                    raise ValueError('Cannot depend on undefined sub-parameter {p!r}.')
-            if p in owner.param:
-                pobj = owner.param[p]
-                if pobj not in params:
-                    params.append(pobj)
-            else:
-                for sp in extract_dependencies(getattr(owner, p)):
-                    if sp not in params:
-                        params.append(sp)
-        elif p not in params:
-            params.append(p)
-    return params
-
-
 def value_as_datetime(value):
     """
     Retrieve the value tuple as a tuple of datetime objects.
@@ -311,31 +276,6 @@ def url_path(url: str) -> str:
     """
     subpaths = url.split('//')[1:]
     return '/'.join('/'.join(subpaths).split('/')[1:])
-
-
-# This functionality should be contributed to param
-# See https://github.com/holoviz/param/issues/379
-@contextmanager
-def edit_readonly(parameterized: param.Parameterized) -> Iterator:
-    """
-    Temporarily set parameters on Parameterized object to readonly=False
-    to allow editing them.
-    """
-    params = parameterized.param.objects("existing").values()
-    readonlys = [p.readonly for p in params]
-    constants = [p.constant for p in params]
-    for p in params:
-        p.readonly = False
-        p.constant = False
-    try:
-        yield
-    except Exception:
-        raise
-    finally:
-        for (p, readonly) in zip(params, readonlys):
-            p.readonly = readonly
-        for (p, constant) in zip(params, constants):
-            p.constant = constant
 
 
 def lazy_load(module, model, notebook=False, root=None, ext=None):
@@ -470,20 +410,6 @@ def relative_to(path, other_path):
         return True
     except Exception:
         return False
-
-_unset = object()
-
-def param_watchers(parameterized, value=_unset):
-    if Version(param.__version__) <= Version('2.0.0a2'):
-        if value is not _unset:
-            parameterized._param_watchers = value
-        else:
-            return parameterized._param_watchers
-    else:
-        if value is not _unset:
-            parameterized.param.watchers = value
-        else:
-            return parameterized.param.watchers
 
 
 def flatten(line):

--- a/panel/util/param.py
+++ b/panel/util/param.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import inspect
+
+from contextlib import contextmanager
+from typing import Any, Dict, Iterator
+
+import param
+
+from packaging.version import Version
+
+_unset = object()
+
+
+def should_inherit(parameterized: param.Parameterized, p: str, v: Any) -> Any:
+    pobj = parameterized.param[p]
+    return v is not pobj.default and not pobj.readonly and (v is not None or pobj.allow_None)
+
+
+def get_params_to_inherit(parameterized: param.Parameterized) -> Dict:
+    return {
+        p: v for p, v in parameterized.param.values().items()
+        if should_inherit(parameterized, p, v)
+    }
+
+
+def get_method_owner(meth):
+    """
+    Returns the instance owning the supplied instancemethod or
+    the class owning the supplied classmethod.
+    """
+    if inspect.ismethod(meth):
+        return meth.__self__
+
+
+# This functionality should be contributed to param
+# See https://github.com/holoviz/param/issues/379
+@contextmanager
+def edit_readonly(parameterized: param.Parameterized) -> Iterator:
+    """
+    Temporarily set parameters on Parameterized object to readonly=False
+    to allow editing them.
+    """
+    params = parameterized.param.objects("existing").values()
+    readonlys = [p.readonly for p in params]
+    constants = [p.constant for p in params]
+    for p in params:
+        p.readonly = False
+        p.constant = False
+    try:
+        yield
+    except Exception:
+        raise
+    finally:
+        for (p, readonly) in zip(params, readonlys):
+            p.readonly = readonly
+        for (p, constant) in zip(params, constants):
+            p.constant = constant
+
+
+def extract_dependencies(function):
+    """
+    Extract references from a method or function that declares the references.
+    """
+    subparameters = list(function._dinfo['dependencies'])+list(function._dinfo['kw'].values())
+    params = []
+    for p in subparameters:
+        if isinstance(p, str):
+            owner = get_method_owner(function)
+            *subps, p = p.split('.')
+            for subp in subps:
+                owner = getattr(owner, subp, None)
+                if owner is None:
+                    raise ValueError('Cannot depend on undefined sub-parameter {p!r}.')
+            if p in owner.param:
+                pobj = owner.param[p]
+                if pobj not in params:
+                    params.append(pobj)
+            else:
+                for sp in extract_dependencies(getattr(owner, p)):
+                    if sp not in params:
+                        params.append(sp)
+        elif p not in params:
+            params.append(p)
+    return params
+
+
+def param_watchers(parameterized: param.Parameterized, value=_unset):
+    if Version(param.__version__) <= Version('2.0.0a2'):
+        if value is not _unset:
+            parameterized._param_watchers = value
+        else:
+            return parameterized._param_watchers
+    else:
+        if value is not _unset:
+            parameterized.param.watchers = value
+        else:
+            return parameterized.param.watchers

--- a/panel/util/parameters.py
+++ b/panel/util/parameters.py
@@ -96,3 +96,16 @@ def param_watchers(parameterized: param.Parameterized, value=_unset):
             parameterized.param.watchers = value
         else:
             return parameterized.param.watchers
+
+
+def recursive_parameterized(parameterized: param.Parameterized, objects=None) -> list[param.Parameterized]:
+    """
+    Recursively searches a Parameterized object for other Parmeterized
+    objects.
+    """
+    objects = [] if objects is None else objects
+    objects.append(parameterized)
+    for p in parameterized.param.values().values():
+        if isinstance(p, param.Parameterized) and not any(p is o for o in objects):
+            recursive_parameterized(p, objects)
+    return objects

--- a/panel/viewable.py
+++ b/panel/viewable.py
@@ -45,7 +45,7 @@ from .io.notebook import (
 from .io.save import save
 from .io.state import curdoc_locked, set_curdoc, state
 from .util import escape, param_reprs
-from .util.param import get_params_to_inherit
+from .util.parameters import get_params_to_inherit
 from .util.warnings import deprecated
 
 if TYPE_CHECKING:

--- a/panel/viewable.py
+++ b/panel/viewable.py
@@ -45,6 +45,7 @@ from .io.notebook import (
 from .io.save import save
 from .io.state import curdoc_locked, set_curdoc, state
 from .util import escape, param_reprs
+from .util.param import get_params_to_inherit
 from .util.warnings import deprecated
 
 if TYPE_CHECKING:
@@ -55,15 +56,6 @@ if TYPE_CHECKING:
     from .io.location import Location
     from .io.server import StoppableThread
 
-def _should_inherit(self, p, v):
-        _p = self.param[p]
-        return v is not _p.default and not _p.readonly and (v is not None or _p.allow_None)
-
-def _get_items_to_inherit(self: param.Parameterized)->Dict:
-    return {
-        p: v for p, v in self.param.values().items()
-        if _should_inherit(self, p, v)
-    }
 
 class Layoutable(param.Parameterized):
     """
@@ -859,7 +851,7 @@ class Viewable(Renderable, Layoutable, ServableMixin):
         -------
         Cloned Viewable object
         """
-        inherited = _get_items_to_inherit(self)
+        inherited = get_params_to_inherit(self)
         return type(self)(**dict(inherited, **params))
 
     def pprint(self) -> None:


### PR DESCRIPTION
Pane.clone did the same look up three times which was costly.

This changes to one lookup and also makes the code more readable.

## Measurement 1

Running pytest on below code shows ~3% speed up consistently.

```python
import panel as pn
item = pn.pane.Markdown("Hello World")

def test_html_clone():
    for i in range(20000):
        item.clone()
```

The reason why I found this is that I can see in apps `.clone` loops over `self.param.values().items()`. And loops over `self.param.values().items()` takes up +5% of the time of loading apps in my tests. My hypothesis is that that one could be improved significantly.