### PR TITLE
Set ChatMessage min_width_0 and break anywhere

### DIFF
--- a/panel/dist/css/chat_message.css
+++ b/panel/dist/css/chat_message.css
@@ -71,18 +71,19 @@
     color-mix(in srgb, var(--panel-shadow-color) 15%, transparent) 0px 1px 3px
       1px;
   font-size: 1.25em;
-  min-width: 50px;
   min-height: 50px;
   margin-block: 0px;
   margin-left: 10px; /* Space for avatar */
   margin-right: 5px; /* Space for reaction */
   background-color: var(--panel-surface-color, #f1f1f1);
+  min-width: 0;
   max-width: calc(100% - 40px);
   padding: 5px;
   width: fit-content;
   display: flex;
   align-items: center;
   justify-content: center;
+  overflow-wrap: anywhere;
 }
 
 .footer {


### PR DESCRIPTION
Simon mentioned this: https://www.youtube.com/watch?v=cH8VbLM1958 
https://www.joshwcomeau.com/css/interactive-guide-to-flexbox/#the-minimum-size-gotcha-11

Awkward overflowing before:
<img width="542" alt="image" src="https://github.com/holoviz/panel/assets/15331990/b0bb7415-3ddf-4cc7-84d4-8f3b52d8d8e4">

Now:
<img width="512" alt="image" src="https://github.com/holoviz/panel/assets/15331990/b7c6b0bd-f56f-4a22-af2d-f5e78e650441">

