### PR TITLE
Fix ChatFeed / Interface tests and async generator placeholders

### DIFF
--- a/panel/chat/feed.py
+++ b/panel/chat/feed.py
@@ -10,7 +10,10 @@ import traceback
 
 from enum import Enum
 from functools import partial
-from inspect import isasyncgen, isawaitable, isgenerator
+from inspect import (
+    isasyncgen, isasyncgenfunction, isawaitable, iscoroutinefunction,
+    isgenerator,
+)
 from io import BytesIO
 from typing import (
     TYPE_CHECKING, Any, Callable, ClassVar, Dict, List, Literal,
@@ -470,12 +473,24 @@ class ChatFeed(ListPanel):
             return
 
         start = asyncio.get_event_loop().time()
-        while not self._callback_state == CallbackState.IDLE and num_entries == len(self._chat_log):
+        while not task.done() and num_entries == len(self._chat_log):
             duration = asyncio.get_event_loop().time() - start
             if duration > self.placeholder_threshold:
                 self.append(self._placeholder)
                 return
             await asyncio.sleep(0.28)
+
+    async def _handle_callback(self, message, loop):
+        callback_args = self._gather_callback_args(message)
+        if iscoroutinefunction(self.callback):
+            response = await self.callback(*callback_args)
+        elif isasyncgenfunction(self.callback):
+            response = self.callback(*callback_args)
+        else:
+            response = await loop.run_in_executor(
+                None, partial(self.callback, *callback_args)
+            )
+        await self._serialize_response(response)
 
     async def _prepare_response(self, _) -> None:
         """
@@ -496,19 +511,12 @@ class ChatFeed(ListPanel):
                 return
 
             num_entries = len(self._chat_log)
-            callback_args = self._gather_callback_args(message)
             loop = asyncio.get_event_loop()
-            if asyncio.iscoroutinefunction(self.callback):
-                future = loop.create_task(self.callback(*callback_args))
-            else:
-                future = loop.run_in_executor(None, partial(self.callback, *callback_args))
+            future = loop.create_task(self._handle_callback(message, loop))
             self._callback_future = future
-            await self._schedule_placeholder(future, num_entries)
-
-            if not future.cancelled():
-                await future
-                response = future.result()
-                await self._serialize_response(response)
+            await asyncio.gather(
+                self._schedule_placeholder(future, num_entries), future,
+            )
         except StopCallback:
             # callback was stopped by user
             self._callback_state = CallbackState.STOPPED
@@ -527,10 +535,16 @@ class ChatFeed(ListPanel):
             else:
                 raise e
         finally:
-            with param.parameterized.batch_call_watchers(self):
-                self._replace_placeholder(None)
-                self._callback_state = CallbackState.IDLE
-                self.disabled = self._was_disabled
+            await self._cleanup_response()
+
+    async def _cleanup_response(self):
+        """
+        Events to always execute after the callback is done.
+        """
+        with param.parameterized.batch_call_watchers(self):
+            self._replace_placeholder(None)
+            self._callback_state = CallbackState.IDLE
+            self.disabled = self._was_disabled
 
     # Public API
 

--- a/panel/chat/feed.py
+++ b/panel/chat/feed.py
@@ -478,7 +478,7 @@ class ChatFeed(ListPanel):
             if duration > self.placeholder_threshold:
                 self.append(self._placeholder)
                 return
-            await asyncio.sleep(0.28)
+            await asyncio.sleep(0.1)
 
     async def _handle_callback(self, message, loop):
         callback_args = self._gather_callback_args(message)

--- a/panel/chat/interface.py
+++ b/panel/chat/interface.py
@@ -591,3 +591,10 @@ class ChatInterface(ChatFeed):
             with param.parameterized.batch_call_watchers(self):
                 self._buttons["send"].visible = False
                 self._buttons["stop"].visible = True
+
+    async def _cleanup_response(self):
+        """
+        Events to always execute after the callback is done.
+        """
+        await super()._cleanup_response()
+        await self._update_input_disabled()

--- a/panel/tests/chat/test_interface.py
+++ b/panel/tests/chat/test_interface.py
@@ -1,3 +1,5 @@
+import asyncio
+
 from io import BytesIO
 
 import pytest
@@ -6,9 +8,11 @@ import requests
 from panel.chat.interface import ChatInterface
 from panel.layout import Row, Tabs
 from panel.pane import Image
-from panel.tests.util import wait_until
+from panel.tests.util import async_wait_until, wait_until
 from panel.widgets.button import Button
 from panel.widgets.input import FileInput, TextAreaInput, TextInput
+
+ChatInterface.callback_exception = "raise"
 
 
 class TestChatInterface:
@@ -88,12 +92,10 @@ class TestChatInterface:
     def test_show_stop_disabled(self, chat_interface: ChatInterface):
         async def callback(msg, user, instance):
             yield "A"
-            send_button = chat_interface._input_layout[1]
-            stop_button = chat_interface._input_layout[2]
-            assert send_button.name == "Send"
-            assert stop_button.name == "Stop"
-            assert send_button.visible
-            assert not send_button.disabled
+            send_button = instance._buttons["send"]
+            stop_button = instance._buttons["stop"]
+            wait_until(lambda: send_button.visible)
+            wait_until(lambda: send_button.disabled) #  should be disabled while callback is running
             assert not stop_button.visible
             yield "B"  # should not stream this
 
@@ -110,12 +112,10 @@ class TestChatInterface:
 
     def test_show_stop_for_async(self, chat_interface: ChatInterface):
         async def callback(msg, user, instance):
-            send_button = instance._input_layout[1]
-            stop_button = instance._input_layout[2]
-            assert send_button.name == "Send"
-            assert stop_button.name == "Stop"
-            assert not send_button.visible
-            assert stop_button.visible
+            send_button = instance._buttons["send"]
+            stop_button = instance._buttons["stop"]
+            await async_wait_until(lambda: stop_button.visible)
+            await async_wait_until(lambda: not send_button.visible)
 
         chat_interface.callback = callback
         chat_interface.send("Message", respond=True)
@@ -124,12 +124,10 @@ class TestChatInterface:
 
     def test_show_stop_for_sync(self, chat_interface: ChatInterface):
         def callback(msg, user, instance):
-            send_button = instance._input_layout[1]
-            stop_button = instance._input_layout[2]
-            assert send_button.name == "Send"
-            assert stop_button.name == "Stop"
-            assert not send_button.visible
-            assert stop_button.visible
+            send_button = instance._buttons["send"]
+            stop_button = instance._buttons["stop"]
+            wait_until(lambda: stop_button.visible)
+            wait_until(lambda: not send_button.visible)
 
         chat_interface.callback = callback
         chat_interface.send("Message", respond=True)
@@ -138,25 +136,21 @@ class TestChatInterface:
 
     def test_click_stop(self, chat_interface: ChatInterface):
         async def callback(msg, user, instance):
-            send_button = instance._input_layout[1]
-            stop_button = instance._input_layout[2]
-            assert send_button.name == "Send"
-            assert stop_button.name == "Stop"
-            assert not send_button.visible
-            assert stop_button.visible
-            wait_until(lambda: len(instance.objects) == 2)
-            assert instance._placeholder in instance.objects
+            send_button = instance._buttons["send"]
+            stop_button = instance._buttons["stop"]
+            await async_wait_until(lambda: stop_button.visible)
+            await async_wait_until(lambda: not send_button.visible)
             instance._click_stop(None)
-            assert send_button.visible
-            assert not send_button.disabled
-            assert not stop_button.visible
-            assert instance._placeholder not in instance.objects
 
         chat_interface.callback = callback
         chat_interface.placeholder_threshold = 0.001
-        chat_interface.send("Message", respond=True)
-        send_button = chat_interface._input_layout[1]
-        assert not send_button.disabled
+        try:
+            chat_interface.send("Message", respond=True)
+        except asyncio.exceptions.CancelledError:
+            pass
+        wait_until(lambda: not chat_interface._buttons["send"].disabled)
+        wait_until(lambda: chat_interface._buttons["send"].visible)
+        wait_until(lambda: not chat_interface._buttons["stop"].visible)
 
     @pytest.mark.parametrize("widget", [TextInput(), TextAreaInput()])
     def test_auto_send_types(self, chat_interface: ChatInterface, widget):


### PR DESCRIPTION
Ensures that the tests actually run and raises errors by setting `callback_exception = "raise"` rather than having the errors piped to the chat logs

This resulted in finding a lot of tests failing, **but** most of them were just tests not written properly (e.g. not using `wait_until` to assert)

The only bug I found was a result of https://github.com/holoviz/panel/pull/6105, where async generator functions execution time was based on `placeholder_threshold`, i.e. `await _schedule_placeholder` had to run in completion, before the *actual callback* started executing.

This was remedied by wrapping `_serialize_response` (where the iteration of the generator was happening) alongside the actual callback so that when checking `task.done()`, it checks the execution of both of these.