### PR TITLE
Fixes async dispatch regression on server

### DIFF
--- a/panel/io/document.py
+++ b/panel/io/document.py
@@ -167,6 +167,9 @@ async def _dispatch_msgs(doc, msgs):
         else:
             futures = dispatch_django(conn, msg=msg)
         await _run_write_futures(futures)
+    if not remaining:
+        return
+    await asyncio.sleep(0.01)
     _dispatch_write_task(doc, _dispatch_msgs, doc, remaining)
 
 #---------------------------------------------------------------------


### PR DESCRIPTION
The 1.3.5 release caused a major regression in server performance caused by continuously accumulating async callbacks. Specifically when dispatching messages to the frontend we were continuously rescheduling tasks, which would accumulate over time and effectively cause the server to get bogged down processing pointless old tasks.