### PR TITLE
Docs: hide the output of `chat_message.param.update`

### DIFF
--- a/examples/reference/chat/ChatMessage.ipynb
+++ b/examples/reference/chat/ChatMessage.ipynb
@@ -217,7 +217,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "chat_message.param.update(user=\"Jolly Guy\", avatar=\"🎅\")"
+    "chat_message.param.update(user=\"Jolly Guy\", avatar=\"🎅\");"
    ]
   },
   {


### PR DESCRIPTION
It's not really useful (there's an output because `update` can be used as a context manager).

![image](https://github.com/holoviz/panel/assets/35924738/4c527574-5f9e-4364-a362-250295405eec)

The change should hide the output.