### PR TITLE
Tabulator: fix valuesLookup set up for older list-like editors

### DIFF
--- a/panel/widgets/tables.py
+++ b/panel/widgets/tables.py
@@ -1851,7 +1851,7 @@ class Tabulator(BaseTable):
                 col_dict['editor'] = 'list'
                 if col_dict.get('editorParams', {}).get('values', False) is True:
                     del col_dict['editorParams']['values']
-                    col_dict['editorParams']['valuesLookup']
+                    col_dict['editorParams']['valuesLookup'] = True
             if field in self.frozen_columns or i in self.frozen_columns:
                 col_dict['frozen'] = True
             if isinstance(self.widths, dict) and isinstance(self.widths.get(field), str):


### PR DESCRIPTION
Supersedes https://github.com/holoviz/panel/pull/5945

The statement was incomplete, based on the logic https://github.com/holoviz/panel/commit/d2e6671e5d85676b2517aa1fdfe4dd870f9e8cdc it should set `valuesLookup` to `True`.