### PR TITLE
Fix `obj.save()` when threading is enabled

### DIFF
--- a/panel/config.py
+++ b/panel/config.py
@@ -393,7 +393,11 @@ class _config(_base_config):
         if not init or (attr.startswith('_') and attr.endswith('_')) or attr == '_validating':
             return super().__setattr__(attr, value)
         value = getattr(self, f'_{attr}_hook', lambda x: x)(value)
-        if attr in _config._globals or self.param._TRIGGER:
+        if (
+            attr in _config._globals
+            or (attr.startswith("_") and attr[1:] in _config._globals)
+            or self.param._TRIGGER
+        ):
             super().__setattr__(attr if attr in self.param else f'_{attr}', value)
         elif state.curdoc is not None:
             if attr in _config._parameter_set:


### PR DESCRIPTION
Fixes https://github.com/holoviz/panel/issues/5957

`.save()` internally calls `with config.set(embed=True)`, and `config.set()` stores the original values of all the config Parameters plus their overrides, to reset them later when the context manager exits. This leads to `config.__setattr__` being called quite a lot and I noticed that while `nthreads` was declared in `config._globals`, setting `_nthreads` would still go through the code path that sets up `config._session_config`. This change deals with such case, i.e. when the string declared in `config._globals` is not a reference to the parameter name itself (e.g. `admin_plugins`) but to its property (e.g. `nthreads`, `comms`).