### PR TITLE
Optimize rendering of ChatMessage

### DIFF
--- a/panel/chat/message.py
+++ b/panel/chat/message.py
@@ -206,7 +206,7 @@ class ChatMessage(PaneBase):
     user = param.Parameter(default="User", doc="""
         Name of the user who sent the message.""")
 
-    _object_panel = param.Parameter(doc="The rendered object panel.")
+    _object_panel = param.Parameter(allow_refs=False, doc="The rendered object panel.")
 
     _stylesheets: ClassVar[List[str]] = [f"{CDN_DIST}css/chat_message.css"]
 
@@ -250,7 +250,7 @@ class ChatMessage(PaneBase):
             visible=self.param.show_avatar,
             sizing_mode=None,
         )
-        self.param.watch(self._update_avatar, "avatar")
+        self.param.watch(self._update_avatar_pane, "avatar")
 
         self._object_panel = self._create_panel(self.object)
         self._center_row = Row(
@@ -260,7 +260,7 @@ class ChatMessage(PaneBase):
             stylesheets=self._stylesheets,
             sizing_mode=None
         )
-        self.param.watch(self._update_object, "object")
+        self.param.watch(self._update_object_pane, "object")
 
         self._user_html = HTML(
             self.param.user, height=20, css_classes=["name"],
@@ -531,21 +531,23 @@ class ChatMessage(PaneBase):
                 avatar_pane = HTML(avatar, **avatar_params)
         return avatar_pane
 
-    def _update_avatar(self, event):
+    def _update_avatar_pane(self, event=None):
         new_avatar = self._render_avatar()
         old_type = type(self._left_col[0])
         new_type = type(new_avatar)
         if isinstance(event.old, (HTML, ImageBase)) or new_type is not old_type:
             self._left_col[:] = [new_avatar]
         else:
-            self._left_col[0].param.update(new_avatar.param.values())
+            params = new_avatar.param.values()
+            del params['name']
+            self._left_col[0].param.update(**params)
 
     def _update(self, ref, old_models):
         """
         Internals will be updated inplace.
         """
 
-    def _update_object(self):
+    def _update_object_pane(self, event=None):
         self._center_row[0] = self._object_panel = self._create_panel(self.object)
 
     @param.depends("avatar_lookup", "user", watch=True)

--- a/panel/dist/css/chat_message.css
+++ b/panel/dist/css/chat_message.css
@@ -59,8 +59,12 @@
 }
 
 .message {
-  width: fit-content;
   border-radius: 5px;
+  box-shadow:
+    color-mix(in srgb, var(--panel-shadow-color) 30%, transparent) 0px 1px 2px
+      0px,
+    color-mix(in srgb, var(--panel-shadow-color) 15%, transparent) 0px 1px 3px
+      1px;
   font-size: 1.25em;
   min-width: 50px;
   min-height: 50px;
@@ -68,11 +72,9 @@
   margin-left: 10px; /* Space for avatar */
   margin-right: 5px; /* Space for reaction */
   background-color: var(--panel-surface-color, #f1f1f1);
-  box-shadow:
-    color-mix(in srgb, var(--panel-shadow-color) 30%, transparent) 0px 1px 2px
-      0px,
-    color-mix(in srgb, var(--panel-shadow-color) 15%, transparent) 0px 1px 3px
-      1px;
+  max-width: calc(100% - 40px);
+  padding: 5px;
+  width: fit-content;
 }
 
 .footer {

--- a/panel/dist/css/chat_message.css
+++ b/panel/dist/css/chat_message.css
@@ -91,7 +91,6 @@
 .markdown {
   padding-block: 0px;
   padding-inline: 15px;
-  width: calc(100% - 15px);
 }
 
 .avatar.rotating-placeholder {

--- a/panel/tests/chat/test_feed.py
+++ b/panel/tests/chat/test_feed.py
@@ -603,7 +603,8 @@ class TestChatFeedCallback:
     def test_renderers_widget(self, chat_feed):
         chat_feed.renderers = [TextAreaInput]
         chat_feed.send("Hello!")
-        area_input = chat_feed.objects[0]._render_object()
+        area_input = chat_feed[0]._update_object_pane()
+        area_input = chat_feed[0]._object_panel
         assert isinstance(area_input, TextAreaInput)
         assert area_input.value == "Hello!"
         assert area_input.height == 500

--- a/panel/tests/chat/test_message.py
+++ b/panel/tests/chat/test_message.py
@@ -32,7 +32,7 @@ class TestChatMessage:
         columns = message._composite.objects
         assert len(columns) == 2
 
-        avatar_pane = columns[0][0].object()
+        avatar_pane = columns[0][0]
         assert isinstance(avatar_pane, HTML)
         assert avatar_pane.object == "🧑"
 
@@ -44,7 +44,7 @@ class TestChatMessage:
         center_row = columns[1][1]
         assert isinstance(center_row, Row)
 
-        object_pane = center_row[0].object()
+        object_pane = center_row[0]
         assert isinstance(object_pane, Markdown)
         assert object_pane.object == "ABC"
 
@@ -75,20 +75,20 @@ class TestChatMessage:
     def test_update_avatar(self):
         message = ChatMessage(avatar="A")
         columns = message._composite.objects
-        avatar_pane = columns[0][0].object()
+        avatar_pane = columns[0][0]
         assert isinstance(avatar_pane, HTML)
         assert avatar_pane.object == "A"
 
         message.avatar = "B"
-        avatar_pane = columns[0][0].object()
+        avatar_pane = columns[0][0]
         assert avatar_pane.object == "B"
 
         message.avatar = "❤️"
-        avatar_pane = columns[0][0].object()
+        avatar_pane = columns[0][0]
         assert avatar_pane.object == "❤️"
 
         message.avatar = "https://assets.holoviz.org/panel/samples/jpg_sample.jpg"
-        avatar_pane = columns[0][0].object()
+        avatar_pane = columns[0][0]
         assert isinstance(avatar_pane, Image)
         assert (
             avatar_pane.object
@@ -96,13 +96,13 @@ class TestChatMessage:
         )
 
         message.show_avatar = False
-        avatar_pane = columns[0][0].object()
-        assert not avatar_pane.visible
+        avatar_layout = columns[0]
+        assert not avatar_layout.visible
 
         message.avatar = SVG(
             "https://tabler-icons.io/static/tabler-icons/icons/user.svg"
         )
-        avatar_pane = columns[0][0].object()
+        avatar_pane = columns[0][0]
         assert isinstance(avatar_pane, SVG)
 
     def test_update_user(self):
@@ -123,19 +123,19 @@ class TestChatMessage:
     def test_update_object(self):
         message = ChatMessage(object="Test")
         columns = message._composite.objects
-        object_pane = columns[1][1][0].object()
+        object_pane = columns[1][1][0]
         assert isinstance(object_pane, Markdown)
         assert object_pane.object == "Test"
 
         message.object = TextInput(value="Also testing...")
-        object_pane = columns[1][1][0].object()
+        object_pane = columns[1][1][0]
         assert isinstance(object_pane, TextInput)
         assert object_pane.value == "Also testing..."
 
         message.object = _FileInputMessage(
             contents=b"I am a file", file_name="test.txt", mime_type="text/plain"
         )
-        object_pane = columns[1][1][0].object()
+        object_pane = columns[1][1][0]
         assert isinstance(object_pane, Markdown)
         assert object_pane.object == "I am a file"
 


### PR DESCRIPTION
Attempt at improving https://github.com/holoviz/panel/issues/6064

```python
%%timeit
pn.chat.ChatMessage('Some content', user='user')
```

Before:

> 19.6 ms ± 591 µs per loop (mean ± std. dev. of 7 runs, 10 loops each

After:

> 10.9 ms ± 138 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)

The main performance gains here came from avoiding use of `ParamMethod` and instead favoring manual watch callbacks.

Note those numbers also already account for the changes in: https://github.com/holoviz/param/pull/893

Without that it goes from:

> 21.6 ms ± 974 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)

to:

> 11.7 ms ± 280 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
