### PR TITLE
Allow stopping respond callbacks midway

### DIFF
--- a/examples/reference/chat/ChatFeed.ipynb
+++ b/examples/reference/chat/ChatFeed.ipynb
@@ -344,7 +344,7 @@
    "source": [
     "The `ChatFeed` also support *async* `callback`s.\n",
     "\n",
-    "In fact, we recommend using *async* `callback`s whenever possible to keep your app fast and responsive."
+    "In fact, we recommend using *async* `callback`s whenever possible to keep your app fast and responsive, *as long as there's nothing blocking the event loop in the function*."
    ]
   },
   {
@@ -359,6 +359,40 @@
     "\n",
     "async def parrot_message(contents, user, instance):\n",
     "    await asyncio.sleep(2.8)\n",
+    "    return {\"value\": f\"No, {contents.lower()}\", \"user\": \"Parrot\", \"avatar\": \"🦜\"}\n",
+    "\n",
+    "chat_feed = pn.chat.ChatFeed(callback=parrot_message, callback_user=\"Echo Bot\")\n",
+    "chat_feed"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "message = chat_feed.send(\"Are you a parrot?\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Do not mark the function as async if there's something blocking your event loop--if you do, the placeholder will **not** appear."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import panel as pn\n",
+    "import time\n",
+    "pn.extension()\n",
+    "\n",
+    "async def parrot_message(contents, user, instance):\n",
+    "    time.sleep(2.8)\n",
     "    return {\"value\": f\"No, {contents.lower()}\", \"user\": \"Parrot\", \"avatar\": \"🦜\"}\n",
     "\n",
     "chat_feed = pn.chat.ChatFeed(callback=parrot_message, callback_user=\"Echo Bot\")\n",

--- a/examples/reference/chat/ChatFeed.ipynb
+++ b/examples/reference/chat/ChatFeed.ipynb
@@ -66,6 +66,7 @@
     "\n",
     "##### Other\n",
     "\n",
+    "* **`stop`**: Cancels the current callback task if possible.\n",
     "* **`clear`**: Clears the chat log and returns the messages that were cleared.\n",
     "* **`respond`**: Executes the callback with the latest message in the chat log.\n",
     "* **`undo`**: Removes the last `count` of messages from the chat log and returns them. Default `count` is 1.\n",

--- a/examples/reference/chat/ChatInterface.ipynb
+++ b/examples/reference/chat/ChatInterface.ipynb
@@ -25,7 +25,7 @@
     "- Remove messages until the previous `user` input [`ChatMessage`](ChatMessage.ipynb).\n",
     "- Clear the chat log, erasing all [`ChatMessage`](ChatMessage.ipynb) objects.\n",
     "\n",
-    "Since `ChatInterface` inherits from [`ChatFeed`](ChatFeed.ipynb), it features all the capabilities of [`ChatFeed`](ChatFeed.ipynb); please see [ChatFeed.ipynb](ChatFeed.ipynb) for its backend capabilities.\n",
+    "**Since `ChatInterface` inherits from [`ChatFeed`](ChatFeed.ipynb), it features all the capabilities of [`ChatFeed`](ChatFeed.ipynb); please see [ChatFeed.ipynb](ChatFeed.ipynb) for its backend capabilities.**\n",
     "\n",
     "Check out the [panel-chat-examples](https://holoviz-topics.github.io/panel-chat-examples/) docs to see applicable examples related to [LangChain](https://python.langchain.com/docs/get_started/introduction), [OpenAI](https://openai.com/blog/chatgpt), [Mistral](https://www.google.com/url?sa=t&rct=j&q=&esrc=s&source=web&cd=&ved=2ahUKEwjZtP35yvSBAxU00wIHHerUDZAQFnoECBEQAQ&url=https%3A%2F%2Fdocs.mistral.ai%2F&usg=AOvVaw2qpx09O_zOzSksgjBKiJY_&opi=89978449), [Llama](https://ai.meta.com/llama/), etc. If you have an example to demo, we'd love to add it to the panel-chat-examples gallery!\n",
     "\n",
@@ -45,6 +45,7 @@
     "##### Styling\n",
     "\n",
     "* **`show_send`** (`bool`): Whether to show the send button. Default is True.\n",
+    "* **`show_stop`** (`bool`): Whether to show the stop button, temporarily replacing the send button during callback; has no effect if `callback` is not async.\n",
     "* **`show_rerun`** (`bool`): Whether to show the rerun button. Default is True.\n",
     "* **`show_undo`** (`bool`): Whether to show the undo button. Default is True.\n",
     "* **`show_clear`** (`bool`): Whether to show the clear button. Default is True.\n",
@@ -458,7 +459,10 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Check out the [panel-chat-examples](https://holoviz-topics.github.io/panel-chat-examples/) docs for more examples related to [LangChain](https://python.langchain.com/docs/get_started/introduction), [OpenAI](https://openai.com/blog/chatgpt), [Mistral](https://www.google.com/url?sa=t&rct=j&q=&esrc=s&source=web&cd=&ved=2ahUKEwjZtP35yvSBAxU00wIHHerUDZAQFnoECBEQAQ&url=https%3A%2F%2Fdocs.mistral.ai%2F&usg=AOvVaw2qpx09O_zOzSksgjBKiJY_&opi=89978449), [Llama](https://ai.meta.com/llama/), etc."
+    "Check out the [panel-chat-examples](https://holoviz-topics.github.io/panel-chat-examples/) docs for more examples related to [LangChain](https://python.langchain.com/docs/get_started/introduction), [OpenAI](https://openai.com/blog/chatgpt), [Mistral](https://www.google.com/url?sa=t&rct=j&q=&esrc=s&source=web&cd=&ved=2ahUKEwjZtP35yvSBAxU00wIHHerUDZAQFnoECBEQAQ&url=https%3A%2F%2Fdocs.mistral.ai%2F&usg=AOvVaw2qpx09O_zOzSksgjBKiJY_&opi=89978449), [Llama](https://ai.meta.com/llama/), etc.\n",
+    "\n",
+    "\n",
+    "Also, since `ChatInterface` inherits from [`ChatFeed`](ChatFeed.ipynb), be sure to also read [ChatFeed.ipynb](ChatFeed.ipynb) to understand `ChatInterface`'s full potential!"
    ]
   }
  ],

--- a/panel/chat/feed.py
+++ b/panel/chat/feed.py
@@ -571,7 +571,7 @@ class ChatFeed(ListPanel):
 
     def stop(self) -> bool:
         """
-        Cancels the current callback task.
+        Cancels the current callback task if possible.
 
         Returns
         -------

--- a/panel/chat/interface.py
+++ b/panel/chat/interface.py
@@ -88,8 +88,8 @@ class ChatInterface(ChatFeed):
         Whether to show the send button.""")
 
     show_stop = param.Boolean(default=True, doc="""
-        Whether to show the stop button; has no effect
-        if `callback` is not async.""")
+        Whether to show the stop button temporarily replacing the send button during
+        callback; has no effect if `callback` is not async.""")
 
     show_rerun = param.Boolean(default=True, doc="""
         Whether to show the rerun button.""")
@@ -385,7 +385,7 @@ class ChatInterface(ChatFeed):
         instance: "ChatInterface" | None = None
     ) -> bool:
         """
-        Cancel the input when the user presses the Stop button.
+        Cancel the callback when the user presses the Stop button.
         """
         return self.stop()
 

--- a/panel/chat/interface.py
+++ b/panel/chat/interface.py
@@ -135,6 +135,9 @@ class ChatInterface(ChatFeed):
     _button_data = param.Dict(default={}, doc="""
         Metadata and data related to the buttons.""")
 
+    _buttons = param.Dict(default={}, doc="""
+        The rendered buttons.""")
+
     _stylesheets: ClassVar[List[str]] = [f"{CDN_DIST}css/chat_interface.css"]
 
     def __init__(self, *objects, **params):
@@ -188,6 +191,7 @@ class ChatInterface(ChatFeed):
         """
         default_button_properties = {
             "send": {"icon": "send", "_default_callback": self._click_send},
+            "stop": {"icon": "player-stop", "_default_callback": self._click_stop},
             "rerun": {"icon": "repeat", "_default_callback": self._click_rerun},
             "undo": {"icon": "arrow-back", "_default_callback": self._click_undo},
             "clear": {"icon": "trash", "_default_callback": self._click_clear},
@@ -265,11 +269,11 @@ class ChatInterface(ChatFeed):
                 css_classes=["chat-interface-input-widget"]
             )
 
-            buttons = []
+            self._buttons = {}
             for button_data in self._button_data.values():
                 action = button_data.name
                 try:
-                    visible = self.param[f'show_{action}']
+                    visible = self.param[f'show_{action}'] if action != "stop" else False
                 except KeyError:
                     visible = True
                 show_expr = self.param.show_button_name.rx()
@@ -283,15 +287,16 @@ class ChatInterface(ChatFeed):
                     align="start",
                     visible=visible
                 )
-                self._link_disabled_loading(button)
+                if action != "stop":
+                    self._link_disabled_loading(button)
                 callback = partial(button_data.callback, self)
                 button.on_click(callback)
-                buttons.append(button)
+                self._buttons[action] = button
                 button_data.buttons.append(button)
 
             message_row = Row(
                 widget,
-                *buttons,
+                *list(self._buttons.values()),
                 sizing_mode="stretch_width",
                 css_classes=["chat-interface-input-row"],
                 stylesheets=self._stylesheets,
@@ -369,6 +374,16 @@ class ChatInterface(ChatFeed):
             return  # no message entered
         self._reset_button_data()
         self.send(value=value, user=self.user, avatar=self.avatar, respond=True)
+
+    def _click_stop(
+        self,
+        event: param.parameterized.Event | None = None,
+        instance: "ChatInterface" | None = None
+    ) -> None:
+        """
+        Cancel the input when the user presses the Stop button.
+        """
+        self.stop()
 
     def _get_last_user_entry_index(self) -> int:
         """
@@ -547,3 +562,14 @@ class ChatInterface(ChatFeed):
                 "assistant": [self.callback_user],
             }
         return super()._serialize_for_transformers(role_names, default_role, custom_serializer)
+
+    @param.depends("_async_task", watch=True)
+    async def _update_input_disabled(self):
+        if self._async_task is not None:
+            with param.batch_watch(self):
+                self._buttons["send"].visible = False
+                self._buttons["stop"].visible = True
+        else:
+            with param.batch_watch(self):
+                self._buttons["send"].visible = True
+                self._buttons["stop"].visible = False

--- a/panel/chat/interface.py
+++ b/panel/chat/interface.py
@@ -22,7 +22,7 @@ from ..viewable import Viewable
 from ..widgets.base import Widget
 from ..widgets.button import Button
 from ..widgets.input import FileInput, TextInput
-from .feed import ChatFeed
+from .feed import CallbackState, ChatFeed
 from .message import _FileInputMessage
 
 
@@ -567,9 +567,10 @@ class ChatInterface(ChatFeed):
             }
         return super()._serialize_for_transformers(role_names, default_role, custom_serializer)
 
-    @param.depends("_callback_is_running", watch=True)
+    @param.depends("_callback_state", watch=True)
     async def _update_input_disabled(self):
-        if not self.show_stop or not self._callback_is_running:
+        busy_states = (CallbackState.RUNNING, CallbackState.GENERATING)
+        if not self.show_stop or self._callback_state not in busy_states:
             with param.parameterized.batch_call_watchers(self):
                 self._buttons["send"].visible = True
                 self._buttons["stop"].visible = False

--- a/panel/chat/interface.py
+++ b/panel/chat/interface.py
@@ -567,16 +567,13 @@ class ChatInterface(ChatFeed):
             }
         return super()._serialize_for_transformers(role_names, default_role, custom_serializer)
 
-    @param.depends("_stoppable_task", watch=True)
+    @param.depends("_callback_is_running", watch=True)
     async def _update_input_disabled(self):
-        if not self.show_stop:
-            return
-
-        if self._stoppable_task is not None:
-            with param.batch_watch(self):
-                self._buttons["send"].visible = False
-                self._buttons["stop"].visible = True
-        else:
-            with param.batch_watch(self):
+        if not self.show_stop or not self._callback_is_running:
+            with param.parameterized.batch_call_watchers(self):
                 self._buttons["send"].visible = True
                 self._buttons["stop"].visible = False
+        else:
+            with param.parameterized.batch_call_watchers(self):
+                self._buttons["send"].visible = False
+                self._buttons["stop"].visible = True

--- a/panel/tests/chat/test_feed.py
+++ b/panel/tests/chat/test_feed.py
@@ -1,8 +1,6 @@
 import asyncio
 import time
 
-from unittest.mock import MagicMock
-
 import pytest
 
 from panel.chat.feed import ChatFeed
@@ -10,7 +8,7 @@ from panel.chat.message import ChatMessage
 from panel.layout import Column, Row
 from panel.pane.image import Image
 from panel.pane.markup import HTML
-from panel.tests.util import wait_until
+from panel.tests.util import async_wait_until, wait_until
 from panel.widgets.indicators import LinearGauge
 from panel.widgets.input import TextAreaInput, TextInput
 
@@ -343,7 +341,8 @@ class TestChatFeed:
     def test_no_recursion_error(self, chat_feed):
         chat_feed.send("Some time ago, there was a recursion error like this")
 
-    def test_chained_response(self, chat_feed):
+    @pytest.mark.asyncio
+    async def test_chained_response(self, chat_feed):
         async def callback(contents, user, instance):
             if user == "User":
                 yield {
@@ -363,7 +362,7 @@ class TestChatFeed:
 
         chat_feed.callback = callback
         chat_feed.send("Testing!", user="User")
-        wait_until(lambda: len(chat_feed.objects) == 3)
+        await async_wait_until(lambda: len(chat_feed.objects) == 3)
         assert chat_feed.objects[1].user == "arm"
         assert chat_feed.objects[1].avatar == "🦾"
         assert chat_feed.objects[1].object == "Hey, leg! Did you hear the user?"
@@ -529,100 +528,69 @@ class TestChatFeedCallback:
 
     def test_placeholder_disabled(self, chat_feed):
         def echo(contents, user, instance):
-            time.sleep(0.25)
-            yield "hey testing"
+            time.sleep(1.25)
+            assert instance._placeholder not in instance._chat_log
+            return "hey testing"
 
         chat_feed.placeholder_threshold = 0
         chat_feed.callback = echo
-        chat_feed.append = MagicMock(
-            side_effect=lambda message: chat_feed._chat_log.append(message)
-        )
         chat_feed.send("Message", respond=True)
-        # only append sent message
-        assert chat_feed.append.call_count == 2
+        assert chat_feed._placeholder not in chat_feed._chat_log
 
     def test_placeholder_enabled(self, chat_feed):
         def echo(contents, user, instance):
-            time.sleep(0.25)
-            yield "hey testing"
+            time.sleep(1.25)
+            assert instance._placeholder in instance._chat_log
+            return chat_feed.stream("hey testing")
 
         chat_feed.callback = echo
-        chat_feed.append = MagicMock(
-            side_effect=lambda message: chat_feed._chat_log.append(message)
-        )
         chat_feed.send("Message", respond=True)
+        assert chat_feed._placeholder not in chat_feed._chat_log
         # append sent message and placeholder
-        assert chat_feed.append.call_args_list[1].args[0] == chat_feed._placeholder
 
     def test_placeholder_threshold_under(self, chat_feed):
         async def echo(contents, user, instance):
             await asyncio.sleep(0.25)
+            assert instance._placeholder not in instance._chat_log
             return "hey testing"
 
         chat_feed.placeholder_threshold = 5
         chat_feed.callback = echo
-        chat_feed.append = MagicMock(
-            side_effect=lambda message: chat_feed._chat_log.append(message)
-        )
         chat_feed.send("Message", respond=True)
-        assert chat_feed.append.call_args_list[1].args[0] != chat_feed._placeholder
+        assert chat_feed._placeholder not in chat_feed._chat_log
 
     def test_placeholder_threshold_under_generator(self, chat_feed):
         async def echo(contents, user, instance):
+            assert instance._placeholder not in instance._chat_log
             await asyncio.sleep(0.25)
+            assert instance._placeholder not in instance._chat_log
             yield "hey testing"
 
         chat_feed.placeholder_threshold = 5
         chat_feed.callback = echo
-        chat_feed.append = MagicMock(
-            side_effect=lambda message: chat_feed._chat_log.append(message)
-        )
         chat_feed.send("Message", respond=True)
-        assert chat_feed.append.call_args_list[1].args[0] != chat_feed._placeholder
 
     def test_placeholder_threshold_exceed(self, chat_feed):
         async def echo(contents, user, instance):
             await asyncio.sleep(0.5)
-            yield "hello testing"
+            assert instance._placeholder in instance._chat_log
+            return "hello testing"
 
         chat_feed.placeholder_threshold = 0.1
         chat_feed.callback = echo
-        chat_feed.append = MagicMock(
-            side_effect=lambda message: chat_feed._chat_log.append(message)
-        )
         chat_feed.send("Message", respond=True)
-        assert chat_feed.append.call_args_list[1].args[0] == chat_feed._placeholder
+        assert chat_feed._placeholder not in chat_feed._chat_log
 
     def test_placeholder_threshold_exceed_generator(self, chat_feed):
         async def echo(contents, user, instance):
             await asyncio.sleep(0.5)
+            assert instance._placeholder in instance._chat_log
             yield "hello testing"
 
         chat_feed.placeholder_threshold = 0.1
         chat_feed.callback = echo
-        chat_feed.append = MagicMock(
-            side_effect=lambda message: chat_feed._chat_log.append(message)
-        )
         chat_feed.send("Message", respond=True)
-        assert chat_feed.append.call_args_list[1].args[0] == chat_feed._placeholder
-
-    def test_placeholder_threshold_sync(self, chat_feed):
-        """
-        Placeholder should always be appended if the
-        callback is synchronous.
-        """
-
-        def echo(contents, user, instance):
-            time.sleep(0.25)
-            yield "hey testing"
-
-        chat_feed.placeholder_threshold = 5
-        chat_feed.callback = echo
-        chat_feed.append = MagicMock(
-            side_effect=lambda message: chat_feed._chat_log.append(message)
-        )
-        chat_feed.send("Message", respond=True)
-        assert chat_feed.append.call_args_list[1].args[0] == chat_feed._placeholder
+        assert chat_feed._placeholder not in chat_feed._chat_log
 
     def test_renderers_pane(self, chat_feed):
         chat_feed.renderers = [HTML]
@@ -707,20 +675,19 @@ class TestChatFeedCallback:
             yield "B"  # should not reach this point
 
         chat_feed.callback = callback
-        with pytest.raises(asyncio.CancelledError):
-            chat_feed.send("Message", respond=True)
+        chat_feed.send("Message", respond=True)
         assert chat_feed.objects[-1].object == "A"
 
     def test_callback_stop_not_async(self, chat_feed):
         def callback(msg, user, instance):
             message = instance.stream("A")
-            assert not chat_feed.stop()  # has no effect
+            assert chat_feed.stop()
             time.sleep(2)
-            instance.stream("B", message=message)
+            instance.stream("B", message=message)  # should not reach this point
 
         chat_feed.callback = callback
         chat_feed.send("Message", respond=True)
-        assert chat_feed.objects[-1].object == "AB"
+        assert chat_feed.objects[-1].object == "A"
 
 
 @pytest.mark.xdist_group("chat")

--- a/panel/tests/chat/test_interface.py
+++ b/panel/tests/chat/test_interface.py
@@ -21,7 +21,7 @@ class TestChatInterface:
         return ChatInterface()
 
     def test_init(self, chat_interface):
-        assert len(chat_interface._button_data) == 4
+        assert len(chat_interface._button_data) == 5
         assert len(chat_interface._widgets) == 1
         assert isinstance(chat_interface._input_layout, Row)
         assert isinstance(chat_interface._widgets["TextInput"], TextInput)

--- a/panel/tests/chat/test_interface.py
+++ b/panel/tests/chat/test_interface.py
@@ -1,7 +1,6 @@
 
 
 import asyncio
-import time
 
 from io import BytesIO
 
@@ -89,11 +88,17 @@ class TestChatInterface:
         chat_interface._click_send(None)
         assert len(chat_interface.objects) == 1
 
-    def test_show_stop(self, chat_interface: ChatInterface):
+    def test_show_stop_disabled(self, chat_interface: ChatInterface):
         async def callback(msg, user, instance):
             yield "A"
+            send_button = chat_interface._input_layout[1]
+            stop_button = chat_interface._input_layout[2]
+            assert send_button.name == "Send"
+            assert stop_button.name == "Stop"
+            assert send_button.visible
+            assert not stop_button.visible
             await asyncio.sleep(2)
-            yield "B"  # should not reach this point
+            yield "B"  # should not stream this
 
         chat_interface.callback = callback
         chat_interface.show_stop = False
@@ -105,36 +110,29 @@ class TestChatInterface:
         assert send_button.visible
         assert not stop_button.visible
 
-    def test_click_stop_for_async(self, chat_interface: ChatInterface):
+    def test_show_stop_for_async(self, chat_interface: ChatInterface):
         async def callback(msg, user, instance):
-            yield "A"
             send_button = instance._input_layout[1]
             stop_button = instance._input_layout[2]
             assert send_button.name == "Send"
             assert stop_button.name == "Stop"
-            assert instance._click_stop(None)
-            await asyncio.sleep(2)
-            yield "B"  # should not reach this point
-
-        chat_interface.callback = callback
-        with pytest.raises(asyncio.CancelledError):
-            chat_interface.send("Message", respond=True)
-        assert chat_interface.objects[-1].object == "A"
-
-    def test_click_stop_for_sync(self, chat_interface: ChatInterface):
-        def callback(msg, user, instance):
-            yield "A"
-            send_button = instance._input_layout[1]
-            stop_button = instance._input_layout[2]
-            assert send_button.name == "Send"
-            assert stop_button.name == "Stop"
-            instance._click_stop(None)
-            time.sleep(2)
-            yield "B"
+            assert not send_button.visible
+            assert stop_button.visible
 
         chat_interface.callback = callback
         chat_interface.send("Message", respond=True)
-        assert chat_interface.objects[-1].object == "B"
+
+    def test_show_stop_for_sync(self, chat_interface: ChatInterface):
+        def callback(msg, user, instance):
+            send_button = instance._input_layout[1]
+            stop_button = instance._input_layout[2]
+            assert send_button.name == "Send"
+            assert stop_button.name == "Stop"
+            assert not send_button.visible
+            assert stop_button.visible
+
+        chat_interface.callback = callback
+        chat_interface.send("Message", respond=True)
 
     @pytest.mark.parametrize("widget", [TextInput(), TextAreaInput()])
     def test_auto_send_types(self, chat_interface: ChatInterface, widget):


### PR DESCRIPTION
Closes https://github.com/holoviz/panel/issues/5943

Upon sending a message, if the callback is async, the Send button gets hidden and the Stop button appears. Clicking it will cancel the callback midway.

https://github.com/holoviz/panel/assets/15331990/9cf8957e-ffd1-4c22-9b61-c642d5da0e4b

Makes it so that sync tasks are submitted to a separate thread so it's cancellable.

https://github.com/holoviz/panel/assets/15331990/94df994e-5ddc-4594-abea-1941d7f39e0c

```python
import panel as pn
from openai import OpenAI

pn.extension()


def callback(contents: str, user: str, instance: pn.chat.ChatInterface):
    response = client.chat.completions.create(
        model="gpt-3.5-turbo",
        messages=[{"role": "user", "content": contents}],
        stream=True,
    )
    message = None
    for chunk in response:
        part = chunk.choices[0].delta.content
        if part is not None:
            message = instance.stream(part, user="OpenAI", message=message)


client = OpenAI()
chat_interface = pn.chat.ChatInterface(callback=callback, callback_user="ChatGPT")
chat_interface.send(
    "Send a message to get a reply from ChatGPT!", user="System", respond=False
)
chat_interface.stream("Hello")
chat_interface.show()
```


Also, I think I made it more performant for sync too.