### PR TITLE
Fix broken link to `panel` tagged items in holoviz blog

### DIFF
--- a/doc/about/releases.md
+++ b/doc/about/releases.md
@@ -1,6 +1,6 @@
 # Releases
 
-See [the HoloViz blog](https://blog.holoviz.org/tag/panel.html) for a visual summary of the major features added in each release.
+See [the HoloViz blog](https://blog.holoviz.org/#category=panel) for a visual summary of the major features added in each release.
 
 ## Version 1.3.1
 


### PR DESCRIPTION
The link to panel tagged items in holoviz blog was broken.

Broken link:  https://blog.holoviz.org/tag/panel.html
Correct link: https://blog.holoviz.org/#category=panel