### PR TITLE
Use watchfiles library for detecting changed files

### DIFF
--- a/doc/api/config.md
+++ b/doc/api/config.md
@@ -70,7 +70,7 @@ Default: None | Type: Callable
 
 ### `autoreload`
 
-Whether to autoreload server when script changes.
+Whether to autoreload the page whenever the script or one of its dependencies changes.
 
 Default: False | Type: Boolean
 

--- a/doc/getting_started/core_concepts.md
+++ b/doc/getting_started/core_concepts.md
@@ -41,6 +41,10 @@ Once you run that command Panel will launch a server that will serve your app, o
 
 <img src="https://assets.holoviz.org/panel/gifs/vscode_autoreload.gif" style="margin-left: auto; margin-right: auto; display: block;"></img>
 
+```{note}
+We recommend installing `watchfiles`, which will provide a significantly better user experience when using `--autoreload`.
+```
+
 > Checkout [How-to > Prepare to develop](../how_to/prepare_to_develop.md) for more guidance on each of the development environment options.
 ## Control flow
 

--- a/doc/how_to/server/commandline.md
+++ b/doc/how_to/server/commandline.md
@@ -14,8 +14,11 @@ or even serve a number of apps at once:
 
 For development it can be particularly helpful to use the ``--autoreload`` option to `panel serve` as that will automatically reload the page whenever the application code or any of its imports change.
 
-The ``panel serve`` command has the following options:
+```{note}
+We recommend installing `watchfiles`, which will provide a significantly better user experience when using `--autoreload`.
+```
 
+The ``panel serve`` command has the following options:
 
 ``` console
 positional arguments:

--- a/panel/io/reload.py
+++ b/panel/io/reload.py
@@ -124,7 +124,8 @@ async def setup_autoreload_watcher(stop_event=None):
             '--autoreload functionality now depends on the watchfiles '
             'library. In future versions autoreload will not work without '
             'watchfiles being installed. Since it provides a much better '
-            'user experience consider installing it today.', FutureWarning
+            'user experience consider installing it today.', FutureWarning,
+            stacklevel=0
         )
     _reload_logger.debug('Setting up global autoreload watcher.')
     await async_file_watcher(stop_event=stop_event)
@@ -178,7 +179,7 @@ def _reload(changes):
         elif state._loaded.get(doc):
             loc.reload = True
             continue
-        def reload_session(event):
+        def reload_session(event, loc=loc):
             loc.reload = True
         doc.on_event('document_ready', reload_session)
 

--- a/panel/io/reload.py
+++ b/panel/io/reload.py
@@ -84,11 +84,13 @@ async def async_file_watcher():
             path = path[:-1]
         modules[path] = module_name
         files.append(path)
+
     async for changes in awatch(*files):
         for _, path in changes:
             if path in modules:
+                module = modules[path]
                 if module in sys.modules:
-                    del sys.modules[modules[path]]
+                    del sys.modules[module]
         _reload()
 
 def autoreload_watcher():

--- a/panel/io/reload.py
+++ b/panel/io/reload.py
@@ -93,7 +93,7 @@ async def async_file_watcher():
                     del sys.modules[module]
         _reload()
 
-def autoreload_watcher():
+def setup_autoreload_watcher():
     """
     Installs a periodic callback which checks for changes in watched
     files and sys.modules.

--- a/panel/io/reload.py
+++ b/panel/io/reload.py
@@ -12,7 +12,6 @@ from .state import state
 
 _watched_files = set()
 _modules = set()
-_callbacks = {}
 
 # List of paths to ignore
 DEFAULT_FOLDER_DENYLIST = [
@@ -64,7 +63,6 @@ def file_is_in_folder_glob(filepath, folderpath_glob):
 
     file_dir = os.path.dirname(filepath) + "/"
     return fnmatch.fnmatch(file_dir, folderpath_glob)
-
 
 async def async_file_watcher():
     files = list(_watched_files)

--- a/panel/io/server.py
+++ b/panel/io/server.py
@@ -391,11 +391,15 @@ class Server(BokehServer):
             self._loop.add_callback(setup_autoreload_watcher, stop_event=stop_event)
 
     def stop(self, wait: bool = True) -> None:
+        if self._autoreload_stop_event:
+            self._autoreload_stop_event.set()
+            # For the stop event to be processed we have to restart
+            # the IOLoop briefly, ensuring an orderly cleanup
+            sleep = asyncio.sleep(0.1)
+            self._loop.asyncio_loop.run_until_complete(sleep)
         super().stop(wait=wait)
         if state._admin_context:
             state._admin_context.run_unload_hook()
-        if self._autoreload_stop_event:
-            self._autoreload_stop_event.set()
 
 bokeh.server.server.Server = Server
 

--- a/panel/io/server.py
+++ b/panel/io/server.py
@@ -81,7 +81,6 @@ from .logging import (
 )
 from .markdown import build_single_handler_application
 from .profile import profile_ctx
-from .reload import autoreload_watcher
 from .resources import (
     BASE_TEMPLATE, CDN_DIST, COMPONENT_PATH, ERROR_TEMPLATE, LOCAL_DIST,
     Resources, _env, bundle_resources, patch_model_css, resolve_custom_path,
@@ -803,6 +802,7 @@ def modify_document(self, doc: 'Document'):
     bk_set_curdoc(doc)
 
     if config.autoreload:
+        from .reload import autoreload_watcher
         set_curdoc(doc)
         state.onload(autoreload_watcher)
 

--- a/panel/io/server.py
+++ b/panel/io/server.py
@@ -802,9 +802,9 @@ def modify_document(self, doc: 'Document'):
     bk_set_curdoc(doc)
 
     if config.autoreload:
-        from .reload import autoreload_watcher
+        from .reload import setup_autoreload_watcher
         set_curdoc(doc)
-        state.onload(autoreload_watcher)
+        state.onload(setup_autoreload_watcher)
 
     sessions = []
 

--- a/panel/io/state.py
+++ b/panel/io/state.py
@@ -757,6 +757,7 @@ class _state(param.Parameterized):
         """
         self.kill_all_servers()
         self._indicators.clear()
+        self._location = None
         self._locations.clear()
         self._templates.clear()
         self._views.clear()

--- a/panel/tests/conftest.py
+++ b/panel/tests/conftest.py
@@ -1,6 +1,7 @@
 """
 A module containing testing utilities and fixtures.
 """
+import asyncio
 import atexit
 import os
 import pathlib
@@ -149,7 +150,6 @@ PORT = [get_default_port()]
 def document():
     return Document()
 
-
 @pytest.fixture
 def server_document():
     doc = Document()
@@ -163,6 +163,13 @@ def server_document():
 def comm():
     return Comm()
 
+@pytest.fixture
+def stop_event():
+    event = asyncio.Event()
+    try:
+        yield
+    finally:
+        event.set()
 
 @pytest.fixture
 def port():

--- a/panel/tests/conftest.py
+++ b/panel/tests/conftest.py
@@ -167,7 +167,7 @@ def comm():
 def stop_event():
     event = asyncio.Event()
     try:
-        yield
+        yield event
     finally:
         event.set()
 

--- a/panel/tests/conftest.py
+++ b/panel/tests/conftest.py
@@ -10,6 +10,7 @@ import shutil
 import signal
 import socket
 import tempfile
+import threading
 import time
 import unittest
 
@@ -331,6 +332,16 @@ def module_cleanup():
         name: model for name, model in _default_resolver._known_models.items()
         if not any(model.__module__.startswith(tr) for tr in to_reset)
     }
+
+@pytest.fixture(autouse=True)
+def asyncio_cleanup():
+    """
+    Kill worker thread used by watchfiles.
+    """
+    yield
+    for thread in threading.enumerate():
+        if thread.name == 'AnyIO worker thread':
+            thread.stop()
 
 @pytest.fixture(autouse=True)
 def server_cleanup():

--- a/panel/tests/conftest.py
+++ b/panel/tests/conftest.py
@@ -10,7 +10,6 @@ import shutil
 import signal
 import socket
 import tempfile
-import threading
 import time
 import unittest
 
@@ -332,16 +331,6 @@ def module_cleanup():
         name: model for name, model in _default_resolver._known_models.items()
         if not any(model.__module__.startswith(tr) for tr in to_reset)
     }
-
-@pytest.fixture(autouse=True)
-def asyncio_cleanup():
-    """
-    Kill worker thread used by watchfiles.
-    """
-    yield
-    for thread in threading.enumerate():
-        if thread.name == 'AnyIO worker thread':
-            thread.stop()
 
 @pytest.fixture(autouse=True)
 def server_cleanup():

--- a/panel/tests/conftest.py
+++ b/panel/tests/conftest.py
@@ -24,6 +24,7 @@ from pyviz_comms import Comm
 
 from panel import config, serve
 from panel.config import panel_extension
+from panel.io.reload import _modules, _watched_files
 from panel.io.state import set_curdoc, state
 from panel.pane import HTML, Markdown
 
@@ -156,6 +157,7 @@ def server_document():
     doc._session_context = lambda: session_context
     with set_curdoc(doc):
         yield doc
+    doc._session_context = None
 
 @pytest.fixture
 def comm():
@@ -332,6 +334,8 @@ def server_cleanup():
         yield
     finally:
         state.reset()
+        _watched_files.clear()
+        _modules.clear()
 
 @pytest.fixture(autouse=True)
 def cache_cleanup():

--- a/panel/tests/io/test_reload.py
+++ b/panel/tests/io/test_reload.py
@@ -52,20 +52,5 @@ async def test_reload_on_update(server_document, stop_event):
         await asyncio.sleep(0.51)
         temp.write(b'Bar')
         temp.flush()
-
-        await async_wait_until(lambda: location.reload)
-    del task
-
-@pytest.mark.flaky(reruns=3)
-async def test_reload_on_delete(server_document, stop_event):
-    location = Location()
-    state._locations[server_document] = location
-    state._loaded[server_document] = True
-    with tempfile.NamedTemporaryFile() as temp:
-        temp.write(b'Foo')
-        temp.flush()
-        watch(temp.name)
-        task = asyncio.create_task(async_file_watcher(stop_event))
-
-    await async_wait_until(lambda: location.reload)
+        await wait_until_async(lambda: location.reload)
     del task

--- a/panel/tests/io/test_reload.py
+++ b/panel/tests/io/test_reload.py
@@ -52,5 +52,5 @@ async def test_reload_on_update(server_document, stop_event):
         await asyncio.sleep(0.51)
         temp.write(b'Bar')
         temp.flush()
-        await wait_until_async(lambda: location.reload)
+        await async_wait_until(lambda: location.reload)
     del task

--- a/panel/tests/io/test_reload.py
+++ b/panel/tests/io/test_reload.py
@@ -1,13 +1,8 @@
 import os
 
-import pytest
-
-from panel.io.location import Location
 from panel.io.reload import (
-    _check_file, _modules, _reload_on_update, _watched_files, in_denylist,
-    record_modules, watch,
+    _check_file, _modules, _watched_files, in_denylist, record_modules, watch,
 )
-from panel.io.state import state
 
 
 def test_record_modules_not_stdlib():
@@ -35,17 +30,3 @@ def test_watch():
     assert _watched_files == {filepath}
     # Cleanup
     _watched_files.clear()
-
-@pytest.mark.flaky(reruns=3)
-def test_reload_on_update():
-    location = Location()
-    state._location = location
-    filepath = os.path.abspath(__file__)
-    watch(filepath)
-    modify_times = {filepath: os.stat(__file__).st_mtime-1}
-    _reload_on_update(modify_times)
-    assert location.reload
-
-    # Cleanup
-    _watched_files.clear()
-    state._location = None

--- a/panel/tests/util.py
+++ b/panel/tests/util.py
@@ -232,7 +232,7 @@ async def async_wait_until(fn, page=None, timeout=5000, interval=100):
         elapsed_ms = elapsed * 1000
         return elapsed_ms > timeout
 
-    timeout_msg = f"wait_until timed out in {timeout} milliseconds"
+    timeout_msg = f"async_wait_until timed out in {timeout} milliseconds"
 
     while True:
         try:
@@ -245,7 +245,7 @@ async def async_wait_until(fn, page=None, timeout=5000, interval=100):
         else:
             if result not in (None, True, False):
                 raise ValueError(
-                    "`wait_until` callback must return None, True, or "
+                    "`async_wait_until` callback must return None, True, or "
                     f"False, returned {result!r}"
                 )
             # None is returned when the function has an assert

--- a/setup.py
+++ b/setup.py
@@ -113,7 +113,6 @@ install_requires = [
     'bleach',
     'typing_extensions',
     'pandas >=1.2',
-    'watchfiles >=0.20'
 ]
 
 _recommended = [

--- a/setup.py
+++ b/setup.py
@@ -113,7 +113,7 @@ install_requires = [
     'bleach',
     'typing_extensions',
     'pandas >=1.2',
-    'watchfiles'
+    'watchfiles >=0.20'
 ]
 
 _recommended = [

--- a/setup.py
+++ b/setup.py
@@ -113,6 +113,7 @@ install_requires = [
     'bleach',
     'typing_extensions',
     'pandas >=1.2',
+    'watchfiles'
 ]
 
 _recommended = [


### PR DESCRIPTION
Using our own periodic callback handler sucked and turned out to be somewhat slow/unreliable. The [watchfiles library](https://github.com/samuelcolvin/watchfiles) on the other hand works exceptionally well, is very fast (since it is written in Rust) and simplifies our code. I think the dependency is worth it on balance, particularly since I have another usecase in mind.

@MarcSkovMadsen You may want to experiment.