### PR TITLE
Set step in DatetimeRangeSlider to 1 minute

### DIFF
--- a/examples/reference/widgets/DatetimeRangeSlider.ipynb
+++ b/examples/reference/widgets/DatetimeRangeSlider.ipynb
@@ -29,7 +29,7 @@
     "\n",
     "* **``start``** (datetime): The range's lower bound\n",
     "* **``end``** (datetime): The range's upper bound\n",
-    "* **``step``** (int): Step in milliseconds, default is 10 minute (600.000 ms)\n",
+    "* **``step``** (int): Step in milliseconds, default is 10 minutes (600.000 ms)\n",
     "* **``value``** (tuple): Tuple of upper and lower bounds of the selected range expressed as datetime types\n",
     "* **``value_throttled``** (tuple): Tuple of upper and lower bounds of the selected range expressed as datetime types throttled until mouseup\n",
     "\n",

--- a/examples/reference/widgets/DatetimeRangeSlider.ipynb
+++ b/examples/reference/widgets/DatetimeRangeSlider.ipynb
@@ -29,7 +29,7 @@
     "\n",
     "* **``start``** (datetime): The range's lower bound\n",
     "* **``end``** (datetime): The range's upper bound\n",
-    "* **``step``** (int): Step in milliseconds, default is 10 minutes (600.000 ms)\n",
+    "* **``step``** (int): Step in milliseconds, default is 1 minute (60.000 ms)\n",
     "* **``value``** (tuple): Tuple of upper and lower bounds of the selected range expressed as datetime types\n",
     "* **``value_throttled``** (tuple): Tuple of upper and lower bounds of the selected range expressed as datetime types throttled until mouseup\n",
     "\n",

--- a/examples/reference/widgets/DatetimeRangeSlider.ipynb
+++ b/examples/reference/widgets/DatetimeRangeSlider.ipynb
@@ -29,7 +29,7 @@
     "\n",
     "* **``start``** (datetime): The range's lower bound\n",
     "* **``end``** (datetime): The range's upper bound\n",
-    "* **``step``** (int): Step in milliseconds\n",
+    "* **``step``** (int): Step in milliseconds, default is 10 minute (600.000 ms)\n",
     "* **``value``** (tuple): Tuple of upper and lower bounds of the selected range expressed as datetime types\n",
     "* **``value_throttled``** (tuple): Tuple of upper and lower bounds of the selected range expressed as datetime types throttled until mouseup\n",
     "\n",

--- a/panel/widgets/slider.py
+++ b/panel/widgets/slider.py
@@ -774,8 +774,8 @@ class DatetimeRangeSlider(DateRangeSlider):
     ... )
     """
 
-    step = param.Number(default=600_000, doc="""
-        The step size in ms. Default is 10 min.""")
+    step = param.Number(default=60_000, doc="""
+        The step size in ms. Default is 1 min.""")
 
     _property_conversion = staticmethod(value_as_datetime)
 

--- a/panel/widgets/slider.py
+++ b/panel/widgets/slider.py
@@ -774,6 +774,9 @@ class DatetimeRangeSlider(DateRangeSlider):
     ... )
     """
 
+    step = param.Number(default=600_000, doc="""
+        The step size in ms. Default is 10 min.""")
+
     _property_conversion = staticmethod(value_as_datetime)
 
     @property


### PR DESCRIPTION
I noticed the step was set to 1ms on DatetimeRangeSlider; this sets it to a more sensible default. 

This makes it possible to update the sliders with the arrow key and actual see a change.

https://github.com/holoviz/panel/assets/19758978/41c2e831-cf95-4a49-b9fe-42c322614f53


``` python
import panel as pn
from datetime import datetime
pn.extension()

pn.widgets.DatetimeRangeSlider(value=(datetime(2020, 1, 1), datetime(2020, 3, 1)), start=datetime(2020, 1, 1), end=datetime(2020, 3, 1))
```