### PR TITLE
Only set HoloViews backend in first extension call

### DIFF
--- a/panel/config.py
+++ b/panel/config.py
@@ -798,7 +798,7 @@ class panel_extension(_pyviz_extension):
                 backend = hv.Store.current_backend
             else:
                 backend = 'bokeh'
-            if not loaded and backend != hv.Store.current_backend and hasattr(hv.Store, 'set_current_backend'):
+            if not loaded or (loaded and backend != hv.Store.current_backend) and hasattr(hv.Store, 'set_current_backend'):
                 hv.Store.set_current_backend(backend)
             else:
                 hv.Store.current_backend = backend

--- a/panel/config.py
+++ b/panel/config.py
@@ -798,7 +798,7 @@ class panel_extension(_pyviz_extension):
                 backend = hv.Store.current_backend
             else:
                 backend = 'bokeh'
-            if hasattr(hv.Store, 'set_current_backend'):
+            if not loaded and backend != hv.Store.current_backend and hasattr(hv.Store, 'set_current_backend'):
                 hv.Store.set_current_backend(backend)
             else:
                 hv.Store.current_backend = backend


### PR DESCRIPTION
`hv.Store.set_current_backend` can be a fairly expensive operation (around 40ms) and does not have to be run each time. So unless the backend does not match the current backend we do not rerun it each time.