### PR TITLE
Add DateRangePicker widget

### DIFF
--- a/examples/reference/widgets/DateRangePicker.ipynb
+++ b/examples/reference/widgets/DateRangePicker.ipynb
@@ -1,0 +1,104 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import panel as pn\n",
+    "\n",
+    "pn.extension()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The ``DateRangePicker`` widget allows selecting a date range using a text box and the browser's date-picking utility.\n",
+    "\n",
+    "Discover more on using widgets to add interactivity to your applications in the [how-to guides on interactivity](../how_to/interactivity/index.md). Alternatively, learn [how to set up callbacks and (JS-)links between parameters](../../how_to/links/index.md) or [how to use them as part of declarative UIs with Param](../../how_to/param/index.html).\n",
+    "\n",
+    "#### Parameters:\n",
+    "\n",
+    "For details on other options for customizing the component see the [layout](../../how_to/layout/index.md) and [styling](../../how_to/styling/index.md) how-to guides.\n",
+    "\n",
+    "##### Core\n",
+    "\n",
+    "* **``end``** (date): The latest selectable date\n",
+    "* **``start``** (date): The earliest selectable date\n",
+    "* **``value``** (tuple): Tuple of upper and lower bounds of the selected range expressed as date types\n",
+    "\n",
+    "##### Display\n",
+    "\n",
+    "* **``disabled``** (boolean): Whether the widget is editable\n",
+    "* **``name``** (str): The title of the widget\n",
+    "* **``disabled_dates``** (list): dates to make unavailable for selection; others will be available\n",
+    "* **``enabled_dates``** (list): dates to make available for selection; others will be unavailable\n",
+    "\n",
+    "___"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "``DateRangePicker`` uses a browser-dependent calendar widget to select the date range:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "date_range_picker = pn.widgets.DateRangePicker(name='Date Range Picker')\n",
+    "\n",
+    "date_range_picker"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "``DateRangePicker.value`` returns a tuple of date values type that can be read out or set like other widgets:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "date_range_picker.value"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Controls\n",
+    "\n",
+    "The `DateRangePicker` widget exposes a number of options which can be changed from both Python and Javascript. Try out \n",
+    "the effect of these parameters interactively:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pn.Row(date_range_picker.controls(jslink=True), date_range_picker)"
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/panel/tests/widgets/test_input.py
+++ b/panel/tests/widgets/test_input.py
@@ -8,9 +8,9 @@ from bokeh.models.widgets import FileInput as BkFileInput
 
 from panel import config
 from panel.widgets import (
-    ArrayInput, Checkbox, DatePicker, DatetimeInput, DatetimePicker,
-    DatetimeRangeInput, DatetimeRangePicker, FileInput, FloatInput, IntInput,
-    LiteralInput, StaticText, TextInput,
+    ArrayInput, Checkbox, DatePicker, DateRangePicker, DatetimeInput,
+    DatetimePicker, DatetimeRangeInput, DatetimeRangePicker, FileInput,
+    FloatInput, IntInput, LiteralInput, StaticText, TextInput,
 )
 
 
@@ -58,6 +58,42 @@ def test_date_picker(document, comm):
     assert widget.value == '2018-09-04'
 
 
+def test_daterange_picker(document, comm):
+    date_range_picker = DateRangePicker(name='DateRangePicker',
+                                        value=(date(2018, 9, 2), date(2018, 9, 3)),
+                                        start=date(2018, 9, 1),
+                                        end=date(2018, 9, 10))
+
+    widget = date_range_picker.get_root(document, comm=comm)
+
+    assert isinstance(widget, date_range_picker._widget_type)
+    assert widget.title == 'DateRangePicker'
+    assert widget.value == ('2018-09-02', '2018-09-03')
+    assert widget.min_date == '2018-09-01'
+    assert widget.max_date == '2018-09-10'
+
+    date_range_picker._process_events({'value': ('2018-09-03', '2018-09-04')})
+    assert date_range_picker.value == (date(2018, 9, 3), date(2018, 9, 4))
+
+    date_range_picker._process_events({'value': ('2018-09-05', '2018-09-08')})
+    assert date_range_picker.value == (date(2018, 9, 5), date(2018, 9, 8))
+
+    value = date_range_picker._process_param_change({'value': (date(2018, 9, 4), date(2018, 9, 5))})
+    assert value['value'] == ('2018-09-04', '2018-09-05')
+
+    value = date(2018, 9, 4)
+    assert date_range_picker._convert_date_to_string(value) == '2018-09-04'
+    assert date_range_picker._convert_string_to_date(date_range_picker._convert_date_to_string(value)) == value
+
+    # Check start value
+    with pytest.raises(ValueError):
+        date_range_picker._process_events({'value': ('2018-08-31', '2018-09-01')})
+
+    # Check end value
+    with pytest.raises(ValueError):
+        date_range_picker._process_events({'value': ('2018-09-10', '2018-09-11')})
+
+
 def test_datetime_picker(document, comm):
     datetime_picker = DatetimePicker(
         name='DatetimePicker', value=datetime(2018, 9, 2, 1, 5),
@@ -94,7 +130,6 @@ def test_datetime_picker(document, comm):
         datetime_picker._process_events({'value': '2018-09-10 00:00:01'})
 
 
-
 def test_datetime_range_picker(document, comm):
     datetime_range_picker = DatetimeRangePicker(
         name='DatetimeRangePicker', value=(datetime(2018, 9, 2, 1, 5), datetime(2018, 9, 2, 1, 6)),
@@ -128,7 +163,6 @@ def test_datetime_range_picker(document, comm):
     # Check end value
     with pytest.raises(ValueError):
         datetime_range_picker._process_events({'value': '2018-09-10 00:00:01'})
-
 
 
 def test_file_input(document, comm):

--- a/panel/widgets/__init__.py
+++ b/panel/widgets/__init__.py
@@ -43,10 +43,10 @@ from .indicators import (  # noqa
     TooltipIcon, Tqdm, Trend,
 )
 from .input import (  # noqa
-    ArrayInput, Checkbox, ColorPicker, DatePicker, DatetimeInput,
-    DatetimePicker, DatetimeRangeInput, DatetimeRangePicker, FileInput,
-    FloatInput, IntInput, LiteralInput, NumberInput, PasswordInput, Spinner,
-    StaticText, Switch, TextAreaInput, TextInput,
+    ArrayInput, Checkbox, ColorPicker, DatePicker, DateRangePicker,
+    DatetimeInput, DatetimePicker, DatetimeRangeInput, DatetimeRangePicker,
+    FileInput, FloatInput, IntInput, LiteralInput, NumberInput, PasswordInput,
+    Spinner, StaticText, Switch, TextAreaInput, TextInput,
 )
 from .misc import FileDownload, JSONEditor, VideoStream  # noqa
 from .player import DiscretePlayer, Player  # noqa
@@ -83,6 +83,7 @@ __all__ = (
     "CrossSelector",
     "DataFrame",
     "DatePicker",
+    "DateRangePicker",
     "DateRangeSlider",
     "DatetimeRangeSlider",
     "DateSlider",


### PR DESCRIPTION
Replaces https://github.com/holoviz/panel/pull/2804
Closes https://github.com/holoviz/panel/issues/5844 and maybe https://github.com/holoviz/panel/issues/3789

As far as I know this reuse of Bokeh's implementation works fine.

As it's my first widget addition I'm open to suggestions to get closer to existing practices.

A small code to try it:

```python
import datetime as dt
import panel as pn
import panel.widgets as pnw


def display_value(event):
    col.append(date_range_picker.value)


def set_value(event):
    date_range_picker.value = (dt.date(2019, 1, 2), dt.date(2019, 1, 5))


def set_start_end(event):
    date_range_picker.start = dt.date(2020, 1, 2)
    date_range_picker.end = dt.date(2020, 2, 5)


date_range_picker = pnw.DateRangePicker(name='Date Range Picker', start=dt.date(2019, 1, 1), end=dt.date(2019, 1, 10))
button1 = pnw.Button(name='Display Value', on_click=display_value)
button2 = pnw.Button(name='Set Value', on_click=set_value)
button3 = pnw.Button(name='Set start end', on_click=set_start_end)

row = pn.Row(date_range_picker, pn.Column(button1, button2, button3))
col = pn.Column(row)

col.servable()
```