### PR TITLE
Improvements to the ReactiveExpr reference guide

### DIFF
--- a/examples/reference/panes/ReactiveExpr.ipynb
+++ b/examples/reference/panes/ReactiveExpr.ipynb
@@ -9,30 +9,36 @@
    "outputs": [],
    "source": [
     "import panel as pn\n",
-    "import param\n",
     "\n",
-    "pn.extension('tabulator')"
+    "pn.extension('tabulator', design=\"material\")"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The `panel.ReactiveExpr` pane renders a Param `rx` object which represents a reactive expression, displaying both the widgets that are part of the expression and the final output of the expression. The position of the widgets relative to the output can be set, or widgets can be removed entirely. [See the Param documentation on `param.rx`](https://param.holoviz.org/user_guide/Reactive_Expressions.html) for details on using `rx`.\n",
+    "The `panel.ReactiveExpr` pane renders a [Param `rx` object](https://param.holoviz.org/user_guide/Reactive_Expressions.html) which represents a reactive expression, displaying both the widgets that are part of the expression and the final output of the expression. The position of the widgets relative to the output can be set, or widgets can be removed entirely.\n",
+    "\n",
+    "Please note that you can use use `pn.rx` instead of [`param.rx`](https://param.holoviz.org/user_guide/Reactive_Expressions.html) when you `import panel as pn`.\n",
+    "\n",
+    "See the [`param.rx` documentation](https://param.holoviz.org/user_guide/Reactive_Expressions.html) for details on using `rx`.\n",
     "\n",
     "#### Parameters:\n",
     "\n",
     "The basic parameters are:\n",
     "\n",
-    "* **`object`** (param.reactive): A `param.reactive` expression \n",
+    "* **`object`** (param.reactive): A [`param.reactive`](https://param.holoviz.org/user_guide/Reactive_Expressions.html) expression\n",
     "\n",
     "The more advanced parameters which give you more control are:\n",
     " \n",
-    "* **`default_layout`** (panel.layout.base.ListPanel): A layout like Column, Row, etc. or a GridBox.\n",
-    "* **`center`** (bool): Whether to center the output.\n",
-    "* **`show_widgets`** (bool): Whether to display the widget inputs.\n",
-    "* **`widget_layout`** (panel.layout.base.ListPanel): The layout object to display the widgets in.\n",
+    "* **`center`** (bool): Whether to center the output horizontally.\n",
+    "* **`show_widgets`** (bool): Whether to show the widgets.\n",
+    "* **`widget_layout`** (ListPanel): The layout object to display the widgets in. For example `pn.WidgetBox` (default), `pn.Column` or `pn.Row`.\n",
     "* **`widget_location`** (str): The location of the widgets relative to the output of the reactive expression. One of  'left', 'right', 'top', 'bottom', 'top_left', 'top_right', 'bottom_left', 'bottom_right', 'left_top' (default), 'right_top',right_bottom'.\n",
+    "\n",
+    "#### Properties\n",
+    "\n",
+    "* **`widgets`** (ListPanel): Returns the widgets in a `widget_layout`.\n",
     "\n",
     "For more layout and styling related parameters see the [customization user guide](../../user_guide/Customization.ipynb).\n",
     "___"
@@ -44,30 +50,29 @@
     "tags": []
    },
    "source": [
-    "The `param.rx` API is a powerful tool for building declarative and reactive UIs and the `ReactiveExpr` pane allows turning these declarative expressions into viewable components that render both the (widget) inputs and the outputs of the expression:"
+    "The [`param.rx`](https://param.holoviz.org/user_guide/Reactive_Expressions.html) API is a powerful tool for building declarative and reactive UIs.\n",
+    "\n",
+    "Lets take a few examples"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
-    "v1 = pn.widgets.FloatInput(value=35)\n",
-    "v2 = pn.widgets.FloatInput(value=7)\n",
+    "def model(n):\n",
+    "    return f\"🤖 {n}x2 is {n*2}\"\n",
     "\n",
-    "expr = v1.rx() + v2.rx()\n",
-    "\n",
-    "pn.ReactiveExpr(expr)"
+    "n = pn.widgets.IntSlider(value=2, start=0, end=10)\n",
+    "pn.rx(model)(n=n)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "When Panel is imported an `rx` expression will automatically be rendered using the `ReactiveExpr` object, i.e. displaying `expr` on its own or putting it in a layout is exactly equivalent to the version above."
+    "Behind the scenes panel has made sure the *reactive expression* above is rendered in a `pn.ReactiveExpr` pane. You can also do this explicitly"
    ]
   },
   {
@@ -76,6 +81,45 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "n = pn.widgets.IntSlider(value=2, start=0, end=10)\n",
+    "pn.ReactiveExpr(pn.rx(model)(n=n))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "A reactive expression is never a *dead end*. You can always update and change a *reactive expression*."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "n = pn.widgets.IntSlider(value=2, start=0, end=10)\n",
+    "\n",
+    "pn.rx(model)(n=n) + \"\\n\\n🧑 Thanks\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can also combine *reactive expressions*"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "x = pn.widgets.IntSlider(value=2, start=0, end=10, name=\"x\")\n",
+    "y = pn.widgets.IntSlider(value=2, start=0, end=10, name=\"y\")\n",
+    "\n",
+    "expr = x.rx()*\"⭐\" + y.rx()*\"⭐\"\n",
     "expr"
    ]
   },
@@ -83,7 +127,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Note that this is different from using the expression as a *reference*, i.e. passing it to another component for it to resolve the value of the expression dynamically:"
+    "## Layouts"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can change the `widget_location`."
    ]
   },
   {
@@ -92,16 +143,149 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "pn.Row(v1, '`+`', v2, '`=`', pn.pane.Str(expr))"
+    "x = pn.widgets.IntSlider(value=2, start=0, end=10, name=\"x\")\n",
+    "y = pn.widgets.IntSlider(value=2, start=0, end=10, name=\"y\")\n",
+    "\n",
+    "expr = x.rx()*\"⭐\" + \"\\n\\n\" + y.rx()*\"❤️\"\n",
+    "\n",
+    "pn.ReactiveExpr(expr, widget_location=\"top\")"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The *reference* approach should generally be preferred as it is more declarative and explicit, allowing Panel to efficiently update the existing view(s) rather than completely re-rendering the output.\n",
+    "You can change the `widget_layout` to `Row`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pn.ReactiveExpr(expr, widget_layout=pn.Row)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can `center` the output horizontally"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pn.ReactiveExpr(expr, center=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can hide the widgets by setting `show_widgets=False`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pn.ReactiveExpr(expr, show_widgets=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can access the `.widgets` in a `widget_layout` and lay them out as you please"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pn.ReactiveExpr(expr).widgets"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Reactive expressions as references\n",
     "\n",
-    "The `ReactiveExpr` pane is therefore primarily a way to quickly and interactively work with an expression (particularly in a notebook) or generate a quick UI for a data pipeline. Once you have built the expression and want to integrate it in a larger application it is generally recommended that you use it as a reference as to narrowly scope the precise updates you want to make.\n",
+    "Using the `pn.ReactiveExpr` pane implicitly or explicitly is great for exploration in a notebook. But its not very performant because every time the reactive expression rerenders, Panel has to create a new pane to render your output in.\n",
+    "\n",
+    "Instead you can and should pass the *reactive expression* as a *reference* to a specific Panel component. The Panel component can resolve the value of the expression dynamically:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "x = pn.widgets.IntSlider(value=2, start=0, end=10, name=\"x\")\n",
+    "y = pn.widgets.IntSlider(value=2, start=0, end=10, name=\"y\")\n",
+    "\n",
+    "ref = x.rx() + y.rx()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pn.pane.Str(ref)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pn.indicators.Progress(name='Progress', value=ref, max=20)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Try changing the `x` and `y` values using the widgets below!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pn.ReactiveExpr(ref).widgets"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<div class=\"alert alert-block alert-info\">\n",
+    "<p><b>The <em>reference approach</em> should generally be preferred</b> as it is more declarative and explicit, allowing Panel to efficiently update the existing view(s) rather than completely re-rendering the output.</p>\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Styled DataFrame Example\n",
     "\n",
     "Let us work through this in a slightly more complex example, and build an expression to dynamically load some data and sample N rows from it:"
    ]
@@ -121,7 +305,7 @@
     "nrows = pn.widgets.IntSlider(value=5, start=0, end=20, name='N rows')\n",
     "\n",
     "# Load the currently selected dataset and sample nrows from it\n",
-    "df_rx = pn.bind(pd.read_csv, dataset).rx().sample(n=nrows)\n",
+    "df_rx = pn.rx(pd.read_csv)(dataset).sample(n=nrows)\n",
     "\n",
     "df_rx"
    ]

--- a/panel/param.py
+++ b/panel/param.py
@@ -1084,7 +1084,7 @@ class ReactiveExpr(PaneBase):
             self.layout[:] = [self._generate_layout()]
 
     @classmethod
-    def applies(self, object):
+    def applies(cls, object):
         return isinstance(object, param.rx)
 
     @classmethod


### PR DESCRIPTION
I had problems understanding the new `ReactiveExpr` pane from the reference guide. Especially how to layout things.

During that process I discovered that one of the problems is that `default_layout` is mentioned in the `reference guide`. And it should not be. See https://github.com/holoviz/panel/issues/5948. This PR will be Closing #5948 .

I added more small examples to help the user understand what reactive expressions are and how powerful they can be.

I added in emojis. I know some people think its too much. But I just think they communicate better when you open up the notebook during a training session, a conference talk or if you record a video for social media. I also believe that users when studying the notebook feel its more fun and engaging to study. For the same reason I used the `material` design.

## Todo

- [ ] Fix the bug https://github.com/holoviz/panel/issues/5958. I don't plan to do this. I hope Phillip will.