### PR TITLE
Loosen callback future type

### DIFF
--- a/panel/chat/feed.py
+++ b/panel/chat/feed.py
@@ -205,9 +205,6 @@ class ChatFeed(ListPanel):
         The placeholder wrapped in a ChatMessage object;
         primarily to prevent recursion error in _update_placeholder.""")
 
-    _callback_future = param.Parameter(allow_None=True, doc="""
-        The current, cancellable async task being executed.""")
-
     _callback_state = param.ObjectSelector(objects=list(CallbackState), doc="""
         The current state of the callback.""")
 
@@ -217,6 +214,8 @@ class ChatFeed(ListPanel):
     _stylesheets: ClassVar[List[str]] = [f"{CDN_DIST}css/chat_feed.css"]
 
     def __init__(self, *objects, **params):
+        self._callback_future = None
+
         if params.get("renderers") and not isinstance(params["renderers"], list):
             params["renderers"] = [params["renderers"]]
         if params.get("width") is None and params.get("sizing_mode") is None:

--- a/panel/chat/feed.py
+++ b/panel/chat/feed.py
@@ -205,7 +205,7 @@ class ChatFeed(ListPanel):
         The placeholder wrapped in a ChatMessage object;
         primarily to prevent recursion error in _update_placeholder.""")
 
-    _callback_future = param.ClassSelector(class_=asyncio.Future, allow_None=True, doc="""
+    _callback_future = param.Parameter(allow_None=True, doc="""
         The current, cancellable async task being executed.""")
 
     _callback_state = param.ObjectSelector(objects=list(CallbackState), doc="""


### PR DESCRIPTION
Fixes https://github.com/holoviz/panel/issues/6118.

I print the type of `future` and it results in `<class 'asyncio.futures.Future'>`

I also do:
```
            print(isinstance(future, asyncio.Future), isinstance(future, asyncio.futures.Future))
```
which returns True, True

but I still get:
```
ValueError: ClassSelector parameter 'ChatInterface._callback_future' value must be an instance of Future, not <Future pending cb=[_chain_future.<locals>._call_check_cancel() at /Users/ahuang/miniconda3/envs/panel/lib/python3.10/asyncio/futures.py:385]>.
```

So I just set to param.Parameter and it works.

<img width="1279" alt="image" src="https://github.com/holoviz/panel/assets/15331990/e2072278-bbd8-4eb1-afb3-a8fe81cde4a8">

Also, I needed to specify the height manually in the app, or else no messages show up:
<img width="1315" alt="image" src="https://github.com/holoviz/panel/assets/15331990/63d46d64-690f-4d2b-aa8d-0855e7910c62">
