### PR TITLE
Fix generator placeholder and optimize updates

### DIFF
--- a/panel/chat/feed.py
+++ b/panel/chat/feed.py
@@ -221,6 +221,8 @@ class ChatFeed(ListPanel):
             params["renderers"] = [params["renderers"]]
         if params.get("width") is None and params.get("sizing_mode") is None:
             params["sizing_mode"] = "stretch_width"
+
+        self._placeholder = None
         super().__init__(*objects, **params)
 
         # instantiate the card's column) is not None)
@@ -277,6 +279,10 @@ class ChatFeed(ListPanel):
 
     @param.depends("placeholder_text", watch=True, on_init=True)
     def _update_placeholder(self):
+        if self._placeholder is not None:
+            self._placeholder.param.update(object=self.placeholder_text)
+            return
+
         loading_avatar = SVG(
             PLACEHOLDER_SVG, sizing_mode=None, css_classes=["rotating-placeholder"]
         )
@@ -429,7 +435,7 @@ class ChatFeed(ListPanel):
             return
 
         start = asyncio.get_event_loop().time()
-        while not task.done() and num_entries == len(self._chat_log):
+        while not self._callback_state == CallbackState.IDLE and num_entries == len(self._chat_log):
             duration = asyncio.get_event_loop().time() - start
             if duration > self.placeholder_threshold:
                 self.append(self._placeholder)

--- a/panel/chat/feed.py
+++ b/panel/chat/feed.py
@@ -221,8 +221,6 @@ class ChatFeed(ListPanel):
             params["renderers"] = [params["renderers"]]
         if params.get("width") is None and params.get("sizing_mode") is None:
             params["sizing_mode"] = "stretch_width"
-
-        self._placeholder = None
         super().__init__(*objects, **params)
 
         # instantiate the card's column) is not None)

--- a/panel/tests/chat/test_feed.py
+++ b/panel/tests/chat/test_feed.py
@@ -352,7 +352,9 @@ class TestChatFeed:
                 }
                 instance.respond()
             elif user == "arm":
-                user_entry = instance.objects[-2]
+                for user_entry in instance.objects:
+                    if user_entry.user == "User":
+                        break
                 user_contents = user_entry.object
                 yield {
                     "user": "leg",
@@ -440,8 +442,7 @@ class TestChatFeedCallback:
 
         chat_feed.callback = echo
         chat_feed.send("Message", respond=True)
-        await asyncio.sleep(0.5)
-        assert len(chat_feed.objects) == 2
+        await async_wait_until(lambda: len(chat_feed.objects) == 2)
         assert chat_feed.objects[1].object == "Message"
 
     @pytest.mark.parametrize("callback_user", [None, "Bob"])
@@ -490,12 +491,12 @@ class TestChatFeedCallback:
 
         chat_feed.callback = echo
         chat_feed.send("Message", respond=True)
-        await asyncio.sleep(0.5)
+        await async_wait_until(lambda: len(chat_feed.objects) == 2)
         assert len(chat_feed.objects) == 2
         assert chat_feed.objects[1].object == "Message"
 
     @pytest.mark.asyncio
-    async def test_generator(self, chat_feed):
+    def test_generator(self, chat_feed):
         async def echo(contents, user, instance):
             message = ""
             for char in contents:
@@ -504,7 +505,7 @@ class TestChatFeedCallback:
 
         chat_feed.callback = echo
         chat_feed.send("Message", respond=True)
-        await asyncio.sleep(0.5)
+        wait_until(lambda: len(chat_feed.objects) == 2)
         assert len(chat_feed.objects) == 2
         assert chat_feed.objects[1].object == "Message"
 
@@ -522,8 +523,7 @@ class TestChatFeedCallback:
 
         chat_feed.callback = echo
         chat_feed.send("Message", respond=True)
-        await asyncio.sleep(0.5)
-        assert len(chat_feed.objects) == 2
+        await async_wait_until(lambda: len(chat_feed.objects) == 2)
         assert chat_feed.objects[1].object == "Message"
 
     def test_placeholder_disabled(self, chat_feed):

--- a/panel/tests/chat/test_feed.py
+++ b/panel/tests/chat/test_feed.py
@@ -583,11 +583,13 @@ class TestChatFeedCallback:
 
     def test_placeholder_threshold_exceed_generator(self, chat_feed):
         async def echo(contents, user, instance):
+            assert instance._placeholder not in instance._chat_log
             await asyncio.sleep(0.5)
             assert instance._placeholder in instance._chat_log
             yield "hello testing"
+            assert instance._placeholder not in instance._chat_log
 
-        chat_feed.placeholder_threshold = 0.1
+        chat_feed.placeholder_threshold = 0.2
         chat_feed.callback = echo
         chat_feed.send("Message", respond=True)
         assert chat_feed._placeholder not in chat_feed._chat_log


### PR DESCRIPTION
In generator tasks, the condition `while not task.done() and num_entries == len(self._chat_log):` leads to tasks completing almost instantly, as generators are lazily evaluated. Consequently, relying on `task.done()` becomes unreliable.

When using `submit_task(generator)`, the `state.FiNISHED` is quickly reached because, technically, the generator is lazily evaluated and returned. To illustrate, the generator is considered "finished" in a mere 1.33 microseconds, as depicted in the image below:

![image](https://github.com/holoviz/panel/assets/15331990/30fce3d5-6649-4719-82b6-3ad4422a2576)

So it's not reliable to depend on `task.done()` Instead, we should use `callback_state.IDLE` to track business (when re-reading this, I was confused and realized, business -> busy-ness)

Also, this updates how the placeholder text gets updated.

Addresses
https://discourse.holoviz.org/t/spinning-icon-effect-that-appears-when-the-user-sends-a-message-in-chatinterface/6582/10?u=ahuang11