### PR TITLE
SVG Reference doc improvements

### DIFF
--- a/examples/reference/panes/SVG.ipynb
+++ b/examples/reference/panes/SVG.ipynb
@@ -45,7 +45,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "pn.pane.SVG('https://assets.holoviz.org/panel/samples/svg_sample.svg', link_url = \"https://panel.holoviz.org\", width=300)"
+    "pn.pane.SVG('https://panel.holoviz.org/_static/logo_stacked.svg', link_url = \"https://panel.holoviz.org\", width=300)"
    ]
   },
   {
@@ -61,7 +61,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "svg_pane = pn.pane.SVG('https://assets.holoviz.org/panel/samples/svg_sample.svg', width=150)\n",
+    "svg_pane = pn.pane.SVG('https://panel.holoviz.org/_static/logo_stacked.svg', width=150)\n",
     "svg_pane"
    ]
   },

--- a/examples/reference/panes/SVG.ipynb
+++ b/examples/reference/panes/SVG.ipynb
@@ -45,9 +45,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "svg_pane = pn.pane.SVG('https://assets.holoviz.org/panel/samples/svg_sample.svg', width=300)\n",
-    "\n",
-    "svg_pane"
+    "pn.pane.SVG('https://assets.holoviz.org/panel/samples/svg_sample.svg', link_url = \"https://panel.holoviz.org\", width=300)"
    ]
   },
   {
@@ -63,7 +61,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "svg_pane.clone(width=150)"
+    "svg_pane = pn.pane.SVG('https://assets.holoviz.org/panel/samples/svg_sample.svg', width=150)\n",
+    "svg_pane"
    ]
   },
   {
@@ -71,6 +70,22 @@
    "metadata": {},
    "source": [
     "Like any other pane, the ``SVG`` pane can be updated by setting the ``object`` parameter:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "svg_pane.object = \"https://panel.holoviz.org/_static/jupyterlite.svg\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can also use a *responsive* `sizing_mode` like `'stretch_width'`."
    ]
   },
   {


### PR DESCRIPTION
I primarely wanted to get the Panel green logo updated to Panel blue. But then took the chance to make things a bit more specific.

If you want to keep the original link to the Panel logo you should update the link link `https://assets.holoviz.org/panel/samples/svg_sample.svg` to the Panel blue logo. I cannot do that.