### PR TITLE
Fix and improve fast templates

### DIFF
--- a/panel/template/fast/fast.css
+++ b/panel/template/fast/fast.css
@@ -146,7 +146,7 @@ img.app-logo {
   transform-origin: center left;
   height: calc(100vh - 76px);
   overflow-y: auto;
-  padding: 15px 10px 5px 0;
+  padding: 15px 10px 5px 5px;
 }
 
 #sidebar.hidden {

--- a/panel/template/fast/fast.css
+++ b/panel/template/fast/fast.css
@@ -214,6 +214,10 @@ img.app-logo {
   margin-block-end: 0;
 }
 
+div.pn-wrapper {
+  height: 100%;
+}
+
 .pn-modal-close {
   position: absolute;
   right: 10%;

--- a/panel/template/fast/grid/fast_grid_template.html
+++ b/panel/template/fast/grid/fast_grid_template.html
@@ -63,6 +63,9 @@
   #sidebar {
     min-width: var(--sidebar-width);
     max-width: var(--sidebar-width);
+    {% if not main_layout %}
+    background-color: var(--panel-surface-color);
+    {% endif %}
   }
 </style>
 

--- a/panel/template/fast/list/fast_list_template.html
+++ b/panel/template/fast/list/fast_list_template.html
@@ -53,6 +53,9 @@
   #sidebar {
     min-width: var(--sidebar-width);
     max-width: var(--sidebar-width);
+	{% if not main_layout %}
+	background-color: var(--panel-surface-color);
+	{% endif %}
   }
 </style>
 

--- a/panel/theme/css/fast.css
+++ b/panel/theme/css/fast.css
@@ -472,7 +472,20 @@ input[type='file']:active {
     (var(--base-height-multiplier) + var(--density)) * var(--design-unit) * 1px
   );
 }
-
+.bk-btn-default:focus,
+.bk-btn-default:active,
+.bk-btn-primary:focus,
+.bk-btn-primary:active,
+.bk-btn-success:focus,
+.bk-btn-success:active,
+.bk-btn-warning:focus,
+.bk-btn-warning:active,
+.bk-btn-danger:focus,
+.bk-btn-danger:active,
+.bk-btn-light:focus,
+.bk-btn-light:active {
+  outline: none;
+}
 .bk-btn a {
   text-decoration: none;
   color: inherit;

--- a/panel/theme/css/fast.css
+++ b/panel/theme/css/fast.css
@@ -564,7 +564,20 @@ input[type='file']:active {
   cursor: not-allowed;
   opacity: var(--disabled-opacity);
 }
-
+:host(.outline) .bk-btn.bk-btn-primary {
+  border-color: var(--accent-fill-rest);
+  color: var(--neutral-foreground-rest);
+}
+:host(.outline) .bk-btn.bk-btn-primary.bk-active,
+:host(.outline) .bk-btn.bk-btn-primary:active {
+  border-color: var(--accent-fill-active);
+  color: var(--neutral-foreground-active);
+}
+:host(.outline) .bk-btn.bk-btn-primary.bk-active:hover,
+:host(.outline) .bk-btn.bk-btn-primary:hover {
+  border-color: var(--accent-fill-hover);
+  color: var(--neutral-foreground-hover);
+}
 :host(.outline) .bk-btn-success.bk-active,
 :host(.outline) .bk-btn-success:hover {
   color: var(--neutral-foreground-rest);

--- a/panel/theme/css/fast.css
+++ b/panel/theme/css/fast.css
@@ -525,7 +525,7 @@ input[type='file']:active {
 
 :host(.outline) .bk-btn.bk-btn-default.bk-active {
   color: var(--foreground-on-accent-rest);
-  box-shadow: inset 0px 3px 5px rgb(0 0 0 / 25%);
+  box-shadow: none;
 }
 
 :host(.outline) .bk-btn-group .bk-btn-default.bk-active {
@@ -533,10 +533,11 @@ input[type='file']:active {
   color: var(--foreground-on-accent-active);
 }
 
+:host(.outline) .bk-btn-group .bk-btn-primary.bk-active,
 :host(.solid) .bk-btn.bk-btn-primary,
 :host(.solid) .bk-btn.bk-btn-primary[disabled],
 :host(.solid) .bk-btn.bk-btn-primary[disabled]:hover {
-  background: var(--accent-fill-rest);
+  background-color: var(--accent-fill-rest);
   border-color: var(--accent-fill-rest);
   color: var(--accent-foreground-cut-rest);
 }
@@ -553,6 +554,7 @@ input[type='file']:active {
   border-color: var(--accent-fill-active);
   color: var(--accent-foreground-cut-rest);
 }
+:host(.outline) .bk-btn-group .bk-btn-primary.bk-active:hover,
 :host(.solid) .bk-btn.bk-btn-primary.bk-active:hover {
   background-color: var(--accent-fill-hover);
 }

--- a/panel/theme/css/fast.css
+++ b/panel/theme/css/fast.css
@@ -527,28 +527,47 @@ input[type='file']:active {
   color: var(--foreground-on-accent-active);
 }
 
+:host(.solid)
+  .bk-btn.bk-btn-primary
+  :host(.solid)
+  .bk-btn.bk-btn-primary.bk-active {
+  border-color: var(--accent-fill-active);
+}
+:host(.solid) .bk-btn.bk-btn-primary:hover {
+  border-color: var(--accent-fill-hover);
+}
 :host(.solid) .bk-btn.bk-btn-primary {
-  background-color: var(--accent-fill-rest);
+  border-color: var(--accent-fill-rest);
 }
 
-:host(.solid) .bk-btn.bk-btn-primary.bk-active {
+:host(.solid) .bk-btn.bk-btn-primary,
+:host(.solid) .bk-btn.bk-btn-primary[disabled],
+:host(.solid) .bk-btn.bk-btn-primary[disabled]:hover {
+  color: var(--accent-foreground-cut-rest);
+  background: var(--accent-fill-rest);
+}
+:host(.solid) .bk-btn.bk-btn-primary:hover {
+  color: white;
+  color: var(--accent-foreground-cut-rest);
+  background-color: var(--accent-fill-hover);
+}
+:host(.solid) .bk-btn.bk-btn-primary.bk-active,
+:host(.solid) .bk-btn.bk-btn-primary:active,
+:host(.solid) .bk-btn.bk-btn-primary.bk-active[disabled],
+:host(.solid) .bk-btn.bk-btn-primary.bk-active[disabled]:hover {
+  color: var(--accent-foreground-cut-rest);
   background-color: var(--accent-fill-active);
-  box-shadow: inset 0px 3px 5px rgb(0 0 0 / 25%);
 }
-
-:host(.outline) .bk-btn-primary {
-  background-color: transparent;
-  color: var(--neutral-foreground-rest);
+:host(.solid) .bk-btn.bk-btn-primary.bk-active:hover {
+  background-color: var(--accent-fill-hover);
 }
-
-:host(.outline) .bk-btn-primary.bk-active,
-:host(.outline) .bk-btn-primary:hover {
-  color: var(--neutral-foreground-rest);
-}
-
-:host(.outline) .bk-btn-group .bk-btn-primary.bk-active {
-  background-color: var(--accent-fill-rest);
-  color: var(--foreground-on-accent-active);
+:host(.solid) .bk-btn.bk-btn-primary[disabled],
+:host(.solid) .bk-btn.bk-btn-primary[disabled]:hover,
+:host(.solid) .bk-btn.bk-btn-primary[disabled]:focus,
+:host(.solid) .bk-btn.bk-btn-primary[disabled].bk-active {
+  pointer-events: none !important;
+  cursor: not-allowed;
+  opacity: var(--disabled-opacity);
 }
 
 :host(.outline) .bk-btn-success.bk-active,

--- a/panel/theme/css/fast.css
+++ b/panel/theme/css/fast.css
@@ -20,6 +20,13 @@
   --panel-primary-color: var(--accent-foreground-rest);
   --panel-on-primary-color: var(--foreground-on-accent-rest);
 }
+/* Anchor */
+a {
+  color: var(--accent-fill-rest);
+}
+a:hover {
+  color: var(--accent-fill-hover);
+}
 
 /* Track */
 
@@ -653,6 +660,10 @@ input[type='file']:active {
 
 select:not([type='file']).bk-input {
   margin: 0;
+}
+select:not([multiple]).bk-input,
+select:not([size]).bk-input {
+  background-image: url('data:image/svg+xml;utf8,<svg version="1.1" viewBox="0 0 25 20" xmlns="http://www.w3.org/2000/svg"><path d="M 0,0 25,0 12.5,20 Z" fill="darkgrey"/></svg>');
 }
 
 /* Checkbox/Radio */

--- a/panel/theme/css/fast.css
+++ b/panel/theme/css/fast.css
@@ -486,6 +486,12 @@ input[type='file']:active {
 .bk-btn-light:active {
   outline: none;
 }
+.bk-btn:active,
+::file-selector-button:active,
+.bk-active.bk-btn,
+.bk-active::file-selector-button {
+  box-shadow: none;
+}
 .bk-btn a {
   text-decoration: none;
   color: inherit;
@@ -527,36 +533,25 @@ input[type='file']:active {
   color: var(--foreground-on-accent-active);
 }
 
-:host(.solid)
-  .bk-btn.bk-btn-primary
-  :host(.solid)
-  .bk-btn.bk-btn-primary.bk-active {
-  border-color: var(--accent-fill-active);
-}
-:host(.solid) .bk-btn.bk-btn-primary:hover {
-  border-color: var(--accent-fill-hover);
-}
-:host(.solid) .bk-btn.bk-btn-primary {
-  border-color: var(--accent-fill-rest);
-}
-
 :host(.solid) .bk-btn.bk-btn-primary,
 :host(.solid) .bk-btn.bk-btn-primary[disabled],
 :host(.solid) .bk-btn.bk-btn-primary[disabled]:hover {
-  color: var(--accent-foreground-cut-rest);
   background: var(--accent-fill-rest);
+  border-color: var(--accent-fill-rest);
+  color: var(--accent-foreground-cut-rest);
 }
 :host(.solid) .bk-btn.bk-btn-primary:hover {
-  color: white;
-  color: var(--accent-foreground-cut-rest);
   background-color: var(--accent-fill-hover);
+  border-color: var(--accent-fill-hover);
+  color: var(--accent-foreground-cut-hover);
 }
 :host(.solid) .bk-btn.bk-btn-primary.bk-active,
 :host(.solid) .bk-btn.bk-btn-primary:active,
 :host(.solid) .bk-btn.bk-btn-primary.bk-active[disabled],
 :host(.solid) .bk-btn.bk-btn-primary.bk-active[disabled]:hover {
-  color: var(--accent-foreground-cut-rest);
   background-color: var(--accent-fill-active);
+  border-color: var(--accent-fill-active);
+  color: var(--accent-foreground-cut-rest);
 }
 :host(.solid) .bk-btn.bk-btn-primary.bk-active:hover {
   background-color: var(--accent-fill-hover);

--- a/panel/theme/css/fast.css
+++ b/panel/theme/css/fast.css
@@ -16,6 +16,9 @@
   --switch-size: 12px;
   --container-background: var(--panel-surface-color);
   color: var(--neutral-foreground-rest);
+
+  --panel-primary-color: var(--accent-foreground-rest);
+  --panel-on-primary-color: var(--foreground-on-accent-rest);
 }
 
 /* Track */
@@ -486,6 +489,12 @@ input[type='file']:active {
 .bk-btn-light:active {
   outline: none;
 }
+.bk-btn:active {
+  transform: none;
+}
+
+:host(.solid) .bk-btn-group .bk-btn.bk-btn-default.bk-active,
+:host(.solid) .bk-btn-group .bk-btn.bk-btn-primary.bk-active,
 .bk-btn:active,
 ::file-selector-button:active,
 .bk-active.bk-btn,
@@ -510,27 +519,39 @@ input[type='file']:active {
 
 :host(.solid) .bk-btn.bk-btn-default:hover {
   background-color: var(--neutral-fill-hover);
+  color: var(--neutral-foreground-hover);
+}
+
+:host(.solid) .bk-btn.bk-btn-default:active,
+:host(.solid) .bk-btn.bk-btn-default.bk-active {
+  background-color: var(--neutral-fill-active);
+  color: var(--neutral-foreground-active);
 }
 
 :host(.outline) .bk-btn.bk-btn-default {
   background-color: transparent;
-  border: 1px solid var(--neutral-fill-strong-rest);
+  border: 1px solid var(--neutral-stroke-rest);
   color: var(--neutral-fill-strong-rest);
 }
 
 :host(.outline) .bk-btn.bk-btn-default:hover {
-  background-color: var(--neutral-fill-hover);
-  color: var(--neutral-foreground-rest);
+  border-color: var(--neutral-stroke-hover);
+  color: var(--neutral-fill-strong-hover);
+}
+
+:host(.outline) .bk-btn.bk-btn-default:active {
+  border-color: var(--neutral-stroke-active);
+  color: var(--neutral-fill-strong-active);
 }
 
 :host(.outline) .bk-btn.bk-btn-default.bk-active {
-  color: var(--foreground-on-accent-rest);
+  color: var(--neutral-foreground-rest);
   box-shadow: none;
 }
 
 :host(.outline) .bk-btn-group .bk-btn-default.bk-active {
   background-color: var(--neutral-fill-active);
-  color: var(--foreground-on-accent-active);
+  color: var(--neutral-foreground-rest);
 }
 
 :host(.outline) .bk-btn-group .bk-btn-primary.bk-active,
@@ -539,12 +560,12 @@ input[type='file']:active {
 :host(.solid) .bk-btn.bk-btn-primary[disabled]:hover {
   background-color: var(--accent-fill-rest);
   border-color: var(--accent-fill-rest);
-  color: var(--accent-foreground-cut-rest);
+  color: var(--foreground-on-accent-rest);
 }
 :host(.solid) .bk-btn.bk-btn-primary:hover {
   background-color: var(--accent-fill-hover);
   border-color: var(--accent-fill-hover);
-  color: var(--accent-foreground-cut-hover);
+  color: var(--foreground-on-accent-hover);
 }
 :host(.solid) .bk-btn.bk-btn-primary.bk-active,
 :host(.solid) .bk-btn.bk-btn-primary:active,
@@ -552,11 +573,12 @@ input[type='file']:active {
 :host(.solid) .bk-btn.bk-btn-primary.bk-active[disabled]:hover {
   background-color: var(--accent-fill-active);
   border-color: var(--accent-fill-active);
-  color: var(--accent-foreground-cut-rest);
+  color: var(--foreground-on-accent-active);
 }
 :host(.outline) .bk-btn-group .bk-btn-primary.bk-active:hover,
 :host(.solid) .bk-btn.bk-btn-primary.bk-active:hover {
   background-color: var(--accent-fill-hover);
+  color: var(--foreground-on-accent-hover);
 }
 :host(.solid) .bk-btn.bk-btn-primary[disabled],
 :host(.solid) .bk-btn.bk-btn-primary[disabled]:hover,
@@ -566,20 +588,21 @@ input[type='file']:active {
   cursor: not-allowed;
   opacity: var(--disabled-opacity);
 }
-:host(.outline) .bk-btn.bk-btn-primary {
-  border-color: var(--accent-fill-rest);
-  color: var(--neutral-foreground-rest);
+:host(.outline) .bk-btn.bk-btn-primary.bk-active:hover,
+:host(.outline) .bk-btn.bk-btn-primary:hover {
+  border-color: var(--accent-fill-hover);
+  color: var(--neutral-foreground-hover);
 }
 :host(.outline) .bk-btn.bk-btn-primary.bk-active,
 :host(.outline) .bk-btn.bk-btn-primary:active {
   border-color: var(--accent-fill-active);
   color: var(--neutral-foreground-active);
 }
-:host(.outline) .bk-btn.bk-btn-primary.bk-active:hover,
-:host(.outline) .bk-btn.bk-btn-primary:hover {
-  border-color: var(--accent-fill-hover);
-  color: var(--neutral-foreground-hover);
+:host(.outline) .bk-btn.bk-btn-primary {
+  border-color: var(--accent-fill-rest);
+  color: var(--neutral-foreground-rest);
 }
+
 :host(.outline) .bk-btn-success.bk-active,
 :host(.outline) .bk-btn-success:hover {
   color: var(--neutral-foreground-rest);


### PR DESCRIPTION
This PR fixes various *fast* styling issues introduced by Panel 1.0.

- Removing the bootstrap styling and adding the fast styling to Buttons.
- Giving links the accent color
- Making the triangle in the `Select` widget visible - also in dark mode.

It also improves the template styling when `main_layout=None` giving it the familiar *Streamlit Gray Sidebar* look. I think I will be using this version and more and more because I think it looks the best.

- I was thinking maybe we should add a deprecation warning that we will be changing the default value of `main_layout` to `None` in Panel 1.6 or similar?

I also add a tiny bid of left padding to the sidebar too make it look more symmetric and less cramped.

I also fix https://github.com/holoviz/panel/issues/6024.

## Test Script

I've been using the below test script

```python
import panel as pn

pn.extension(sizing_mode="stretch_width", inline=True)

ACCENT = "#da1a5f"

disabled = pn.widgets.Checkbox(name="Disabled", value=False)

@pn.depends(disabled)
def get_buttons(disabled):
       buttons = pn.Row(
       *(pn.Column(*(pn.widgets.Button(name=p, button_type=p, button_style=bs, disabled=disabled) for p in pn.widgets.Button.param.button_type.objects))
       for bs in pn.widgets.Button.param.button_style.objects)
       )
       button_radioboxes = pn.Row(
       *(pn.Column(*(pn.widgets.RadioButtonGroup(name=p, options=["AAA", "BBB"], button_type=p, button_style=bs, disabled=disabled) for p in pn.widgets.Button.param.button_type.objects))
       for bs in pn.widgets.Button.param.button_style.objects)
       )
       description="""## Header
Some text and a [link](https://panel.holoviz.org)
       
"""
       select = pn.widgets.Select(value="Option A", options=["Option A", "Option B"])
       return pn.Column(
              buttons, button_radioboxes, description, select, margin=0
       )


pn.template.FastListTemplate(
       title="Test App", 
       main=[],
       sidebar=[disabled, get_buttons],
       accent=ACCENT,
       # main_layout=None,
).servable()
```

## After

This is how things will be looking when applying this PR.

![image](https://github.com/holoviz/panel/assets/42288570/f01b6264-8981-4e53-a682-0185c887b1be)

![image](https://github.com/holoviz/panel/assets/42288570/6b4ff7ea-9917-40f7-b0ae-5e833329bfa1)

### `main_layout=None`

![image](https://github.com/holoviz/panel/assets/42288570/01ea2c5c-92dd-4910-a9c5-8b0b8af5e45a)

![image](https://github.com/holoviz/panel/assets/42288570/76c1618d-0e89-4892-aae8-5057226642d1)
