### PR TITLE
Fix post callback for default

### DIFF
--- a/panel/chat/interface.py
+++ b/panel/chat/interface.py
@@ -203,7 +203,11 @@ class ChatInterface(ChatFeed):
             if default_properties:
                 default_callback = default_properties["_default_callback"]
                 callback = (
-                    self._wrap_callbacks(callback=callback, post_callback=post_callback)(default_callback)
+                    self._wrap_callbacks(
+                        callback=callback,
+                        post_callback=post_callback,
+                        name=name,
+                    )(default_callback)
                     if callback is not None or post_callback is not None else default_callback
                 )
             elif callback is not None and post_callback is not None:
@@ -259,7 +263,8 @@ class ChatInterface(ChatFeed):
                 type(widget) is TextInput
             )
             if auto_send and widget in new_widgets:
-                widget.param.watch(self._click_send, "value")
+                callback = partial(self._button_data["send"].callback, self)
+                widget.param.watch(callback, "value")
             widget.param.update(
                 sizing_mode="stretch_width",
                 css_classes=["chat-interface-input-widget"]
@@ -309,13 +314,18 @@ class ChatInterface(ChatFeed):
     def _wrap_callbacks(
             self,
             callback: Callable | None = None,
-            post_callback: Callable | None = None
+            post_callback: Callable | None = None,
+            name: str = ""
         ):
         """
         Wrap the callback and post callback around the default callback.
         """
         def decorate(default_callback: Callable):
             def wrapper(self, event: param.parameterized.Event):
+                if name == "send" and not self.active_widget.value:
+                    # don't trigger if no message to prevent duplication
+                    return
+
                 if callback is not None:
                     try:
                         self.disabled = True

--- a/panel/chat/interface.py
+++ b/panel/chat/interface.py
@@ -204,7 +204,7 @@ class ChatInterface(ChatFeed):
                 default_callback = default_properties["_default_callback"]
                 callback = (
                     self._wrap_callbacks(callback=callback, post_callback=post_callback)(default_callback)
-                    if callback is not None else default_callback
+                    if callback is not None or post_callback is not None else default_callback
                 )
             elif callback is not None and post_callback is not None:
                 callback = self._wrap_callbacks(post_callback=post_callback)(callback)

--- a/panel/tests/chat/test_interface.py
+++ b/panel/tests/chat/test_interface.py
@@ -215,6 +215,19 @@ class TestChatInterface:
         assert chat_interface.objects[0].object == "1"
         assert chat_interface.objects[1].object == "2"
 
+    def test_button_properties_default_callback_and_post_callback(self, chat_interface):
+        def post_callback(instance, event):
+            instance.send("This should show", respond=False)
+
+        chat_interface.widgets = TextAreaInput()
+        chat_interface.button_properties = {
+            "reset": {"post_callback": post_callback},
+        }
+        check_button = chat_interface._input_layout[-1]
+        chat_interface.send("This shouldn't show up!", respond=False)
+        check_button.param.trigger("clicks")
+        assert chat_interface.objects[0].object == "This should show"
+
     def test_button_properties_new_button_missing_callback(self, chat_interface):
         chat_interface.widgets = TextAreaInput()
         with pytest.raises(ValueError, match="A 'callback' key is required for"):

--- a/panel/tests/chat/test_interface.py
+++ b/panel/tests/chat/test_interface.py
@@ -1,5 +1,7 @@
 
 
+import time
+
 from io import BytesIO
 
 import pytest
@@ -219,14 +221,29 @@ class TestChatInterface:
         def post_callback(instance, event):
             instance.send("This should show", respond=False)
 
+        chat_interface.button_properties = {
+            "clear": {"post_callback": post_callback},
+        }
+        clear_button = chat_interface._input_layout[-1]
+        chat_interface.send("This shouldn't show up!", respond=False)
+        clear_button.param.trigger("clicks")
+        time.sleep(0.5)
+        assert chat_interface.objects[0].object == "This should show"
+
+    def test_button_properties_send_with_callback_no_duplicate(self, chat_interface):
+        def post_callback(instance, event):
+            instance.send("This should show", respond=False)
+
         chat_interface.widgets = TextAreaInput()
         chat_interface.button_properties = {
-            "reset": {"post_callback": post_callback},
+            "send": {"post_callback": post_callback},
         }
-        check_button = chat_interface._input_layout[-1]
-        chat_interface.send("This shouldn't show up!", respond=False)
-        check_button.param.trigger("clicks")
-        assert chat_interface.objects[0].object == "This should show"
+        chat_interface.active_widget.value = "This is it!"
+        send_button = chat_interface._input_layout[1]
+        send_button.param.trigger("clicks")
+        assert chat_interface.objects[0].object == "This is it!"
+        assert chat_interface.objects[1].object == "This should show"
+        assert len(chat_interface.objects) == 2
 
     def test_button_properties_new_button_missing_callback(self, chat_interface):
         chat_interface.widgets = TextAreaInput()


### PR DESCRIPTION
Fixes post callback for existing buttons.

Also, attaches callback/post_callback to auto send on value change.

```python
import panel as pn
pn.extension()

def pre_callback(instance, event):
    instance.send("This sends before send", respond=False)

def post_callback(instance, event):
    instance.send("This sends after send", respond=False)

chat_interface = pn.chat.ChatInterface(button_properties = {
    "send": {"post_callback": post_callback, "callback": pre_callback},
})
chat_interface.show()

```

https://github.com/holoviz/panel/assets/15331990/4c057283-33c2-42e0-b197-f1ba56796e44



