### PR TITLE
Tabulator: prevent JS error

### DIFF
--- a/panel/models/tabulator.ts
+++ b/panel/models/tabulator.ts
@@ -367,6 +367,8 @@ export class DataTabulatorView extends HTMLBoxView {
     this.connect(p.sorters.change, () => this.setSorters())
     this.connect(p.theme_classes.change, () => this.setCSSClasses(this.tabulator.element))
     this.connect(this.model.source.properties.data.change, () => {
+      if (this.tabulator === undefined)
+        return
       this._selection_updating = true
       this.setData()
       this._selection_updating = false


### PR DESCRIPTION
I have a somewhat complex app with Tabulator widgets nested in an Accordion that started to raise Javascript errors related to Panel's tabulator code. The error is raised from the last condition of the second line because `this.tabulator` is `undefined`, `setData` being called from the callback triggered by `this.model.source.properties.data.change`.

https://github.com/holoviz/panel/blob/6b6eb3fe4f2c9fa30cf4fcd2684b35de4ea88e30/panel/models/tabulator.ts#L904-L905

It seems like this was the consequence of https://github.com/holoviz/panel/pull/5786. I haven't found what exactly can cause `this.tabulator` to be undefined in this context, so I'm just adding a guard in the `this.model.source.properties.data.change` callback and that seems to do the job.