### PR TITLE
Stylize chat components

### DIFF
--- a/examples/reference/chat/ChatFeed.ipynb
+++ b/examples/reference/chat/ChatFeed.ipynb
@@ -781,6 +781,39 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "It's possible to customize the appearance of the chat feed by setting the `message_params` parameter.\n",
+    "\n",
+    "Please visit [`ChatMessage`](ChatMessage.ipynb) for a full list of customizable, target CSS classes (e.g. `.avatar`, `.name`, etc)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "chat_feed = pn.chat.ChatFeed(\n",
+    "    show_activity_dot=True,\n",
+    "    message_params={\n",
+    "        \"stylesheets\": [\n",
+    "            \"\"\"\n",
+    "            .message {\n",
+    "                background-color: tan;\n",
+    "                font-family: \"Courier New\";\n",
+    "                font-size: 24px;\n",
+    "            }\n",
+    "            \"\"\"\n",
+    "        ]\n",
+    "    },\n",
+    ")\n",
+    "chat_feed.send(\"I am so stylish!\")\n",
+    "chat_feed"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "You can build your own custom chat interface too on top of `ChatFeed`, but remember there's a pre-built [`ChatInterface`](ChatInterface.ipynb)!"
    ]
   },

--- a/examples/reference/chat/ChatMessage.ipynb
+++ b/examples/reference/chat/ChatMessage.ipynb
@@ -322,7 +322,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "You can set the usual styling and layout parameters like `sizing_mode`, `height`, `width`, `max_height`, `max_width`, `styles` and `stylesheet`."
+    "You can set the usual styling and layout parameters like `sizing_mode`, `height`, `width`, `max_height`, `max_width`, and `styles`."
    ]
   },
   {
@@ -339,6 +339,70 @@
     "    sizing_mode=\"stretch_width\",\n",
     "    max_width=600,\n",
     "    styles={\"background\": \"#CBC3E3\"},\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can also use stylesheets to target parts of the `ChatMessage`\n",
+    "\n",
+    "Note, it's best practice to use a path to a `.css` stylesheet, but for demo purposes, we will be using a multi-line string here."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "path_to_stylesheet = \"\"\"\n",
+    "    .message {\n",
+    "        background-color: tan;\n",
+    "        font-size: 24px;\n",
+    "        font-family: \"Courier New\";\n",
+    "    }\n",
+    "    .avatar {\n",
+    "        background-color: red;\n",
+    "        border-radius: 5%;\n",
+    "    }\n",
+    "    .header {\n",
+    "        background-color: green;\n",
+    "    }\n",
+    "    .footer {\n",
+    "        background-color: blue;\n",
+    "    }\n",
+    "    .name {\n",
+    "        background-color: orange;\n",
+    "    }\n",
+    "    .timestamp {\n",
+    "        background-color: purple;\n",
+    "    }\n",
+    "    .activity-dot {\n",
+    "        background-color: black;\n",
+    "    }\n",
+    "    .reaction-icons {\n",
+    "        background-color: white;\n",
+    "    }\n",
+    "    .copy-icon {\n",
+    "        background-color: gold;\n",
+    "    }\n",
+    "    .right {\n",
+    "        background-color: grey;\n",
+    "    }\n",
+    "    .center {\n",
+    "        background-color: pink;\n",
+    "    }\n",
+    "    .left {\n",
+    "        background-color: yellow;\n",
+    "    }\n",
+    "\"\"\"\n",
+    "\n",
+    "ChatMessage(\n",
+    "    \"Style me up!\",\n",
+    "    show_activity_dot=True,\n",
+    "    stylesheets=[path_to_stylesheet],\n",
     ")"
    ]
   },

--- a/panel/chat/icon.py
+++ b/panel/chat/icon.py
@@ -98,6 +98,8 @@ class ChatCopyIcon(ReactiveHTML):
 
     value = param.String(default=None, doc="The text to copy to the clipboard.")
 
+    css_classes = param.List(default=["copy-icon"], doc="The CSS classes of the widget.")
+
     _template = """
         <div
             type="button"

--- a/panel/chat/message.py
+++ b/panel/chat/message.py
@@ -219,9 +219,6 @@ class ChatMessage(PaneBase):
 
     def __init__(self, object=None, **params):
         self._exit_stack = ExitStack()
-        self.chat_copy_icon = ChatCopyIcon(
-            visible=False, width=15, height=15, css_classes=["copy-icon"]
-        )
         if params.get("timestamp") is None:
             tz = params.get("timestamp_tz")
             if tz is not None:
@@ -237,6 +234,11 @@ class ChatMessage(PaneBase):
             )
         self._internal = True
         super().__init__(object=object, **params)
+        self.chat_copy_icon = ChatCopyIcon(
+            visible=False, width=15, height=15, css_classes=["copy-icon"],
+            stylesheets=self._stylesheets + self.param.stylesheets.rx(),
+        )
+        self.reaction_icons.stylesheets = self._stylesheets + self.param.stylesheets.rx()
         self.reaction_icons.link(self, value="reactions", bidirectional=True)
         self.reaction_icons.visible = self.param.show_reaction_icons
         if not self.avatar:
@@ -245,14 +247,17 @@ class ChatMessage(PaneBase):
 
     def _build_layout(self):
         self._activity_dot = HTML(
-            "●", css_classes=["activity-dot"], visible=self.param.show_activity_dot
+            "●",
+            css_classes=["activity-dot"],
+            visible=self.param.show_activity_dot,
+            stylesheets=self._stylesheets + self.param.stylesheets.rx(),
         )
         self._left_col = left_col = Column(
             self._render_avatar(),
             max_width=60,
             height=100,
             css_classes=["left"],
-            stylesheets=self._stylesheets,
+            stylesheets=self._stylesheets + self.param.stylesheets.rx(),
             visible=self.param.show_avatar,
             sizing_mode=None,
         )
@@ -264,7 +269,7 @@ class ChatMessage(PaneBase):
             self._object_panel,
             self.reaction_icons,
             css_classes=["center"],
-            stylesheets=self._stylesheets,
+            stylesheets=self._stylesheets + self.param.stylesheets.rx(),
             sizing_mode=None
         )
         self.param.watch(self._update_object_pane, "object")
@@ -273,24 +278,34 @@ class ChatMessage(PaneBase):
             self.param.user, height=20, css_classes=["name"],
             visible=self.param.show_user, stylesheets=self._stylesheets,
         )
+        header_row = Row(
+            self._user_html,
+            self.chat_copy_icon,
+            self._activity_dot,
+            stylesheets=self._stylesheets + self.param.stylesheets.rx(),
+            sizing_mode="stretch_width",
+            css_classes=["header"]
+        )
+
         self._timestamp_html = HTML(
             self.param.timestamp.rx().strftime(self.param.timestamp_format),
             css_classes=["timestamp"],
             visible=self.param.show_timestamp
         )
-        self._right_col = right_col = Column(
-            Row(
-                self._user_html,
-                self.chat_copy_icon,
-                self._activity_dot,
-                stylesheets=self._stylesheets,
-                sizing_mode="stretch_width",
-                css_classes=["header"]
-            ),
-            self._center_row,
+
+        footer_row = Row(
             self._timestamp_html,
+            stylesheets=self._stylesheets + self.param.stylesheets.rx(),
+            sizing_mode="stretch_width",
+            css_classes=["footer"]
+        )
+
+        self._right_col = right_col = Column(
+            header_row,
+            self._center_row,
+            footer_row,
             css_classes=["right"],
-            stylesheets=self._stylesheets,
+            stylesheets=self._stylesheets + self.param.stylesheets.rx(),
             sizing_mode=None
         )
         viewable_params = {

--- a/panel/tests/chat/test_message.py
+++ b/panel/tests/chat/test_message.py
@@ -51,7 +51,10 @@ class TestChatMessage:
         icons = center_row[1]
         assert isinstance(icons, ChatReactionIcons)
 
-        timestamp_pane = columns[1][2]
+        footer_row = columns[1][2]
+        assert isinstance(footer_row, Row)
+
+        timestamp_pane = footer_row[0]
         assert isinstance(timestamp_pane, HTML)
 
     def test_reactions_link(self):
@@ -143,39 +146,39 @@ class TestChatMessage:
     def test_update_timestamp(self):
         message = ChatMessage()
         columns = message._composite.objects
-        timestamp_pane = columns[1][2]
+        timestamp_pane = columns[1][2][0]
         assert isinstance(timestamp_pane, HTML)
         dt_str = datetime.datetime.now().strftime("%H:%M")
         assert timestamp_pane.object == dt_str
 
         message = ChatMessage(timestamp_tz="UTC")
         columns = message._composite.objects
-        timestamp_pane = columns[1][2]
+        timestamp_pane = columns[1][2][0]
         assert isinstance(timestamp_pane, HTML)
         dt_str = datetime.datetime.utcnow().strftime("%H:%M")
         assert timestamp_pane.object == dt_str
 
         message = ChatMessage(timestamp_tz="US/Pacific")
         columns = message._composite.objects
-        timestamp_pane = columns[1][2]
+        timestamp_pane = columns[1][2][0]
         assert isinstance(timestamp_pane, HTML)
         dt_str = datetime.datetime.now(tz=ZoneInfo("US/Pacific")).strftime("%H:%M")
         assert timestamp_pane.object == dt_str
 
         special_dt = datetime.datetime(2023, 6, 24, 15)
         message.timestamp = special_dt
-        timestamp_pane = columns[1][2]
+        timestamp_pane = columns[1][2][0]
         dt_str = special_dt.strftime("%H:%M")
         assert timestamp_pane.object == dt_str
 
         mm_dd_yyyy = "%b %d, %Y"
         message.timestamp_format = mm_dd_yyyy
-        timestamp_pane = columns[1][2]
+        timestamp_pane = columns[1][2][0]
         dt_str = special_dt.strftime(mm_dd_yyyy)
         assert timestamp_pane.object == dt_str
 
         message.show_timestamp = False
-        timestamp_pane = columns[1][2]
+        timestamp_pane = columns[1][2][0]
         assert not timestamp_pane.visible
 
     def test_does_not_turn_widget_into_str(self):


### PR DESCRIPTION
Allows properly targeting and styling parts of the ChatMessage
```python
import panel as pn

pn.extension()

pn.chat.ChatMessage(
    "Testing",
    show_activity_dot=True,
    stylesheets=[
        """                    
    .message {
        background-color: tan;
        font-size: 24px;
        font-family: "Courier New";
    }
    .avatar {
        background-color: red;
        border-radius: 5%;
    }
    .right {
        background-color: grey;
    }
    .center {
        background-color: pink;
    }
    .left {
        background-color: yellow;
    }
    .header {
        background-color: green;
    }
    .footer {
        background-color: blue;
    }
    .name {
        background-color: orange;
    }
    .timestamp {
        background-color: purple;
    }
    .activity-dot {
        background-color: black;
    }
    .reaction-icons {
        background-color: white;
    }
    .copy-icon {
        background-color: gold;
    }
"""
    ],
).show()
```

<img width="1209" alt="image" src="https://github.com/holoviz/panel/assets/15331990/b978efef-cc16-4059-bd4a-bd01ce30b7bb">

I did notice that parts of the chat message alignment isn't ideal (e.g. left doesn't fill all the way squarely).