### PR TITLE
Fix lazy load and static analysis issue

### DIFF
--- a/panel/__init__.py
+++ b/panel/__init__.py
@@ -54,6 +54,7 @@ from . import pane  # noqa
 from . import param  # noqa
 from . import pipeline  # noqa
 from . import reactive  # noqa
+from . import template  # noqa
 from . import viewable  # noqa
 from . import widgets  # noqa
 from .config import __version__, config, panel_extension as extension  # noqa
@@ -108,6 +109,7 @@ __all__ = (
     "rx",
     "serve",
     "state",
+    "template",
     "viewable",
     "widgets",
     "widget"


### PR DESCRIPTION
Closes #6292

## Testing

The below is a pytest for the issue. I have not added it because I believe it could change the way panel is imported for all or many pytests which could have unintended consequences now or some day in the future.

```python
"""Panel takes a long time to import. Some users would like to lazily import panel"""
import importlib.util
import sys

def lazy_import(name):
    """Best practice lazy import"""
    # See https://docs.python.org/3/library/importlib.html#implementing-lazy-imports
    spec = importlib.util.find_spec(name)
    loader = importlib.util.LazyLoader(spec.loader)
    spec.loader = loader
    module = importlib.util.module_from_spec(spec)
    sys.modules[name] = module
    loader.exec_module(module)
    return module

def test_pn_template():
    lazy_import("panel")
    import panel as pn
    assert hasattr(pn, "template")
```