### PR TITLE
Fixes and guards for rendering ChatFeed and Card

### DIFF
--- a/panel/chat/feed.py
+++ b/panel/chat/feed.py
@@ -277,7 +277,10 @@ class ChatFeed(ListPanel):
         self, doc: Document, root: Model | None = None,
         parent: Model | None = None, comm: Comm | None = None
     ) -> Model:
-        return self._card._get_model(doc, root, parent, comm)
+        model = self._card._get_model(doc, root, parent, comm)
+        ref = (root or model).ref['id']
+        self._models[ref] = (model, parent)
+        return model
 
     def _cleanup(self, root: Model | None = None) -> None:
         self._card._cleanup(root)

--- a/panel/models/card.ts
+++ b/panel/models/card.ts
@@ -12,8 +12,7 @@ export class CardView extends ColumnView {
   connect_signals(): void {
     super.connect_signals()
 
-    const {active_header_background, children, collapsed, header_background, header_color, hide_header} = this.model.properties
-    this.on_change(children, () => this.render())
+    const {active_header_background, collapsed, header_background, header_color, hide_header} = this.model.properties
     this.on_change(collapsed, () => this._collapse())
     this.on_change([header_color, hide_header], () => this.render())
 

--- a/panel/theme/base.py
+++ b/panel/theme/base.py
@@ -246,6 +246,8 @@ class Design(param.Parameterized, ResourceComponent):
         # this may end up causing issues.
         from ..io.resources import CDN_DIST, patch_stylesheet
 
+        if mref not in viewable._models:
+            return
         model, _ = viewable._models[mref]
         params = {
             k: v for k, v in modifiers.items() if k != 'children' and


### PR DESCRIPTION
- Ensure Theme does not error out if a child of a layout has not yet initialized a model
- Do not re-render `Card` superfluously, which could cause race conditions and rendering issues
- Ensure that `ChatFeed` reflects the model of layout it is rendering to ensure that components that assume a component has a corresponding model will find one.

Fixes https://github.com/holoviz/panel/issues/6140