### PR TITLE
Improve date and datetime picker functionality

### DIFF
--- a/panel/dist/css/widgetbox.css
+++ b/panel/dist/css/widgetbox.css
@@ -4,6 +4,4 @@
   border-radius: 4px;
   -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.05);
   box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.05);
-  overflow-x: hidden;
-  overflow-y: hidden;
 }

--- a/panel/models/datetime_picker.py
+++ b/panel/models/datetime_picker.py
@@ -10,7 +10,7 @@ class DatetimePicker(InputWidget):
 
     '''
 
-    value = Nullable(Either(String, Date, Datetime), help="""
+    value = Nullable(String, help="""
     The initial or picked date.
     """)
 

--- a/panel/models/datetime_picker.py
+++ b/panel/models/datetime_picker.py
@@ -10,7 +10,7 @@ class DatetimePicker(InputWidget):
 
     '''
 
-    value = Nullable(String, help="""
+    value = Nullable(Either(String, Date, Datetime), help="""
     The initial or picked date.
     """)
 

--- a/panel/tests/pane/test_holoviews.py
+++ b/panel/tests/pane/test_holoviews.py
@@ -743,3 +743,20 @@ def test_holoviews_property_override(document, comm):
 
     assert model.styles["background"] == 'red'
     assert model.children[0].css_classes == ['test_class']
+
+
+@hv_available
+def test_holoviews_datetime_picker_widget(document, comm):
+    ds = {
+        "time": [np.datetime64("2000-01-01"), np.datetime64("2000-01-02")],
+        "x": [0, 1],
+        "y": [0, 1],
+    }
+    viz = hv.Dataset(ds, ["x", "time"], ["y"])
+    layout = pn.panel(viz.to(
+        hv.Scatter, ["x"], ["y"]), widgets={"time": pn.widgets.DatetimePicker}
+    )
+    widget_box = layout[0][1]
+    assert isinstance(layout, pn.Row)
+    assert isinstance(widget_box, pn.WidgetBox)
+    assert isinstance(widget_box[0], pn.widgets.DatetimePicker)

--- a/panel/tests/pane/test_holoviews.py
+++ b/panel/tests/pane/test_holoviews.py
@@ -746,6 +746,23 @@ def test_holoviews_property_override(document, comm):
 
 
 @hv_available
+def test_holoviews_date_picker_widget(document, comm):
+    ds = {
+        "time": [np.datetime64("2000-01-01"), np.datetime64("2000-01-02")],
+        "x": [0, 1],
+        "y": [0, 1],
+    }
+    viz = hv.Dataset(ds, ["x", "time"], ["y"])
+    layout = pn.panel(viz.to(
+        hv.Scatter, ["x"], ["y"]), widgets={"time": pn.widgets.DatePicker}
+    )
+    widget_box = layout[0][1]
+    assert isinstance(layout, pn.Row)
+    assert isinstance(widget_box, pn.WidgetBox)
+    assert isinstance(widget_box[0], pn.widgets.DatePicker)
+
+
+@hv_available
 def test_holoviews_datetime_picker_widget(document, comm):
     ds = {
         "time": [np.datetime64("2000-01-01"), np.datetime64("2000-01-02")],

--- a/panel/tests/ui/widgets/test_input.py
+++ b/panel/tests/ui/widgets/test_input.py
@@ -1,5 +1,6 @@
 import datetime
 
+import numpy as np
 import pytest
 
 pytest.importorskip("playwright")
@@ -601,6 +602,34 @@ def test_datetimepicker_remove_value(page, datetime_start_end):
     datetime_picker.press("Escape")
 
     wait_until(lambda: datetime_picker_widget.value is None, page)
+
+
+def test_datetime_picker_start_end_datetime64(page):
+    datetime_picker_widget = DatetimePicker(
+        value=datetime.datetime(2021, 3, 2),
+        start=np.datetime64("2021-03-02"),
+        end=np.datetime64("2021-03-03")
+    )
+
+    serve_component(page, datetime_picker_widget)
+
+    datetime_picker = page.locator('.flatpickr-input')
+    datetime_picker.dblclick()
+
+    # locate by aria label March 1, 2021
+    prev_month_day = page.locator('[aria-label="March 1, 2021"]')
+    # assert class "flatpickr-day flatpickr-disabled"
+    assert "flatpickr-disabled" in prev_month_day.get_attribute("class"), "The date should be disabled"
+
+    # locate by aria label March 3, 2021
+    next_month_day = page.locator('[aria-label="March 3, 2021"]')
+    # assert not class "flatpickr-day flatpickr-disabled"
+    assert "flatpickr-disabled" not in next_month_day.get_attribute("class"), "The date should be enabled"
+
+    # locate by aria label March 4, 2021
+    next_next_month_day = page.locator('[aria-label="March 4, 2021"]')
+    # assert class "flatpickr-day flatpickr-disabled"
+    assert "flatpickr-disabled" in next_next_month_day.get_attribute("class"), "The date should be disabled"
 
 
 def test_text_area_auto_grow_init(page):

--- a/panel/tests/widgets/test_input.py
+++ b/panel/tests/widgets/test_input.py
@@ -58,6 +58,16 @@ def test_date_picker(document, comm):
     assert widget.value == '2018-09-04'
 
 
+def test_date_picker_options(document, comm):
+    options = [date(2018, 9, 1), date(2018, 9, 2), date(2018, 9, 3)]
+    datetime_picker = DatePicker(
+        name='DatetimePicker', value=date(2018, 9, 2),
+        options=options
+    )
+    assert datetime_picker.value == date(2018, 9, 2)
+    assert datetime_picker.enabled_dates == options
+
+
 def test_daterange_picker(document, comm):
     date_range_picker = DateRangePicker(name='DateRangePicker',
                                         value=(date(2018, 9, 2), date(2018, 9, 3)),

--- a/panel/tests/widgets/test_input.py
+++ b/panel/tests/widgets/test_input.py
@@ -130,6 +130,16 @@ def test_datetime_picker(document, comm):
         datetime_picker._process_events({'value': '2018-09-10 00:00:01'})
 
 
+def test_datetime_picker_options(document, comm):
+    options = [datetime(2018, 9, 1), datetime(2018, 9, 2), datetime(2018, 9, 3)]
+    datetime_picker = DatetimePicker(
+        name='DatetimePicker', value=datetime(2018, 9, 2, 1, 5),
+        options=options
+    )
+    assert datetime_picker.value == datetime(2018, 9, 2, 1, 5)
+    assert datetime_picker.enabled_dates == options
+
+
 def test_datetime_range_picker(document, comm):
     datetime_range_picker = DatetimeRangePicker(
         name='DatetimeRangePicker', value=(datetime(2018, 9, 2, 1, 5), datetime(2018, 9, 2, 1, 6)),

--- a/panel/util/__init__.py
+++ b/panel/util/__init__.py
@@ -469,6 +469,6 @@ def styler_update(styler, new_df):
 
 
 def try_datetime64_to_datetime(value):
-    if hasattr(value, "astype"):
+    if isinstance(value, np.datetime64):
         value = value.astype('datetime64[ms]').astype(datetime)
     return value

--- a/panel/util/__init__.py
+++ b/panel/util/__init__.py
@@ -466,3 +466,9 @@ def styler_update(styler, new_df):
         todo = tuple(ops)
         todos.append(todo)
     return todos
+
+
+def try_datetime64_to_datetime(value):
+    if hasattr(value, "astype"):
+        value = value.astype('datetime64[ms]').astype(datetime)
+    return value

--- a/panel/widgets/input.py
+++ b/panel/widgets/input.py
@@ -334,6 +334,21 @@ class DatePicker(Widget):
 
     _widget_type: ClassVar[Type[Model]] = _BkDatePicker
 
+    def __init__(self, **params):
+        if 'options' in params:
+            options = list(params.pop('options'))
+            params['enabled_dates'] = options
+        if 'value' in params and hasattr(params['value'], "astype"):
+            value = (
+                params['value']
+                .astype('datetime64[ms]')
+                .astype(datetime)
+            )
+            if hasattr(value, "date"):
+                value = value.date()
+            params["value"] = value
+        super().__init__(**params)
+
     def _process_property_change(self, msg):
         msg = super()._process_property_change(msg)
         for p in ('start', 'end', 'value'):

--- a/panel/widgets/input.py
+++ b/panel/widgets/input.py
@@ -470,14 +470,17 @@ class _DatetimePickerBase(Widget):
     __abstract = True
 
     def __init__(self, **params):
-        if "options" in params:
-            options = list(params.pop("options"))
-            params["enabled_dates"] = options
+        if 'options' in params:
+            options = list(params.pop('options'))
+            params['enabled_dates'] = options
         super().__init__(**params)
         self._update_value_bounds()
 
     @staticmethod
     def _convert_to_datetime(v):
+        if v is None:
+            return
+
         if isinstance(v, Iterable) and not isinstance(v, str):
             container_type = type(v)
             return container_type(

--- a/panel/widgets/input.py
+++ b/panel/widgets/input.py
@@ -335,6 +335,9 @@ class DatePicker(Widget):
     _widget_type: ClassVar[Type[Model]] = _BkDatePicker
 
     def __init__(self, **params):
+        # Since options is the standard for other widgets,
+        # it makes sense to also support options here, converting
+        # it to enabled_dates
         if 'options' in params:
             options = list(params.pop('options'))
             params['enabled_dates'] = options
@@ -489,6 +492,9 @@ class _DatetimePickerBase(Widget):
     __abstract = True
 
     def __init__(self, **params):
+        # Since options is the standard for other widgets,
+        # it makes sense to also support options here, converting
+        # it to enabled_dates
         if 'options' in params:
             options = list(params.pop('options'))
             params['enabled_dates'] = options
@@ -509,7 +515,7 @@ class _DatetimePickerBase(Widget):
                 for vv in v
             )
 
-        if hasattr(v, "astype") or self.as_numpy_datetime64:
+        if hasattr(v, "astype"):
             return v.astype('datetime64[ms]').astype(datetime)
         elif isinstance(v, datetime):
             return v

--- a/panel/widgets/input.py
+++ b/panel/widgets/input.py
@@ -493,9 +493,7 @@ class _DatetimePickerBase(Widget):
         # it to enabled_dates
         if 'options' in params:
             options = list(params.pop('options'))
-            params['enabled_dates'] = [
-                self._convert_to_datetime(option).date() for option in options
-            ]
+            params['enabled_dates'] = options
         if params.get('as_numpy_datetime64', None) is None:
             params['as_numpy_datetime64'] = isinstance(
                 params.get("value"), np.datetime64)


### PR DESCRIPTION
Some bug fixes (start/end were not applied if datetime64) and makes the following work:


Closes https://github.com/holoviz/panel/issues/6143

<img width="959" alt="image" src="https://github.com/holoviz/panel/assets/15331990/b288d840-84b6-448b-a048-dc72ef4ca922">

```python
import datetime as dt
import panel as pn
import numpy as np
import xarray as xr
import hvplot.xarray

pn.extension()

ds = xr.tutorial.open_dataset("air_temperature")
viz = ds["air"].hvplot(x="lon", y="lat")
pn.panel(viz, widgets={"time": pn.widgets.DatetimePicker}).show()
```