### PR TITLE
Allow interrupting sync calls midway for ChatInterface

### DIFF
--- a/examples/reference/chat/ChatFeed.ipynb
+++ b/examples/reference/chat/ChatFeed.ipynb
@@ -344,7 +344,7 @@
    "source": [
     "The `ChatFeed` also support *async* `callback`s.\n",
     "\n",
-    "In fact, we recommend using *async* `callback`s whenever possible to keep your app fast and responsive."
+    "In fact, we recommend using *async* `callback`s whenever possible to keep your app fast and responsive, *as long as there's nothing blocking the event loop in the function*."
    ]
   },
   {
@@ -359,6 +359,40 @@
     "\n",
     "async def parrot_message(contents, user, instance):\n",
     "    await asyncio.sleep(2.8)\n",
+    "    return {\"value\": f\"No, {contents.lower()}\", \"user\": \"Parrot\", \"avatar\": \"🦜\"}\n",
+    "\n",
+    "chat_feed = pn.chat.ChatFeed(callback=parrot_message, callback_user=\"Echo Bot\")\n",
+    "chat_feed"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "message = chat_feed.send(\"Are you a parrot?\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Do not mark the function as async if there's something blocking your event loop--if you do, the placeholder will **not** appear."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import panel as pn\n",
+    "import time\n",
+    "pn.extension()\n",
+    "\n",
+    "async def parrot_message(contents, user, instance):\n",
+    "    time.sleep(2.8)\n",
     "    return {\"value\": f\"No, {contents.lower()}\", \"user\": \"Parrot\", \"avatar\": \"🦜\"}\n",
     "\n",
     "chat_feed = pn.chat.ChatFeed(callback=parrot_message, callback_user=\"Echo Bot\")\n",

--- a/panel/chat/interface.py
+++ b/panel/chat/interface.py
@@ -567,16 +567,13 @@ class ChatInterface(ChatFeed):
             }
         return super()._serialize_for_transformers(role_names, default_role, custom_serializer)
 
-    @param.depends("_callback_future", watch=True)
+    @param.depends("_callback_is_running", watch=True)
     async def _update_input_disabled(self):
-        if not self.show_stop:
-            return
-
-        if self._callback_future is not None:
-            with param.batch_watch(self):
-                self._buttons["send"].visible = False
-                self._buttons["stop"].visible = True
-        else:
+        if not self.show_stop or not self._callback_is_running:
             with param.batch_watch(self):
                 self._buttons["send"].visible = True
                 self._buttons["stop"].visible = False
+        else:
+            with param.batch_watch(self):
+                self._buttons["send"].visible = False
+                self._buttons["stop"].visible = True

--- a/panel/chat/interface.py
+++ b/panel/chat/interface.py
@@ -570,10 +570,10 @@ class ChatInterface(ChatFeed):
     @param.depends("_callback_is_running", watch=True)
     async def _update_input_disabled(self):
         if not self.show_stop or not self._callback_is_running:
-            with param.batch_watch(self):
+            with param.parameterized.batch_call_watchers(self):
                 self._buttons["send"].visible = True
                 self._buttons["stop"].visible = False
         else:
-            with param.batch_watch(self):
+            with param.parameterized.batch_call_watchers(self):
                 self._buttons["send"].visible = False
                 self._buttons["stop"].visible = True

--- a/panel/chat/interface.py
+++ b/panel/chat/interface.py
@@ -567,12 +567,12 @@ class ChatInterface(ChatFeed):
             }
         return super()._serialize_for_transformers(role_names, default_role, custom_serializer)
 
-    @param.depends("_stoppable_task", watch=True)
+    @param.depends("_callback_future", watch=True)
     async def _update_input_disabled(self):
         if not self.show_stop:
             return
 
-        if self._stoppable_task is not None:
+        if self._callback_future is not None:
             with param.batch_watch(self):
                 self._buttons["send"].visible = False
                 self._buttons["stop"].visible = True

--- a/panel/tests/chat/test_feed.py
+++ b/panel/tests/chat/test_feed.py
@@ -1,8 +1,6 @@
 import asyncio
 import time
 
-from unittest.mock import MagicMock
-
 import pytest
 
 from panel.chat.feed import ChatFeed
@@ -10,7 +8,7 @@ from panel.chat.message import ChatMessage
 from panel.layout import Column, Row
 from panel.pane.image import Image
 from panel.pane.markup import HTML
-from panel.tests.util import wait_until
+from panel.tests.util import async_wait_until, wait_until
 from panel.widgets.indicators import LinearGauge
 from panel.widgets.input import TextAreaInput, TextInput
 
@@ -343,7 +341,8 @@ class TestChatFeed:
     def test_no_recursion_error(self, chat_feed):
         chat_feed.send("Some time ago, there was a recursion error like this")
 
-    def test_chained_response(self, chat_feed):
+    @pytest.mark.asyncio
+    async def test_chained_response(self, chat_feed):
         async def callback(contents, user, instance):
             if user == "User":
                 yield {
@@ -363,7 +362,7 @@ class TestChatFeed:
 
         chat_feed.callback = callback
         chat_feed.send("Testing!", user="User")
-        wait_until(lambda: len(chat_feed.objects) == 3)
+        await async_wait_until(lambda: len(chat_feed.objects) == 3)
         assert chat_feed.objects[1].user == "arm"
         assert chat_feed.objects[1].avatar == "🦾"
         assert chat_feed.objects[1].object == "Hey, leg! Did you hear the user?"
@@ -529,100 +528,69 @@ class TestChatFeedCallback:
 
     def test_placeholder_disabled(self, chat_feed):
         def echo(contents, user, instance):
-            time.sleep(0.25)
-            yield "hey testing"
+            time.sleep(1.25)
+            assert instance._placeholder not in instance._chat_log
+            return "hey testing"
 
         chat_feed.placeholder_threshold = 0
         chat_feed.callback = echo
-        chat_feed.append = MagicMock(
-            side_effect=lambda message: chat_feed._chat_log.append(message)
-        )
         chat_feed.send("Message", respond=True)
-        # only append sent message
-        assert chat_feed.append.call_count == 2
+        assert chat_feed._placeholder not in chat_feed._chat_log
 
     def test_placeholder_enabled(self, chat_feed):
         def echo(contents, user, instance):
-            time.sleep(0.25)
-            yield "hey testing"
+            time.sleep(1.25)
+            assert instance._placeholder in instance._chat_log
+            return chat_feed.stream("hey testing")
 
         chat_feed.callback = echo
-        chat_feed.append = MagicMock(
-            side_effect=lambda message: chat_feed._chat_log.append(message)
-        )
         chat_feed.send("Message", respond=True)
+        assert chat_feed._placeholder not in chat_feed._chat_log
         # append sent message and placeholder
-        assert chat_feed.append.call_args_list[1].args[0] == chat_feed._placeholder
 
     def test_placeholder_threshold_under(self, chat_feed):
         async def echo(contents, user, instance):
             await asyncio.sleep(0.25)
+            assert instance._placeholder not in instance._chat_log
             return "hey testing"
 
         chat_feed.placeholder_threshold = 5
         chat_feed.callback = echo
-        chat_feed.append = MagicMock(
-            side_effect=lambda message: chat_feed._chat_log.append(message)
-        )
         chat_feed.send("Message", respond=True)
-        assert chat_feed.append.call_args_list[1].args[0] != chat_feed._placeholder
+        assert chat_feed._placeholder not in chat_feed._chat_log
 
     def test_placeholder_threshold_under_generator(self, chat_feed):
         async def echo(contents, user, instance):
+            assert instance._placeholder not in instance._chat_log
             await asyncio.sleep(0.25)
+            assert instance._placeholder not in instance._chat_log
             yield "hey testing"
 
         chat_feed.placeholder_threshold = 5
         chat_feed.callback = echo
-        chat_feed.append = MagicMock(
-            side_effect=lambda message: chat_feed._chat_log.append(message)
-        )
         chat_feed.send("Message", respond=True)
-        assert chat_feed.append.call_args_list[1].args[0] != chat_feed._placeholder
 
     def test_placeholder_threshold_exceed(self, chat_feed):
         async def echo(contents, user, instance):
             await asyncio.sleep(0.5)
-            yield "hello testing"
+            assert instance._placeholder in instance._chat_log
+            return "hello testing"
 
         chat_feed.placeholder_threshold = 0.1
         chat_feed.callback = echo
-        chat_feed.append = MagicMock(
-            side_effect=lambda message: chat_feed._chat_log.append(message)
-        )
         chat_feed.send("Message", respond=True)
-        assert chat_feed.append.call_args_list[1].args[0] == chat_feed._placeholder
+        assert chat_feed._placeholder not in chat_feed._chat_log
 
     def test_placeholder_threshold_exceed_generator(self, chat_feed):
         async def echo(contents, user, instance):
             await asyncio.sleep(0.5)
+            assert instance._placeholder in instance._chat_log
             yield "hello testing"
 
         chat_feed.placeholder_threshold = 0.1
         chat_feed.callback = echo
-        chat_feed.append = MagicMock(
-            side_effect=lambda message: chat_feed._chat_log.append(message)
-        )
         chat_feed.send("Message", respond=True)
-        assert chat_feed.append.call_args_list[1].args[0] == chat_feed._placeholder
-
-    def test_placeholder_threshold_sync(self, chat_feed):
-        """
-        Placeholder should always be appended if the
-        callback is synchronous.
-        """
-
-        def echo(contents, user, instance):
-            time.sleep(0.25)
-            yield "hey testing"
-
-        chat_feed.placeholder_threshold = 5
-        chat_feed.callback = echo
-        chat_feed.append = MagicMock(
-            side_effect=lambda message: chat_feed._chat_log.append(message)
-        )
-        chat_feed.send("Message", respond=True)
-        assert chat_feed.append.call_args_list[1].args[0] == chat_feed._placeholder
+        assert chat_feed._placeholder not in chat_feed._chat_log
 
     def test_renderers_pane(self, chat_feed):
         chat_feed.renderers = [HTML]
@@ -707,8 +675,7 @@ class TestChatFeedCallback:
             yield "B"  # should not reach this point
 
         chat_feed.callback = callback
-        with pytest.raises(asyncio.CancelledError):
-            chat_feed.send("Message", respond=True)
+        chat_feed.send("Message", respond=True)
         assert chat_feed.objects[-1].object == "A"
 
     def test_callback_stop_not_async(self, chat_feed):

--- a/panel/tests/chat/test_feed.py
+++ b/panel/tests/chat/test_feed.py
@@ -714,13 +714,13 @@ class TestChatFeedCallback:
     def test_callback_stop_not_async(self, chat_feed):
         def callback(msg, user, instance):
             message = instance.stream("A")
-            assert not chat_feed.stop()  # has no effect
+            assert chat_feed.stop()
             time.sleep(2)
-            instance.stream("B", message=message)
+            instance.stream("B", message=message)  # should not reach this point
 
         chat_feed.callback = callback
         chat_feed.send("Message", respond=True)
-        assert chat_feed.objects[-1].object == "AB"
+        assert chat_feed.objects[-1].object == "A"
 
 
 @pytest.mark.xdist_group("chat")

--- a/panel/tests/chat/test_interface.py
+++ b/panel/tests/chat/test_interface.py
@@ -89,7 +89,7 @@ class TestChatInterface:
         chat_interface._click_send(None)
         assert len(chat_interface.objects) == 1
 
-    def test_show_stop(self, chat_interface: ChatInterface):
+    def test_not_show_stop(self, chat_interface: ChatInterface):
         async def callback(msg, user, instance):
             yield "A"
             await asyncio.sleep(2)
@@ -134,7 +134,7 @@ class TestChatInterface:
 
         chat_interface.callback = callback
         chat_interface.send("Message", respond=True)
-        assert chat_interface.objects[-1].object == "B"
+        assert chat_interface.objects[-1].object == "A"
 
     @pytest.mark.parametrize("widget", [TextInput(), TextAreaInput()])
     def test_auto_send_types(self, chat_interface: ChatInterface, widget):


### PR DESCRIPTION
Makes it so that sync tasks are submitted to a separate thread so it's cancellable.


https://github.com/holoviz/panel/assets/15331990/94df994e-5ddc-4594-abea-1941d7f39e0c

```python
import panel as pn
from openai import OpenAI

pn.extension()


def callback(contents: str, user: str, instance: pn.chat.ChatInterface):
    response = client.chat.completions.create(
        model="gpt-3.5-turbo",
        messages=[{"role": "user", "content": contents}],
        stream=True,
    )
    message = None
    for chunk in response:
        part = chunk.choices[0].delta.content
        if part is not None:
            message = instance.stream(part, user="OpenAI", message=message)


client = OpenAI()
chat_interface = pn.chat.ChatInterface(callback=callback, callback_user="ChatGPT")
chat_interface.send(
    "Send a message to get a reply from ChatGPT!", user="System", respond=False
)
chat_interface.stream("Hello")
chat_interface.show()
```

