### PR TITLE
Only set `text_align` on index formatter if it has the attribute

### DIFF
--- a/panel/tests/widgets/test_tables.py
+++ b/panel/tests/widgets/test_tables.py
@@ -6,8 +6,9 @@ import pytest
 
 from bokeh.models.widgets.tables import (
     AvgAggregator, CellEditor, CheckboxEditor, DataCube, DateEditor,
-    DateFormatter, IntEditor, MinAggregator, NumberEditor, NumberFormatter,
-    SelectEditor, StringEditor, StringFormatter, SumAggregator,
+    DateFormatter, HTMLTemplateFormatter, IntEditor, MinAggregator,
+    NumberEditor, NumberFormatter, SelectEditor, StringEditor, StringFormatter,
+    SumAggregator,
 )
 from packaging.version import Version
 from pandas._testing import (
@@ -2136,3 +2137,15 @@ def test_bokeh_formatter_with_text_align_conflict(align):
         columns = model._get_column_definitions("x", data)
     output = columns[0].formatter.text_align
     assert output == "right"
+
+def test_bokeh_formatter_index_with_no_textalign():
+    df = pd.DataFrame({"A": [1, 2, 3], "B": [1, 2, 3]})
+    df = df.set_index("A")
+
+    index_format = HTMLTemplateFormatter(
+        template='<a href="https://www.google.com/search?code=<%= value %>"><%= value %></a>'
+    )
+
+    table = Tabulator(df, formatters={"A": index_format})
+    serve_and_request(table)
+    wait_until(lambda: bool(table._models))

--- a/panel/widgets/tables.py
+++ b/panel/widgets/tables.py
@@ -234,7 +234,7 @@ class BaseTable(ReactiveData, Widget):
                 if not default_text_align:
                     msg = f"The 'text_align' in Tabulator.formatters[{col!r}] is overridden by Tabulator.text_align[{col!r}]"
                     warn(msg, RuntimeWarning)
-            elif col in self.indexes:
+            elif col in self.indexes and hasattr(formatter, "text_align"):
                 formatter.text_align = 'left'
 
             if isinstance(self.widths, int):


### PR DESCRIPTION
Fixes #5915