### PR TITLE
Improve HoloViews reference guide

### DIFF
--- a/examples/reference/panes/HoloViews.ipynb
+++ b/examples/reference/panes/HoloViews.ipynb
@@ -6,33 +6,62 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import holoviews as hva\n",
     "import panel as pn\n",
-    "pn.extension('plotly')"
+    "\n",
+    "hv.extension(\"bokeh\") # DON'T KNOW WHY THIS WAS SUDDENLY NEEDED. PLEASE HELP\n",
+    "pn.extension('plotly') # We add 'plotly' to be able to use the 'plotly' plot backend"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The ``HoloViews`` pane renders HoloViews plots with one of the plotting backends supported by HoloViews. It supports the regular HoloViews widgets for exploring the key dimensions of a ``HoloMap`` or ``DynamicMap``, but is more flexible than the native HoloViews widgets since it also allows customizing widget types and their position relative to the plot.\n",
+    "[HoloViews](https://holoviews.org/) is a very powerful data visualization library supporting many data and plotting *backends*.\n",
+    "\n",
+    "[hvPlot](https://hvplot.holoviz.org/index.html) (quick viz) and [GeoViews](https://holoviz.org/assets/geoviews.png) (spatial viz) are built on top of HoloViews and produces `HoloViews` objects.\n",
+    "\n",
+    "**Panel, HoloViews, hvPlot and GeoViews are all members of the [HoloViz](https://holoviz.org) ecosystem and you can expect them to work perfectly together**.\n",
+    "\n",
+    "<img src=\"https://holoviz.org/assets/holoviews.png\" style=\"height:50px;margin-right:10px\"> <img src=\"https://holoviz.org/assets/hvplot.png\" style=\"height:50px;margin-right:10px\"> <img src=\"https://holoviz.org/assets/geoviews.png\" style=\"height:50px;margin-right:10px\"> <img src=\"https://holoviz.org/assets/panel.png\" style=\"height:50px;margin-right:10px\">\n",
+    "\n",
+    "In this reference notebook we will assume a basic level of understanding of HoloViews and optionally hvPlot or Geoviews if you want to use them with Panel.\n",
+    "\n",
+    "---\n",
+    "\n",
+    "The `HoloViews` pane renders [HoloViews](https://holoviews.org/) objects with one of the *plotting backends* supported by HoloViews. This includes objects produced by [hvPlot](https://hvplot.holoviz.org/index.html) and [GeoViews](https://holoviz.org/assets/geoviews.png).\n",
+    "\n",
+    "The `HoloViews` pane supports displaying interactive [`HoloMap`](https://holoviews.org/reference/containers/bokeh/HoloMap.html) and [`DynamicMap`](https://holoviews.org/reference/containers/bokeh/DynamicMap.html) objects containing widgets. The `HoloViews` pane even allows customizing the widget types and their position relative to the plot.\n",
     "\n",
     "#### Parameters:\n",
     "\n",
     "For details on other options for customizing the component see the [layout](../../how_to/layout/index.md) and [styling](../../how_to/styling/index.md) how-to guides.\n",
     "\n",
-    "* **``backend``** (str): Any of the supported HoloViews backends ('bokeh', 'matplotlib', or 'plotly')\n",
-    "* **``center``** (boolean, default=False): Whether to center the plot\n",
-    "* **``linked_axes``** (boolean, default=True): Whether to link axes across plots in a panel layout\n",
+    "The main argument is the `object` parameter\n",
+    "\n",
     "* **``object``** (object): The HoloViews object being displayed\n",
+    "\n",
+    "You can control the way the `object` is rendered and sharing axes with other plots via the parameters\n",
+    "\n",
+    "* **``backend``** (str): Any of the supported HoloViews backends ('bokeh', 'matplotlib', or 'plotly'). If none is specified defaults to the active holoviews renderer. This is by default 'bokeh'.\n",
+    "* **``linked_axes``** (boolean, default=True): Whether to link axes across plots in a panel layout\n",
+    "* **``renderer``**: Explicit [HoloViews Renderer](https://holoviews.org/user_guide/Plots_and_Renderers.html#renderers) instance to use for rendering the HoloViews  plot. Overrides the` backend` parameter.\n",
+    "* **``theme`` (str, Theme)**: [Bokeh theme](https://docs.bokeh.org/en/latest/docs/reference/themes.html) to apply to the HoloViews plot.\n",
+    "\n",
+    "You can access the layout and (optional) widgets via\n",
+    "\n",
+    "* **``layout``** (pn.layout.Panel): The layout containing the plot pane and (optionally) the `widget_box` layout.\n",
+    "* **``widget_box``** (ListPanel): The layout containing the widgets\n",
+    "\n",
+    "##### Layout and Widget Parameters\n",
+    "\n",
+    "The below parameters are used to control the layout and widgets using `pn.panel` or `pn.pane.HoloViews(...).layout`.\n",
+    "\n",
+    "* **``center``** (boolean, default=False): Whether to center the plot or not.\n",
+    "* **``widgets``** (dict, argument): A mapping from dimension name to a widget class, instance, or dictionary of overrides to modify the default widgets. Provided as an argument.\n",
     "* **``widget_location``** (str): Where to lay out the widget relative to the plot \n",
-    "* **``widget_layout``** (ListPanel type): The object to lay the widgets out in, one of ``Row``, ``Column`` or ``WidgetBox``\n",
+    "* **``widget_layout``** (ListPanel): The object to lay the widgets out in, one of ``Row``, ``Column`` or ``WidgetBox``\n",
     "* **``widget_type``** (str): Whether to generate individual widgets for each dimension, or to use a global linear scrubber with dimensions concatenated.\n",
-    "* **``widgets``** (dict): A mapping from dimension name to a widget class, instance, or dictionary of overrides to modify the default widgets.\n",
-    "\n",
-    "##### Display\n",
-    "\n",
-    "* **``default_layout``** (pn.layout.Panel, default=Row): Layout to wrap the plot and widgets in\n",
-    "\n",
     "___"
    ]
   },
@@ -40,7 +69,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The `panel` function will automatically convert any ``HoloViews`` object into a displayable panel, while keeping all of its interactive features:"
+    "The `pn.pane.HoloViews` pane will automatically convert any ``HoloViews`` object into a displayable panel, while keeping all of its interactive features:"
    ]
   },
   {
@@ -50,11 +79,11 @@
    "outputs": [],
    "source": [
     "import numpy as np\n",
-    "import holoviews as hv\n",
     "\n",
-    "box = hv.BoxWhisker((np.random.randint(0, 10, 100), np.random.randn(100)), 'Group').sort()\n",
+    "data = {\"group\": np.random.randint(0, 10, 100), \"value\": np.random.randn(100)}\n",
+    "box = hv.Scatter(data, kdims=\"group\", vdims=\"value\").sort().opts()\n",
     "\n",
-    "hv_layout = pn.panel(box)\n",
+    "hv_layout = pn.pane.HoloViews(box, height=300, sizing_mode=\"stretch_width\")\n",
     "hv_layout"
    ]
   },
@@ -71,16 +100,18 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "hv_layout.object = hv.Violin(box).opts(violin_color='Group', cmap='Category20')"
+    "hv_layout.object = hv.Violin(box).opts(violin_color='Group', cmap='Category20', responsive=True, height=300)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Widgets\n",
+    "You can display [`HoloMap`](https://holoviews.org/reference/containers/bokeh/HoloMap.html) and [`DynamicMap`](https://holoviews.org/reference/containers/bokeh/DynamicMap.html) too. \n",
     "\n",
-    "HoloViews natively renders plots with widgets if a HoloMap or DynamicMap declares any key dimensions. Unlike Panel's ``interact`` functionality, this approach efficiently updates just the data inside a plot instead of replacing it entirely. Calling ``pn.panel`` on the DynamicMap will return a ``Row`` layout (configurable via the ``default_layout`` option), which is equivalent to calling ``pn.pane.HoloViews(dmap).layout``:"
+    "[HoloViews](https://holoviews.org/) (the framework) natively renders plots with widgets if a [`HoloMap`](https://holoviews.org/reference/containers/bokeh/HoloMap.html) or [DynamicMap](https://holoviews.org/reference/containers/bokeh/DynamicMap.html) declares any *key dimensions*. This approach efficiently updates just the data inside a plot instead of replacing the plot entirely.\n",
+    "\n",
+    "Please note that if you want to use the layout and widgets parameters, then you must use use `pn.panel` or `pn.pane.HoloViews(...).layout` instead of `pn.pane.HoloViews`. More info below."
    ]
   },
   {
@@ -96,13 +127,324 @@
     "def sine(frequency=1.0, amplitude=1.0, function='sin'):\n",
     "    xs = np.arange(200)/200*20.0\n",
     "    ys = amplitude*getattr(np, function)(frequency*xs)\n",
-    "    return pd.DataFrame(dict(y=ys), index=xs).hvplot()\n",
+    "    return pd.DataFrame(dict(y=ys), index=xs).hvplot(height=250, responsive=True)\n",
     "\n",
     "dmap = hv.DynamicMap(sine, kdims=['frequency', 'amplitude', 'function']).redim.range(\n",
     "    frequency=(0.1, 10), amplitude=(1, 10)).redim.values(function=['sin', 'cos', 'tan'])\n",
     "\n",
-    "hv_panel = pn.panel(dmap)\n",
+    "hv_panel = pn.pane.HoloViews(dmap)\n",
+    "hv_panel"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The `layout` parameter contains the `HoloViews` pane and the `widget_box`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(hv_panel.layout, \"\\n\\n\", hv_panel.widget_box)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can use [hvPlot](https://hvplot.holoviz.org/) (and [GeoViews](https://geoviews.org/)) too."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import hvplot.pandas\n",
     "\n",
+    "df = pd.DataFrame(data)\n",
+    "plot = df.hvplot.box(by=\"group\", y=\"value\", responsive=True, height=300)\n",
+    "pn.pane.HoloViews(plot, height=300, sizing_mode=\"stretch_width\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Backend\n",
+    "\n",
+    "The ``HoloViews`` pane will default to the 'bokeh' plotting backend if no backend has been loaded via `holoviews`, but you can change the backend to any of the 'bokeh', 'matplotlib' and 'plotly' backends as needed.\n",
+    "\n",
+    "### Bokeh\n",
+    "\n",
+    "Bokeh is the default plotting backend, so normally you don't have to specify it. But lets do it here to show how it works."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot = df.hvplot.scatter(x=\"group\", y=\"value\")\n",
+    "pn.pane.HoloViews(plot, backend='bokeh', sizing_mode=\"stretch_width\", height=300)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Matplotlib"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot = df.hvplot.scatter(x=\"group\", y=\"value\")\n",
+    "pn.pane.HoloViews(plot, backend='matplotlib', sizing_mode=\"stretch_width\", height=300)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Please note that in a *server context* you might have to set the matplotlib backend like below depending on your setup.\n",
+    "\n",
+    "```python\n",
+    "import matplotlib\n",
+    "matplotlib.use('agg')\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can make your matplotlib plot stretch responsively by ?? **DON'T KNOW HOW TO. PLEASE HELP**"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Plotly\n",
+    "\n",
+    "To use the 'plotly' plotting backend you will need to run `hv.extension(\"plotly\")` to configure the 'plotly' backend.\n",
+    "\n",
+    "If you are using `hvPlot` you can use `hvplot.extension(\"plotly\")` instead."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "hvplot.extension(\"plotly\")\n",
+    "\n",
+    "plot = df.hvplot.scatter(x=\"group\", y=\"value\", height=300, responsive=True)\n",
+    "pn.pane.HoloViews(plot, backend='plotly', height=300)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**DO NOT WORK!**. This plot is higher than 300px. **DON'T KNOW HOW TO SOLVE**.\n",
+    "\n",
+    "Lets change the default backend back to 'bokeh'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "hvplot.extension(\"bokeh\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Dynamic\n",
+    "\n",
+    "You can change the plotting backend dynamically via a widget too."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot = df.hvplot.scatter(x=\"group\", y=\"value\", height=300, responsive=True, title=\"Try changing the backend\")\n",
+    "plot_pane = pn.pane.HoloViews(plot, backend='bokeh', sizing_mode=\"stretch_width\", height=300)\n",
+    "widget = pn.widgets.RadioButtonGroup.from_param(plot_pane.param.backend, button_type=\"primary\", button_style=\"outline\")\n",
+    "pn.Column(widget, plot_pane)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**DOES NOT WORK WELL!**. The matplotlib and plotly plots don't have the title. And they don't stretch their width. And the plotly plot is higher than the 300px specified. **DON'T KNOW HOW TO FIX. PLEASE HELP**"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Linked Axes\n",
+    "\n",
+    "By default the axes of plots with shared key or value dimensions are linked. You can remove the link by setting the `linked_axes` parameter to `False`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "not_linked_plot = df.hvplot.scatter(x=\"group\", y=\"value\", responsive=True, title=\"Not Linked Axes\").opts(active_tools=['box_zoom'])\n",
+    "linked_plot = df.hvplot.scatter(x=\"group\", y=\"value\", responsive=True, title=\"Linked Axes\").opts(active_tools=['box_zoom'])\n",
+    "\n",
+    "\n",
+    "pn.Column(\n",
+    "    pn.pane.HoloViews(not_linked_plot, backend='bokeh', sizing_mode=\"stretch_width\", height=200, linked_axes=False),\n",
+    "    pn.pane.HoloViews(linked_plot, backend='bokeh', sizing_mode=\"stretch_width\", height=200),\n",
+    "    pn.pane.HoloViews(linked_plot, backend='bokeh', sizing_mode=\"stretch_width\", height=200),\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Theme\n",
+    "\n",
+    "You can change the `theme`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot = df.hvplot.scatter(x=\"group\", y=\"value\", height=300, responsive=True)\n",
+    "pn.pane.HoloViews(plot, height=300, theme=\"night_sky\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "DON'T KNOW IF THIS WORKS IN JUPYTER. IN VS CODE IT DOES NOT WORK"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Layout and Widget Parameters\n",
+    "\n",
+    "Please note that above we used the `Holoviews` pane to display HoloViews objects.\n",
+    "\n",
+    "The parameters we explain below works with `pn.panel` and equivalently `pn.pane.HoloViews(...).layout` instead.\n",
+    "\n",
+    "### Center\n",
+    "\n",
+    "You can center your plots via the `center` parameter."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot = df.hvplot.scatter(x=\"group\", y=\"value\", height=300, width=400)\n",
+    "\n",
+    "pn.Column(\n",
+    "    \"## Not Centered: `center=False`\",\n",
+    "    pn.panel(plot, sizing_mode=\"stretch_width\"),\n",
+    "    \"## Centered: `center=True`\",\n",
+    "    pn.panel(plot, center=True, sizing_mode=\"stretch_width\"),\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**DO NOT WORK AS I WOULD EXPECT!**. I would have expected the NOT CENTERED plot to have been left aligned and 400px wide."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### HoloMap and DynamicMap with Widgets\n",
+    "\n",
+    "[HoloViews](https://holoviews.org/) (the framework) natively renders plots with widgets if a [`HoloMap`](https://holoviews.org/reference/containers/bokeh/HoloMap.html) or [DynamicMap](https://holoviews.org/reference/containers/bokeh/DynamicMap.html) declares any *key dimensions*. This approach efficiently updates just the data inside a plot instead of replacing it entirely.\n",
+    "\n",
+    "You can control the layout via the parameters\n",
+    "\n",
+    "layout\n",
+    "widgets\n",
+    "widgets\n",
+    "widget_location\n",
+    "widget_layout\n",
+    "widget_type"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import hvplot.pandas\n",
+    "import holoviews.plotting.bokeh\n",
+    "\n",
+    "def sine(frequency=1.0, amplitude=1.0, function='sin'):\n",
+    "    xs = np.arange(200)/200*20.0\n",
+    "    ys = amplitude*getattr(np, function)(frequency*xs)\n",
+    "    return pd.DataFrame(dict(y=ys), index=xs).hvplot(height=250, responsive=True)\n",
+    "\n",
+    "dmap = hv.DynamicMap(sine, kdims=['frequency', 'amplitude', 'function']).redim.range(\n",
+    "    frequency=(0.1, 10), amplitude=(1, 10)).redim.values(function=['sin', 'cos', 'tan'])\n",
+    "\n",
+    "pn.panel(dmap, height=500, widget_location=\"bottom\", widget_layout=pn.Row, sizing_mode=\"stretch_width\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**DOES NOT WORK!**. The `default_layout` is not taken into account. And why is the frequency and amplitude widgets not aligned vertically?\n",
+    "\n",
+    "Lets inspect the layout"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "print(hv_panel)"
    ]
   },
@@ -110,7 +452,55 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can see the widgets generated for each of the dimensions and arrange them any way we like, e.g. by unpacking them into a ``Row``:"
+    "You can see that\n",
+    "\n",
+    "- the outer `Row` contains the `HoloViews` pane and a `WidgetBox`.\n",
+    "- the 3 widgets corresponding to the 3 *key dimensions* (`kdims`) are laid out in the `WidgetBox`\n",
+    "\n",
+    "Lets inspect the `widgets`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(hv_panel.widgets)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Lets inspect the `widgets`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "Lets try to change the name of the `FloatSlider`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "float_slider = hv_panel[1][0]\n",
+    "float_slider.name=\"Frequency (updated)\"\n",
+    "float_slider"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Lets try to reorganize the layout"
    ]
   },
   {
@@ -121,9 +511,7 @@
    "source": [
     "widgets = hv_panel[1]\n",
     "\n",
-    "pn.Column(\n",
-    "    pn.Row(*widgets),\n",
-    "    hv_panel[0])"
+    "pn.Column(hv_panel[0], pn.Column(*widgets))"
    ]
   },
   {
@@ -180,53 +568,6 @@
     "    'function': pn.widgets.RadioButtonGroup,\n",
     "    'frequency': {'value': 5}\n",
     "}).layout"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Switching backends\n",
-    "\n",
-    "The ``HoloViews`` pane will default to the Bokeh backend if no backend has been loaded, but you can override the backend as needed."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import holoviews.plotting.mpl\n",
-    "import holoviews.plotting.plotly\n",
-    "\n",
-    "hv_pane = pn.pane.HoloViews(dmap, backend='matplotlib')\n",
-    "hv_pane"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Please note that in a *server context* you will also have to set the matplotlib backend like below\n",
-    "\n",
-    "```python\n",
-    "import matplotlib\n",
-    "matplotlib.use('agg')\n",
-    "```\n",
-    "\n",
-    "The ``backend``, like all other parameters, can be modified after the fact.  To demonstrate, we can set up a select widget to toggle between backends for the above plot:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "backend_select = pn.widgets.RadioButtonGroup(name='Backend Selector:', options=['bokeh', 'matplotlib', 'plotly'])\n",
-    "backend_select.link(hv_pane[0], value='backend')\n",
-    "backend_select"
    ]
   }
  ],

--- a/panel/pane/holoviews.py
+++ b/panel/pane/holoviews.py
@@ -52,7 +52,7 @@ class HoloViews(PaneBase):
     """
 
     backend = param.ObjectSelector(
-        default=None, objects=['bokeh', 'plotly', 'matplotlib'], doc="""
+        default=None, objects=['bokeh', 'matplotlib', 'plotly'], doc="""
         The HoloViews backend used to render the plot (if None defaults
         to the currently selected renderer).""")
 


### PR DESCRIPTION
Via https://github.com/holoviz/panel/issues/5628 its clear that the `HoloViews` reference notebook does not clearly explain how things are expected to work. After working with it I can also see that its not updated to reflect how the `HoloViews` pane works today. And there are also a issues (bugs).