### PR TITLE
Improve documentation on TextAreaInput

### DIFF
--- a/examples/reference/widgets/TextAreaInput.ipynb
+++ b/examples/reference/widgets/TextAreaInput.ipynb
@@ -39,7 +39,7 @@
     "* **`name`** (str): The title of the widget\n",
     "* **`placeholder`** (str): A placeholder string displayed when no value is entered\n",
     "* **`rows`** (int, default=2): The number of rows in the text input field. \n",
-    "* **`resizable`** (boolean | str, default='both'): Whether the layout is interactively resizable, and if so in which dimensions: `width`, `height`, or `both`. Can only be set during initialization.\n",
+    "* **`resizable`** (boolean | str, default='both'): Whether the layout is interactively resizable, and if so in which dimensions: `width`, `height`, or `both`.\n",
     "\n",
     "___"
    ]
@@ -92,6 +92,22 @@
     "2. Bar\n",
     "3. Baz\n",
     "\"\"\", width=500)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If you only want the text area to be resizable in the vertical direction, you can set the resizeable parameter to 'height':"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pn.widgets.TextAreaInput(name=\"Vertical Adjustable TextArea\", resizable=\"height\")"
    ]
   },
   {

--- a/examples/reference/widgets/TextAreaInput.ipynb
+++ b/examples/reference/widgets/TextAreaInput.ipynb
@@ -39,7 +39,7 @@
     "* **`name`** (str): The title of the widget\n",
     "* **`placeholder`** (str): A placeholder string displayed when no value is entered\n",
     "* **`rows`** (int, default=2): The number of rows in the text input field. \n",
-    "* **`resizable`** (boolean | str): Whether the layout is interactively resizable, and if so in which dimensions: `width`, `height`, or `both`.\n",
+    "* **`resizable`** (boolean | str, default='both'): Whether the layout is interactively resizable, and if so in which dimensions: `width`, `height`, or `both`. Can only be set during initialization.\n",
     "\n",
     "___"
    ]

--- a/panel/widgets/input.py
+++ b/panel/widgets/input.py
@@ -143,9 +143,11 @@ class TextAreaInput(TextInput):
     rows = param.Integer(default=2, doc="""
         Number of rows in the text input field.""")
 
-    resizable = param.ObjectSelector(objects=["both", "width", "height", False], doc="""
+    resizable = param.ObjectSelector(
+        objects=["both", "width", "height", False], readonly=True, doc="""
         Whether the layout is interactively resizable,
-        and if so in which dimensions: `width`, `height`, or `both`.""")
+        and if so in which dimensions: `width`, `height`, or `both`.
+        Can only be set during initialization.""")
 
     _widget_type: ClassVar[Type[Model]] = _bkTextAreaInput
 

--- a/panel/widgets/input.py
+++ b/panel/widgets/input.py
@@ -144,7 +144,7 @@ class TextAreaInput(TextInput):
         Number of rows in the text input field.""")
 
     resizable = param.ObjectSelector(
-        objects=["both", "width", "height", False], readonly=True, doc="""
+        objects=["both", "width", "height", False], doc="""
         Whether the layout is interactively resizable,
         and if so in which dimensions: `width`, `height`, or `both`.
         Can only be set during initialization.""")


### PR DESCRIPTION
Closes https://github.com/holoviz/panel/issues/6246#issuecomment-1906209924

Added mention of default, an example, and ~enable readonly=True.~ Okay readonly doesn't initialize.

Unsure how to remove / disable resizable from the jslink side since it can't be set after it has been initialized.

I can't even find resizable on Bokeh's TextAreaInput:
https://github.com/bokeh/bokeh/blob/4b61612d14f840b990a74e455d49feb012badc12/bokehjs/src/lib/models/widgets/textarea_input.ts#L41

Only https://github.com/bokeh/bokeh/blob/4b61612d14f840b990a74e455d49feb012badc12/src/bokeh/models/layouts.py#L287-L289

But it works

https://github.com/holoviz/panel/assets/15331990/ec4780b9-6d9d-486d-98b3-35721d77fc67


