### PR TITLE
Persist select when `pagination=remote`

### DIFF
--- a/panel/models/tabulator.py
+++ b/panel/models/tabulator.py
@@ -56,7 +56,7 @@ class SelectionEvent(ModelEvent):
 
     event_name = 'selection-change'
 
-    def __init__(self, model, indices, selected):
+    def __init__(self, model, indices, selected, flush):
         """ Selection Event
 
         Parameters
@@ -67,14 +67,17 @@ class SelectionEvent(ModelEvent):
             A list of changed indices selected/deselected rows.
         selected : bool
             If true the rows were selected, if false they were deselected.
+        flush : bool
+            Whether the current selection should be emptied before adding the new indices.
         """
         self.indices = indices
         self.selected = selected
+        self.flush = flush
         super().__init__(model=model)
 
     def __repr__(self):
         return (
-            f'{type(self).__name__}(indices={self.indices}, selected={self.selected})'
+            f'{type(self).__name__}(indices={self.indices}, selected={self.selected}, flush={self.flush})'
         )
 
 

--- a/panel/tests/ui/widgets/test_tabulator.py
+++ b/panel/tests/ui/widgets/test_tabulator.py
@@ -3312,6 +3312,7 @@ class Test_Selection_RemotePagination:
 
     def goto_page(self, page, page_number):
         page.locator(f'button.tabulator-page[data-page="{page_number}"]').click()
+        page.wait_for_timeout(100)
 
     def click_sorting(self, page):
         page.locator('div.tabulator-col-title').get_by_text("index").click()

--- a/panel/tests/ui/widgets/test_tabulator.py
+++ b/panel/tests/ui/widgets/test_tabulator.py
@@ -3333,6 +3333,27 @@ class Test_Selection_RemotePagination:
             rows.nth(0).click()
         self.check_selected(page, [])
 
+    def test_one_item_first_page_and_then_another(self, page):
+        serve_component(page, self.widget)
+        rows = self.get_rows(page)
+
+        rows.nth(0).click()
+        self.check_selected(page, [0])
+
+        rows.nth(1).click()
+        self.check_selected(page, [1])
+
+    def test_two_items_first_page(self, page):
+        serve_component(page, self.widget)
+        rows = self.get_rows(page)
+
+        rows.nth(0).click()
+        self.check_selected(page, [0])
+
+        with self.hold_down_ctrl(page):
+            rows.nth(1).click()
+        self.check_selected(page, [0, 1])
+
     def test_one_item_first_page_goto_second_page(self, page):
         serve_component(page, self.widget)
         rows = self.get_rows(page)
@@ -3354,6 +3375,33 @@ class Test_Selection_RemotePagination:
 
         self.goto_page(page, 2)
         self.check_selected(page, [0, 10], 1)
+
+    # Failing
+    def test_one_item_both_pages(self, page):
+        serve_component(page, self.widget)
+
+        rows = self.get_rows(page)
+        rows.nth(0).click()
+        self.check_selected(page, [0], 1)
+
+        self.goto_page(page, 2)
+        rows = self.get_rows(page)
+        with self.hold_down_ctrl(page):
+            rows.nth(0).click()
+        self.check_selected(page, [0, 10], 1)
+
+    # Failing
+    def test_one_item_and_then_second_page(self, page):
+        serve_component(page, self.widget)
+
+        rows = self.get_rows(page)
+        rows.nth(0).click()
+        self.check_selected(page, [0], 1)
+
+        self.goto_page(page, 2)
+        rows = self.get_rows(page)
+        rows.nth(0).click()
+        self.check_selected(page, [10], 1)
 
     # Failing
     @pytest.mark.parametrize("selection", (0, 10), ids=["page1", "page2"])

--- a/panel/tests/ui/widgets/test_tabulator.py
+++ b/panel/tests/ui/widgets/test_tabulator.py
@@ -3377,7 +3377,6 @@ class Test_Selection_RemotePagination:
         self.goto_page(page, 2)
         self.check_selected(page, [0, 10], 1)
 
-    # Failing
     def test_one_item_both_pages(self, page):
         serve_component(page, self.widget)
 
@@ -3391,7 +3390,6 @@ class Test_Selection_RemotePagination:
             rows.nth(0).click()
         self.check_selected(page, [0, 10], 1)
 
-    # Failing
     def test_one_item_and_then_second_page(self, page):
         serve_component(page, self.widget)
 
@@ -3404,7 +3402,6 @@ class Test_Selection_RemotePagination:
         rows.nth(0).click()
         self.check_selected(page, [10], 1)
 
-    # Failing
     @pytest.mark.parametrize("selection", (0, 10), ids=["page1", "page2"])
     def test_sorting(self, page, selection):
         self.widget.selection = [selection]
@@ -3423,7 +3420,6 @@ class Test_Selection_RemotePagination:
         self.click_sorting(page)
         self.check_selected(page, [selection], int(selection == 0))
 
-    # Failing
     @pytest.mark.parametrize("selection", (0, 10), ids=["page1", "page2"])
     def test_filtering(self, page, selection):
         self.widget.selection = [selection]

--- a/panel/tests/ui/widgets/test_tabulator.py
+++ b/panel/tests/ui/widgets/test_tabulator.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import datetime as dt
 
+from contextlib import contextmanager
+
 import numpy as np
 import pandas as pd
 import param
@@ -3277,6 +3279,113 @@ def test_tabulator_update_hidden_columns(page):
         (title.bounding_box()['x'] == cell.bounding_box()['x']) and
         (title.bounding_box()['width'] == cell.bounding_box()['width'])
     ), page)
+
+
+class Test_Selection_RemotePagination:
+
+    def setup_method(self):
+        self.widget = Tabulator(
+            value=pd.DataFrame(np.arange(20) + 100),
+            disabled=True,
+            pagination="remote",
+            page_size=10,
+            selectable=True,
+            header_filters=True,
+        )
+
+    def check_selected(self, page, expected, ui_count=None):
+        if ui_count is None:
+            ui_count = len(expected)
+
+        expect(page.locator('.tabulator-selected')).to_have_count(ui_count)
+        wait_until(lambda: self.widget.selection == expected, page)
+
+    @contextmanager
+    def hold_down_ctrl(self, page):
+        key = get_ctrl_modifier()
+        page.keyboard.down(key)
+        yield
+        page.keyboard.up(key)
+
+    def get_rows(self, page):
+        return page.locator('.tabulator-row[role="row"]')
+
+    def goto_page(self, page, page_number):
+        page.locator(f'button.tabulator-page[data-page="{page_number}"]').click()
+
+    def click_sorting(self, page):
+        page.locator('div.tabulator-col-title').get_by_text("index").click()
+        page.wait_for_timeout(100)
+
+    def set_filtering(self, page, number):
+        number_input = page.locator('input[type="number"]').first
+        number_input.fill(str(number))
+        number_input.press("Enter")
+
+    def test_one_item_first_page(self, page):
+        serve_component(page, self.widget)
+        rows = self.get_rows(page)
+
+        rows.nth(0).click()
+        self.check_selected(page, [0])
+
+        with self.hold_down_ctrl(page):
+            rows.nth(0).click()
+        self.check_selected(page, [])
+
+    def test_one_item_first_page_goto_second_page(self, page):
+        serve_component(page, self.widget)
+        rows = self.get_rows(page)
+
+        rows.nth(0).click()
+        self.check_selected(page, [0], 1)
+
+        self.goto_page(page, 2)
+        self.check_selected(page, [0], 0)
+
+        self.goto_page(page, 1)
+        self.check_selected(page, [0], 1)
+
+    def test_one_item_both_pages_python(self, page):
+        serve_component(page, self.widget)
+
+        self.widget.selection = [0, 10]
+        self.check_selected(page, [0, 10], 1)
+
+        self.goto_page(page, 2)
+        self.check_selected(page, [0, 10], 1)
+
+    # Failing
+    @pytest.mark.parametrize("selection", (0, 10), ids=["page1", "page2"])
+    def test_sorting(self, page, selection):
+        self.widget.selection = [selection]
+        serve_component(page, self.widget)
+        self.check_selected(page, [selection], int(selection == 0))
+
+        # First sort ascending
+        self.click_sorting(page)
+        self.check_selected(page, [selection], int(selection == 0))
+
+        # Then sort descending
+        self.click_sorting(page)
+        self.check_selected(page, [selection], int(selection == 10))
+
+        # Then back to ascending
+        self.click_sorting(page)
+        self.check_selected(page, [selection], int(selection == 0))
+
+    # Failing
+    @pytest.mark.parametrize("selection", (0, 10), ids=["page1", "page2"])
+    def test_filtering(self, page, selection):
+        self.widget.selection = [selection]
+        serve_component(page, self.widget)
+        self.check_selected(page, [selection], int(selection == 0))
+
+        self.set_filtering(page, selection)
+        self.check_selected(page, [selection], 1)
+
+        self.set_filtering(page, 1)
+        self.check_selected(page, [selection], 0)
 
 
 class Test_CheckboxSelection_RemotePagination:

--- a/panel/widgets/tables.py
+++ b/panel/widgets/tables.py
@@ -1537,11 +1537,7 @@ class Tabulator(BaseTable):
         elif events and all(e.name in page_events for e in events) and not self.pagination:
             self._processed, _ = self._get_data()
             return
-        elif (
-            self.pagination == 'remote'
-            and isinstance(self.selectable, str)
-            and "checkbox" in self.selectable
-        ):
+        elif self.pagination == 'remote':
             self._processed = None
         recompute = not all(
             e.name in ('page', 'page_size', 'pagination') for e in events
@@ -1615,8 +1611,8 @@ class Tabulator(BaseTable):
             ilocs = []
         else:  # SelectionEvent
             selected = indices.selected
+            ilocs = [] if indices.flush else self.selection
             indices = indices.indices
-            ilocs = self.selection
 
         nrows = self.page_size
         start = (self.page-1)*nrows
@@ -1629,9 +1625,10 @@ class Tabulator(BaseTable):
                 continue
             if selected:
                 ilocs.append(iloc)
-            else:
+            elif iloc in ilocs:
                 ilocs.remove(iloc)
         self.selection = list(dict.fromkeys(ilocs))
+        self.param.trigger('selection')
 
     def _get_properties(self, doc: Document) -> Dict[str, Any]:
         properties = super()._get_properties(doc)


### PR DESCRIPTION
 **TODO:**

- [ ] I need to handle shift key logic


**Example**

https://github.com/holoviz/panel/assets/19758978/40f7da16-93b9-40a1-b619-6df5913cc188



``` python
import numpy as np
import pandas as pd
import panel as pn

pn.extension("tabulator")

data = np.arange(20) + 100
df = pd.DataFrame(data)
tab = pn.widgets.Tabulator(
    value=df,
    disabled=True,
    pagination="remote",
    page_size=10,
    header_filters=True,
)
tab.servable()
```


