### PR TITLE
Add bokeh dev conda channel to editable install

### DIFF
--- a/doc/developer_guide/index.md
+++ b/doc/developer_guide/index.md
@@ -132,7 +132,7 @@ conda activate panel_dev
 To perform an editable install of Panel, including all the dependencies required to run the full unit test suite, run the following:
 
 ```bash
-doit develop_install -c pyviz/label/dev -c conda-forge -c bokeh -o build -o tests -o recommended
+doit develop_install -c pyviz/label/dev -c conda-forge -c bokeh -c bokeh/label/dev -o build -o tests -o recommended
 ```
 
 The above command installs Panel's dependencies using conda, then performs a pip editable install of Panel. If it fails, `nodejs>=14.0.0` may be missing from your environment, fix it with `conda install -c conda-forge nodejs` then rerun above command.


### PR DESCRIPTION
Tried setting up the dev environment for the first time and this command didn't work as Conda wasn't finding bokeh==3.4.0.dev8 which is in the dependency reqiurements. For me needs the dev channel added.

Should the library use the latest dev version of Bokeh?
Also, should I raise an issue first for this small pull request?
