### PR TITLE
Allow callables to be used as options for NestedSelect

### DIFF
--- a/examples/reference/widgets/NestedSelect.ipynb
+++ b/examples/reference/widgets/NestedSelect.ipynb
@@ -211,7 +211,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Or, alternatively, `options` can be a callable, or even its nested levels, e.g. `options={\"Daily\": list_options, \"Monthly\": list_options}`.\n",
+    "Alternatively, `options` can be a callable. Its nested levels too: e.g. `options={\"Daily\": list_options, \"Monthly\": list_options}`.\n",
     "\n",
     "Note, the callable can vary across `options`, and `levels` must be provided if any of the `options` is callable."
    ]

--- a/examples/reference/widgets/NestedSelect.ipynb
+++ b/examples/reference/widgets/NestedSelect.ipynb
@@ -22,7 +22,7 @@
     "\n",
     "##### Core\n",
     "\n",
-    "* **``options``** (dict | callable): The options to select from. The options may be nested dictionaries, lists, or callables that return those types.\n",
+    "* **``options``** (dict | callable): The options to select from. The options may be nested dictionaries, lists, or callables that return those types. If callables are used, the callables must accept `level` and `value` keyword arguments, where `level` is the level that updated and `value` is a dictionary of the current values, containing keys up to the level that was updated.\n",
     "* **``value``** (dict): The value from all the Select widgets; the keys are the levels names. If no levels names are specified, the keys are the levels indices.\n",
     "* **``levels``** (list): Either a list of strings or a list of dictionaries. If a list of strings, the strings are used as the names of the levels. If a list of dictionaries, each dictionary may have a \"name\" key, which is used as the name of the level, a \"type\" key, which is used as the type of widget, and any corresponding widget keyword arguments. Must be specified if options is callable.\n",
     "\n",
@@ -212,6 +212,8 @@
    "metadata": {},
    "source": [
     "Alternatively, `options` can be a callable. Its nested levels too: e.g. `options={\"Daily\": list_options, \"Monthly\": list_options}`.\n",
+    "\n",
+    "If callables are used, the callables must accept `level` and `value` keyword arguments, where `level` is the level that updated and `value` is a dictionary of the current values, containing keys up to the level that was updated.\n",
     "\n",
     "Note, the callable can vary across `options`, and `levels` must be provided if any of the `options` is callable."
    ]

--- a/examples/reference/widgets/NestedSelect.ipynb
+++ b/examples/reference/widgets/NestedSelect.ipynb
@@ -22,7 +22,7 @@
     "\n",
     "##### Core\n",
     "\n",
-    "* **``options``** (dict): The options to select from. The options may be nested dictionaries, lists, or callables that return those types.\n",
+    "* **``options``** (dict | callable): The options to select from. The options may be nested dictionaries, lists, or callables that return those types.\n",
     "* **``value``** (dict): The value from all the Select widgets; the keys are the levels names. If no levels names are specified, the keys are the levels indices.\n",
     "* **``levels``** (list): Either a list of strings or a list of dictionaries. If a list of strings, the strings are used as the names of the levels. If a list of dictionaries, each dictionary may have a \"name\" key, which is used as the name of the level, a \"type\" key, which is used as the type of widget, and any corresponding widget keyword arguments. Must be specified if options is callable.\n",
     "\n",

--- a/examples/reference/widgets/NestedSelect.ipynb
+++ b/examples/reference/widgets/NestedSelect.ipynb
@@ -22,9 +22,9 @@
     "\n",
     "##### Core\n",
     "\n",
-    "* **``options``** (dict): The options to select from. The options may be nested dictionaries or lists.\n",
+    "* **``options``** (dict): The options to select from. The options may be nested dictionaries, lists, or callables that return those types.\n",
     "* **``value``** (dict): The value from all the Select widgets; the keys are the levels names. If no levels names are specified, the keys are the levels indices.\n",
-    "* **``levels``** (list): Either a list of strings or a list of dictionaries. If a list of strings, the strings are used as the names of the levels. If a list of dictionaries, each dictionary may have a \"name\" key, which is used as the name of the level, a \"type\" key, which is used as the type of widget, and any corresponding widget keyword arguments.\n",
+    "* **``levels``** (list): Either a list of strings or a list of dictionaries. If a list of strings, the strings are used as the names of the levels. If a list of dictionaries, each dictionary may have a \"name\" key, which is used as the name of the level, a \"type\" key, which is used as the type of widget, and any corresponding widget keyword arguments. Must be specified if options is callable.\n",
     "\n",
     "##### Display\n",
     "\n",
@@ -205,6 +205,67 @@
    "outputs": [],
    "source": [
     "select.value = {\"Model\": \"NAME\"}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Or, alternatively, `options` can be a callable, or even its nested levels, e.g. `options={\"Daily\": list_options, \"Monthly\": list_options}`.\n",
+    "\n",
+    "Note, the callable can vary across `options`, and `levels` must be provided if any of the `options` is callable."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def list_options(level, value):\n",
+    "    if level == \"time_step\":\n",
+    "        options = {\"Daily\": list_options, \"Monthly\": list_options}\n",
+    "    elif level == \"level_type\":\n",
+    "        options = {f\"{value['time_step']}_upper\": list_options, f\"{value['time_step']}_lower\": list_options}\n",
+    "    else:\n",
+    "        options = [f\"{value['level_type']}.json\", f\"{value['level_type']}.csv\"]\n",
+    "\n",
+    "    return options\n",
+    "\n",
+    "pn.widgets.NestedSelect(\n",
+    "    options=list_options,\n",
+    "    levels=[\"time_step\", \"level_type\", \"file_type\"],\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This is useful if you are trying to use options from a hosted source.\n",
+    "\n",
+    "```python\n",
+    "def list_options(level, value):\n",
+    "    value_path = \"/\".join(list(value.values()))\n",
+    "    url = f\"https://downloads.psl.noaa.gov/Datasets/ncep.reanalysis/{value_path}\"\n",
+    "\n",
+    "    options = [var.rstrip(\"/\") for var in pd.read_html(url)[0][\"Name\"].dropna()[1:]]\n",
+    "    if level == \"time_step\":\n",
+    "        options = {option: list_options for option in options if option[0].isupper()}\n",
+    "    elif level == \"level_type\":\n",
+    "        options = {option: list_options for option in options if option[0].islower()}\n",
+    "    else:\n",
+    "        options = [option for option in options if option.endswith(\".nc\")]\n",
+    "\n",
+    "    return options\n",
+    "\n",
+    "\n",
+    "select = pn.widgets.NestedSelect(\n",
+    "    options=list_options,\n",
+    "    levels=[\"time_step\", \"level_type\", \"file\"],\n",
+    ")\n",
+    "select\n",
+    "```"
    ]
   },
   {

--- a/examples/reference/widgets/NestedSelect.ipynb
+++ b/examples/reference/widgets/NestedSelect.ipynb
@@ -246,7 +246,13 @@
    "source": [
     "This is useful if you are trying to use options from a hosted source.\n",
     "\n",
+    "Using `pn.cache` here can help improve user experience and reduce the risk of rate limits.\n",
+    "\n",
     "```python\n",
+    "import panel as pn\n",
+    "pn.extension()\n",
+    "\n",
+    "@pn.cache()\n",
     "def list_options(level, value):\n",
     "    value_path = \"/\".join(list(value.values()))\n",
     "    url = f\"https://downloads.psl.noaa.gov/Datasets/ncep.reanalysis/{value_path}\"\n",

--- a/panel/widgets/select.py
+++ b/panel/widgets/select.py
@@ -343,14 +343,15 @@ class NestedSelect(CompositeWidget):
         If no levels names are specified, the keys are the levels indices.""")
 
     options = param.ClassSelector(class_=(dict, FunctionType), doc="""
-        The options to select from. The options may be nested dictionaries or lists.""")
+        The options to select from. The options may be nested dictionaries, lists,
+        or callables that return those types.""")
 
     levels = param.List(doc="""
         Either a list of strings or a list of dictionaries. If a list of strings, the strings
         are used as the names of the levels. If a list of dictionaries, each dictionary may
         have a "name" key, which is used as the name of the level, a "type" key, which
         is used as the type of widget, and any corresponding widget keyword arguments.
-    """)
+        Must be specified if options is callable.""")
 
     disabled = param.Boolean(default=False, doc="""
         Whether the widget is disabled.""")

--- a/panel/widgets/select.py
+++ b/panel/widgets/select.py
@@ -344,7 +344,10 @@ class NestedSelect(CompositeWidget):
 
     options = param.ClassSelector(class_=(dict, FunctionType), doc="""
         The options to select from. The options may be nested dictionaries, lists,
-        or callables that return those types.""")
+        or callables that return those types. If callables are used, the callables
+        must accept `level` and `value` keyword arguments, where `level` is the
+        level that updated and `value` is a dictionary of the current values, containing keys
+        up to the level that was updated.""")
 
     levels = param.List(doc="""
         Either a list of strings or a list of dictionaries. If a list of strings, the strings
@@ -418,7 +421,7 @@ class NestedSelect(CompositeWidget):
     def _resolve_callable_options(self, i, options) -> dict | list:
         level = self.levels[i]
         value = self._gather_values_from_widgets(up_to_i=i)
-        options = options(level, value)
+        options = options(level=level, value=value)
         return options
 
     @param.depends("options", "levels", watch=True)


### PR DESCRIPTION
As mentioned here: https://github.com/holoviz/panel/pull/5791#issuecomment-1815036598

```python
@pn.cache
def list_options(level, value):
    value_path = "/".join(list(value.values()))
    url = f"https://downloads.psl.noaa.gov/Datasets/ncep.reanalysis/{value_path}"

    options = [var.rstrip("/") for var in pd.read_html(url)[0]["Name"].dropna()[1:]]
    if level == "time_step":
        options = {option: list_options for option in options if option[0].isupper()}
    elif level == "level_type":
        options = {option: list_options for option in options if option[0].islower()}
    else:
        options = [option for option in options if option.endswith(".nc")]

    return options


select = pn.widgets.NestedSelect(
    options=list_options,
    levels=["time_step", "level_type", "file"],
)
select
```

https://github.com/holoviz/panel/assets/15331990/e3275f38-cb29-41bb-86a0-d7677bdecbfc

