### PR TITLE
Allow adjusting templates' header height and hiding it

### DIFF
--- a/panel/template/base.py
+++ b/panel/template/base.py
@@ -655,6 +655,9 @@ class BasicTemplate(BaseTemplate):
     header_color = param.String(doc="""
         Optional header text color override.""")
 
+    header_height = param.String(default="64px", doc="""
+        Optional header height override.""")
+
     location = param.Boolean(default=True, readonly=True)
 
     _actions = param.ClassSelector(default=TemplateActions(), class_=TemplateActions)
@@ -772,6 +775,7 @@ class BasicTemplate(BaseTemplate):
         self._render_variables['app_favicon'] = favicon
         self._render_variables['app_favicon_type'] = self._get_favicon_type(self.favicon)
         self._render_variables['header_background'] = self.header_background
+        self._render_variables['header_height'] = self.header_height
         self._render_variables['header_color'] = self.header_color
         self._render_variables['main_max_width'] = self.main_max_width
         self._render_variables['sidebar_width'] = self.sidebar_width

--- a/panel/template/fast/list/fast_list_template.html
+++ b/panel/template/fast/list/fast_list_template.html
@@ -40,6 +40,13 @@
     background-color: var(--background-color);
     font-family: var(--body-font);
   }
+  #header {
+	{% if header_height.startswith('0') %}
+	display: none;
+	{% else %}
+	height: {{ header_height }};
+	{% endif %}
+  }
   #header a {
     color: currentColor;
   }
@@ -87,7 +94,7 @@ document.addEventListener('DOMContentLoaded', (event) => {
 <fast-design-system-provider id="body-design-provider" use-defaults>
   <div id="container">
     <fast-design-system-provider id="header-design-provider">
-      <nav id="header" {{ 'class="shadow"' if style.shadow else '' }} >
+	  <nav id="header" {% if hide_header %}style="display: none;"{% endif %} {{ 'class="shadow"' if style.shadow else '' }} >
 	{% if nav or sidebar_footer %}
 	<span onclick="{{ 'openNav()' if collapsed_sidebar else 'closeNav()' }}" id="sidebar-button">
 	  <div class="pn-bar"></div>

--- a/panel/template/material/material.html
+++ b/panel/template/material/material.html
@@ -55,14 +55,28 @@
       #header {
           --mdc-theme-background: var(--header-background);
           --mdc-theme-on-background: var(--header-color);
-	  background-color: var(--header-background);
-	  color: var(--header-color);
+          background-color: var(--header-background);
+          color: var(--header-color);
+      }
+      #header-items {
+          height: 100%;
+      }
+      .mdc-top-app-bar__section--align-start {
+          height: {{ header_height }}; /* Adjust the height for the align-start section */
+
       }
       .mdc-drawer {
 	  width: var(--sidebar-width) !important;
       }
       .mdc-drawer.mdc-drawer--open:not(.mdc-drawer--closing)+.mdc-drawer-app-content {
 	  margin-left: var(--sidebar-width) !important;
+      }
+      .mdc-top-app-bar--fixed-adjust {
+        {% if header_height.startswith('0') %}
+          padding-top: 0px;
+        {% else %}
+          padding-top: calc({{ header_height }} + 10px); /* Adjust the padding so sidebar / main isn't underneath */
+        {% endif %}
       }
     </style>
 
@@ -78,7 +92,7 @@
 <!-- goes in body -->
 {% block contents %}
 <div class="mdc-typography" id="container">
-  <header class="mdc-top-app-bar app-bar mdc-top-app-bar--fixed" id="header">
+  <header class="mdc-top-app-bar app-bar mdc-top-app-bar--fixed" id="header" {% if header_height.startswith('0') %}style="display: none;"{% endif %}>
     <div class="mdc-top-app-bar__row">
       <section class="mdc-top-app-bar__section mdc-top-app-bar__section--align-start">
 	{% if nav %}


### PR DESCRIPTION
Allows adjusting header height, and if `header_height='0'`, the header is hidden.

FastListTemplate 250px
<img width="1336" alt="image" src="https://github.com/holoviz/panel/assets/15331990/44aaeaf7-1d64-4f4e-97a3-a22278e3baa2">

FastListTemplate 0
<img width="1337" alt="image" src="https://github.com/holoviz/panel/assets/15331990/36b7c4c1-d4e4-474e-802d-577a7858b94a">


MaterialTemplate 250px
<img width="1336" alt="image" src="https://github.com/holoviz/panel/assets/15331990/f8c6ba3f-3611-476a-97e6-95e3dc503505">

MaterialTemplate 0
<img width="1320" alt="image" src="https://github.com/holoviz/panel/assets/15331990/7609a505-0340-4397-8807-c6b7f58615c5">


```python
import panel as pn

pn.extension()

template = pn.template.FastListTemplate(
    header=[
        pn.Column(
            pn.widgets.TextInput(placeholder="Header", width=250),
            pn.widgets.IntInput(placeholder="Header", width=250),
            pn.widgets.FloatInput(placeholder="Header", width=250),
        ),
        pn.widgets.TextAreaInput(placeholder="Header", width=250),
    ],
    main=["Hello", "Yolo"],
    sidebar=["Sidebar", "Testing"],
    header_height="250px",
)
template.servable()
```