### PR TITLE
Do not freeze document models unless needed

### DIFF
--- a/panel/io/document.py
+++ b/panel/io/document.py
@@ -345,7 +345,7 @@ def freeze_doc(doc: Document, model: HasProps, properties: Dict[str, Any], force
             visit_immediate_value_references(getattr(model, key, None), mark_dirty)
             visit_immediate_value_references(value, mark_dirty)
     if dirty_count:
-        doc._models._push_freeze()
+        doc.models._push_freeze()
     yield
     if dirty_count:
-        doc._models._pop_freeze()
+        doc.models._pop_freeze()

--- a/panel/io/document.py
+++ b/panel/io/document.py
@@ -11,7 +11,7 @@ import threading
 from contextlib import contextmanager
 from functools import partial, wraps
 from typing import (
-    Callable, Iterator, List, Optional,
+    TYPE_CHECKING, Any, Callable, Dict, Iterator, List, Optional,
 )
 
 from bokeh.application.application import SessionContext
@@ -20,6 +20,7 @@ from bokeh.document.events import (
     ColumnDataChangedEvent, ColumnsPatchedEvent, ColumnsStreamedEvent,
     DocumentChangedEvent, ModelChangedEvent,
 )
+from bokeh.model.util import visit_immediate_value_references
 from bokeh.models import CustomJS
 
 from ..config import config
@@ -27,6 +28,9 @@ from ..util import param_watchers
 from .loading import LOADING_INDICATOR_CSS_CLASS
 from .model import hold, monkeypatch_events  # noqa: F401 API import
 from .state import curdoc_locked, state
+
+if TYPE_CHECKING:
+    from bokeh.core.has_props import HasProps
 
 logger = logging.getLogger(__name__)
 
@@ -323,3 +327,25 @@ def immediate_dispatch(doc: Document | None = None):
         yield
     doc.callbacks._hold = held
     doc.callbacks._held_events = old_events
+
+@contextmanager
+def freeze_doc(doc: Document, model: HasProps, properties: Dict[str, Any], force: bool = False):
+    """
+    Freezes the document model references if any of the properties
+    are themselves a model.
+    """
+    if force:
+        dirty_count = 1
+    else:
+        dirty_count = 0
+        def mark_dirty(_: HasProps):
+            nonlocal dirty_count
+            dirty_count += 1
+        for key, value in properties.items():
+            visit_immediate_value_references(getattr(model, key, None), mark_dirty)
+            visit_immediate_value_references(value, mark_dirty)
+    if dirty_count:
+        doc._models._push_freeze()
+    yield
+    if dirty_count:
+        doc._models._pop_freeze()

--- a/panel/layout/grid.py
+++ b/panel/layout/grid.py
@@ -202,7 +202,8 @@ class GridBox(ListPanel):
 
         msg = dict(msg)
         preprocess = any(self._rename.get(k, k) in self._preprocess_params for k in msg)
-        if self._rename['objects'] in msg or 'ncols' in msg or 'nrows' in msg:
+        update_children = self._rename['objects'] in msg
+        if update_children or 'ncols' in msg or 'nrows' in msg:
             if 'objects' in events:
                 old = events['objects'].old
             else:
@@ -218,7 +219,7 @@ class GridBox(ListPanel):
             update = Panel._batch_update
             Panel._batch_update = True
             try:
-                with freeze_doc(doc, model, msg):
+                with freeze_doc(doc, model, msg, force=update_children):
                     super(Panel, self)._update_model(events, msg, root, model, doc, comm)
                     if update:
                         return

--- a/panel/layout/grid.py
+++ b/panel/layout/grid.py
@@ -16,6 +16,7 @@ import param
 
 from bokeh.models import FlexBox as BkFlexBox, GridBox as BkGridBox
 
+from ..io.document import freeze_doc
 from ..io.model import hold
 from ..io.resources import CDN_DIST
 from .base import (
@@ -217,7 +218,7 @@ class GridBox(ListPanel):
             update = Panel._batch_update
             Panel._batch_update = True
             try:
-                with doc.models.freeze():
+                with freeze_doc(doc, model, msg):
                     super(Panel, self)._update_model(events, msg, root, model, doc, comm)
                     if update:
                         return


### PR DESCRIPTION
Currently we freeze the Document model references every time a property is changed, triggering reference invalidation which is expensive. Instead we should check if we are adding/removing a model and only freeze the model references if that's the case.