### PR TITLE
Actually pass card_params into ChatFeed's internal Card

### DIFF
--- a/panel/chat/feed.py
+++ b/panel/chat/feed.py
@@ -279,6 +279,10 @@ class ChatFeed(ListPanel):
         self._card._cleanup(root)
         super()._cleanup(root)
 
+    @param.depends("card_params", watch=True)
+    def _update_card_params(self):
+        self._card.param.update(**self.card_params)
+
     @param.depends("placeholder_text", watch=True, on_init=True)
     def _update_placeholder(self):
         loading_avatar = SVG(

--- a/panel/chat/feed.py
+++ b/panel/chat/feed.py
@@ -240,10 +240,8 @@ class ChatFeed(ListPanel):
             stylesheets=self._stylesheets,
             **linked_params
         )
-        self.link(self._chat_log, objects='objects', bidirectional=True)
-        # we have a card for the title
-        self._card = Card(
-            self._chat_log, VSpacer(),
+        card_params = linked_params.copy()
+        card_params.update(
             margin=self.param.margin,
             align=self.param.align,
             header=self.header,
@@ -257,7 +255,14 @@ class ChatFeed(ListPanel):
             title_css_classes=["chat-feed-title"],
             styles={"padding": "0px"},
             stylesheets=self._stylesheets + self.param.stylesheets.rx(),
-            **linked_params
+        )
+        card_params.update(self.card_params)
+        self.link(self._chat_log, objects='objects', bidirectional=True)
+        # we have a card for the title
+        self._card = Card(
+            self._chat_log,
+            VSpacer(),
+            **card_params
         )
 
         # handle async callbacks using this trick

--- a/panel/tests/chat/test_feed.py
+++ b/panel/tests/chat/test_feed.py
@@ -41,6 +41,18 @@ class TestChatFeed:
         chat_feed.header = ""
         assert chat_feed._card.hide_header
 
+    def test_card_params(self):
+        chat_feed = ChatFeed(
+            card_params={
+                "header_background": "red",
+                "header": "Test",
+                "hide_header": False
+            },
+        )
+        assert chat_feed._card.header_background == "red"
+        assert chat_feed._card.header == "Test"
+        assert not chat_feed._card.hide_header
+
     def test_send(self, chat_feed):
         message = chat_feed.send("Message")
         wait_until(lambda: len(chat_feed.objects) == 1)

--- a/panel/tests/chat/test_feed.py
+++ b/panel/tests/chat/test_feed.py
@@ -41,14 +41,12 @@ class TestChatFeed:
         chat_feed.header = ""
         assert chat_feed._card.hide_header
 
-    def test_card_params(self):
-        chat_feed = ChatFeed(
-            card_params={
-                "header_background": "red",
-                "header": "Test",
-                "hide_header": False
-            },
-        )
+    def test_card_params(self, chat_feed):
+        chat_feed.card_params = {
+            "header_background": "red",
+            "header": "Test",
+            "hide_header": False
+        }
         assert chat_feed._card.header_background == "red"
         assert chat_feed._card.header == "Test"
         assert not chat_feed._card.hide_header


### PR DESCRIPTION
Addresses https://github.com/Quansight/ragna/pull/261/files/716373b2e6d51c9a74c8065d2cf1414b87115981#diff-3caa7ff25182aa89f6a4e030b8004c8666a48de3c2d496008192393eec29b618R423

```python
import panel as pn

pn.extension()

pn.chat.ChatFeed(
    "Hello",
    card_params={"header_background": "red", "header": "Test", "hide_header": False},
).show()

```
<img width="352" alt="image" src="https://github.com/holoviz/panel/assets/15331990/ad0f243c-8620-416e-8ab2-fb059455c793">
