### PR TITLE
Reduce blur effect applied when loading=True

### DIFF
--- a/panel/dist/css/loading.css
+++ b/panel/dist/css/loading.css
@@ -5,7 +5,7 @@
 
 :host(.pn-loading) > *,
 .pn-loading > * {
-  filter: blur(1px) opacity(0.5);
+  filter: blur(0.5px) opacity(0.5);
 }
 
 :host(.pn-loading):before,


### PR DESCRIPTION
The blur we now apply when `loading=True` was a little heavy handed. This PR reduces the amount of blur from `1px` to `0.5px`. The reason for switching to a blur and opacity filter was that the previous approach did not work well at all for dark themes (and in fact was not compatible with the masking approach we now use to render the spinner itself). Some examples:

## Before `blur(1px)`

<img width="886" alt="Screenshot 2024-01-17 at 23 08 16" src="https://github.com/holoviz/panel/assets/1550771/a80a8efe-9e37-491b-8799-f7eb9c2a0dfa">

<img width="886" alt="Screenshot 2024-01-17 at 23 08 44" src="https://github.com/holoviz/panel/assets/1550771/79cab257-2d5d-4a32-b618-94148e740161">

## After `blur(0.5px)`

<img width="883" alt="Screenshot 2024-01-17 at 23 11 46" src="https://github.com/holoviz/panel/assets/1550771/0419c93c-67a4-472d-ab88-ad6210772b28">

<img width="886" alt="Screenshot 2024-01-17 at 23 10 50" src="https://github.com/holoviz/panel/assets/1550771/aeb2dcd7-aaac-49e1-a945-28405766fdb4">

