### PR TITLE
Initialize empty Matplotlib pane

### DIFF
--- a/panel/pane/plot.py
+++ b/panel/pane/plot.py
@@ -349,6 +349,9 @@ class Matplotlib(Image, IPyWidget):
         manager.canvas.draw_idle()
 
     def _data(self, obj):
+        if obj is None:
+            return
+
         try:
             obj.set_dpi(self.dpi)
         except Exception as ex:

--- a/panel/tests/pane/test_plot.py
+++ b/panel/tests/pane/test_plot.py
@@ -41,6 +41,19 @@ def test_get_matplotlib_pane_type():
 
 
 @mpl_available
+def test_matplotlib_pane_initially_empty(document, comm):
+    pane = pn.pane.Matplotlib()
+    assert pane.object is None
+
+    model = pane.get_root(document, comm=comm)
+    assert model.text == '<img></img>'
+
+    pane.object = mpl_figure()
+    assert model.text.startswith('&lt;img src=&quot;data:image/png;base64,')
+    assert pane._models[model.ref['id']][0] is model
+
+
+@mpl_available
 def test_matplotlib_pane(document, comm):
     pane = pn.pane.Matplotlib(mpl_figure())
 


### PR DESCRIPTION
Closes https://github.com/holoviz/panel/issues/6121

```python
import matplotlib.pyplot as plt
import panel as pn
pn.extension()

mpl = pn.pane.Matplotlib()
mpl
```

```python
fig, ax = plt.subplots()
ax.plot([1, 2, 3])
mpl.object = fig
```