### PR TITLE
Infrastructure compability wit  Bokeh 3.4

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -41,7 +41,7 @@ jobs:
         with:
           name: doc_build
           python-version: "3.9"
-          channels: pyviz/label/dev,bokeh,conda-forge,nodefaults
+          channels: pyviz/label/dev,bokeh/label/dev,conda-forge,nodefaults
           conda-update: 'true'
           nodejs: true
           # Remove when all examples tools can be installed on 3.10

--- a/lite/requirements.txt
+++ b/lite/requirements.txt
@@ -1,5 +1,5 @@
 awscli
-bokeh
+bokeh ==3.4.0.dev8
 ipywidgets
 jupyter_bokeh
 jupyterlab


### PR DESCRIPTION
This should enable running the docs and jupyterlite with Bokeh 3.4.