### PR TITLE
Add NestedSelect dynamic levels

### DIFF
--- a/panel/tests/widgets/test_select.py
+++ b/panel/tests/widgets/test_select.py
@@ -629,6 +629,8 @@ def test_nested_select_dynamic_levels(document, comm):
     assert select._widgets[2].options == []
     assert select._widgets[3].options == []
 
+    assert select.value == {"A": "Easy", "B": "Easy_A", "C": None, "D": None}
+
     # now update to Medium
     select.value = {"A": "Medium", "B": "Medium_C"}
     assert select._widgets[0].visible
@@ -641,6 +643,8 @@ def test_nested_select_dynamic_levels(document, comm):
     assert select._widgets[2].options == ["Medium_C_1", "Medium_C_2"]
     assert select._widgets[3].options == ["Medium_C_1_1"]
 
+    assert select.value == {"A": "Medium", "B": "Medium_C", "C": "Medium_C_1", "D": "Medium_C_1_1"}
+
     # now update to Hard
     select.value = {"A": "Hard"}
     assert select._widgets[0].visible
@@ -652,6 +656,8 @@ def test_nested_select_dynamic_levels(document, comm):
     assert select._widgets[1].options == []
     assert select._widgets[2].options == []
     assert select._widgets[3].options == []
+
+    assert select.value == {"A": "Hard", "B": None, "C": None, "D": None}
 
 
 def test_nested_select_callable_must_have_levels(document, comm):

--- a/panel/tests/widgets/test_select.py
+++ b/panel/tests/widgets/test_select.py
@@ -459,7 +459,7 @@ def test_nested_select_partial_options_set(document, comm):
         },
     }
     select = NestedSelect(options=options)
-    select.options = {"Ben": {}}
+    select.options = {"Ben": []}
     assert select._widgets[0].value == 'Ben'
     assert select._widgets[0].visible
     assert select.value == {0: 'Ben'}
@@ -607,37 +607,51 @@ def test_nested_select_dynamic_levels(document, comm):
             "Easy": {"Easy_A": {}, "Easy_B": {}},
             "Medium": {
                 "Medium_A": {},
-                "Medium_B": {},
+                "Medium_B": {"Medium_B_1": []},
                 "Medium_C": {
                     "Medium_C_1": ["Medium_C_1_1"],
                     "Medium_C_2": ["Medium_C_2_1", "Medium_C_2_2"],
                 },
             },
+            "Hard": {}
         },
-        levels=["Source", "Product", "Var", "GPH"],
+        levels=["A", "B", "C", "D"],
     )
-    select.value = {"Source": "Easy", "Product": "Easy_A"}
+    select
+    select.value = {"A": "Easy", "B": "Easy_A"}
     assert select._widgets[0].visible
     assert select._widgets[1].visible
     assert not select._widgets[2].visible
     assert not select._widgets[3].visible
 
-    assert select._widgets[0].options == ["Easy", "Medium"]
+    assert select._widgets[0].options == ["Easy", "Medium", "Hard"]
     assert select._widgets[1].options == ["Easy_A", "Easy_B"]
     assert select._widgets[2].options == []
     assert select._widgets[3].options == []
 
     # now update to Medium
-    select.value = {"Source": "Medium", "Product": "Medium_C"}
+    select.value = {"A": "Medium", "B": "Medium_C"}
     assert select._widgets[0].visible
     assert select._widgets[1].visible
     assert select._widgets[2].visible
     assert select._widgets[3].visible
 
-    assert select._widgets[0].options == ["Easy", "Medium"]
+    assert select._widgets[0].options == ["Easy", "Medium", "Hard"]
     assert select._widgets[1].options == ["Medium_A", "Medium_B", "Medium_C"]
     assert select._widgets[2].options == ["Medium_C_1", "Medium_C_2"]
     assert select._widgets[3].options == ["Medium_C_1_1"]
+
+    # now update to Hard
+    select.value = {"A": "Hard"}
+    assert select._widgets[0].visible
+    assert not select._widgets[1].visible
+    assert not select._widgets[2].visible
+    assert not select._widgets[3].visible
+
+    assert select._widgets[0].options == ["Easy", "Medium", "Hard"]
+    assert select._widgets[1].options == []
+    assert select._widgets[2].options == []
+    assert select._widgets[3].options == []
 
 
 def test_nested_select_callable_must_have_levels(document, comm):

--- a/panel/tests/widgets/test_select.py
+++ b/panel/tests/widgets/test_select.py
@@ -617,8 +617,6 @@ def test_nested_select_dynamic_levels(document, comm):
         },
         levels=["A", "B", "C", "D"],
     )
-    select
-    select.value = {"A": "Easy", "B": "Easy_A"}
     assert select._widgets[0].visible
     assert select._widgets[1].visible
     assert not select._widgets[2].visible

--- a/panel/tests/widgets/test_select.py
+++ b/panel/tests/widgets/test_select.py
@@ -601,6 +601,45 @@ def test_nested_select_callable_mid_level(document, comm):
     assert select._max_depth == 3
 
 
+def test_nested_select_dynamic_levels(document, comm):
+    select = NestedSelect(
+        options={
+            "Easy": {"Easy_A": {}, "Easy_B": {}},
+            "Medium": {
+                "Medium_A": {},
+                "Medium_B": {},
+                "Medium_C": {
+                    "Medium_C_1": ["Medium_C_1_1"],
+                    "Medium_C_2": ["Medium_C_2_1", "Medium_C_2_2"],
+                },
+            },
+        },
+        levels=["Source", "Product", "Var", "GPH"],
+    )
+    select.value = {"Source": "Easy", "Product": "Easy_A"}
+    assert select._widgets[0].visible
+    assert select._widgets[1].visible
+    assert not select._widgets[2].visible
+    assert not select._widgets[3].visible
+
+    assert select._widgets[0].options == ["Easy", "Medium"]
+    assert select._widgets[1].options == ["Easy_A", "Easy_B"]
+    assert select._widgets[2].options == []
+    assert select._widgets[3].options == []
+
+    # now update to Medium
+    select.value = {"Source": "Medium", "Product": "Medium_C"}
+    assert select._widgets[0].visible
+    assert select._widgets[1].visible
+    assert select._widgets[2].visible
+    assert select._widgets[3].visible
+
+    assert select._widgets[0].options == ["Easy", "Medium"]
+    assert select._widgets[1].options == ["Medium_A", "Medium_B", "Medium_C"]
+    assert select._widgets[2].options == ["Medium_C_1", "Medium_C_2"]
+    assert select._widgets[3].options == ["Medium_C_1_1"]
+
+
 def test_nested_select_callable_must_have_levels(document, comm):
     def list_options(level, value):
         pass

--- a/panel/widgets/select.py
+++ b/panel/widgets/select.py
@@ -414,7 +414,9 @@ class NestedSelect(CompositeWidget):
         for value in d.values():
             if isinstance(value, dict):
                 max_depth = max(max_depth, self._find_max_depth(value, depth + 1))
-            if len(value) == 0:
+            # dict means it's a level, so it's not the last level
+            # list means it's a leaf, so it's the last level
+            if isinstance(value, list) and len(value) == 0:
                 max_depth -= 1
         return max_depth
 

--- a/panel/widgets/select.py
+++ b/panel/widgets/select.py
@@ -562,7 +562,7 @@ class NestedSelect(CompositeWidget):
                             options = options[select.value]
                         else:
                             options = options[list(options.keys())[0]]
-                    visible = True
+                    visible = bool(options)
 
                 if i < start_i:
                     # If the select widget is before the one

--- a/panel/widgets/select.py
+++ b/panel/widgets/select.py
@@ -385,7 +385,7 @@ class NestedSelect(CompositeWidget):
                 name = level.get("name", i)
             else:
                 name = level
-            values[name] = select.value
+            values[name] = select.value if select.options else None
 
         return values
 
@@ -416,7 +416,7 @@ class NestedSelect(CompositeWidget):
                 max_depth = max(max_depth, self._find_max_depth(value, depth + 1))
             # dict means it's a level, so it's not the last level
             # list means it's a leaf, so it's the last level
-            if isinstance(value, list) and len(value) == 0:
+            if isinstance(value, list) and len(value) == 0 and max_depth > 0:
                 max_depth -= 1
         return max_depth
 


### PR DESCRIPTION
Apparently dynamic levels was already supported after changes for this https://github.com/holoviz/panel/pull/5791#issuecomment-1830373970

There was just a tiny fix to make to hide the subsequent options.

https://github.com/holoviz/panel/assets/15331990/cc007860-936c-47cf-89e0-78695bb957c8

