### PR TITLE
Fix vtk_warp.ipynb gallery example

### DIFF
--- a/examples/gallery/vtk_warp.ipynb
+++ b/examples/gallery/vtk_warp.ipynb
@@ -36,7 +36,7 @@
     "    return np.sin(((ys/alpha)**alpha+time)*xs)\n",
     "\n",
     "# 3d plane to support the data\n",
-    "mesh_ref = pv.UniformGrid(\n",
+    "mesh_ref = pv.ImageData(\n",
     "    dimensions=(xvals.size, yvals.size, 1), #dims\n",
     "    spacing=(xvals[1]-xvals[0],yvals[1]-yvals[0],1), #spacing\n",
     "    origin=(xvals.min(),yvals.min(),0) #origin\n",


### PR DESCRIPTION
Tests failing due to VTK changes; this PR fixes it by replacing `pv.UniformGrid` with `pv.ImageData`

Addresses: https://github.com/holoviz/panel/pull/6018#issuecomment-1847707425