### PR TITLE
Speed up config.__getattr__ with a factor 10 corresponding to 5-10% app speed up.

### DIFF
--- a/panel/config.py
+++ b/panel/config.py
@@ -336,7 +336,7 @@ class _config(_base_config):
         super().__init__(**params)
         self._validating = False
         self._parameter_set = set(self.param)
-        for p in self.param:
+        for p in self._parameter_set:
             if p.startswith('_') and p[1:] not in _config._globals:
                 setattr(self, p+'_', None)
         if self.log_level:
@@ -372,7 +372,7 @@ class _config(_base_config):
     def set(self, **kwargs):
         values = [(k, v) for k, v in self.param.values().items() if k != 'name']
         overrides = [
-            (k, getattr(self, k+'_')) for k in self.param
+            (k, getattr(self, k+'_')) for k in self._parameter_set
             if k.startswith('_') and k[1:] not in _config._globals
         ]
         for k, v in kwargs.items():
@@ -398,9 +398,9 @@ class _config(_base_config):
         if attr in _config._globals or self.param._TRIGGER:
             super().__setattr__(attr if attr in self.param else f'_{attr}', value)
         elif state.curdoc is not None:
-            if attr in self.param:
+            if attr in self._parameter_set:
                 validate_config(self, attr, value)
-            elif f'_{attr}' in self.param:
+            elif f'_{attr}' in self._parameter_set:
                 validate_config(self, f'_{attr}', value)
             else:
                 raise AttributeError(f'{attr!r} is not a valid config parameter.')
@@ -410,7 +410,7 @@ class _config(_base_config):
             watchers = param_watchers(self).get(attr, {}).get('value', [])
             for w in watchers:
                 w.fn()
-        elif f'_{attr}' in self.param and hasattr(self, f'_{attr}_'):
+        elif f'_{attr}' in self._parameter_set and hasattr(self, f'_{attr}_'):
             validate_config(self, f'_{attr}', value)
             super().__setattr__(f'_{attr}_', value)
         else:

--- a/panel/config.py
+++ b/panel/config.py
@@ -445,7 +445,7 @@ class _config(_base_config):
             curdoc and attr not in session_config[curdoc]):
             new_obj = copy.copy(super().__getattribute__(attr))
             setattr(self, attr, new_obj)
-        if attr in self._globals or attr == 'theme':
+        if attr in config._globals or attr == 'theme':
             return super().__getattribute__(attr)
         elif curdoc and curdoc in session_config and attr in session_config[curdoc]:
             return session_config[curdoc][attr]

--- a/panel/config.py
+++ b/panel/config.py
@@ -324,7 +324,7 @@ class _config(_base_config):
         'oauth_secret', 'oauth_jwt_user', 'oauth_redirect_uri',
         'oauth_encryption_key', 'oauth_extra_params', 'npm_cdn',
         'layout_compatibility', 'oauth_refresh_tokens', 'oauth_guest_endpoints',
-        'oauth_optional'
+        'oauth_optional', 'admin'
     }
 
     _truthy = ['True', 'true', '1', True, 1]

--- a/panel/config.py
+++ b/panel/config.py
@@ -55,6 +55,7 @@ GLOBALS = {
 from collections import defaultdict
 
 ATTRS = defaultdict(lambda: 0)
+_PARAMS = None
 
 def validate_config(config, parameter, value):
     """
@@ -450,10 +451,15 @@ class _config(_base_config):
         if attr=="param":
             return super().__getattribute__(attr)
 
+        global _PARAMS
+        if not _PARAMS and init:
+            _PARAMS = set(super().__getattribute__('param'))
+
         if init and not attr.startswith('__'):
-            params = set(super().__getattribute__('param'))
+            _params=_PARAMS
         else:
-            params = []
+            _params = {}
+
         session_config = super().__getattribute__('_session_config')
         curdoc = state.curdoc
         if curdoc and curdoc not in session_config:
@@ -466,7 +472,7 @@ class _config(_base_config):
             return super().__getattribute__(attr)
         elif curdoc and curdoc in session_config and attr in session_config[curdoc]:
             return session_config[curdoc][attr]
-        elif f'_{attr}' in params and getattr(self, f'_{attr}_') is not None:
+        elif f'_{attr}' in _params and getattr(self, f'_{attr}_') is not None:
             return super().__getattribute__(f'_{attr}_')
         return super().__getattribute__(attr)
 

--- a/panel/config.py
+++ b/panel/config.py
@@ -445,7 +445,7 @@ class _config(_base_config):
             curdoc and attr not in session_config[curdoc]):
             new_obj = copy.copy(super().__getattribute__(attr))
             setattr(self, attr, new_obj)
-        if attr in config._globals or attr == 'theme':
+        if attr in _config._globals or attr == 'theme':
             return super().__getattribute__(attr)
         elif curdoc and curdoc in session_config and attr in session_config[curdoc]:
             return session_config[curdoc][attr]

--- a/panel/config.py
+++ b/panel/config.py
@@ -447,7 +447,7 @@ class _config(_base_config):
         except AttributeError:
             init = super().__getattribute__('initialized')
 
-        if attr==param:
+        if attr=="param":
             return super().__getattribute__('_param__private')
 
         if init and not attr.startswith('__'):

--- a/panel/config.py
+++ b/panel/config.py
@@ -438,7 +438,7 @@ class _config(_base_config):
 
         # ATTRS[attr]+=1
         # print(ATTRS)
-        if attr in ('_param__private', '__class__', 'npm_cdn'):
+        if attr in ('_param__private', '__class__', 'npm_cdn', 'param'):
             return super().__getattribute__(attr)
 
         # _param__private added in Param 2
@@ -448,10 +448,10 @@ class _config(_base_config):
             init = super().__getattribute__('initialized')
 
         if attr=="param":
-            return super().__getattribute__('_param__private')
+            return super().__getattribute__(attr)
 
         if init and not attr.startswith('__'):
-            params = super().__getattribute__('param')
+            params = set(super().__getattribute__('param'))
         else:
             params = []
         session_config = super().__getattribute__('_session_config')


### PR DESCRIPTION
Closes #5850

## Pytest

I've run the below test on the `main` branch and `this` branch.

```python
from pathlib import Path
import pytest
from pyinstrument import Profiler
import panel as pn

TESTS_ROOT = Path.cwd()

@pytest.fixture(autouse=True)
def auto_profile(request):
    PROFILE_ROOT = (TESTS_ROOT / ".profiles")
    # Turn profiling on
    profiler = Profiler()
    profiler.start()

    yield  # Run test

    profiler.stop()
    PROFILE_ROOT.mkdir(exist_ok=True)
    results_file = PROFILE_ROOT / f"{request.node.name}.html"
    profiler.write_html(results_file)

item = pn.pane.Markdown("Hello World")

def method1():
    pn.config.loading_indicator
    pn.config.npm_cdn
    pn.config.sizing_mode
    pn.config.admin

def test_performance():
    N = 100000
    for i in range(N):
        method1()
```

I've achieved a 75% speed up. Left is `main` branch, Right is `this` branch

![image](https://github.com/holoviz/panel/assets/42288570/1a82f720-10d5-42e5-83af-7952bf261233)

## App

Compared to the profiling of the app in the reported issue, it looks much better. `config.__getattribute__` is only in one place with a smaller proportion of 1% compared to the 11% before. Still I think that is too much.

![image](https://github.com/holoviz/panel/assets/42288570/3cbcd449-b338-4933-a484-1a66c5f2078e)
