### PR TITLE
Fix loading indicator background size

### DIFF
--- a/panel/io/resources.py
+++ b/panel/io/resources.py
@@ -183,7 +183,7 @@ def loading_css(loading_spinner, color, max_height):
     return textwrap.dedent(f"""
     :host(.pn-loading):before, .pn-loading:before {{
       background-color: {color};
-      background-size: auto calc(min(50%, {max_height}px));
+      mask-size: auto calc(min(50%, {max_height}px));
     }}""")
 
 def resolve_custom_path(


### PR DESCRIPTION
Follow up fix for https://github.com/holoviz/panel/pull/6112 which incorrectly used `background-size` instead of `mask-size` to control the loading indicator size.