### PR TITLE
Do no update objects inplace unless explicitly requested

### DIFF
--- a/panel/pane/base.py
+++ b/panel/pane/base.py
@@ -682,20 +682,9 @@ class ReplacementPane(PaneBase):
                 old_object.object = object
         else:
             # Replace pane entirely
-            pane = panel(object, **{k: v for k, v in kwargs.items()
-                                    if k in pane_type.param})
-            if pane is object:
-                # If all watchers on the object are internal watchers
-                # we can make a clone of the object and update this
-                # clone going forward, otherwise we have replace the
-                # model entirely which is more expensive.
-                if not (custom_watchers or links):
-                    pane = object.clone()
-                    internal = True
-                else:
-                    internal = False
-            else:
-                internal = object is not old_object
+            pane_params = {k: v for k, v in kwargs.items() if k in pane_type.param}
+            pane = panel(object, **pane_params)
+            internal = pane is not object
         return pane, internal
 
     def _update_inner(self, new_object: Any) -> None:

--- a/panel/tests/test_param.py
+++ b/panel/tests/test_param.py
@@ -1315,20 +1315,20 @@ def test_param_function_pane_update(document, comm):
 
     pane = panel(view)
     inner_pane = pane._pane
-    assert inner_pane is not objs[0]
+    assert inner_pane is objs[0]
     assert inner_pane.object is objs[0].object
-    assert pane._internal
+    assert not pane._internal
 
     test.a = 1
 
-    assert pane._pane is inner_pane
-    assert pane._internal
+    assert pane._pane is not inner_pane
+    assert not pane._internal
 
     objs[0].param.watch(print, ['object'])
 
     test.a = 0
 
-    assert pane._pane is not inner_pane
+    assert pane._pane is inner_pane
     assert not pane._internal
 
 


### PR DESCRIPTION
In an attempt to be clever and optimize updates to objects we added some internal handling that would copy the returned object from a dynamically rendered function or method and then update it inplace. The major problem with this approach is that if the user has a handle on the original object any changes they make to it won't be propagated to the rendered object. Since we now have support for parameter references throughout and are slowly updating our guidance to make users aware of the efficiency gains of providing a reference to a component to update it's parameters I think it is fine to remove this optimization and thereby fix a range of bugs.

Fixes https://github.com/holoviz/panel/issues/6044
Fixes https://github.com/holoviz/panel/issues/6043
Fixes https://github.com/holoviz/panel/issues/6042