### PR TITLE
Allow running onload and defer_load tasks on threads

### DIFF
--- a/doc/how_to/callbacks/defer_load.md
+++ b/doc/how_to/callbacks/defer_load.md
@@ -24,11 +24,9 @@ import panel as pn
 
 pn.extension(template="bootstrap")
 
-
 def some_long_running_task():
     time.sleep(5)
     return "# Wow. That took some time. Are you still here?"
-
 
 pn.panel(some_long_running_task).servable()
 ```
@@ -39,8 +37,7 @@ Now lets learn how to defer long running tasks to after the application has load
 
 ## Defer all Tasks
 
-Its easy defer the execution of all bound and displayed functions with
-`pn.extension(..., defer_load=True)`.
+Its easy defer the execution of all bound and displayed functions with `pn.extension(..., defer_load=True)`.
 
 ```python
 import time
@@ -67,15 +64,12 @@ import panel as pn
 
 pn.extension(loading_indicator=True, template="bootstrap")
 
-
 def short_running_task():
     return "# I'm shown on load"
-
 
 def long_running_task():
     time.sleep(3)
     return "# I'm deferred and shown after load"
-
 
 pn.Column(
     short_running_task,
@@ -84,3 +78,7 @@ pn.Column(
 ```
 
 ![panel-defer-specific-example](https://assets.holoviz.org/panel/gifs/defer_specific_task.gif)
+
+```{note}
+If you [enable threading](../concurrency/threading.md) by setting `config.nthreads` or `--num-threads` on the commandline deferred callbacks will be executed concurrently on separate threads.
+```

--- a/doc/how_to/callbacks/load.md
+++ b/doc/how_to/callbacks/load.md
@@ -58,7 +58,7 @@ layout.servable()
 
 ![panel-onload-example](https://assets.holoviz.org/panel/gifs/onload_callback.gif)
 
-Note that `pn.state.onload` accepts both *sync* and *async* functions.
+Note that `pn.state.onload` accepts both *sync* and *async* functions and also accepts a `threaded` argument, which, when combined with [enabling `config.nthreads`](../concurrency/threading.md) will run the callbacks concurrently on separate threads.
 
 This example could also be implemented using a *bound and displayed function*. We recommend using that method together with `defer_load` when possible. See the [Defer Bound and Displayed Functions Guide](defer_load.md).
 

--- a/doc/how_to/concurrency/threading.md
+++ b/doc/how_to/concurrency/threading.md
@@ -41,3 +41,7 @@ In a threaded context on the other hand the two clicks will be processed concurr
 > Finished processing 1th click.
 > Finished processing 2th click.
 ```
+
+```{note}
+Note that the global ThreadPool is used to dispatch events triggered by changes in parameters, events (such as click events), [`defer_load`](../callbacks/defer_load.md) callbacks and optionally [`onload` callbacks](../callbacks/load.md).
+```

--- a/panel/io/state.py
+++ b/panel/io/state.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 import asyncio
 import datetime as dt
-import functools
 import inspect
 import logging
 import shutil
@@ -377,24 +376,26 @@ class _state(param.Parameterized):
 
     def _on_load(self, doc: Optional[Document] = None) -> None:
         doc = doc or self.curdoc
-        self._loaded[doc] = True
         callbacks = self._onload.pop(doc, [])
         if not callbacks:
+            self._loaded[doc] = True
             return
 
         from ..config import config
         from .profile import profile_ctx
         with set_curdoc(doc):
             if (doc and doc in self._launching) or not config.profiler:
-                for cb in callbacks:
-                    self.execute(cb, schedule=False)
+                for cb, threaded in callbacks:
+                    self.execute(cb, schedule='thread' if threaded else False)
                 return
+
             with profile_ctx(config.profiler) as sessions:
-                for cb in callbacks:
-                    self.execute(cb, schedule=False)
+                for cb, threaded in callbacks:
+                    self.execute(cb, schedule='thread' if threaded else False)
             path = doc.session_context.request.path
             self._profiles[(path+':on_load', config.profiler)] += sessions
             self.param.trigger('_profiles')
+        self._loaded[doc] = True
 
     async def _scheduled_cb(self, name: str) -> None:
         if name not in self._scheduled:
@@ -573,10 +574,17 @@ class _state(param.Parameterized):
                     pass
         self._memoize_cache.clear()
 
+    def _execute_on_thread(self, doc, callback):
+        with set_curdoc(doc):
+            if param.parameterized.iscoroutinefunction(callback):
+                param.parameterized.async_executor(callback)
+            else:
+                self.execute(callback, schedule=False)
+
     def execute(
         self,
         callback: Callable([], None),
-        schedule: bool | Literal['auto'] = 'auto'
+        schedule: bool | Literal['auto', 'thread'] = 'auto'
     ) -> None:
         """
         Executes both synchronous and asynchronous callbacks
@@ -589,15 +597,17 @@ class _state(param.Parameterized):
         ---------
         callback: Callable[[], None]
           Callback to execute
-        schedule: boolean | Literal['auto']
-          Whether to schedule synchronous callback on the event loop
-          or execute it immediately.
+        schedule: boolean | Literal['auto', 'thread']
+          Whether to schedule the callback on the event loop, on a thread
+          or execute them immediately.
         """
-        cb = callback
-        while isinstance(cb, functools.partial):
-            cb = cb.func
         doc = self.curdoc
-        if param.parameterized.iscoroutinefunction(cb):
+        if schedule == 'thread':
+            if not state._thread_pool:
+                raise RuntimeError('Cannot execute callback on thread')
+            future = state._thread_pool.submit(partial(self._execute_on_thread, doc, callback))
+            future.add_done_callback(self._handle_future_exception)
+        elif param.parameterized.iscoroutinefunction(callback):
             param.parameterized.async_executor(callback)
         elif doc and doc.session_context and (schedule == True or (schedule == 'auto' and not self._unblocked(doc))):
             doc.add_next_tick_callback(self._handle_exception_wrapper(callback))
@@ -658,7 +668,7 @@ class _state(param.Parameterized):
             msg = LOG_USER_MSG.format(msg=msg)
         getattr(_state_logger, level.lower())(msg, *args)
 
-    def onload(self, callback: Callable[[], None | Awaitable[None]] | Coroutine[Any, Any, None]):
+    def onload(self, callback: Callable[[], None | Awaitable[None]] | Coroutine[Any, Any, None], threaded: bool = False):
         """
         Callback that is triggered when a session has been served.
 
@@ -666,6 +676,8 @@ class _state(param.Parameterized):
         ---------
         callback: Callable[[], None] | Coroutine[Any, Any, None]
            Callback that is executed when the application is loaded
+        threaded: bool
+          Whether the onload callback can be threaded
         """
         if self.curdoc is None or self._is_pyodide:
             if self._thread_pool:
@@ -680,7 +692,7 @@ class _state(param.Parameterized):
                 self.curdoc.on_event('document_ready', partial(self._schedule_on_load, self.curdoc))
             except AttributeError:
                 pass # Document already cleaned up
-        self._onload[self.curdoc].append(callback)
+        self._onload[self.curdoc].append((callback, threaded))
 
     def on_session_created(self, callback: Callable[[BokehSessionContext], None]) -> None:
         """

--- a/panel/io/state.py
+++ b/panel/io/state.py
@@ -604,7 +604,10 @@ class _state(param.Parameterized):
         doc = self.curdoc
         if schedule == 'thread':
             if not state._thread_pool:
-                raise RuntimeError('Cannot execute callback on thread')
+                raise RuntimeError(
+                    'Cannot execute callback on thread. Ensure you have '
+                    'enabled threading setting `config.nthreads`.'
+                )
             future = state._thread_pool.submit(partial(self._execute_on_thread, doc, callback))
             future.add_done_callback(self._handle_future_exception)
         elif param.parameterized.iscoroutinefunction(callback):

--- a/panel/param.py
+++ b/panel/param.py
@@ -942,7 +942,10 @@ class ParamMethod(ReplacementPane):
         if not self._evaled:
             deferred = self.defer_load and not state.loaded
             if deferred:
-                state.onload(partial(self._replace_pane, force=True))
+                state.onload(
+                    partial(self._replace_pane, force=True),
+                    threaded=bool(state._thread_pool)
+                )
             self._replace_pane(force=not deferred)
         return super()._get_model(doc, root, parent, comm)
 


### PR DESCRIPTION
Currently `onload` callbacks and components that use `defer_load` run consecutively when in many cases they could be running in parallel on the configured thread pool. This PR does a few things to enable this:

- Allow `pn.state.execute(cb, schedule='thread')` as an option to schedule a callback on a thread
- Add support for `pn.state.onload(cb, threaded=True)` to register an onload callback that can be run on a thread 
- Components which have `defer_load=True` will automatically be scheduled on the thread pool (if available)

Tasks:

- [x] Adds support for https://github.com/holoviz/panel/issues/5862, https://github.com/holoviz/panel/issues/5819
- [x] Add tests
- [x] Add docs
