### PR TITLE
Don't pop ChatInterface variables

### DIFF
--- a/panel/chat/feed.py
+++ b/panel/chat/feed.py
@@ -231,8 +231,8 @@ class ChatFeed(ListPanel):
 
         # forward message params to ChatMessage for convenience
         message_params = params.get("message_params", {})
-        for param_key in list(params.keys()):
-            if param_key not in ChatFeed.param and param_key in ChatMessage.param:
+        for param_key in params.copy():
+            if param_key not in self.param and param_key in ChatMessage.param:
                 message_params[param_key] = params.pop(param_key)
         params["message_params"] = message_params
 

--- a/panel/chat/interface.py
+++ b/panel/chat/interface.py
@@ -628,7 +628,12 @@ class ChatInterface(ChatFeed):
         -------
         The message that was created.
         """
-        return super().send(value, user=user or self.user, avatar=avatar or self.avatar, respond=respond)
+        if not isinstance(value, ChatMessage):
+            if user is None:
+                user = self.user
+            if avatar is None:
+                avatar = self.avatar
+        return super().send(value, user=user, avatar=avatar, respond=respond)
 
     def stream(
         self,

--- a/panel/chat/interface.py
+++ b/panel/chat/interface.py
@@ -597,3 +597,73 @@ class ChatInterface(ChatFeed):
         """
         await super()._cleanup_response()
         await self._update_input_disabled()
+
+
+    def send(
+        self,
+        value: ChatMessage | dict | Any,
+        user: str | None = None,
+        avatar: str | bytes | BytesIO | None = None,
+        respond: bool = True,
+    ) -> ChatMessage | None:
+        """
+        Sends a value and creates a new message in the chat log.
+
+        If `respond` is `True`, additionally executes the callback, if provided.
+
+        Arguments
+        ---------
+        value : ChatMessage | dict | Any
+            The message contents to send.
+        user : str | None
+            The user to send as; overrides the message message's user if provided.
+            Will default to the user parameter.
+        avatar : str | bytes | BytesIO | None
+            The avatar to use; overrides the message message's avatar if provided.
+            Will default to the avatar parameter.
+        respond : bool
+            Whether to execute the callback.
+
+        Returns
+        -------
+        The message that was created.
+        """
+        return super().send(value, user=user or self.user, avatar=avatar or self.avatar, respond=respond)
+
+    def stream(
+        self,
+        value: str,
+        user: str | None = None,
+        avatar: str | bytes | BytesIO | None = None,
+        message: ChatMessage | None = None,
+        replace: bool = False,
+    ) -> ChatMessage | None:
+        """
+        Streams a token and updates the provided message, if provided.
+        Otherwise creates a new message in the chat log, so be sure the
+        returned message is passed back into the method, e.g.
+        `message = chat.stream(token, message=message)`.
+
+        This method is primarily for outputs that are not generators--
+        notably LangChain. For most cases, use the send method instead.
+
+        Arguments
+        ---------
+        value : str | dict | ChatMessage
+            The new token value to stream.
+        user : str | None
+            The user to stream as; overrides the message's user if provided.
+            Will default to the user parameter.
+        avatar : str | bytes | BytesIO | None
+            The avatar to use; overrides the message's avatar if provided.
+            Will default to the avatar parameter.
+        message : ChatMessage | None
+            The message to update.
+        replace : bool
+            Whether to replace the existing text when streaming a string or dict.
+
+        Returns
+        -------
+        The message that was updated.
+        """
+        return super().stream(value, user=user or self.user, avatar=avatar or self.avatar, message=message, replace=replace)

--- a/panel/tests/chat/test_interface.py
+++ b/panel/tests/chat/test_interface.py
@@ -358,6 +358,10 @@ class TestChatInterface:
         assert chat_interface.objects[1].object == "2"
         assert chat_interface.objects[2].object == "3"
 
+    def test_manual_user(self):
+        chat_interface = ChatInterface(user="New User")
+        assert chat_interface.user == "New User"
+
 class TestChatInterfaceWidgetsSizingMode:
     def test_none(self):
         chat_interface = ChatInterface()

--- a/panel/tests/chat/test_interface.py
+++ b/panel/tests/chat/test_interface.py
@@ -361,6 +361,8 @@ class TestChatInterface:
     def test_manual_user(self):
         chat_interface = ChatInterface(user="New User")
         assert chat_interface.user == "New User"
+        chat_interface.send("Test")
+        assert chat_interface.objects[0].user == "New User"
 
 class TestChatInterfaceWidgetsSizingMode:
     def test_none(self):


### PR DESCRIPTION
Without these changes, ChatInterface will not use the new username.

``` python
import panel as pn
pn.extension()

pn.chat.ChatInterface(callback=lambda _0, user, _2: user, user="NEW USERNAME")
```

![image](https://github.com/holoviz/panel/assets/19758978/c98d2467-1d52-4525-8aa5-b7d880e2be9c)
