### PR TITLE
Patch HoloViews client comm to ensure server comm is initialized

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,8 @@ This patch release focuses on a number of fixes and minor enhancements for the c
 - Fix pyodide loading message styling issues ([#6194](https://github.com/holoviz/panel/pull/6194))
 - More complete patch for the `TextEditor` to support being rendered in the Shadow DOM ([#6222](https://github.com/holoviz/panel/pull/6222))
 - Add guard to `Tabulator` ensuring that it does not error when it is not rendered ([#6223](https://github.com/holoviz/panel/pull/6223))
-- Fix race conditions when instantiating Comm in Jupyter causing notifications to break ([#6229](https://github.com/holoviz/panel/pull/6229))
+- Fix race conditions when instantiating Comm in Jupyter causing notifications to break ([#6229](https://github.com/holoviz/panel/pull/6229), [#6234](https://github.com/holoviz/panel/pull/6234))
+- Handle duplicate attempts at refreshing auth tokens ([#6233](https://github.com/holoviz/panel/pull/6233))
 
 ### Compatibility & Security
 

--- a/doc/about/releases.md
+++ b/doc/about/releases.md
@@ -36,7 +36,8 @@ This patch release focuses on a number of fixes and minor enhancements for the c
 - Fix pyodide loading message styling issues ([#6194](https://github.com/holoviz/panel/pull/6194))
 - More complete patch for the `TextEditor` to support being rendered in the Shadow DOM ([#6222](https://github.com/holoviz/panel/pull/6222))
 - Add guard to `Tabulator` ensuring that it does not error when it is not rendered ([#6223](https://github.com/holoviz/panel/pull/6223))
-- Fix race conditions when instantiating Comm in Jupyter causing notifications to break ([#6229](https://github.com/holoviz/panel/pull/6229))
+- Fix race conditions when instantiating Comm in Jupyter causing notifications to break ([#6229](https://github.com/holoviz/panel/pull/6229), [#6234](https://github.com/holoviz/panel/pull/6234))
+- Handle duplicate attempts at refreshing auth tokens ([#6233](https://github.com/holoviz/panel/pull/6233))
 
 ### Compatibility & Security
 

--- a/panel/io/notebook.py
+++ b/panel/io/notebook.py
@@ -241,6 +241,13 @@ def render_mimebundle(
     Displays bokeh output inside a notebook using the PyViz display
     and comms machinery.
     """
+    # WARNING: Patches the client comm created by some external library
+    #          e.g. HoloViews, with an on_open handler that will initialize
+    #          the server comm.
+    if manager.client_comm_id in _JupyterCommManager._comms:
+        client_comm = _JupyterCommManager._comms[manager.client_comm_id]
+        if not client_comm._on_open:
+            client_comm._on_open = lambda _: comm.init()
     if not isinstance(model, Model):
         raise ValueError('Can only render bokeh LayoutDOM models')
     add_to_doc(model, doc, True)

--- a/panel/io/notebook.py
+++ b/panel/io/notebook.py
@@ -244,7 +244,7 @@ def render_mimebundle(
     # WARNING: Patches the client comm created by some external library
     #          e.g. HoloViews, with an on_open handler that will initialize
     #          the server comm.
-    if manager.client_comm_id in _JupyterCommManager._comms:
+    if manager and manager.client_comm_id in _JupyterCommManager._comms:
         client_comm = _JupyterCommManager._comms[manager.client_comm_id]
         if not client_comm._on_open:
             client_comm._on_open = lambda _: comm.init()


### PR DESCRIPTION
HoloViews has it's own code to initialize Jupyter comms here: https://github.com/holoviz/holoviews/blob/main/holoviews/plotting/renderer.py#L408

Sadly this means that the recent changes in https://github.com/holoviz/panel/pull/6229 to have the client Comm be responsible to initialize the server comm does not work for HoloViews. For now we therefore have to manually patch the client comm created by HoloViews with the required `on_open` callback. I will separately open a PR in HoloViews to add the `on_open` handler properly.