### PR TITLE
Remove contourpy fro pyodide again

### DIFF
--- a/scripts/build_pyodide_wheels.py
+++ b/scripts/build_pyodide_wheels.py
@@ -69,7 +69,7 @@ for item in zin.infolist():
                 for line in buffer.decode("utf-8").split("\n")
                 if not (
                     "Requires-Dist:" in line
-                    and "tornado" in line
+                    and ("tornado" in line or "contourpy" in line)
                 )
             ]
         ).encode("utf-8")


### PR DESCRIPTION
I was too eager with the removal of contourpy here. 

We are using an old version of pyodide which did not package a newer version of contourpy. 