### PR TITLE
Fix pyodide loading text css issue

### DIFF
--- a/panel/dist/css/loading.css
+++ b/panel/dist/css/loading.css
@@ -32,7 +32,7 @@
 
 :host(.pn-loading) .pn-loading-msg,
 .pn-loading .pn-loading-msg {
-  color: black;
+  color: var(--panel-on-background-color, black);
   font-size: 2em;
   position: absolute;
   top: 72%;


### PR DESCRIPTION
Currently the loading text in a `panel convert ... --to pyodide-worker` app is black. This does not work well if the theme is dark. For example when using the FastListTemplate with a dark theme.

This one-liner solves the issue.