### PR TITLE
Remove animation from loading spinner without spin

### DIFF
--- a/panel/dist/css/loadingspinner.css
+++ b/panel/dist/css/loadingspinner.css
@@ -22,7 +22,6 @@
   height: var(--loading-spinner-size);
   width: var(--loading-spinner-size);
   position: absolute;
-  animation: spin 2s linear infinite;
 }
 
 :host(.loader) div > span {


### PR DESCRIPTION
Fixes #6321 

Animation is set on: `:host(.loader.spin) div::after {`

``` python
import panel as pn

pn.extension()
active = pn.indicators.LoadingSpinner(
    width=100, height=100, bgcolor="dark", value=True, color="primary"
)
idle = pn.indicators.LoadingSpinner(
    width=100, height=100, bgcolor="dark", value=False, color="primary"
)
pn.Row(active, idle).servable()
```

https://github.com/holoviz/panel/assets/19758978/30561a6a-c16c-4ded-8d16-c3d026ac2e04

