### PR TITLE
Micro optimizations for Viewable

### DIFF
--- a/panel/chat/icon.py
+++ b/panel/chat/icon.py
@@ -35,29 +35,17 @@ class ChatReactionIcons(CompositeWidget):
     >>> ChatReactionIcons(value=["like"], options={"like": "thumb-up", "dislike": "thumb-down"})
     """
 
-    active_icons = param.Dict(
-        default={},
-        doc="""
-        The mapping of reactions to their corresponding active icon names;
-        if not set, the active icon name will default to its "filled" version.""",
-    )
-
-    options = param.Dict(
-        default={"favorite": "heart"},
-        doc="""
-        A key-value pair of reaction values and their corresponding tabler icon names
-        found on https://tabler-icons.io.""",
-    )
-
-    value = param.List(doc="The active reactions.")
+    active_icons = param.Dict(default={}, doc="""
+        The mapping of reactions to their corresponding active icon names.
+        If not set, the active icon name will default to its "filled" version.""")
 
     css_classes = param.List(default=["reaction-icons"], doc="The CSS classes of the widget.")
 
-    _rendered_icons = param.Dict(
-        default={},
-        doc="""
-        The rendered icons mapping reaction to icon.""",
-    )
+    options = param.Dict(default={"favorite": "heart"}, doc="""
+        A key-value pair of reaction values and their corresponding tabler icon names
+        found on https://tabler-icons.io.""")
+
+    value = param.List(doc="The active reactions.")
 
     _stylesheets: ClassVar[List[str]] = [f"{CDN_DIST}css/chat_reaction_icons.css"]
 
@@ -103,9 +91,10 @@ class ChatReactionIcons(CompositeWidget):
 
 
 class ChatCopyIcon(ReactiveHTML):
-    value = param.String(default=None, doc="The text to copy to the clipboard.")
 
     fill = param.String(default="none", doc="The fill color of the icon.")
+
+    value = param.String(default=None, doc="The text to copy to the clipboard.")
 
     _template = """
         <div

--- a/panel/chat/message.py
+++ b/panel/chat/message.py
@@ -232,6 +232,8 @@ class ChatMessage(PaneBase):
                 value=params.get('reactions', []),
                 visible=self.param.show_reaction_icons
             )
+        else:
+            reaction_icons.visible = self.param.show_reaction_icons
         self._internal = True
         super().__init__(object=object, **params)
         self.reaction_icons.link(self, value="reactions", bidirectional=True)

--- a/panel/chat/message.py
+++ b/panel/chat/message.py
@@ -228,17 +228,15 @@ class ChatMessage(PaneBase):
         reaction_icons = params.get("reaction_icons", {"favorite": "heart"})
         if isinstance(reaction_icons, dict):
             params["reaction_icons"] = ChatReactionIcons(
-                options=reaction_icons, width=15, height=15
+                options=reaction_icons, width=15, height=15,
+                value=params.get('reactions', []),
+                visible=self.param.show_reaction_icons
             )
         self._internal = True
         super().__init__(object=object, **params)
-        self.reaction_icons.link(
-            self, value="reactions", visible="show_reaction_icons",
-            bidirectional=True
-        )
-        self.param.trigger("reactions", "show_reaction_icons")
+        self.reaction_icons.link(self, value="reactions", bidirectional=True)
         if not self.avatar:
-            self.param.trigger("avatar_lookup")
+            self._update_avatar()
         self._build_layout()
 
     def _build_layout(self):

--- a/panel/chat/message.py
+++ b/panel/chat/message.py
@@ -230,13 +230,11 @@ class ChatMessage(PaneBase):
             params["reaction_icons"] = ChatReactionIcons(
                 options=reaction_icons, width=15, height=15,
                 value=params.get('reactions', []),
-                visible=self.param.show_reaction_icons
             )
-        else:
-            reaction_icons.visible = self.param.show_reaction_icons
         self._internal = True
         super().__init__(object=object, **params)
         self.reaction_icons.link(self, value="reactions", bidirectional=True)
+        self.reaction_icons.visible = self.param.show_reaction_icons
         if not self.avatar:
             self._update_avatar()
         self._build_layout()

--- a/panel/viewable.py
+++ b/panel/viewable.py
@@ -696,7 +696,8 @@ class Viewable(Renderable, Layoutable, ServableMixin):
         super().__init__(**params)
         self._hooks = hooks
 
-        self._update_loading()
+        if self.loading:
+            self._update_loading()
         self._update_background()
         self._update_design()
         self._internal_callbacks.extend([

--- a/panel/viewable.py
+++ b/panel/viewable.py
@@ -11,6 +11,7 @@ and become viewable including:
 from __future__ import annotations
 
 import asyncio
+import functools
 import logging
 import os
 import sys
@@ -18,9 +19,9 @@ import threading
 import traceback
 import uuid
 
-from functools import partial
 from typing import (
     IO, TYPE_CHECKING, Any, Callable, ClassVar, Dict, List, Mapping, Optional,
+    Type,
 )
 
 import param  # type: ignore
@@ -55,6 +56,7 @@ if TYPE_CHECKING:
 
     from .io.location import Location
     from .io.server import StoppableThread
+    from .theme import Design
 
 
 class Layoutable(param.Parameterized):
@@ -507,9 +509,9 @@ class MimeRenderMixin:
         ref = model.ref['id']
         manager = CommManager(comm_id=comm.id, plot_id=ref)
         client_comm = state._comm_manager.get_client_comm(
-            on_msg=partial(self._on_msg, ref, manager),
-            on_error=partial(self._on_error, ref),
-            on_stdout=partial(self._on_stdout, ref)
+            on_msg=functools.partial(self._on_msg, ref, manager),
+            on_error=functools.partial(self._on_error, ref),
+            on_stdout=functools.partial(self._on_stdout, ref)
         )
         self._comms[ref] = (comm, client_comm)
         manager.client_comm_id = client_comm.id
@@ -706,15 +708,19 @@ class Viewable(Renderable, Layoutable, ServableMixin):
             self.param.watch(self._update_loading, 'loading')
         ])
 
+    @staticmethod
+    @functools.cache
+    def _instantiate_design(design: Type[Design], theme: str) -> Design:
+        return design(theme=theme)
+
     def _update_design(self, *_):
         from .theme import Design
         from .theme.native import Native
         if isinstance(self.design, Design):
             self._design = self.design
-        elif self.design:
-            self._design = self.design(theme=config.theme)
         else:
-            self._design = Native(theme=config.theme)
+            design = self.design or Native
+            self._design = self._instantiate_design(design, config.theme)
 
     def _update_loading(self, *_) -> None:
         if self.loading:


### PR DESCRIPTION
Some small optimizations on `Viewable` that do add up when you create a lot of components:

- Cache Design instances created internally (99% of the time the Design can and should be shared across all Viewable instances)
- Do not run stop_loading if `loading=False` on instantiation (this is pointless to run on instantiation)
- Small optimization avoiding `.param.trigger()` on ChatMessage 