### PR TITLE
Choose position to freeze tabulator columns.

### DIFF
--- a/examples/reference/widgets/Tabulator.ipynb
+++ b/examples/reference/widgets/Tabulator.ipynb
@@ -37,7 +37,12 @@
     "* **`expanded`** (`list`): The currently expanded rows as a list of integer indexes.\n",
     "* **`filters`** (`list`): A list of client-side filter definitions that are applied to the table.\n",
     "* **`formatters`** (`dict`): A dictionary mapping from column name to a bokeh `CellFormatter` instance or *Tabulator* formatter specification.\n",
-    "* **`frozen_columns`** (`list`): List of columns to freeze, preventing them from scrolling out of frame. Column can be specified by name or index.\n",
+    "* **`frozen_columns`** (`list` or `dict`): Defines the frozen columns:\n",
+    "  * `list`\n",
+    "      List of columns to freeze, preventing them from scrolling out of frame. Column can be specified by name or index.\n",
+    "  * `dict`\n",
+    "      Dict of columns to freeze and the position in table (`'left'` or `'right'`) to freeze them in. Column names or index can be used as keys. If value does not match\n",
+    "      `left` or `right` then the default behaviour is to not be frozen at all.\n",
     "* **`frozen_rows`**: (`list`): List of rows to freeze, preventing them from scrolling out of frame. Rows can be specified by positive or negative index.\n",
     "* **`groupby`** (`list`): Groups rows in the table by one or more columns.\n",
     "* **`header_align`** (`dict` or `str`): A mapping from column name to header alignment or a fixed header alignment, which should be one of `'left'`, `'center'`, `'right'`.\n",
@@ -633,6 +638,29 @@
    "outputs": [],
    "source": [
     "pn.widgets.Tabulator(df, frozen_columns=['index'], width=400)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "By default, columns given in the list format are frozen to the left hand side of the table. If you want to customize where columns are frozen to on the table, you can specify this with a dictionary:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pn.widgets.Tabulator(df, frozen_columns={'index': 'left', 'float': 'right'}, width=400)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The 'index' column will be frozen on the left side of the table, and the 'float' on the right. Non-frozen columns will scroll between these two."
    ]
   },
   {

--- a/panel/widgets/tables.py
+++ b/panel/widgets/tables.py
@@ -1051,9 +1051,12 @@ class Tabulator(BaseTable):
         List of client-side filters declared as dictionaries containing
         'field', 'type' and 'value' keys.""")
 
-    frozen_columns = param.List(default=[], nested_refs=True, doc="""
-        List indicating the columns to freeze. The column(s) may be
-        selected by name or index.""")
+    frozen_columns = param.ClassSelector(class_=(list, dict), default=[], nested_refs=True, doc="""
+        One of:
+        - List indicating the columns to freeze. The column(s) may be
+        selected by name or index.
+        - Dict indicating columns to freeze as keys and their freeze location
+        as values, freeze location is either 'right' or 'left'.""")
 
     frozen_rows = param.List(default=[], nested_refs=True, doc="""
         List indicating the rows to freeze. If set, the
@@ -1771,23 +1774,31 @@ class Tabulator(BaseTable):
                 "frozen": True,
                 "width": 40,
             })
-
-        ordered = []
-        for col in self.frozen_columns:
-            if isinstance(col, int):
-                ordered.append(column_objs.pop(col))
-            else:
-                cols = [c for c in column_objs if c.field == col]
-                if cols:
-                    ordered.append(cols[0])
-                    column_objs.remove(cols[0])
-        ordered += column_objs
+        if isinstance(self.frozen_columns, dict):
+            left_frozen_columns = [col for col in column_objs if
+                                   self.frozen_columns.get(col.field, self.frozen_columns.get(column_objs.index(col))) == "left"]
+            right_frozen_columns = [col for col in column_objs if
+                                    self.frozen_columns.get(col.field, self.frozen_columns.get(column_objs.index(col))) == "right"]
+            non_frozen_columns = [col for col in column_objs if
+                                  col.field not in self.frozen_columns and column_objs.index(col) not in self.frozen_columns]
+            ordered_columns = left_frozen_columns + non_frozen_columns + right_frozen_columns
+        else:
+            ordered_columns = []
+            for col in self.frozen_columns:
+                if isinstance(col, int):
+                    ordered_columns.append(column_objs.pop(col))
+                else:
+                    cols = [c for c in column_objs if c.field == col]
+                    if cols:
+                        ordered_columns.append(cols[0])
+                        column_objs.remove(cols[0])
+            ordered_columns += column_objs
 
         grouping = {
             group: [str(gc) for gc in group_cols]
             for group, group_cols in self.groups.items()
         }
-        for i, column in enumerate(ordered):
+        for i, column in enumerate(ordered_columns):
             field = column.field
             matching_groups = [
                 group for group, group_cols in grouping.items()


### PR DESCRIPTION
As a solution to my issue #5901 

Columns are ordered by the panel BE and afterwards given the "frozen": True attribute. Hence to freeze to the right of the table, those columns just needed to be put at the end of the ordered list.

The solution to freeze "left" or "right" only I think makes the most sense and is easy enough to implement - unless there is demand for more complicated ways to freeze columns.

The change only adds a new way to freeze columns, the old way will work identically.

https://github.com/holoviz/panel/assets/60933427/89978d39-3695-4f98-8a25-9ab42e445e5b

