### PR TITLE
Elaborate on callback exception summary

### DIFF
--- a/panel/chat/feed.py
+++ b/panel/chat/feed.py
@@ -471,7 +471,11 @@ class ChatFeed(ListPanel):
         except Exception as e:
             send_kwargs = dict(user="Exception", respond=False)
             if self.callback_exception == "summary":
-                self.send(str(e), **send_kwargs)
+                self.send(
+                    f"Encountered `{e!r}`. "
+                    f"Set `callback_exception='verbose'` to see the full traceback.",
+                    **send_kwargs
+                )
             elif self.callback_exception == "verbose":
                 self.send(f"```python\n{traceback.format_exc()}\n```", **send_kwargs)
             elif self.callback_exception == "ignore":

--- a/panel/tests/chat/test_feed.py
+++ b/panel/tests/chat/test_feed.py
@@ -633,7 +633,7 @@ class TestChatFeedCallback:
         chat_feed.callback = callback
         chat_feed.callback_exception = "summary"
         chat_feed.send("Message", respond=True)
-        assert chat_feed.objects[-1].object == "division by zero"
+        assert "division by zero" in chat_feed.objects[-1].object
         assert chat_feed.objects[-1].user == "Exception"
 
     def test_callback_exception_traceback(self, chat_feed):


### PR DESCRIPTION
Based on feedback from
https://discourse.holoviz.org/t/chatinterface-streaming-error-with-langchain/6589/4
"""
Thank you for your help. Did not know about callback_exception=“verbose”
"""

and
https://www.youtube.com/watch?v=mFmPDyLlj1E:
"""
The simple case works, but when I ask my agents to write code, I get an error in Panel chat. I know the code has run successfully by looking at the terminal. But in the Panel chat it shows a message with Avatar symbol as red X, avatar name 'Exception', and the message content is just the literal string 'name'.
"""

I think users get stuck when errors occur; this PR elaborates on next steps to unblock them.

<img width="863" alt="image" src="https://github.com/holoviz/panel/assets/15331990/e5da746d-3621-4271-8a75-e9a6395c5c83">

```python
import panel as pn
pn.extension()

def callback(content, user, instance):
    1 / 0

pn.chat.ChatInterface(callback=callback).servable()
```

Eventually, I think I want to allow users to add a custom exception handler https://github.com/holoviz/panel/issues/6047