### PR TITLE
Do not trigger event if ReplacementPane object identity is unchanged

### DIFF
--- a/panel/pane/base.py
+++ b/panel/pane/base.py
@@ -677,7 +677,8 @@ class ReplacementPane(PaneBase):
                     cls._recursive_update(old, new)
             elif isinstance(object, Reactive):
                 cls._recursive_update(old_object, object)
-            else:
+            elif old_object.object is not object:
+                # See https://github.com/holoviz/param/pull/901
                 old_object.object = object
         else:
             # Replace pane entirely


### PR DESCRIPTION
Related to https://github.com/holoviz/param/pull/901, which will likely wait on a Param 2.1.0 release. In the meantime we do not want to trigger a re-render of a Pane if the identity of the object is unchanged.

Fixes https://github.com/bokeh/ipywidgets_bokeh/issues/103