### PR TITLE
Fix Material notebook .show() call

### DIFF
--- a/examples/reference/templates/Material.ipynb
+++ b/examples/reference/templates/Material.ipynb
@@ -82,7 +82,7 @@
     "    )\n",
     ")\n",
     "\n",
-    "template.show();"
+    "template.servable();"
    ]
   },
   {


### PR DESCRIPTION
Inconsistent with other notebooks and appears to be causing errors in the windows test suite.