### PR TITLE
Add star history graph at the bottom

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,10 @@ For more detail check out the [HoloViz Community Guide](https://holoviz.org/comm
 
 Check out the [Contributing Guide](CONTRIBUTING.MD).
 
+## Star History
+
+[![Star History Chart](https://api.star-history.com/svg?repos=holoviz/panel&type=Date)](https://star-history.com/#holoviz/panel&Date)
+
 ## License
 
 Panel is completely free and open-source. It is licensed under the [BSD 3-Clause License](https://opensource.org/licenses/BSD-3-Clause).


### PR DESCRIPTION
If users see this, they might provide a star too.

Not sure if the placement is best at the bottom or closer to the top.

<img width="736" alt="image" src="https://github.com/holoviz/panel/assets/15331990/22b48ce6-c6dd-48ed-bf88-8056794e4536">

