### PR TITLE
Improve the user experience for resetting Jupyterlite.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,7 +116,7 @@ jupyter_execute
 # this dir contains the whole website and should not be checked in on main
 builtdocs/
 .doit.db
-
+lite/files/*/
 .jupyterlite.doit.db
 
 # jetbrains settings

--- a/.gitignore
+++ b/.gitignore
@@ -117,7 +117,6 @@ jupyter_execute
 builtdocs/
 .doit.db
 
-lite/
 .jupyterlite.doit.db
 
 # jetbrains settings

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,7 +31,7 @@ repos:
     hooks:
       - id: clean-notebook
         args: [-i, tags]
-        exclude: '^lite/files'
+        exclude: '^lite/files/.*/'
   - repo: https://github.com/codespell-project/codespell
     rev: v2.2.6
     hooks:

--- a/lite/files/Getting_Started.ipynb
+++ b/lite/files/Getting_Started.ipynb
@@ -126,11 +126,6 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python (Pyodide)",
-   "language": "python",
-   "name": "python"
-  },
   "language_info": {
    "name": "python",
    "pygments_lexer": "ipython3"

--- a/lite/files/Getting_Started.ipynb
+++ b/lite/files/Getting_Started.ipynb
@@ -121,46 +121,7 @@
    "id": "f4efdeef-e3c5-4cb0-b358-b40f03c59f93",
    "metadata": {},
    "source": [
-    "The contents of Panelite are updated on every release, however Jupyterlite caches old edits to files. If you want to reset the storage and **delete all modifications you made to the contents** the click the button below."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "a6477040-13bc-4cbf-8939-1e893563bc1e",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from IPython.display import display, HTML\n",
-    "display(HTML(\"\"\"\n",
-    "<button type=\"button\" id=\"button_for_indexeddb\">Clear JupyterLite local storage</button>\n",
-    "<script>\n",
-    "window.button_for_indexeddb.onclick = function(e) {\n",
-    "    window.indexedDB.open('JupyterLite Storage').onsuccess = function(e) {\n",
-    "        // There are also other tables that I'm not clearing:\n",
-    "        // \"counters\", \"settings\", \"local-storage-detect-blob-support\"\n",
-    "        let tables = [\"checkpoints\", \"files\"];\n",
-    "\n",
-    "        let db = e.target.result;\n",
-    "        let t = db.transaction(tables, \"readwrite\");\n",
-    "\n",
-    "        function clearTable(tablename) {\n",
-    "            let st = t.objectStore(tablename);\n",
-    "            st.count().onsuccess = function(e) {\n",
-    "                console.log(\"Deleting \" + e.target.result + \" entries from \" + tablename + \"...\");\n",
-    "                st.clear().onsuccess = function(e) {\n",
-    "                    console.log(tablename + \" is cleared!\");\n",
-    "                }\n",
-    "            }\n",
-    "        }\n",
-    "\n",
-    "        for (let tablename of tables) {\n",
-    "            clearTable(tablename);\n",
-    "        }\n",
-    "    }\n",
-    "};\n",
-    "</script>\n",
-    "\"\"\"))"
+    "The contents of Panelite are updated on every release, however Jupyterlite caches old edits to files. If you want to reset the storage and **delete all modifications you made to the contents** then use the [Reset_Jupyterlite.ipynb](Reset_Jupyterlite.ipynb) notebook."
    ]
   }
  ],

--- a/lite/files/Reset_Jupyterlite.ipynb
+++ b/lite/files/Reset_Jupyterlite.ipynb
@@ -1,0 +1,119 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The contents of Panelite are updated on every release, however Jupyterlite caches old edits to files. If you want to reset the storage and **delete all modifications you made to the contents** then run the code below and click the button `Clear JupyterLite local storage` button."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "<button type=\"button\" id=\"button_for_indexeddb\">Clear JupyterLite local storage</button>\n",
+       "<div id=\"clear-storage-message\"></div>\n",
+       "<script>\n",
+       "window.button_for_indexeddb.onclick = function(e) {\n",
+       "    message = document.getElementById(\"clear-storage-message\")\n",
+       "    message.innerText=\"Running\"\n",
+       "    window.indexedDB.open('JupyterLite Storage').onsuccess = function(e) {\n",
+       "        // There are also other tables that I'm not clearing:\n",
+       "        // \"counters\", \"settings\", \"local-storage-detect-blob-support\"\n",
+       "        let tables = [\"checkpoints\", \"files\"];\n",
+       "\n",
+       "        let db = e.target.result;\n",
+       "        let t = db.transaction(tables, \"readwrite\");\n",
+       "\n",
+       "        function clearTable(tablename) {\n",
+       "            let st = t.objectStore(tablename);\n",
+       "            st.count().onsuccess = function(e) {\n",
+       "                console.log(\"Deleting \" + e.target.result + \" entries from \" + tablename + \"...\");\n",
+       "                st.clear().onsuccess = function(e) {\n",
+       "                    console.log(tablename + \" is cleared!\");\n",
+       "                }\n",
+       "            }\n",
+       "        }\n",
+       "\n",
+       "        for (let tablename of tables) {\n",
+       "            clearTable(tablename);\n",
+       "        }\n",
+       "    }\n",
+       "    message.innerText=\"JupyterLite local storage has successfully been reset\"\n",
+       "};\n",
+       "</script>\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "from IPython.display import display, HTML\n",
+    "display(HTML(\"\"\"\n",
+    "<button type=\"button\" id=\"button_for_indexeddb\">Clear JupyterLite local storage</button>\n",
+    "<div id=\"clear-storage-message\"></div>\n",
+    "<script>\n",
+    "window.button_for_indexeddb.onclick = function(e) {\n",
+    "    message = document.getElementById(\"clear-storage-message\")\n",
+    "    message.innerText=\"Running\"\n",
+    "    window.indexedDB.open('JupyterLite Storaage').onsuccess = function(e) {\n",
+    "        // There are also other tables that I'm not clearing:\n",
+    "        // \"counters\", \"settings\", \"local-storage-detect-blob-support\"\n",
+    "        let tables = [\"checkpoints\", \"files\"];\n",
+    "\n",
+    "        let db = e.target.result;\n",
+    "        let t = db.transaction(tables, \"readwrite\");\n",
+    "\n",
+    "        function clearTable(tablename) {\n",
+    "            let st = t.objectStore(tablename);\n",
+    "            st.count().onsuccess = function(e) {\n",
+    "                console.log(\"Deleting \" + e.target.result + \" entries from \" + tablename + \"...\");\n",
+    "                st.clear().onsuccess = function(e) {\n",
+    "                    console.log(tablename + \" is cleared!\");\n",
+    "                }\n",
+    "            }\n",
+    "        }\n",
+    "\n",
+    "        for (let tablename of tables) {\n",
+    "            clearTable(tablename);\n",
+    "        }\n",
+    "    }\n",
+    "    message.innerText=\"JupyterLite local storage has successfully been reset\"\n",
+    "};\n",
+    "</script>\n",
+    "\"\"\"))"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.13"
+  },
+  "orig_nbformat": 4
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/lite/files/Reset_Jupyterlite.ipynb
+++ b/lite/files/Reset_Jupyterlite.ipynb
@@ -11,51 +11,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "\n",
-       "<button type=\"button\" id=\"button_for_indexeddb\">Clear JupyterLite local storage</button>\n",
-       "<div id=\"clear-storage-message\"></div>\n",
-       "<script>\n",
-       "window.button_for_indexeddb.onclick = function(e) {\n",
-       "    message = document.getElementById(\"clear-storage-message\")\n",
-       "    message.innerText=\"Running\"\n",
-       "    window.indexedDB.open('JupyterLite Storage').onsuccess = function(e) {\n",
-       "        // There are also other tables that I'm not clearing:\n",
-       "        // \"counters\", \"settings\", \"local-storage-detect-blob-support\"\n",
-       "        let tables = [\"checkpoints\", \"files\"];\n",
-       "\n",
-       "        let db = e.target.result;\n",
-       "        let t = db.transaction(tables, \"readwrite\");\n",
-       "\n",
-       "        function clearTable(tablename) {\n",
-       "            let st = t.objectStore(tablename);\n",
-       "            st.count().onsuccess = function(e) {\n",
-       "                console.log(\"Deleting \" + e.target.result + \" entries from \" + tablename + \"...\");\n",
-       "                st.clear().onsuccess = function(e) {\n",
-       "                    console.log(tablename + \" is cleared!\");\n",
-       "                }\n",
-       "            }\n",
-       "        }\n",
-       "\n",
-       "        for (let tablename of tables) {\n",
-       "            clearTable(tablename);\n",
-       "        }\n",
-       "    }\n",
-       "    message.innerText=\"JupyterLite local storage has successfully been reset\"\n",
-       "};\n",
-       "</script>\n"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "from IPython.display import display, HTML\n",
     "display(HTML(\"\"\"\n",
@@ -95,24 +51,10 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": ".venv",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
    "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.10.13"
-  },
-  "orig_nbformat": 4
+   "pygments_lexer": "ipython3"
+  }
  },
  "nbformat": 4,
  "nbformat_minor": 2


### PR DESCRIPTION
I just discovered by coincidence that the Getting_Started notebook in Panelite now contains functionality to reset. This is great.

I think the functionality can improved

- Make it more easily discoverable by putting in separate, clearly named notebook.
- Avoid having to import, run and scroll down. This is slow. This can be avoided by putting it in separate notebook. (Yes. I know you don't have to import and run. But its just a very natural thing to do).
- Send a clear signal that the storage has been cleared. Today when you click the button nothing visible happens. Thus you don't feel confident that the script finished with success.

Furthermore as a developer

- I cannot find the `Getting_Start.ipynb` notebook via my IDE because its actually ignored in the gitignore. So its simply excluded by VS code.
- I do not get the notebook cleaned when I use pre-commit because its actually skipped in the configuration.

This PR fixes these issues.

![image](https://github.com/holoviz/panel/assets/42288570/495e5f1f-c8cc-42fc-86cb-869c872f03b1)