### PR TITLE
Tabulator: don't attempt to set `text_align` on Bokeh formatters that don't support it

### DIFF
--- a/panel/tests/widgets/test_tables.py
+++ b/panel/tests/widgets/test_tables.py
@@ -2149,13 +2149,13 @@ def test_bokeh_formatter_index_with_no_textalign():
     serve_and_request(table)
     wait_until(lambda: bool(table._models))
 
-
-def test_bokeh_formatter_column_with_no_textalign(document, comm):
+@pytest.mark.parametrize('text_align', [{"A": "center"}, "center"], ids=["dict", "str"])
+def test_bokeh_formatter_column_with_no_textalign_but_text_align_set(document, comm, text_align):
     df = pd.DataFrame({"A": [1, 2, 3]})
     table = Tabulator(
         df,
         formatters=dict(A=HTMLTemplateFormatter(template='<b><%= value %>"></b>')),
-        text_align=dict(A='center'),
+        text_align=text_align,
     )
 
     model = table.get_root(document, comm)

--- a/panel/tests/widgets/test_tables.py
+++ b/panel/tests/widgets/test_tables.py
@@ -2148,3 +2148,15 @@ def test_bokeh_formatter_index_with_no_textalign():
     table = Tabulator(df, formatters={"A": index_format})
     serve_and_request(table)
     wait_until(lambda: bool(table._models))
+
+
+def test_bokeh_formatter_column_with_no_textalign(document, comm):
+    df = pd.DataFrame({"A": [1, 2, 3]})
+    table = Tabulator(
+        df,
+        formatters=dict(A=HTMLTemplateFormatter(template='<b><%= value %>"></b>')),
+        text_align=dict(A='center'),
+    )
+
+    model = table.get_root(document, comm)
+    assert model.configuration['columns'][1]['hozAlign'] == 'center'

--- a/panel/widgets/tables.py
+++ b/panel/widgets/tables.py
@@ -229,7 +229,7 @@ class BaseTable(ReactiveData, Widget):
                 if not default_text_align:
                     msg = f"The 'text_align' in Tabulator.formatters[{col!r}] is overridden by Tabulator.text_align"
                     warn(msg, RuntimeWarning)
-            elif col in self.text_align:
+            elif col in self.text_align and hasattr(formatter, "text_align"):
                 formatter.text_align = self.text_align[col]
                 if not default_text_align:
                     msg = f"The 'text_align' in Tabulator.formatters[{col!r}] is overridden by Tabulator.text_align[{col!r}]"

--- a/panel/widgets/tables.py
+++ b/panel/widgets/tables.py
@@ -224,17 +224,19 @@ class BaseTable(ReactiveData, Widget):
                 else:
                     default_text_align = True
 
-            if isinstance(self.text_align, str):
+            if not hasattr(formatter, 'text_align'):
+                pass
+            elif isinstance(self.text_align, str):
                 formatter.text_align = self.text_align
                 if not default_text_align:
                     msg = f"The 'text_align' in Tabulator.formatters[{col!r}] is overridden by Tabulator.text_align"
                     warn(msg, RuntimeWarning)
-            elif col in self.text_align and hasattr(formatter, "text_align"):
+            elif col in self.text_align:
                 formatter.text_align = self.text_align[col]
                 if not default_text_align:
                     msg = f"The 'text_align' in Tabulator.formatters[{col!r}] is overridden by Tabulator.text_align[{col!r}]"
                     warn(msg, RuntimeWarning)
-            elif col in self.indexes and hasattr(formatter, "text_align"):
+            elif col in self.indexes:
                 formatter.text_align = 'left'
 
             if isinstance(self.widths, int):


### PR DESCRIPTION
I got pretty much the same error as reported in https://github.com/holoviz/panel/issues/5915 and fixed in https://github.com/holoviz/panel/pull/5922, where the code fails while trying to set `text_align` on a Bokeh formatter that doesn't support this attribute. https://github.com/holoviz/panel/pull/5922 fixed that for the index but it applies to any other column too.

```py
import pandas as pd
import panel as pn

from bokeh.models import HTMLTemplateFormatter

df = pd.DataFrame(dict(x=['a', 'b']))

pn.widgets.Tabulator(
    df,
    widths=300,
    text_align=dict(x='center'),
    formatters=dict(x=HTMLTemplateFormatter(template='<b><%= value %></b>'))
).servable()
```