### PR TITLE
Fix new lines on ChatMessage when not show_reaction_icons

### DIFF
--- a/panel/dist/css/chat_message.css
+++ b/panel/dist/css/chat_message.css
@@ -54,6 +54,7 @@
 }
 
 .center {
+  width: calc(100% - 15px); /* Without this, words start on a new line */
   margin-right: 10px; /* Space for reaction icons */
   padding: 0px;
 }


### PR DESCRIPTION
```python
import panel as pn

pn.extension()

pn.chat.ChatInterface(message_params={"show_reaction_icons": False}).show()
```
<img width="831" alt="image" src="https://github.com/holoviz/panel/assets/15331990/91e96482-c57e-4d75-b01b-164d70e8cbfa">

with the css:
<img width="847" alt="image" src="https://github.com/holoviz/panel/assets/15331990/9136be15-b2b9-4908-8a8f-103abe4e0f0a">

with reaction icons too
<img width="842" alt="image" src="https://github.com/holoviz/panel/assets/15331990/f886dbd6-4be0-4579-917a-67d693089f5d">
