### PR TITLE
Tweak Chat components alignment

### DIFF
--- a/panel/chat/interface.py
+++ b/panel/chat/interface.py
@@ -292,8 +292,8 @@ class ChatInterface(ChatFeed):
                     sizing_mode="stretch_width",
                     max_width=show_expr.rx.where(90, 45),
                     max_height=50,
-                    margin=(5, 5, 5, 0),
-                    align="start",
+                    margin=(0, 5, 0, 0),
+                    align="center",
                     visible=visible
                 )
                 if action != "stop":

--- a/panel/chat/message.py
+++ b/panel/chat/message.py
@@ -277,6 +277,7 @@ class ChatMessage(PaneBase):
                 self.chat_copy_icon,
                 stylesheets=self._stylesheets,
                 sizing_mode="stretch_width",
+                css_classes=["header"]
             ),
             self._center_row,
             self._timestamp_html,

--- a/panel/dist/css/chat_message.css
+++ b/panel/dist/css/chat_message.css
@@ -47,6 +47,10 @@
   max-width: calc(100% - 80px);
 }
 
+.header {
+  width: fit-content;
+}
+
 .name {
   font-size: 1em;
   margin-bottom: 0px;

--- a/panel/dist/css/chat_message.css
+++ b/panel/dist/css/chat_message.css
@@ -92,7 +92,7 @@
 .timestamp {
   color: #a9a9a9;
   display: flex;
-  margin-top: 0px;
+  margin-top: 3px;
 }
 
 .markdown {


### PR DESCRIPTION
`pn.extension(sizing_mode="stretch_width")`
![image](https://github.com/holoviz/panel/assets/15331990/67bc81ae-7e03-4ca8-aee3-bcd23eba28d0)

This PR:
<img width="355" alt="image" src="https://github.com/holoviz/panel/assets/15331990/738ffd1d-8307-483b-b9a9-7d4696622482">

Aligns buttons better too:
MaterialTemplate
<img width="324" alt="image" src="https://github.com/holoviz/panel/assets/15331990/b94b1dc0-78e6-4e7d-83f3-e2be6621db08">

No template
<img width="1339" alt="image" src="https://github.com/holoviz/panel/assets/15331990/a00550e9-64c8-4657-919f-c41312c6d309">

Also adjusts timestamp margins
<img width="150" alt="image" src="https://github.com/holoviz/panel/assets/15331990/630eb5d7-774c-44f1-be54-7f1884866888">
