### PR TITLE
Split build jobs into seperate jobs

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -55,9 +55,53 @@ jobs:
       - name: conda build
         run: |
           bash ./scripts/build_conda.sh
-      - name: build pyodide wheels for CDN
+      - name: conda dev deploy
+        if: (github.event_name == 'push' && (contains(steps.vars.outputs.tag, 'a') || contains(steps.vars.outputs.tag, 'b') || contains(steps.vars.outputs.tag, 'rc')))
         run: |
-          python ./scripts/build_pyodide_wheels.py
+          VERSION="$(echo "$(ls dist/*.whl)" | cut -d- -f2)"
+          FILE="$CONDA_PREFIX/conda-bld/noarch/panel-$VERSION-py_0.tar.bz2"
+          anaconda --token ${{ secrets.CONDA_UPLOAD_TOKEN }} upload --user pyviz --label=dev $FILE
+      - name: conda main deploy
+        if: (github.event_name == 'push' && !(contains(steps.vars.outputs.tag, 'a') || contains(steps.vars.outputs.tag, 'b') || contains(steps.vars.outputs.tag, 'rc')))
+        run: |
+          VERSION="$(echo "$(ls dist/*.whl)" | cut -d- -f2)"
+          FILE="$CONDA_PREFIX/conda-bld/noarch/panel-$VERSION-py_0.tar.bz2"
+          anaconda --token ${{ secrets.CONDA_UPLOAD_TOKEN }} upload --user pyviz --label=dev --label=main $FILE
+
+  npm_build:
+    name: Build NPM Packages
+    runs-on: 'ubuntu-latest'
+    defaults:
+      run:
+        shell: bash -l {0}
+    env:
+      CHANS_DEV: "-c pyviz/label/dev -c bokeh/label/dev -c conda-forge"
+      PKG_TEST_PYTHON: "--test-python=py39"
+      PYTHON_VERSION: "3.9"
+      MPLBACKEND: "Agg"
+    steps:
+      - name: remove nodejs
+        run: |
+          sudo rm /usr/local/bin/node
+          sudo rm /usr/local/bin/npm
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: "100"
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - uses: conda-incubator/setup-miniconda@v2
+        with:
+          miniconda-version: "latest"
+          python-version: 3.9
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '18'
+      - name: Fetch unshallow
+        run: git fetch --prune --tags --unshallow -f
+      - name: Set output
+        id: vars
+        run: echo "tag=${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT
       - name: npm setup
         run: |
           echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_API_TOKEN }}" > $HOME/.npmrc
@@ -69,36 +113,64 @@ jobs:
           cd ./panel
           npm publish --dry-run
           cd ..
-      - name: conda dev deploy
-        if: (github.event_name == 'push' && (contains(steps.vars.outputs.tag, 'a') || contains(steps.vars.outputs.tag, 'b') || contains(steps.vars.outputs.tag, 'rc')))
-        run: |
-          VERSION="$(echo "$(ls dist/*.whl)" | cut -d- -f2)"
-          FILE="$CONDA_PREFIX/conda-bld/noarch/panel-$VERSION-py_0.tar.bz2"
-          anaconda --token ${{ secrets.CONDA_UPLOAD_TOKEN }} upload --user pyviz --label=dev $FILE
       - name: npm dev deploy
         if: (github.event_name == 'push' && (contains(steps.vars.outputs.tag, 'a') || contains(steps.vars.outputs.tag, 'b') || contains(steps.vars.outputs.tag, 'rc')))
         run: |
           cd ./panel
           npm publish --tag dev
           cd ..
-      - name: conda main deploy
-        if: (github.event_name == 'push' && !(contains(steps.vars.outputs.tag, 'a') || contains(steps.vars.outputs.tag, 'b') || contains(steps.vars.outputs.tag, 'rc')))
-        run: |
-          VERSION="$(echo "$(ls dist/*.whl)" | cut -d- -f2)"
-          FILE="$CONDA_PREFIX/conda-bld/noarch/panel-$VERSION-py_0.tar.bz2"
-          anaconda --token ${{ secrets.CONDA_UPLOAD_TOKEN }} upload --user pyviz --label=dev --label=main $FILE
       - name: npm main deploy
         if: (github.event_name == 'push' && !(contains(steps.vars.outputs.tag, 'a') || contains(steps.vars.outputs.tag, 'b') || contains(steps.vars.outputs.tag, 'rc')))
         run: |
           cd ./panel
           npm publish --tag latest
           cd ..
+
+  cdn:
+    name: Build CDN
+    runs-on: 'ubuntu-latest'
+    defaults:
+      run:
+        shell: bash -l {0}
+    env:
+      CHANS_DEV: "-c pyviz/label/dev -c bokeh/label/dev -c conda-forge"
+      PKG_TEST_PYTHON: "--test-python=py39"
+      PYTHON_VERSION: "3.9"
+      MPLBACKEND: "Agg"
+    steps:
+      - name: remove nodejs
+        run: |
+          sudo rm /usr/local/bin/node
+          sudo rm /usr/local/bin/npm
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: "100"
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - uses: conda-incubator/setup-miniconda@v2
+        with:
+          miniconda-version: "latest"
+          python-version: 3.9
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '18'
+      - name: Fetch unshallow
+        run: git fetch --prune --tags --unshallow -f
+      - name: Set output
+        id: vars
+        run: echo "tag=${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT
+      - name: build pyodide wheels for CDN
+        run: |
+          python ./scripts/build_pyodide_wheels.py
+          SETUPTOOLS_ENABLE_FEATURES="legacy-editable" python -m pip install -ve .
       - name: Deploy to cdn.holoviz.org
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_DEFAULT_REGION: 'us-east-1'
         run: python scripts/cdn_upload.py
+
   pip_build:
     name: Build PyPI Packages
     runs-on: 'ubuntu-latest'

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -51,7 +51,7 @@ jobs:
           conda install -y conda-build anaconda-client build
       - name: conda build
         run: |
-          bash ./scripts/build_conda.sh
+          source ./scripts/build_conda.sh
           echo "CONDA_FILE="$CONDA_PREFIX/conda-bld/noarch/panel-$VERSION-py_0.tar.bz2"" >> $GITHUB_ENV
       - uses: actions/upload-artifact@v3
         if: always()

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -49,7 +49,7 @@ jobs:
           conda config --append channels pyviz/label/dev
           conda config --append channels bokeh/label/dev
           conda install -y conda-build anaconda-client build
-          echo "CONDA_PREFIX=$CONDA_PREFIX" >> $GITHUB_OUTPUT
+          echo "CONDA_PREFIX=$CONDA_PREFIX" >> $GITHUB_ENV
       - name: conda build
         run: |
           bash ./scripts/build_conda.sh
@@ -108,7 +108,7 @@ jobs:
           SETUPTOOLS_ENABLE_FEATURES="legacy-editable" python -m pip install -ve .
           cd ./panel
           TARBALL=$(npm pack .)
-          echo "TARBALL=$TARBALL" >> $GITHUB_OUTPUT
+          echo "TARBALL=$TARBALL" >> $GITHUB_ENV
           npm publish --dry-run $TARBALL
           cd ..
       - uses: actions/upload-artifact@v3

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -49,28 +49,24 @@ jobs:
           conda config --append channels pyviz/label/dev
           conda config --append channels bokeh/label/dev
           conda install -y conda-build anaconda-client build
-          echo "CONDA_PREFIX=$CONDA_PREFIX" >> $GITHUB_ENV
       - name: conda build
         run: |
           bash ./scripts/build_conda.sh
+          echo "CONDA_FILE="$CONDA_PREFIX/conda-bld/noarch/panel-$VERSION-py_0.tar.bz2"" >> $GITHUB_ENV
       - uses: actions/upload-artifact@v3
         if: always()
         with:
           name: conda_build
-          path: ${{ env.CONDA_PREFIX }}/conda-bld/noarch
+          path: ${{ env.CONDA_FILE }}
           if-no-files-found: error
       - name: conda dev deploy
         if: (github.event_name == 'push' && (contains(steps.vars.outputs.tag, 'a') || contains(steps.vars.outputs.tag, 'b') || contains(steps.vars.outputs.tag, 'rc')))
         run: |
-          VERSION="$(echo "$(ls dist/*.whl)" | cut -d- -f2)"
-          FILE="$CONDA_PREFIX/conda-bld/noarch/panel-$VERSION-py_0.tar.bz2"
-          anaconda --token ${{ secrets.CONDA_UPLOAD_TOKEN }} upload --user pyviz --label=dev $FILE
+          anaconda --token ${{ secrets.CONDA_UPLOAD_TOKEN }} upload --user pyviz --label=dev $CONDA_FILE
       - name: conda main deploy
         if: (github.event_name == 'push' && !(contains(steps.vars.outputs.tag, 'a') || contains(steps.vars.outputs.tag, 'b') || contains(steps.vars.outputs.tag, 'rc')))
         run: |
-          VERSION="$(echo "$(ls dist/*.whl)" | cut -d- -f2)"
-          FILE="$CONDA_PREFIX/conda-bld/noarch/panel-$VERSION-py_0.tar.bz2"
-          anaconda --token ${{ secrets.CONDA_UPLOAD_TOKEN }} upload --user pyviz --label=dev --label=main $FILE
+          anaconda --token ${{ secrets.CONDA_UPLOAD_TOKEN }} upload --user pyviz --label=dev --label=main $CONDA_FILE
 
   npm_build:
     name: Build NPM Package

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -86,9 +86,8 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: "100"
-      - uses: conda-incubator/setup-miniconda@v2
+      - uses: actions/setup-python@v4
         with:
-          miniconda-version: "latest"
           python-version: ${{ env.PYTHON_VERSION }}
       - uses: actions/setup-node@v4
         with:
@@ -144,9 +143,8 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: "100"
-      - uses: conda-incubator/setup-miniconda@v2
+      - uses: actions/setup-python@v4
         with:
-          miniconda-version: "latest"
           python-version: ${{ env.PYTHON_VERSION }}
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -55,6 +55,12 @@ jobs:
       - name: conda build
         run: |
           bash ./scripts/build_conda.sh
+      - uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: conda_build
+          path: ${{ env.CONDA_PREFIX }}/conda-bld/noarch
+          if-no-files-found: error
       - name: conda dev deploy
         if: (github.event_name == 'push' && (contains(steps.vars.outputs.tag, 'a') || contains(steps.vars.outputs.tag, 'b') || contains(steps.vars.outputs.tag, 'rc')))
         run: |
@@ -111,19 +117,27 @@ jobs:
         run: |
           SETUPTOOLS_ENABLE_FEATURES="legacy-editable" python -m pip install -ve .
           cd ./panel
-          npm publish --dry-run
+          TARBALL=$(npm pack .)
+          echo $TARBALL > $GITHUB_OUTPUT
+          npm publish --dry-run $TARBALL
           cd ..
+      - uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: npm_build
+          path: $ {{ env.TARBALL }}
+          if-no-files-found: error
       - name: npm dev deploy
         if: (github.event_name == 'push' && (contains(steps.vars.outputs.tag, 'a') || contains(steps.vars.outputs.tag, 'b') || contains(steps.vars.outputs.tag, 'rc')))
         run: |
           cd ./panel
-          npm publish --tag dev
+          npm publish  --tag dev $TARBALL
           cd ..
       - name: npm main deploy
         if: (github.event_name == 'push' && !(contains(steps.vars.outputs.tag, 'a') || contains(steps.vars.outputs.tag, 'b') || contains(steps.vars.outputs.tag, 'rc')))
         run: |
           cd ./panel
-          npm publish --tag latest
+          npm publish --tag latest $TARBALL
           cd ..
 
   cdn:
@@ -164,6 +178,14 @@ jobs:
         run: |
           python ./scripts/build_pyodide_wheels.py
           SETUPTOOLS_ENABLE_FEATURES="legacy-editable" python -m pip install -ve .
+      - uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: cdn_wheels
+          path: |
+            ./build/panel*.whl
+            ./build/bokeh*.whl
+          if-no-files-found: error
       - name: Deploy to cdn.holoviz.org
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -120,7 +120,7 @@ jobs:
         if: (github.event_name == 'push' && (contains(steps.vars.outputs.tag, 'a') || contains(steps.vars.outputs.tag, 'b') || contains(steps.vars.outputs.tag, 'rc')))
         run: |
           cd ./panel
-          npm publish  --tag dev $TARBALL
+          npm publish --tag dev $TARBALL
           cd ..
       - name: npm main deploy
         if: (github.event_name == 'push' && !(contains(steps.vars.outputs.tag, 'a') || contains(steps.vars.outputs.tag, 'b') || contains(steps.vars.outputs.tag, 'rc')))

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -49,7 +49,7 @@ jobs:
           conda config --append channels pyviz/label/dev
           conda config --append channels bokeh/label/dev
           conda install -y conda-build anaconda-client build
-          echo "CONDA_PREFIX=$CONDA_PREFIX >> $GITHUB_OUTPUT
+          echo "CONDA_PREFIX=$CONDA_PREFIX" >> $GITHUB_OUTPUT
       - name: conda build
         run: |
           bash ./scripts/build_conda.sh
@@ -108,7 +108,7 @@ jobs:
           SETUPTOOLS_ENABLE_FEATURES="legacy-editable" python -m pip install -ve .
           cd ./panel
           TARBALL=$(npm pack .)
-          echo "TARBALL=$TARBALL >> $GITHUB_OUTPUT
+          echo "TARBALL=$TARBALL" >> $GITHUB_OUTPUT
           npm publish --dry-run $TARBALL
           cd ..
       - uses: actions/upload-artifact@v3

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -75,6 +75,7 @@ jobs:
   npm_build:
     name: Build NPM Package
     runs-on: 'ubuntu-latest'
+    needs: [conda_build, pip_build]
     defaults:
       run:
         shell: bash -l {0}
@@ -132,6 +133,7 @@ jobs:
   cdn:
     name: Build CDN
     runs-on: 'ubuntu-latest'
+    needs: [conda_build, pip_build]
     defaults:
       run:
         shell: bash -l {0}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,6 +11,11 @@ on:
   schedule:
     - cron: '0 19 * * SUN'
 
+env:
+  PYTHON_VERSION: "3.9"
+  NODE_VERSION: "18"
+  MPLBACKEND: "Agg"
+
 jobs:
   conda_build:
     name: Build Conda Package
@@ -18,11 +23,6 @@ jobs:
     defaults:
       run:
         shell: bash -l {0}
-    env:
-      CHANS_DEV: "-c pyviz/label/dev -c bokeh/label/dev -c conda-forge"
-      PKG_TEST_PYTHON: "--test-python=py39"
-      PYTHON_VERSION: "3.9"
-      MPLBACKEND: "Agg"
     steps:
       - name: remove nodejs
         run: |
@@ -31,16 +31,13 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: "100"
-      - uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python-version }}
       - uses: conda-incubator/setup-miniconda@v2
         with:
           miniconda-version: "latest"
-          python-version: 3.9
+          python-version: ${{ env.PYTHON_VERSION }}
       - uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: ${{ env.NODE_VERSION }}
       - name: Fetch unshallow
         run: git fetch --prune --tags --unshallow -f
       - name: Set output
@@ -81,11 +78,6 @@ jobs:
     defaults:
       run:
         shell: bash -l {0}
-    env:
-      CHANS_DEV: "-c pyviz/label/dev -c bokeh/label/dev -c conda-forge"
-      PKG_TEST_PYTHON: "--test-python=py39"
-      PYTHON_VERSION: "3.9"
-      MPLBACKEND: "Agg"
     steps:
       - name: remove nodejs
         run: |
@@ -94,16 +86,13 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: "100"
-      - uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python-version }}
       - uses: conda-incubator/setup-miniconda@v2
         with:
           miniconda-version: "latest"
-          python-version: 3.9
+          python-version: ${{ env.PYTHON_VERSION }}
       - uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: ${{ env.NODE_VERSION }}
       - name: Fetch unshallow
         run: git fetch --prune --tags --unshallow -f
       - name: Set output
@@ -147,11 +136,6 @@ jobs:
     defaults:
       run:
         shell: bash -l {0}
-    env:
-      CHANS_DEV: "-c pyviz/label/dev -c bokeh/label/dev -c conda-forge"
-      PKG_TEST_PYTHON: "--test-python=py39"
-      PYTHON_VERSION: "3.9"
-      MPLBACKEND: "Agg"
     steps:
       - name: remove nodejs
         run: |
@@ -160,16 +144,13 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: "100"
-      - uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python-version }}
       - uses: conda-incubator/setup-miniconda@v2
         with:
           miniconda-version: "latest"
-          python-version: 3.9
+          python-version: ${{ env.PYTHON_VERSION }}
       - uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: ${{ env.NODE_VERSION }}
       - name: Fetch unshallow
         run: git fetch --prune --tags --unshallow -f
       - name: Set output
@@ -203,9 +184,7 @@ jobs:
     env:
       CHANS_DEV: "-c pyviz/label/dev -c bokeh/label/dev -c conda-forge"
       PKG_TEST_PYTHON: "--test-python=py39"
-      PYTHON_VERSION: "3.9"
       CHANS: "-c pyviz"
-      MPLBACKEND: "Agg"
       PYPI: "https://upload.pypi.org/legacy/"
     steps:
       - name: remove nodejs
@@ -215,15 +194,12 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: "100"
-      - uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python-version }}
       - uses: conda-incubator/setup-miniconda@v2
         with:
           miniconda-version: "latest"
       - uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: ${{ env.NODE_VERSION }}
       - name: Fetch unshallow
         run: git fetch --prune --tags --unshallow -f
       - name: conda setup

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   conda_build:
-    name: Build Conda Packages
+    name: Build Conda Package
     runs-on: 'ubuntu-latest'
     defaults:
       run:
@@ -38,7 +38,7 @@ jobs:
         with:
           miniconda-version: "latest"
           python-version: 3.9
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v4
         with:
           node-version: '18'
       - name: Fetch unshallow
@@ -52,6 +52,7 @@ jobs:
           conda config --append channels pyviz/label/dev
           conda config --append channels bokeh/label/dev
           conda install -y conda-build anaconda-client build
+          echo "CONDA_PREFIX=$CONDA_PREFIX >> $GITHUB_OUTPUT
       - name: conda build
         run: |
           bash ./scripts/build_conda.sh
@@ -75,7 +76,7 @@ jobs:
           anaconda --token ${{ secrets.CONDA_UPLOAD_TOKEN }} upload --user pyviz --label=dev --label=main $FILE
 
   npm_build:
-    name: Build NPM Packages
+    name: Build NPM Package
     runs-on: 'ubuntu-latest'
     defaults:
       run:
@@ -100,7 +101,7 @@ jobs:
         with:
           miniconda-version: "latest"
           python-version: 3.9
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v4
         with:
           node-version: '18'
       - name: Fetch unshallow
@@ -118,14 +119,14 @@ jobs:
           SETUPTOOLS_ENABLE_FEATURES="legacy-editable" python -m pip install -ve .
           cd ./panel
           TARBALL=$(npm pack .)
-          echo $TARBALL > $GITHUB_OUTPUT
+          echo "TARBALL=$TARBALL >> $GITHUB_OUTPUT
           npm publish --dry-run $TARBALL
           cd ..
       - uses: actions/upload-artifact@v3
         if: always()
         with:
           name: npm_build
-          path: $ {{ env.TARBALL }}
+          path: ./panel/${{ env.TARBALL }}
           if-no-files-found: error
       - name: npm dev deploy
         if: (github.event_name == 'push' && (contains(steps.vars.outputs.tag, 'a') || contains(steps.vars.outputs.tag, 'b') || contains(steps.vars.outputs.tag, 'rc')))
@@ -166,7 +167,7 @@ jobs:
         with:
           miniconda-version: "latest"
           python-version: 3.9
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v4
         with:
           node-version: '18'
       - name: Fetch unshallow
@@ -194,7 +195,7 @@ jobs:
         run: python scripts/cdn_upload.py
 
   pip_build:
-    name: Build PyPI Packages
+    name: Build PyPI Package
     runs-on: 'ubuntu-latest'
     defaults:
       run:
@@ -220,7 +221,7 @@ jobs:
       - uses: conda-incubator/setup-miniconda@v2
         with:
           miniconda-version: "latest"
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v4
         with:
           node-version: '18'
       - name: Fetch unshallow

--- a/scripts/build_conda.sh
+++ b/scripts/build_conda.sh
@@ -5,7 +5,7 @@ set -euxo pipefail
 git status
 
 export SETUPTOOLS_ENABLE_FEATURES="legacy-editable"
-python -m build .
+python -m build -w .
 
 git diff --exit-code
 

--- a/scripts/build_conda.sh
+++ b/scripts/build_conda.sh
@@ -9,5 +9,6 @@ python -m build -w .
 
 git diff --exit-code
 
-export VERSION="$(echo "$(ls dist/*.whl)" | cut -d- -f2)"
+VERSION=$(find dist -name "*.whl" -exec basename {} \; | cut -d- -f2)
+export VERSION
 conda build conda.recipe/ --no-anaconda-upload --no-verify

--- a/scripts/build_pyodide_wheels.py
+++ b/scripts/build_pyodide_wheels.py
@@ -69,7 +69,7 @@ for item in zin.infolist():
                 for line in buffer.decode("utf-8").split("\n")
                 if not (
                     "Requires-Dist:" in line
-                    and ("tornado" in line or "contourpy" in line)
+                    and "tornado" in line
                 )
             ]
         ).encode("utf-8")

--- a/scripts/cdn_upload.py
+++ b/scripts/cdn_upload.py
@@ -9,7 +9,7 @@ js_version = package_json['version']
 
 sp = subprocess.Popen(['aws', 's3', 'sync', 'panel/dist', f's3://cdn.holoviz.org/panel/{js_version}/dist/'])
 sp.wait()
-sp2 = subprocess.Popen(['aws', 's3', 'sync', 'panel/dist/wheels/bokeh*', f's3://cdn.holoviz.org/panel/wheels/'])
+sp2 = subprocess.Popen(['aws', 's3', 'sync', 'panel/dist/wheels/bokeh*', 's3://cdn.holoviz.org/panel/wheels/'])
 sp2.wait()
 sp3 = subprocess.Popen(['aws', 's3', 'cp', 'panel/package.json', f's3://cdn.holoviz.org/panel/{js_version}/package.json'])
 sp3.wait()


### PR DESCRIPTION
Split up the job Conda job into three separate jobs. One for Conda itself, one for NPM, and one for the CDN upload.

For these 3 I have added an upload artifact which should make it easy to inspect the build if needed. 

The NPM I have used `npm pack` to be able to save the tarball as an artifact, and then I use that tarball to upload with `npm upload`. 

Also took the time to clean up the build file.  