### PR TITLE
Setup GoatCounter

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -81,7 +81,8 @@ extensions += [
     'sphinx.ext.napoleon',
     'nbsite.gallery',
     'sphinx_copybutton',
-    'nbsite.pyodide'
+    'nbsite.pyodide',
+    'nbsite.analytics',
 ]
 napoleon_numpy_docstring = True
 
@@ -91,6 +92,10 @@ gallery_endpoint = 'panel-gallery-dev' if is_dev else 'panel-gallery'
 gallery_url = f'https://{gallery_endpoint}.pyviz.demo.anaconda.com'
 jlite_url = 'https://pyviz-dev.github.io/panelite-dev' if is_dev else 'https://panelite.holoviz.org'
 pyodide_url = 'https://pyviz-dev.github.io/panel/pyodide' if is_dev else 'https://panel.holoviz.org/pyodide'
+
+nbsite_analytics = {
+    'goatcounter_holoviz': True,
+}
 
 nbsite_gallery_conf = {
     'github_org': 'holoviz',

--- a/setup.py
+++ b/setup.py
@@ -213,8 +213,7 @@ extras_require = {
     'tests': _tests,
     'recommended': _recommended,
     'doc': _recommended + [
-        'nbsite >=0.8.2',
-        'myst-nb >=0.17,<1',
+        'nbsite >=0.8.4',
         'lxml',
         'pandas <2.1.0' # Avoid deprecation warnings
     ],


### PR DESCRIPTION
I'm suggesting not to replace Google Analytics with GoatCounter quite yet, so we have at least a short period (e.g. 1 month) of data collected by both systems to be able to compare them. For the interested reader, to be honest we don't do much with this data (we have so many better things to do!), we ideally hope we could leverage it to guide us when re-vamping our docs (i.e. which pages are the most visited). It also turns out that the global number of page views can be useful in grant proposals like for the Chan Zuckerberg Initiative. We picked GoatCounter as a more more user friendly alternative to Google Analytics.