### PR TITLE
Improve developer experience for notebook preview

### DIFF
--- a/panel/io/jupyter_server_extension.py
+++ b/panel/io/jupyter_server_extension.py
@@ -112,6 +112,8 @@ import os
 import pathlib
 import sys
 
+if os.environ.get('BOKEH_RESOURCES') == 'inline':
+    os.environ['BOKEH_RESOURCES'] = 'server'
 app = r'{{ path }}'
 os.chdir(str(pathlib.Path(app).parent))
 sys.path = [os.getcwd()] + sys.path[1:]

--- a/panel/io/jupyter_server_extension.py
+++ b/panel/io/jupyter_server_extension.py
@@ -112,8 +112,7 @@ import os
 import pathlib
 import sys
 
-if os.environ.get('BOKEH_RESOURCES') == 'inline':
-    os.environ['BOKEH_RESOURCES'] = 'server'
+os.environ['BOKEH_RESOURCES'] = 'server'
 app = r'{{ path }}'
 os.chdir(str(pathlib.Path(app).parent))
 sys.path = [os.getcwd()] + sys.path[1:]

--- a/panel/tests/ui/io/test_jupyter_server_extension.py
+++ b/panel/tests/ui/io/test_jupyter_server_extension.py
@@ -1,3 +1,7 @@
+import sys
+
+from pathlib import Path
+
 import pytest
 
 pytest.importorskip("playwright")
@@ -49,3 +53,9 @@ def test_jupyter_server_session_arg_theme(page, jupyter_preview):
     page.goto(f"{jupyter_preview}/app.py?theme=dark", timeout=30000)
 
     expect(page.locator('body')).to_have_css('color', 'rgb(0, 0, 0)')
+
+
+def test_jupyter_config():
+    # If this test fails run `pip install .` again
+    jp_files = (Path(sys.prefix) / 'etc' / 'jupyter').rglob('panel-client-jupyter.json')
+    assert len(list(jp_files)) == 2

--- a/panel/tests/ui/io/test_jupyter_server_extension.py
+++ b/panel/tests/ui/io/test_jupyter_server_extension.py
@@ -56,6 +56,6 @@ def test_jupyter_server_session_arg_theme(page, jupyter_preview):
 
 
 def test_jupyter_config():
-    # If this test fails run `pip install .` again
+    # If this test fails, run `pip install -e .` again
     jp_files = (Path(sys.prefix) / 'etc' / 'jupyter').rglob('panel-client-jupyter.json')
     assert len(list(jp_files)) == 2

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 import json
 import os
+import shutil
 import sys
 
 from setuptools import find_packages, setup
@@ -47,12 +48,23 @@ def _build_paneljs():
         fcntl.fcntl(sys.stdout, fcntl.F_SETFL, flags&~os.O_NONBLOCK)
 
 
+def _install_jupyter_server_extension():
+    # data_files are not copied for editable installs returning
+    files = setup_args['data_files']
+    for dst, (src,) in files:
+        dst = os.path.join(sys.prefix, dst)
+        os.makedirs(dst, exist_ok=True)
+        shutil.copy2(src, dst)
+        print(f"Copied {src} to {dst}")
+
+
 class CustomDevelopCommand(develop):
     """Custom installation for development mode."""
 
     def run(self):
         if not PANEL_LITE_BUILD:
             _build_paneljs()
+            _install_jupyter_server_extension()
         develop.run(self)
 
 


### PR DESCRIPTION
I have been unable to run the Panel Preview inside my Jupyter environment for the longest time. I would get the following message:

![ Screenshot 2024-02-07 15 14 28](https://github.com/holoviz/panel/assets/19758978/e4042ed5-9037-4204-b6dd-1f483dca7196)

I have found two reasons for this:
1. Editable installs do not copy the jupyter-config to the jupyter folder in the env folder. I'm working with the mentality that if there is a problem, delete the environment and create a new one. Which meant the data-files were never really copied for me. 
2. I run `BOKEH_RESOURCES=inline jupyter lab`, this does not work the panel preview. 

After doing 1, I get an infinity wheel spin with a warning in the terminal
![ Screenshot 2024-02-07 15 18 24](https://github.com/holoviz/panel/assets/19758978/0b675c77-8a70-4910-abfd-e1de622dc96b)

``` python
2024-02-07 15:17:55,875 ERROR: panel.io.jupyter_server_extension - ['\x1b[0;31m---------------------------------------------------------------------------\x1b[0m', '\x1b[0;31mValueError\x1b[0m                                Traceback (most recent call last)', "Cell \x1b[0;32mIn[1], line 12\x1b[0m\n\x1b[1;32m      9\x1b[0m sys\x1b[38;5;241m.\x1b[39mpath \x1b[38;5;241m=\x1b[39m [os\x1b[38;5;241m.\x1b[39mgetcwd()] \x1b[38;5;241m+\x1b[39m sys\x1b[38;5;241m.\x1b[39mpath[\x1b[38;5;241m1\x1b[39m:]\n\x1b[1;32m     11\x1b[0m \x1b[38;5;28;01mfrom\x1b[39;00m \x1b[38;5;21;01mpanel\x1b[39;00m\x1b[38;5;21;01m.\x1b[39;00m\x1b[38;5;21;01mio\x1b[39;00m\x1b[38;5;21;01m.\x1b[39;00m\x1b[38;5;21;01mjupyter_executor\x1b[39;00m \x1b[38;5;28;01mimport\x1b[39;00m PanelExecutor\n\x1b[0;32m---> 12\x1b[0m executor \x1b[38;5;241m=\x1b[39m \x1b[43mPanelExecutor\x1b[49m\x1b[43m(\x1b[49m\x1b[43mapp\x1b[49m\x1b[43m,\x1b[49m\x1b[43m \x1b[49m\x1b[38;5;124;43m'\x1b[39;49m\x1b[38;5;124;43meyJzZXNzaW9uX2lkIjogIkVzZ2NrUWM1WGxJTWhpQ3ljajZ1OFhOS2NXYkEyNldhZTE2V2doaXdhZ2pKIiwgInNlc3Npb25fZXhwaXJ5IjogMTcwNzMxNTc3NCwgIl9fYmtfX3psaWJfIjogImVOck5WRzF2NGpnUV9pc1JuLTcyQ05qT3E2bjQwSVdTcGlwd0xRMXAwVXFWblRpSlM5NDJDUkJZLXRfUENmVDJldHFlN21PVlJQTE1QQjVQbnZFOFB6cWtDRGNKUzZ1eU01Qi12SGFsVHNTSXo0clc3RnhuWlNVV25UanpTQndKWTJDYUp1NElsRk95UXI0TXhjWW1QczBPUEk1Slgtc0I2YmRIQ0Mta1c1NXVhcWsyOVdkZHZaQ0s3UUFpMUFPX1N4YnoxbGtmQVFqRUM2VUpMMWlRMWYwMjJ1Uzk5RHlXdHprclZsZjlxRXJpTHNuem1IdWs0bG5hcnh2UEhfV192VWw4OFgwSWVyakxFeEt5UHRueTRMemNNWnAzdl9TX3RISHo1eEh5TFVuRGpVQTBaN0ZVZGhaZGxyWWc3Ui1ncTlUTGZKNkdEU2c4OEx3ci1TeUlTY1c2RWkwYTNDaExVLVkxUlRTUU5XTzVUR0stWmFkWXR1WnRfdWVRUE4tQ2tmbW45WUJ1cDBOckFYdmlNUUEwVEtoaDFFTV9UVU5SZXFCNUxpU3hhMmhkTmxCZFF4Z2JDdEJibElwMHc4UVgwa2IwSUNVSmtfOXVqOXkwWl9pdGc0NXdBSTRRREFUY1VLQ202dW9SS1lNUE5od1JBQU8ydjRFZVd1NXBNcWxXQzF1M1J6YVlXX1poNWs3VjFUam1LOHNCVS1Rbzh3ZG5OeDlIOFh4OEw3NWxOQjhfb2ZuQ0x1M1J6ZWJKaGJIOWtvWDJlcktoU05Pb2k2RzNfLW8tdVhYc1h5X1hkTl9pMXVSeHRxUFdSSHRFV2tSZGg4XzVKYjl6dFMxTjQ0b3F5NE05V1VYVVdnTGZ2ZF9hZkJmYVNid2hqX2U1eUhNNDUzZFBfdG1XV25qZi1HaTZMT2sxR0I1Vno4TWFOUlZrZWdnQlFnMUJuT0lIaGtJcEJkajBBczJubUtFQW16N3pGUjJidXFCSU1PcXJET3JRcE44Nkh6RnJfb0paaVBISHpKcEhpUFZmTWJ1YkpzN3VDZDI4ekMwSFRjZHJNQnZmS2ZQeGJMMUtydXJwaTdPYm9lbGg5VENMWjZQX1pIYmlQOTVzUGV1SzM0NHVSWWZpZzJmVkVWdmlfNFVucnBiN1ZoelI2LW1wQTQ3VC1wOFFMcWxpQzlfWGplX1daWEEzSEI0VkNva0NDQVFCTWFtdmFicXBFd1BvT3ZROVRSRjNNMUNZaWt5ZkNLSUJVWFJEM0dRQ0dBNncyRU5ob0RTc1B0ZGxFUXdGZzFBblJLWDQ2QnVtb2V1aVBWalJERVdGcHFDTGFocWhxcTlpckFuNkJNbENHbFFJVzgzSncwSm9rMnluSmZNMkJaUHYyZmNOSzF2cDZyU0lCZlBrQ2F1OFNCNnprM0x4b0JCdGVSLWJabjQ3bGFtUWlWRE04dnZvZ2xkdHRHemFtUlU4NUdtbjBVV3ZuZWFUTHI2ZjU5YkY2bHhvV1Z0S2t5OG5WZlMyOXJJa09RdGxZX3BaUW5qNlppV2tsczhxMUppblAzdXpvcXJLc3pUZXY5bGJJY3hucVduQm9zVHlYRzVibzZqcjh4VHpnZHA4OWdMTlQ5VE9abUEtU1RtdnIzOEIycGR2Q3cifQ\x1b[39;49m\x1b[38;5;124;43m'\x1b[39;49m\x1b[43m,\x1b[49m\x1b[43m \x1b[49m\x1b[38;5;124;43m'\x1b[39;49m\x1b[38;5;124;43m/panel-preview\x1b[39;49m\x1b[38;5;124;43m'\x1b[39;49m\x1b[43m)\x1b[49m\n\x1b[1;32m     13\x1b[0m executor\x1b[38;5;241m.\x1b[39mrender()\n", "File \x1b[0;32m~/projects/holoviz/repos/panel/panel/io/jupyter_executor.py:72\x1b[0m, in \x1b[0;36mPanelExecutor.__init__\x1b[0;34m(self, path, token, root_url)\x1b[0m\n\x1b[1;32m     69\x1b[0m \x1b[38;5;28mself\x1b[39m\x1b[38;5;241m.\x1b[39mwrite_lock \x1b[38;5;241m=\x1b[39m tornado\x1b[38;5;241m.\x1b[39mlocks\x1b[38;5;241m.\x1b[39mLock()\n\x1b[1;32m     70\x1b[0m \x1b[38;5;28mself\x1b[39m\x1b[38;5;241m.\x1b[39m_context \x1b[38;5;241m=\x1b[39m \x1b[38;5;28;01mNone\x1b[39;00m\n\x1b[0;32m---> 72\x1b[0m \x1b[38;5;28mself\x1b[39m\x1b[38;5;241m.\x1b[39mresources \x1b[38;5;241m=\x1b[39m \x1b[43mResources\x1b[49m\x1b[43m(\x1b[49m\n\x1b[1;32m     73\x1b[0m \x1b[43m    \x1b[49m\x1b[43mmode\x1b[49m\x1b[38;5;241;43m=\x1b[39;49m\x1b[43mos\x1b[49m\x1b[38;5;241;43m.\x1b[39;49m\x1b[43menviron\x1b[49m\x1b[38;5;241;43m.\x1b[39;49m\x1b[43mget\x1b[49m\x1b[43m(\x1b[49m\x1b[38;5;124;43m'\x1b[39;49m\x1b[38;5;124;43mBOKEH_RESOURCES\x1b[39;49m\x1b[38;5;124;43m'\x1b[39;49m\x1b[43m,\x1b[49m\x1b[43m \x1b[49m\x1b[38;5;124;43m'\x1b[39;49m\x1b[38;5;124;43mserver\x1b[39;49m\x1b[38;5;124;43m'\x1b[39;49m\x1b[43m)\x1b[49m\x1b[43m,\x1b[49m\x1b[43m \x1b[49m\x1b[43mroot_url\x1b[49m\x1b[38;5;241;43m=\x1b[39;49m\x1b[38;5;28;43mself\x1b[39;49m\x1b[38;5;241;43m.\x1b[39;49m\x1b[43mroot_url\x1b[49m\x1b[43m,\x1b[49m\n\x1b[1;32m     74\x1b[0m \x1b[43m    \x1b[49m\x1b[43mpath_versioner\x1b[49m\x1b[38;5;241;43m=\x1b[39;49m\x1b[43mStaticHandler\x1b[49m\x1b[38;5;241;43m.\x1b[39;49m\x1b[43mappend_version\x1b[49m\x1b[43m,\x1b[49m\x1b[43m \x1b[49m\x1b[43mabsolute\x1b[49m\x1b[38;5;241;43m=\x1b[39;49m\x1b[38;5;28;43;01mTrue\x1b[39;49;00m\n\x1b[1;32m     75\x1b[0m \x1b[43m\x1b[49m\x1b[43m)\x1b[49m\n\x1b[1;32m     76\x1b[0m \x1b[38;5;28mself\x1b[39m\x1b[38;5;241m.\x1b[39m_set_state()\n\x1b[1;32m     77\x1b[0m \x1b[38;5;28;01mtry\x1b[39;00m:\n", 'File \x1b[0;32m~/projects/holoviz/repos/panel/panel/io/resources.py:530\x1b[0m, in \x1b[0;36mResources.__init__\x1b[0;34m(self, absolute, notebook, *args, **kwargs)\x1b[0m\n\x1b[1;32m    528\x1b[0m \x1b[38;5;28mself\x1b[39m\x1b[38;5;241m.\x1b[39mabsolute \x1b[38;5;241m=\x1b[39m absolute\n\x1b[1;32m    529\x1b[0m \x1b[38;5;28mself\x1b[39m\x1b[38;5;241m.\x1b[39mnotebook \x1b[38;5;241m=\x1b[39m notebook\n\x1b[0;32m--> 530\x1b[0m \x1b[38;5;28;43msuper\x1b[39;49m\x1b[43m(\x1b[49m\x1b[43m)\x1b[49m\x1b[38;5;241;43m.\x1b[39;49m\x1b[38;5;21;43m__init__\x1b[39;49m\x1b[43m(\x1b[49m\x1b[38;5;241;43m*\x1b[39;49m\x1b[43margs\x1b[49m\x1b[43m,\x1b[49m\x1b[43m \x1b[49m\x1b[38;5;241;43m*\x1b[39;49m\x1b[38;5;241;43m*\x1b[39;49m\x1b[43mkwargs\x1b[49m\x1b[43m)\x1b[49m\n', 'File \x1b[0;32m~/miniconda3/envs/holoviz/lib/python3.11/site-packages/bokeh/resources.py:364\x1b[0m, in \x1b[0;36mResources.__init__\x1b[0;34m(self, mode, version, root_dir, dev, minified, log_level, root_url, path_versioner, components, base_dir)\x1b[0m\n\x1b[1;32m    361\x1b[0m     \x1b[38;5;28;01mraise\x1b[39;00m \x1b[38;5;167;01mValueError\x1b[39;00m(\x1b[38;5;124m"\x1b[39m\x1b[38;5;124msetting \x1b[39m\x1b[38;5;124m\'\x1b[39m\x1b[38;5;124mversion\x1b[39m\x1b[38;5;124m\'\x1b[39m\x1b[38;5;124m makes sense only when \x1b[39m\x1b[38;5;124m\'\x1b[39m\x1b[38;5;124mmode\x1b[39m\x1b[38;5;124m\'\x1b[39m\x1b[38;5;124m is set to \x1b[39m\x1b[38;5;124m\'\x1b[39m\x1b[38;5;124mcdn\x1b[39m\x1b[38;5;124m\'\x1b[39m\x1b[38;5;124m"\x1b[39m)\n\x1b[1;32m    363\x1b[0m \x1b[38;5;28;01mif\x1b[39;00m root_url \x1b[38;5;129;01mand\x1b[39;00m \x1b[38;5;129;01mnot\x1b[39;00m \x1b[38;5;28mself\x1b[39m\x1b[38;5;241m.\x1b[39mmode\x1b[38;5;241m.\x1b[39mstartswith(\x1b[38;5;124m"\x1b[39m\x1b[38;5;124mserver\x1b[39m\x1b[38;5;124m"\x1b[39m):\n\x1b[0;32m--> 364\x1b[0m     \x1b[38;5;28;01mraise\x1b[39;00m \x1b[38;5;167;01mValueError\x1b[39;00m(\x1b[38;5;124m"\x1b[39m\x1b[38;5;124msetting \x1b[39m\x1b[38;5;124m\'\x1b[39m\x1b[38;5;124mroot_url\x1b[39m\x1b[38;5;124m\'\x1b[39m\x1b[38;5;124m makes sense only when \x1b[39m\x1b[38;5;124m\'\x1b[39m\x1b[38;5;124mmode\x1b[39m\x1b[38;5;124m\'\x1b[39m\x1b[38;5;124m is set to \x1b[39m\x1b[38;5;124m\'\x1b[39m\x1b[38;5;124mserver\x1b[39m\x1b[38;5;124m\'\x1b[39m\x1b[38;5;124m"\x1b[39m)\n\x1b[1;32m    366\x1b[0m \x1b[38;5;28mself\x1b[39m\x1b[38;5;241m.\x1b[39mroot_dir \x1b[38;5;241m=\x1b[39m settings\x1b[38;5;241m.\x1b[39mrootdir(root_dir)\n\x1b[1;32m    367\x1b[0m \x1b[38;5;28;01mdel\x1b[39;00m root_dir\n', "\x1b[0;31mValueError\x1b[0m: setting 'root_url' makes sense only when 'mode' is set to 'server'"]
```

Therefore, I updated EXECUTION_TEMPLATE to set BOKEH_RESOURCES to 'server' if they are 'inline'. And with that, I can finally get the experience of Panel preview, like a normal user.
![ Screenshot 2024-02-07 15 19 33](https://github.com/holoviz/panel/assets/19758978/ba8e4967-9a65-4e89-be8b-35e0d4281f11)

