### PR TITLE
Forward not ChatFeed params to message_params

### DIFF
--- a/examples/reference/chat/ChatFeed.ipynb
+++ b/examples/reference/chat/ChatFeed.ipynb
@@ -8,7 +8,6 @@
    },
    "outputs": [],
    "source": [
-    "import time\n",
     "import panel as pn\n",
     "\n",
     "pn.extension()"
@@ -44,7 +43,7 @@
     "##### Styling\n",
     "\n",
     "* **`card_params`** (Dict): Parameters to pass to Card, such as `header`, `header_background`, `header_color`, etc.\n",
-    "* **`message_params`** (Dict): Parameters to pass to each ChatMessage, such as `reaction_icons`, `timestamp_format`, `show_avatar`, `show_user`, and `show_timestamp`.\n",
+    "* **`message_params`** (Dict): Parameters to pass to each ChatMessage, such as `reaction_icons`, `timestamp_format`, `show_avatar`, `show_user`, and `show_timestamp` Params passed that are not ChatFeed params will be forwarded into `message_params`.\n",
     "\n",
     "##### Other\n",
     "\n",
@@ -716,7 +715,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "You can pass `ChatEntry` params through `entry_params`."
+    "You can pass `ChatEntry` params through `message_params`."
    ]
   },
   {
@@ -729,6 +728,25 @@
     "    default_avatars={\"System\": \"S\", \"User\": \"👤\"}, reaction_icons={\"like\": \"thumb-up\"}\n",
     ")\n",
     "chat_feed = pn.chat.ChatFeed(message_params=message_params)\n",
+    "chat_feed.send(user=\"System\", value=\"This is the System speaking.\")\n",
+    "chat_feed.send(user=\"User\", value=\"This is the User speaking.\")\n",
+    "chat_feed"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Alternatively, directly pass those params to the ChatFeed constructor and it'll be forwarded into `message_params` automatically."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "chat_feed = pn.chat.ChatFeed(default_avatars={\"System\": \"S\", \"User\": \"👤\"}, reaction_icons={\"like\": \"thumb-up\"})\n",
     "chat_feed.send(user=\"System\", value=\"This is the System speaking.\")\n",
     "chat_feed.send(user=\"User\", value=\"This is the User speaking.\")\n",
     "chat_feed"

--- a/panel/chat/feed.py
+++ b/panel/chat/feed.py
@@ -163,7 +163,8 @@ class ChatFeed(ListPanel):
 
     message_params = param.Dict(default={}, doc="""
         Params to pass to each ChatMessage, like `reaction_icons`, `timestamp_format`,
-        `show_avatar`, `show_user`, and `show_timestamp`.""")
+        `show_avatar`, `show_user`, and `show_timestamp`. Params passed
+        that are not ChatFeed params will be forwarded into `message_params`.""")
 
     header = param.Parameter(doc="""
         The header of the chat feed; commonly used for the title.

--- a/panel/chat/feed.py
+++ b/panel/chat/feed.py
@@ -221,6 +221,14 @@ class ChatFeed(ListPanel):
             params["renderers"] = [params["renderers"]]
         if params.get("width") is None and params.get("sizing_mode") is None:
             params["sizing_mode"] = "stretch_width"
+
+        # forward message params to ChatMessage for convenience
+        message_params = params.get("message_params", {})
+        for param_key in list(params.keys()):
+            if param_key not in ChatFeed.param and param_key in ChatMessage.param:
+                message_params[param_key] = params.pop(param_key)
+        params["message_params"] = message_params
+
         super().__init__(*objects, **params)
 
         # instantiate the card's column) is not None)

--- a/panel/tests/chat/test_feed.py
+++ b/panel/tests/chat/test_feed.py
@@ -379,6 +379,15 @@ class TestChatFeed:
         wait_until(lambda: len(chat_feed.objects) == 1)
         assert chat_feed.objects[0].object == "Mutated"
 
+    def test_forward_message_params(self, chat_feed):
+        chat_feed = ChatFeed(reaction_icons={"like": "thumb-up"}, reactions=["like"])
+        chat_feed.send("Hey!")
+        chat_message = chat_feed.objects[0]
+        assert chat_feed.message_params == {"reaction_icons": {"like": "thumb-up"}, "reactions": ["like"]}
+        assert chat_message.object == "Hey!"
+        assert chat_message.reactions == ["like"]
+        assert chat_message.reaction_icons.options == {"like": "thumb-up"}
+
 
 @pytest.mark.xdist_group("chat")
 class TestChatFeedCallback:


### PR DESCRIPTION
Makes it possible to do:
```python
import panel as pn

pn.chat.ChatInterface(
    reaction_icons={"like": "thumb-up", "dislike": "thumb-down", "favorite": "heart"}, reactions=["like"]
).servable()
```

Rather than awkwardly nesting dicts:
```python
import panel as pn

pn.chat.ChatInterface(
    message_params={"reaction_icons": {"like": "thumb-up", "dislike": "thumb-down", "favorite": "heart"}, "reactions": ["like"]}
).servable()
```