### PR TITLE
Re-enable B019 cache-instance-method check

### DIFF
--- a/panel/reactive.py
+++ b/panel/reactive.py
@@ -142,7 +142,7 @@ class Syncable(Renderable):
     #----------------------------------------------------------------
 
     @classproperty
-    @lru_cache(maxsize=None)
+    @lru_cache(maxsize=None)  # noqa: B019 (cls is not an instance)
     def _property_mapping(cls):
         rename = {}
         for scls in cls.__mro__[::-1]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,6 @@ ignore = [
     "W605",
     "E701", # Multiple statements on one line
     "B006", # Do not use mutable data structures for argument defaults
-    "B019", # lru_cache and cache are used deliberately
 ]
 select = [
     "B",


### PR DESCRIPTION
Follow up to https://github.com/holoviz/panel/pull/5952#discussion_r1437212138

Explicitly ignores the instance caching check (B019) since here it is on a `classproperty`.