### PR TITLE
Defer Jupyter Comm initialization until frontend is ready

### DIFF
--- a/panel/template/base.py
+++ b/panel/template/base.py
@@ -301,7 +301,8 @@ class BaseTemplate(param.Parameterized, MimeRenderMixin, ServableMixin, Resource
         client_comm = state._comm_manager.get_client_comm(
             on_msg=partial(self._on_msg, ref, manager),
             on_error=partial(self._on_error, ref),
-            on_stdout=partial(self._on_stdout, ref)
+            on_stdout=partial(self._on_stdout, ref),
+            on_open=lambda _: comm.init()
         )
         manager.client_comm_id = client_comm.id
         doc.add_root(manager)

--- a/panel/viewable.py
+++ b/panel/viewable.py
@@ -511,7 +511,8 @@ class MimeRenderMixin:
         client_comm = state._comm_manager.get_client_comm(
             on_msg=functools.partial(self._on_msg, ref, manager),
             on_error=functools.partial(self._on_error, ref),
-            on_stdout=functools.partial(self._on_stdout, ref)
+            on_stdout=functools.partial(self._on_stdout, ref),
+            on_open=lambda _: comm.init()
         )
         self._comms[ref] = (comm, client_comm)
         manager.client_comm_id = client_comm.id


### PR DESCRIPTION
This resolves an issue when there is a race condition between the frontend being fully initialized (i.e. Bokeh and Panel JS and all extensions being loaded) and the backend trying to send an event to the frontend. This could occur if a user loaded the extension, rendered some component and then sent a message to it in rapid succession. Sending a message to the frontend would automatically attempt to open a Comm but if the frontend wasn't ready this Comm would never connect and we'd end up with a completely dead Comm, i.e. no messages could be sent across it.

This PR resolves this issue by waiting on the frontend to open the so called client comm, which indicates that the frontend is fully initialized. Only once the client comm is open we initialize the server comm. If a user attempts to send an event across the unopened server comm we schedule the message on the event loop until the comm has successfully been initialized.

Fixes https://github.com/holoviz/panel/issues/6178