### PR TITLE
Enable selection across different pages with `pagination="remote"` and `selectable="checkbox"`

### DIFF
--- a/panel/models/tabulator.py
+++ b/panel/models/tabulator.py
@@ -57,6 +57,17 @@ class SelectionEvent(ModelEvent):
     event_name = 'selection-change'
 
     def __init__(self, model, indices, selected):
+        """ Selection Event
+
+        Parameters
+        ----------
+        model : ModelEvent
+            An event send when a selection is changed on the frontend.
+        indices : list[int]
+            A list of changed indices selected/deselected rows.
+        selected : bool
+            If true the rows were selected, if false they were deselected.
+        """
         self.indices = indices
         self.selected = selected
         super().__init__(model=model)

--- a/panel/models/tabulator.py
+++ b/panel/models/tabulator.py
@@ -56,14 +56,14 @@ class SelectionEvent(ModelEvent):
 
     event_name = 'selection-change'
 
-    def __init__(self, model, index, selected):
-        self.index = index
+    def __init__(self, model, indices, selected):
+        self.indices = indices
         self.selected = selected
         super().__init__(model=model)
 
     def __repr__(self):
         return (
-            f'{type(self).__name__}(index={self.index}, selected={self.selected})'
+            f'{type(self).__name__}(indices={self.indices}, selected={self.selected})'
         )
 
 

--- a/panel/models/tabulator.py
+++ b/panel/models/tabulator.py
@@ -52,6 +52,21 @@ class TableEditEvent(ModelEvent):
             f'value={self.value}, old={self.old})'
         )
 
+class SelectionEvent(ModelEvent):
+
+    event_name = 'selection-change'
+
+    def __init__(self, model, index, selected):
+        self.index = index
+        self.selected = selected
+        super().__init__(model=model)
+
+    def __repr__(self):
+        return (
+            f'{type(self).__name__}(index={self.index}, selected={self.selected})'
+        )
+
+
 class CellClickEvent(ModelEvent):
 
     event_name = 'cell-click'

--- a/panel/models/tabulator.ts
+++ b/panel/models/tabulator.ts
@@ -43,6 +43,20 @@ export class CellClickEvent extends ModelEvent {
   }
 }
 
+export class SelectionEvent extends ModelEvent {
+  constructor(readonly index: number, readonly selected: boolean) {
+    super()
+  }
+
+  protected get event_values(): Attrs {
+    return {model: this.origin, index: this.index, selected: this.selected}
+  }
+
+  static {
+    this.prototype.event_name = "selection-change"
+  }
+}
+
 declare const Tabulator: any;
 
 function find_group(key: any, value: string, records: any[]): any {
@@ -475,7 +489,7 @@ export class DataTabulatorView extends HTMLBoxView {
     }, 50, false))
 
     // Sync state with model
-    this.tabulator.on("rowSelectionChanged", (data: any, rows: any) => this.rowSelectionChanged(data, rows))
+    this.tabulator.on("rowSelectionChanged", (data: any, rows: any, selected: any, deselected: any) => this.rowSelectionChanged(data, rows, selected, deselected))
     this.tabulator.on("rowClick", (e: any, row: any) => this.rowClicked(e, row))
     this.tabulator.on("cellEdited", (cell: any) => this.cellEdited(cell))
     this.tabulator.on("dataFiltering", (filters: any) => {
@@ -1091,7 +1105,7 @@ export class DataTabulatorView extends HTMLBoxView {
     return filtered
   }
 
-  rowSelectionChanged(data: any, _: any): void {
+  rowSelectionChanged(data: any, _row: any, selected: any, deselected: any): void {
     if (
         this._selection_updating ||
         this._initializing ||
@@ -1100,10 +1114,25 @@ export class DataTabulatorView extends HTMLBoxView {
         this.model.configuration.dataTree
     )
       return
-    const indices: number[] = data.map((row: any) => row._index)
-    const filtered = this._filter_selected(indices)
-    this._selection_updating = indices.length === filtered.length
-    this.model.source.selected.indices = filtered
+    if (this.model.pagination === 'remote') {
+      let selected_index = selected.length ? selected[0]._row.data._index : null
+      let deselected_index = deselected.length ? deselected[0]._row.data._index : null
+      if (selected_index !== null) {
+        this._selection_updating = true
+        this.model.trigger_event(new SelectionEvent(selected_index, selected=true))
+        console.log("Selected :", selected_index)
+      }
+      if (deselected_index !== null) {
+        this._selection_updating = true
+        this.model.trigger_event(new SelectionEvent(deselected_index, selected=false))
+        console.log("Deselected: ", deselected_index)
+      }
+    } else {
+      const indices: number[] = data.map((row: any) => row._index)
+      const filtered = this._filter_selected(indices)
+      this._selection_updating = indices.length === filtered.length
+      this.model.source.selected.indices = filtered
+    }
     this._selection_updating = false
   }
 

--- a/panel/models/tabulator.ts
+++ b/panel/models/tabulator.ts
@@ -44,12 +44,12 @@ export class CellClickEvent extends ModelEvent {
 }
 
 export class SelectionEvent extends ModelEvent {
-  constructor(readonly index: number, readonly selected: boolean) {
+  constructor(readonly indices: Array<number>, readonly selected: boolean) {
     super()
   }
 
   protected get event_values(): Attrs {
-    return {model: this.origin, index: this.index, selected: this.selected}
+    return {model: this.origin, indices: this.indices, selected: this.selected}
   }
 
   static {
@@ -1120,13 +1120,13 @@ export class DataTabulatorView extends HTMLBoxView {
     )
       return
     if (this.model.pagination === 'remote') {
-      let selected_index = selected.length ? selected[0]._row.data._index : null
-      let deselected_index = deselected.length ? deselected[0]._row.data._index : null
-      if (selected_index !== null) {
+      let selected_index = selected.map((x: any) => x._row.data._index)
+      let deselected_index = deselected.map((x: any) => x._row.data._index)
+      if (selected_index.length > 0) {
         this._selection_updating = true
         this.model.trigger_event(new SelectionEvent(selected_index, selected=true))
       }
-      if (deselected_index !== null) {
+      if (deselected_index.length > 0) {
         this._selection_updating = true
         this.model.trigger_event(new SelectionEvent(deselected_index, selected=false))
       }

--- a/panel/models/tabulator.ts
+++ b/panel/models/tabulator.ts
@@ -44,7 +44,7 @@ export class CellClickEvent extends ModelEvent {
 }
 
 export class SelectionEvent extends ModelEvent {
-  constructor(readonly indices: Array<number>, readonly selected: boolean) {
+  constructor(readonly indices: number[], readonly selected: boolean) {
     super()
   }
 
@@ -1120,15 +1120,15 @@ export class DataTabulatorView extends HTMLBoxView {
     )
       return
     if (this.model.pagination === 'remote') {
-      let selected_index = selected.map((x: any) => x._row.data._index)
-      let deselected_index = deselected.map((x: any) => x._row.data._index)
-      if (selected_index.length > 0) {
+      let selected_indices = selected.map((x: any) => x._row.data._index)
+      let deselected_indices = deselected.map((x: any) => x._row.data._index)
+      if (selected_indices.length > 0) {
         this._selection_updating = true
-        this.model.trigger_event(new SelectionEvent(selected_index, selected=true))
+        this.model.trigger_event(new SelectionEvent(selected_indices, selected=true))
       }
-      if (deselected_index.length > 0) {
+      if (deselected_indices.length > 0) {
         this._selection_updating = true
-        this.model.trigger_event(new SelectionEvent(deselected_index, selected=false))
+        this.model.trigger_event(new SelectionEvent(deselected_indices, selected=false))
       }
     } else {
       const indices: number[] = data.map((row: any) => row._index)

--- a/panel/models/tabulator.ts
+++ b/panel/models/tabulator.ts
@@ -366,7 +366,14 @@ export class DataTabulatorView extends HTMLBoxView {
     this.connect(p.frozen_rows.change, () => this.setFrozen())
     this.connect(p.sorters.change, () => this.setSorters())
     this.connect(p.theme_classes.change, () => this.setCSSClasses(this.tabulator.element))
-    this.connect(this.model.source.properties.data.change, () => this.setData())
+    this.connect(this.model.source.properties.data.change, () => {
+      console.log("Before: ", this.model.source.selected.indices)
+      this._selection_updating = true
+      this.setData()
+      this._selection_updating = false
+      this.postUpdate()
+      console.log("After : ",this.model.source.selected.indices)
+    })
     this.connect(this.model.source.streaming, () => this.addData())
     this.connect(this.model.source.patching, () => {
       const inds = this.model.source.selected.indices

--- a/panel/models/tabulator.ts
+++ b/panel/models/tabulator.ts
@@ -367,12 +367,10 @@ export class DataTabulatorView extends HTMLBoxView {
     this.connect(p.sorters.change, () => this.setSorters())
     this.connect(p.theme_classes.change, () => this.setCSSClasses(this.tabulator.element))
     this.connect(this.model.source.properties.data.change, () => {
-      console.log("Before: ", this.model.source.selected.indices)
       this._selection_updating = true
       this.setData()
       this._selection_updating = false
       this.postUpdate()
-      console.log("After : ",this.model.source.selected.indices)
     })
     this.connect(this.model.source.streaming, () => this.addData())
     this.connect(this.model.source.patching, () => {
@@ -1127,12 +1125,10 @@ export class DataTabulatorView extends HTMLBoxView {
       if (selected_index !== null) {
         this._selection_updating = true
         this.model.trigger_event(new SelectionEvent(selected_index, selected=true))
-        console.log("Selected :", selected_index)
       }
       if (deselected_index !== null) {
         this._selection_updating = true
         this.model.trigger_event(new SelectionEvent(deselected_index, selected=false))
-        console.log("Deselected: ", deselected_index)
       }
     } else {
       const indices: number[] = data.map((row: any) => row._index)

--- a/panel/tests/ui/widgets/test_tabulator.py
+++ b/panel/tests/ui/widgets/test_tabulator.py
@@ -3277,3 +3277,50 @@ def test_tabulator_update_hidden_columns(page):
         (title.bounding_box()['x'] == cell.bounding_box()['x']) and
         (title.bounding_box()['width'] == cell.bounding_box()['width'])
     ), page)
+
+
+class Test_CheckboxSelection_RemotePagination:
+
+    def setup_method(self):
+        self.widget = Tabulator(
+            value=pd.DataFrame(np.arange(20) + 100),
+            disabled=True,
+            pagination="remote",
+            page_size=10,
+            selectable="checkbox",
+            header_filters=True,
+        )
+
+    def check_selected(self, page, expected, ui_count=None):
+        if ui_count is None:
+            ui_count = len(expected)
+
+        expect(page.locator('.tabulator-selected')).to_have_count(ui_count)
+        wait_until(lambda: self.widget.selection == expected, page)
+
+    def get_checkboxes(self, page):
+        return page.locator('input[type="checkbox"]')
+
+    def test_full_firstpage(self, page):
+        serve_component(page, self.widget)
+        checkboxes = self.get_checkboxes(page)
+
+        # Select all items on page
+        checkboxes.nth(0).click()
+        self.check_selected(page, list(range(10)))
+
+        # Deselect last one
+        checkboxes.last.click()
+        self.check_selected(page, list(range(9)))
+
+    def test_one_item_first_page(self, page):
+        serve_component(page, self.widget)
+        checkboxes = self.get_checkboxes(page)
+
+        # Select all items on page
+        checkboxes.nth(1).click()
+        self.check_selected(page, [0])
+
+        # Deselect last one
+        checkboxes.nth(1).click()
+        self.check_selected(page, [])

--- a/panel/tests/ui/widgets/test_tabulator.py
+++ b/panel/tests/ui/widgets/test_tabulator.py
@@ -3301,6 +3301,9 @@ class Test_CheckboxSelection_RemotePagination:
     def get_checkboxes(self, page):
         return page.locator('input[type="checkbox"]')
 
+    def goto_page(self, page, page_number):
+        page.locator(f'button.tabulator-page[data-page="{page_number}"]').click()
+
     def test_full_firstpage(self, page):
         serve_component(page, self.widget)
         checkboxes = self.get_checkboxes(page)
@@ -3317,10 +3320,21 @@ class Test_CheckboxSelection_RemotePagination:
         serve_component(page, self.widget)
         checkboxes = self.get_checkboxes(page)
 
-        # Select all items on page
         checkboxes.nth(1).click()
         self.check_selected(page, [0])
 
-        # Deselect last one
         checkboxes.nth(1).click()
         self.check_selected(page, [])
+
+    def test_one_item_first_page_goto_second_page(self, page):
+        serve_component(page, self.widget)
+        checkboxes = self.get_checkboxes(page)
+
+        checkboxes.nth(1).click()
+        self.check_selected(page, [0], 1)
+
+        self.goto_page(page, 2)
+        self.check_selected(page, [0], 0)
+
+        self.goto_page(page, 1)
+        self.check_selected(page, [0], 1)

--- a/panel/tests/widgets/test_tables.py
+++ b/panel/tests/widgets/test_tables.py
@@ -1406,13 +1406,12 @@ def test_tabulator_paginated_sorted_selection(document, comm):
     table._process_events({'indices': [0, 1]})
     assert table.selection == [4, 3]
 
-    table._process_events({'indices': [2]})
-    assert table.selection == [4, 3, 2]
+    table._process_events({'indices': [1]})
+    assert table.selection == [3]
 
     table.sorters = [{'field': 'A', 'sorter': 'number', 'dir': 'asc'}]
     table._process_events({'indices': [1]})
-    assert table.selection == [4, 3, 2, 1]
-
+    assert table.selection == [1]
 
 def test_tabulator_stream_dataframe(document, comm):
     df = makeMixedDataFrame()

--- a/panel/tests/widgets/test_tables.py
+++ b/panel/tests/widgets/test_tables.py
@@ -1406,12 +1406,12 @@ def test_tabulator_paginated_sorted_selection(document, comm):
     table._process_events({'indices': [0, 1]})
     assert table.selection == [4, 3]
 
-    table._process_events({'indices': [1]})
-    assert table.selection == [3]
+    table._process_events({'indices': [2]})
+    assert table.selection == [4, 3, 2]
 
     table.sorters = [{'field': 'A', 'sorter': 'number', 'dir': 'asc'}]
     table._process_events({'indices': [1]})
-    assert table.selection == [1]
+    assert table.selection == [4, 3, 2, 1]
 
 
 def test_tabulator_stream_dataframe(document, comm):

--- a/panel/tests/widgets/test_tables.py
+++ b/panel/tests/widgets/test_tables.py
@@ -1413,6 +1413,7 @@ def test_tabulator_paginated_sorted_selection(document, comm):
     table._process_events({'indices': [1]})
     assert table.selection == [1]
 
+
 def test_tabulator_stream_dataframe(document, comm):
     df = makeMixedDataFrame()
     table = Tabulator(df)

--- a/panel/widgets/tables.py
+++ b/panel/widgets/tables.py
@@ -1569,6 +1569,8 @@ class Tabulator(BaseTable):
     def _update_selected(self, *events: param.parameterized.Event, indices=None):
         kwargs = {}
         if self.pagination == 'remote' and self.value is not None:
+            # Compute integer indexes of the selected rows
+            # on the displayed page
             index = self.value.iloc[self.selection].index
             indices = []
             for ind in index.values:

--- a/panel/widgets/tables.py
+++ b/panel/widgets/tables.py
@@ -1578,7 +1578,7 @@ class Tabulator(BaseTable):
             start = (self.page-1)*nrows
             end = start+nrows
             p_range = self._processed.index[start:end]
-            kwargs['indices'] = [iloc for ind, iloc in indices
+            kwargs['indices'] = [iloc - start for ind, iloc in indices
                                  if ind in p_range]
             print(indices, kwargs['indices'])
         super()._update_selected(*events, **kwargs)

--- a/panel/widgets/tables.py
+++ b/panel/widgets/tables.py
@@ -298,7 +298,7 @@ class BaseTable(ReactiveData, Widget):
         self._processed, data = self._get_data()
         self._update_index_mapping()
         # If there is a selection we have to compute new index
-        if self.selection and old_processed is not None and self.pagination != 'remote':
+        if self.selection and old_processed is not None:
             indexes = list(self._processed.index)
             selection = []
             for sel in self.selection:
@@ -1539,6 +1539,8 @@ class Tabulator(BaseTable):
         elif events and all(e.name in page_events for e in events) and not self.pagination:
             self._processed, _ = self._get_data()
             return
+        elif self.pagination == 'remote':
+            self._processed = None
         recompute = not all(
             e.name in ('page', 'page_size', 'pagination') for e in events
         )
@@ -1607,15 +1609,15 @@ class Tabulator(BaseTable):
             return
         if isinstance(indices, list):
             selected = True
-        else:
-            # Selection event
+            ilocs = []
+        else:  # SelectionEvent
             selected = indices.selected
             indices = [indices.index]
+            ilocs = self.selection
 
         nrows = self.page_size
         start = (self.page-1)*nrows
         index = self._processed.iloc[[start+ind for ind in indices]].index
-        ilocs = self.selection
         for v in index.values:
             try:
                 iloc = self.value.index.get_loc(v)

--- a/panel/widgets/tables.py
+++ b/panel/widgets/tables.py
@@ -1244,7 +1244,6 @@ class Tabulator(BaseTable):
         super()._cleanup(root)
 
     def _process_event(self, event) -> None:
-
         if event.event_name == 'selection-change':
             self._update_selection(event)
             return
@@ -1538,7 +1537,11 @@ class Tabulator(BaseTable):
         elif events and all(e.name in page_events for e in events) and not self.pagination:
             self._processed, _ = self._get_data()
             return
-        elif self.pagination == 'remote':
+        elif (
+            self.pagination == 'remote'
+            and isinstance(self.selectable, str)
+            and "checkbox" in self.selectable
+        ):
             self._processed = None
         recompute = not all(
             e.name in ('page', 'page_size', 'pagination') for e in events
@@ -1568,11 +1571,11 @@ class Tabulator(BaseTable):
         if self.pagination == 'remote' and self.value is not None:
             index = self.value.iloc[self.selection].index
             indices = []
-            for v in index.values:
+            for ind in index.values:
                 try:
-                    iloc = self._processed.index.get_loc(v)
-                    self._validate_iloc(v ,iloc)
-                    indices.append((v, iloc))
+                    iloc = self._processed.index.get_loc(ind)
+                    self._validate_iloc(ind ,iloc)
+                    indices.append((ind, iloc))
                 except KeyError:
                     continue
             nrows = self.page_size

--- a/panel/widgets/tables.py
+++ b/panel/widgets/tables.py
@@ -1659,7 +1659,7 @@ class Tabulator(BaseTable):
             child_panels, doc, root, parent, comm
         )
         self._link_props(model, ['page', 'sorters', 'expanded', 'filters'], doc, root, comm)
-        self._register_events('cell-click', 'table-edit', model=model, doc=doc, comm=comm)
+        self._register_events('cell-click', 'table-edit', 'selection-change', model=model, doc=doc, comm=comm)
         return model
 
     def _get_filter_spec(self, column: TableColumn) -> Dict[str, Any]:

--- a/panel/widgets/tables.py
+++ b/panel/widgets/tables.py
@@ -1295,7 +1295,6 @@ class Tabulator(BaseTable):
         return theme_url
 
     def _update_columns(self, event, model):
-        print(event.name)
         if event.name not in self._config_params:
             super()._update_columns(event, model)
             if (event.name in ('editors', 'formatters', 'sortable') and
@@ -1582,7 +1581,6 @@ class Tabulator(BaseTable):
             p_range = self._processed.index[start:end]
             kwargs['indices'] = [iloc - start for ind, iloc in indices
                                  if ind in p_range]
-            print(indices, kwargs['indices'])
         super()._update_selected(*events, **kwargs)
 
     def _update_column(self, column: str, array: np.ndarray):

--- a/panel/widgets/tables.py
+++ b/panel/widgets/tables.py
@@ -1610,7 +1610,7 @@ class Tabulator(BaseTable):
             ilocs = []
         else:  # SelectionEvent
             selected = indices.selected
-            indices = [indices.index]
+            indices = indices.indices
             ilocs = self.selection
 
         nrows = self.page_size


### PR DESCRIPTION
Fixes https://github.com/holoviz/panel/issues/4367

``` python
import numpy as np
import pandas as pd
import panel as pn

pn.extension("tabulator")

data = np.arange(20) + 100
df = pd.DataFrame(data)
tab = pn.widgets.Tabulator(
    value=df,
    disabled=True,
    pagination="remote",
    page_size=10,
    selectable="checkbox",
    header_filters=True,
)
tab.servable()
```


https://github.com/holoviz/panel/assets/19758978/0a64dcbc-8db2-4f1a-bcb6-b3853629a39b

