### PR TITLE
fix typo

### DIFF
--- a/doc/explanation/dependencies/param.md
+++ b/doc/explanation/dependencies/param.md
@@ -98,7 +98,7 @@ class P(param.Parameterized):
 
 The class `B` below is created with 4 *Parameters*:
 
-- `x` is a `Number` *Parameter* that only accepts Python `int` and `float` values.
+- `t` is a `Number` *Parameter* that only accepts Python `int` and `float` values.
 - `i` is an `Integer` *Parameter* that only accepts Python `int` values and that must be within the interval `[5, 10]`
 - `s` is a `String` *Parameter* that only accepts Python `str` values and is documented with `doc`.
 - `option` is a `Selector` *Parameter* that only accepts one of the values listed in `objects`.


### PR DESCRIPTION
Fixes a small typo in the docs, found on this page: https://panel.holoviz.org/explanation/dependencies/param.html#runtime-type-checking (`x`  should be `t`).