### PR TITLE
Add space between MaterialTemplate app and site title separator

### DIFF
--- a/panel/template/material/material.html
+++ b/panel/template/material/material.html
@@ -88,7 +88,7 @@
           <span class="mdc-top-app-bar__title app-header">
             {% if app_logo %}<a href="{{ site_url }}"><img src="{{ app_logo }}" class="app-logo"></a>{% endif %}
             {% if site_title %}<a class="title" href="{{ site_url }}" >&nbsp;{{ site_title }}</a>{% endif %}
-            {% if site_title and app_title%}<span class="title">-</span>{% endif %}
+            {% if site_title and app_title%}<span class="title">&nbsp;-</span>{% endif %}
             {% if app_title %}<a class="title" href="" >&nbsp;{{ app_title }}</a>{% endif %}
           </span>
           <div id="header-items">


### PR DESCRIPTION
Fixes https://github.com/holoviz/panel/issues/5871