### PR TITLE
Ensure that Design does not override properties on HoloViews pane

### DIFF
--- a/panel/pane/holoviews.py
+++ b/panel/pane/holoviews.py
@@ -388,6 +388,15 @@ class HoloViews(PaneBase):
         finally:
             self._syncing_props = False
 
+    def _process_param_change(self, params):
+        if self._plots:
+            # Handles a design applying custom parameters on the plot
+            # which have to be mapped to properties by the underlying
+            # plot pane, e.g. Bokeh, Matplotlib or Plotly
+            _, pane = next(iter(self._plots.values()))
+            return pane._process_param_change(params)
+        return super()._process_param_change(params)
+
     #----------------------------------------------------------------
     # Model API
     #----------------------------------------------------------------

--- a/panel/pane/plotly.py
+++ b/panel/pane/plotly.py
@@ -311,9 +311,10 @@ class Plotly(ModelPane):
         self, doc: Document, root: Optional[Model] = None,
         parent: Optional[Model] = None, comm: Optional[Comm] = None
     ) -> Model:
-        self._bokeh_model = lazy_load(
-            'panel.models.plotly', 'PlotlyPlot', isinstance(comm, JupyterComm), root
-        )
+        if not hasattr(self, '_bokeh_model'):
+            self._bokeh_model = lazy_load(
+                'panel.models.plotly', 'PlotlyPlot', isinstance(comm, JupyterComm), root
+            )
         return super()._get_model(doc, root, parent, comm)
 
     def _update(self, ref: str, model: Model) -> None:

--- a/panel/tests/pane/test_holoviews.py
+++ b/panel/tests/pane/test_holoviews.py
@@ -18,9 +18,9 @@ except Exception:
 plotly_available = pytest.mark.skipif(hv_plotly is None, reason="requires plotly backend")
 
 from bokeh.models import (
-    Column as BkColumn, ColumnDataSource, GlyphRenderer, GridPlot, Line,
-    Row as BkRow, Scatter, Select as BkSelect, Slider as BkSlider,
-    Spacer as BkSpacer,
+    Column as BkColumn, ColumnDataSource, GlyphRenderer, GridPlot,
+    ImportedStyleSheet, Line, Row as BkRow, Scatter, Select as BkSelect,
+    Slider as BkSlider, Spacer as BkSpacer,
 )
 from bokeh.plotting import figure
 
@@ -30,8 +30,11 @@ from panel.depends import bind
 from panel.layout import (
     Column, FlexBox, HSpacer, Row,
 )
-from panel.pane import HoloViews, PaneBase, panel
+from panel.pane import (
+    HoloViews, PaneBase, Plotly, panel,
+)
 from panel.tests.util import hv_available, mpl_available
+from panel.theme import Native
 from panel.util.warnings import PanelDeprecationWarning
 from panel.widgets import (
     Checkbox, DiscreteSlider, FloatSlider, Select,
@@ -224,6 +227,25 @@ def test_holoviews_pane_reflect_responsive_plotly(document, comm):
 
     assert row.sizing_mode is None
     assert pane.sizing_mode is None
+
+
+@hv_available
+@plotly_available
+def test_holoviews_pane_inherits_design_stylesheets(document, comm):
+    curve = hv.Curve([1, 2, 3]).opts(responsive=True, backend='plotly')
+    pane = HoloViews(curve, backend='plotly')
+
+
+    # Create pane
+    row = pane.get_root(document, comm=comm)
+
+    Native().apply(pane, row)
+
+    plotly_model = row.children[0]
+
+    assert len(plotly_model.stylesheets) == 6
+    stylesheets = [st.url for st in plotly_model.stylesheets if isinstance(st, ImportedStyleSheet)]
+    assert all(st in stylesheets for st in Plotly._stylesheets)
 
 @hv_available
 def test_holoviews_widgets_from_dynamicmap(document, comm):


### PR DESCRIPTION
Fixes an issue reported in https://github.com/holoviz/panel/issues/6026 where applying a Design to a HoloViews pane would override any properties that are specific to the underlying plot pane, e.g. the `Plotly` pane applies a custom stylesheet to fix the toolbar in a shadow DOM context, this was lost because the Design would ask the HoloViews pane to process the overridden defaults which did not know about any custom stylesheets that the `Plotly` pane applied.