### PR TITLE
Tweak Chat Message CSS to center text

### DIFF
--- a/panel/dist/css/chat_message.css
+++ b/panel/dist/css/chat_message.css
@@ -80,6 +80,9 @@
   max-width: calc(100% - 40px);
   padding: 5px;
   width: fit-content;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .footer {


### PR DESCRIPTION
Before this PR, integer objects were not centered:
```python
import panel as pn
pn.extension()

pn.Column(*[pn.chat.ChatMessage(i) for i in range(100)], height=500).show()
```

<img width="156" alt="image" src="https://github.com/holoviz/panel/assets/15331990/30461ec8-8e87-431b-be6d-54208366b636">

After:
<img width="167" alt="image" src="https://github.com/holoviz/panel/assets/15331990/2e4b1755-85f3-47f2-a97a-4efe32e0c8c7">


Strings align properly with/without the change:
```python
import panel as pn
pn.extension()

pn.Column(*[pn.chat.ChatMessage(f"{i}") for i in range(100)], height=500).show()
```
<img width="166" alt="image" src="https://github.com/holoviz/panel/assets/15331990/5eeda181-87f5-42d2-93a2-6750155d63a4">
