### PR TITLE
Auth: execute async scheduled refresh callback

### DIFF
--- a/panel/auth.py
+++ b/panel/auth.py
@@ -1068,7 +1068,7 @@ class OAuthProvider(BasicAuthProvider):
         expiry_date = dt.datetime.now() + dt.timedelta(seconds=expiry_seconds) # schedule_task is in local TZ
         refresh_cb = partial(self._scheduled_refresh, user, refresh_token, application, request)
         if expiry_seconds <= 0:
-            refresh_cb()
+            state.execute(refresh_cb)
             return
         task = f'{user}-refresh-access-tokens'
         try:


### PR DESCRIPTION
`refresh_cb` is a partial built from the `_scheduled_refresh` async method, it cannot be called directly.