### PR TITLE
Correctly set error page to be rendered

### DIFF
--- a/panel/io/server.py
+++ b/panel/io/server.py
@@ -576,8 +576,8 @@ class DocHandler(LoginUrlMixin, BkDocHandler, SessionPrefixHandler):
             if authorized is None:
                 return
             elif not authorized:
-                self._render_auth_error(auth_error)
-                page = self.set_header("Content-Type", 'text/html')
+                page = self._render_auth_error(auth_error)
+                self.set_header("Content-Type", 'text/html')
                 self.write(page)
                 return
 


### PR DESCRIPTION
Correctly sets the error page to be rendered when authorize_callback returns False.

Repro

```
import panel as pn

def authorize(user_info):
    return False

pn.config.authorize_callback = authorize

pn.Row("hello world").servable()

```

I would expect running the above with oidc provider "generic" to return the error page however I get a 500 internal server error with the following in the logs

```TypeError: write() only accepts bytes, unicode, and dict objects```