### PR TITLE
`layout` type for NestedSelect

### DIFF
--- a/examples/reference/widgets/NestedSelect.ipynb
+++ b/examples/reference/widgets/NestedSelect.ipynb
@@ -24,6 +24,7 @@
     "\n",
     "* **``options``** (dict | callable): The options to select from. The options may be nested dictionaries, lists, or callables that return those types. If callables are used, the callables must accept `level` and `value` keyword arguments, where `level` is the level that updated and `value` is a dictionary of the current values, containing keys up to the level that was updated.\n",
     "* **``value``** (dict): The value from all the Select widgets; the keys are the levels names. If no levels names are specified, the keys are the levels indices.\n",
+    "* **`layout``** (ListLike | dict): The layout type of the widgets. If a dictionary, a \"type\" key can be provided, to specify the layout type of the widgets, and any additional keyword arguments will be used to instantiate the layout.\n",
     "* **``levels``** (list): Either a list of strings or a list of dictionaries. If a list of strings, the strings are used as the names of the levels. If a list of dictionaries, each dictionary may have a \"name\" key, which is used as the name of the level, a \"type\" key, which is used as the type of widget, and any corresponding widget keyword arguments. Must be specified if options is callable.\n",
     "\n",
     "##### Display\n",
@@ -71,6 +72,61 @@
    "outputs": [],
    "source": [
     "select.value"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "A different `layout` type can be provided to the `NestedSelect` to change the layout of the widgets."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "select = pn.widgets.NestedSelect(\n",
+    "    options={\n",
+    "        \"GFS\": {\n",
+    "            \"0.25 deg\": [\"00Z\", \"06Z\", \"12Z\", \"18Z\"],\n",
+    "            \"0.5 deg\": [\"00Z\", \"12Z\"],\n",
+    "            \"1 deg\": [\"00Z\", \"12Z\"],\n",
+    "        },\n",
+    "        \"NAME\": {\n",
+    "            \"12 km\": [\"00Z\", \"12Z\"],\n",
+    "            \"3 km\": [\"00Z\", \"12Z\"],\n",
+    "        },\n",
+    "    },\n",
+    "    levels=[\"Model\", \"Resolution\", \"Initialization\"],\n",
+    "    layout=pn.Row\n",
+    ")\n",
+    "select"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "select = pn.widgets.NestedSelect(\n",
+    "    options={\n",
+    "        \"GFS\": {\n",
+    "            \"0.25 deg\": [\"00Z\", \"06Z\", \"12Z\", \"18Z\"],\n",
+    "            \"0.5 deg\": [\"00Z\", \"12Z\"],\n",
+    "            \"1 deg\": [\"00Z\", \"12Z\"],\n",
+    "        },\n",
+    "        \"NAME\": {\n",
+    "            \"12 km\": [\"00Z\", \"12Z\"],\n",
+    "            \"3 km\": [\"00Z\", \"12Z\"],\n",
+    "        },\n",
+    "    },\n",
+    "    levels=[\"Model\", \"Resolution\", \"Initialization\"],\n",
+    "    layout={\"type\": pn.GridBox, \"ncols\": 2}\n",
+    ")\n",
+    "select"
    ]
   },
   {

--- a/examples/reference/widgets/NestedSelect.ipynb
+++ b/examples/reference/widgets/NestedSelect.ipynb
@@ -24,7 +24,7 @@
     "\n",
     "* **``options``** (dict | callable): The options to select from. The options may be nested dictionaries, lists, or callables that return those types. If callables are used, the callables must accept `level` and `value` keyword arguments, where `level` is the level that updated and `value` is a dictionary of the current values, containing keys up to the level that was updated.\n",
     "* **``value``** (dict): The value from all the Select widgets; the keys are the levels names. If no levels names are specified, the keys are the levels indices.\n",
-    "* **``layout``** (ListLike | dict): The layout type of the widgets. If a dictionary, a \"type\" key can be provided, to specify the layout type of the widgets, and any additional keyword arguments will be used to instantiate the layout.\n",
+    "* **``layout``** (ListPanel | dict): The layout type of the widgets. If a dictionary, a \"type\" key can be provided, to specify the layout type of the widgets, and any additional keyword arguments will be used to instantiate the layout.\n",
     "* **``levels``** (list): Either a list of strings or a list of dictionaries. If a list of strings, the strings are used as the names of the levels. If a list of dictionaries, each dictionary may have a \"name\" key, which is used as the name of the level, a \"type\" key, which is used as the type of widget, and any corresponding widget keyword arguments. Must be specified if options is callable.\n",
     "\n",
     "##### Display\n",

--- a/examples/reference/widgets/NestedSelect.ipynb
+++ b/examples/reference/widgets/NestedSelect.ipynb
@@ -24,7 +24,7 @@
     "\n",
     "* **``options``** (dict | callable): The options to select from. The options may be nested dictionaries, lists, or callables that return those types. If callables are used, the callables must accept `level` and `value` keyword arguments, where `level` is the level that updated and `value` is a dictionary of the current values, containing keys up to the level that was updated.\n",
     "* **``value``** (dict): The value from all the Select widgets; the keys are the levels names. If no levels names are specified, the keys are the levels indices.\n",
-    "* **`layout``** (ListLike | dict): The layout type of the widgets. If a dictionary, a \"type\" key can be provided, to specify the layout type of the widgets, and any additional keyword arguments will be used to instantiate the layout.\n",
+    "* **``layout``** (ListLike | dict): The layout type of the widgets. If a dictionary, a \"type\" key can be provided, to specify the layout type of the widgets, and any additional keyword arguments will be used to instantiate the layout.\n",
     "* **``levels``** (list): Either a list of strings or a list of dictionaries. If a list of strings, the strings are used as the names of the levels. If a list of dictionaries, each dictionary may have a \"name\" key, which is used as the name of the level, a \"type\" key, which is used as the type of widget, and any corresponding widget keyword arguments. Must be specified if options is callable.\n",
     "\n",
     "##### Display\n",
@@ -103,6 +103,13 @@
     "    layout=pn.Row\n",
     ")\n",
     "select"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If a dict is provided, a \"type\" key can be provided, to specify the layout type of the widgets, and any additional keyword arguments will be used to instantiate the layout."
    ]
   },
   {

--- a/panel/tests/widgets/test_select.py
+++ b/panel/tests/widgets/test_select.py
@@ -3,6 +3,7 @@ from collections import OrderedDict
 import numpy as np
 import pytest
 
+from panel.layout import GridBox, Row
 from panel.pane import panel
 from panel.tests.util import mpl_available
 from panel.widgets import (
@@ -666,6 +667,65 @@ def test_nested_select_callable_must_have_levels(document, comm):
         NestedSelect(
             options={"Daily": list_options, "Monthly": list_options},
         )
+
+
+def test_nested_select_layout_listlike(document, comm):
+    options = {
+        "Andrew": {
+            "temp": [1000, 925, 700, 500, 300],
+            "vorticity": [500, 300],
+        },
+        "Ben": {
+            "temp": [500, 300],
+            "windspeed": [700, 500, 300],
+        },
+    }
+    select = NestedSelect(
+        options=options,
+        layout=Row,
+    )
+    assert isinstance(select._composite, Row)
+
+
+def test_nested_select_layout_dict(document, comm):
+    options = {
+        "Andrew": {
+            "temp": [1000, 925, 700, 500, 300],
+            "vorticity": [500, 300],
+        },
+        "Ben": {
+            "temp": [500, 300],
+            "windspeed": [700, 500, 300],
+        },
+    }
+    select = NestedSelect(
+        options=options,
+        layout={"type": GridBox, "ncols": 2},
+    )
+    assert isinstance(select._composite, GridBox)
+    assert select._composite.ncols == 2
+
+
+def test_nested_select_layout_dynamic_update(document, comm):
+    options = {
+        "Andrew": {
+            "temp": [1000, 925, 700, 500, 300],
+            "vorticity": [500, 300],
+        },
+        "Ben": {
+            "temp": [500, 300],
+            "windspeed": [700, 500, 300],
+        },
+    }
+    select = NestedSelect(
+        options=options,
+        layout={"type": GridBox, "ncols": 2},
+    )
+    assert isinstance(select._composite, GridBox)
+    assert select._composite.ncols == 2
+
+    select.layout = Row
+    assert isinstance(select._composite, Row)
 
 
 @pytest.mark.parametrize('options', [[10, 20], dict(A=10, B=20)], ids=['list', 'dict'])

--- a/panel/widgets/select.py
+++ b/panel/widgets/select.py
@@ -23,7 +23,7 @@ from bokeh.models.widgets import (
 )
 
 from ..io.resources import CDN_DIST
-from ..layout import Column
+from ..layout import Column, ListLike
 from ..models import (
     CheckboxButtonGroup as _BkCheckboxButtonGroup, CustomSelect,
     RadioButtonGroup as _BkRadioButtonGroup, SingleSelect as _BkSingleSelect,
@@ -356,6 +356,9 @@ class NestedSelect(CompositeWidget):
         is used as the type of widget, and any corresponding widget keyword arguments.
         Must be specified if options is callable.""")
 
+    layout = param.ClassSelector(default=Column, class_=ListLike, is_instance=False, doc="""
+        The layout of the widgets.""")
+
     disabled = param.Boolean(default=False, doc="""
         Whether the widget is disabled.""")
 
@@ -365,8 +368,6 @@ class NestedSelect(CompositeWidget):
 
     _levels = param.List(doc="""
         The internal rep of levels to prevent overwriting user provided levels.""")
-
-    _composite_type = Column
 
     def __init__(self, **params):
         super().__init__(**params)
@@ -466,7 +467,10 @@ class NestedSelect(CompositeWidget):
                     f"{type(options).__name__}"
                 )
 
-        self._composite[:] = self._widgets
+        if isinstance(self._composite, self.layout):
+            self._composite[:] = self._widgets
+        else:
+            self._composite = self.layout(*self._widgets)
 
         if self.options is not None:
             self.value = self._gather_values_from_widgets()

--- a/panel/widgets/select.py
+++ b/panel/widgets/select.py
@@ -23,7 +23,7 @@ from bokeh.models.widgets import (
 )
 
 from ..io.resources import CDN_DIST
-from ..layout import Column, ListLike
+from ..layout.base import Column, ListPanel, NamedListPanel
 from ..models import (
     CheckboxButtonGroup as _BkCheckboxButtonGroup, CustomSelect,
     RadioButtonGroup as _BkRadioButtonGroup, SingleSelect as _BkSingleSelect,
@@ -472,7 +472,7 @@ class NestedSelect(CompositeWidget):
         if isinstance(self.layout, dict):
             layout_type = self.layout.pop("type", Column)
             layout_kwargs = self.layout.copy()
-        elif issubclass(self.layout, ListLike):
+        elif issubclass(self.layout, (ListPanel, NamedListPanel)):
             layout_type = self.layout
             layout_kwargs = {}
         else:


### PR DESCRIPTION
Closes https://github.com/holoviz/panel/issues/6070

```
select = pn.widgets.NestedSelect(
    options={
        "GFS": {
            "0.25 deg": ["00Z", "06Z", "12Z", "18Z"],
            "0.5 deg": ["00Z", "12Z"],
            "1 deg": ["00Z", "12Z"],
        },
        "NAME": {
            "12 km": ["00Z", "12Z"],
            "3 km": ["00Z", "12Z"],
        },
    },
    levels=["Model", "Resolution", "Initialization"],
    layout={"type": pn.GridBox, "ncols": 2}
)
select
```
<img width="549" alt="image" src="https://github.com/holoviz/panel/assets/15331990/24d35a4d-51df-4e29-b957-8867adcab3c0">
