### PR TITLE
Add streaming dot

### DIFF
--- a/panel/chat/message.py
+++ b/panel/chat/message.py
@@ -602,10 +602,12 @@ class ChatMessage(PaneBase):
             if "active" not in object_panel.css_classes:
                 object_panel.css_classes = [*object_panel.css_classes, "active"]
         elif self.streaming_state == "waiting":
+            css_classes = []
             if "active" not in object_panel.css_classes:
-                object_panel.css_classes = [*object_panel.css_classes, "active"]
+                css_classes.append("active")
             if "waiting" not in object_panel.css_classes:
-                object_panel.css_classes = [*object_panel.css_classes, "waiting"]
+                css_classes.append("waiting")
+            object_panel.css_classes = [*object_panel.css_classes, *css_classes]
         elif self.streaming_state is None:
             object_panel.css_classes = [
                 css_class

--- a/panel/dist/css/chat_message.css
+++ b/panel/dist/css/chat_message.css
@@ -97,3 +97,24 @@
 .avatar.rotating-placeholder {
   animation: icon-rotation 1.28s infinite cubic-bezier(0.68, -0.55, 0.27, 1.55);
 }
+
+@keyframes fadeOut {
+  0% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0;
+  }
+}
+
+:host(.active) p::after {
+  content: ' ●';
+  display: inline;
+}
+
+:host(.waiting) p::after {
+  animation: fadeOut 1s infinite cubic-bezier(0.68, -0.55, 0.27, 1.55);
+}

--- a/panel/dist/css/chat_message.css
+++ b/panel/dist/css/chat_message.css
@@ -110,11 +110,8 @@
   }
 }
 
-:host(.active) p::after {
+:host(.streaming) p::after {
   content: ' ●';
-  display: inline;
-}
-
-:host(.waiting) p::after {
+  display: inline-block;
   animation: fadeOut 1s infinite cubic-bezier(0.68, -0.55, 0.27, 1.55);
 }


### PR DESCRIPTION
Tries to close https://github.com/holoviz/panel/issues/5637

https://github.com/holoviz/panel/assets/15331990/298c01f2-a968-441a-bd54-765d1b1292ab


However, I couldn't get my browser to update the CSS classes from the code
```python
import time
import panel as pn
from panel.chat import ChatMessage
pn.extension()

def onload():
    time.sleep(2)
    message.object = "World"
    message.streaming_state = None
    print(message._object_panel.css_classes)

message = ChatMessage("Hello", streaming_state="waiting")
print(message._object_panel.css_classes)
pn.state.onload(onload)
message.servable()
```

This prints
```python
2023-12-02 22:24:16,362 Bokeh app running at: http://localhost:5006/test
2023-12-02 22:24:16,362 Starting Bokeh server with process id: 40487
['message', 'active', 'waiting']
2023-12-02 22:24:17,638 WebSocket connection opened
2023-12-02 22:24:17,639 ServerConnection created
['message']
```

But the browser doesn't reflect that... 
<img width="344" alt="image" src="https://github.com/holoviz/panel/assets/15331990/f68af6ef-ad7c-4d33-8439-83676bc586b8">
