### PR TITLE
Hide ChatMessage footer until hover

### DIFF
--- a/panel/chat/message.py
+++ b/panel/chat/message.py
@@ -297,19 +297,17 @@ class ChatMessage(PaneBase):
             css_classes=["timestamp"],
             visible=self.param.show_timestamp,
         )
-        footer_row = Row(
+        self._footer_row = Row(
             self._timestamp_html,
             stylesheets=self._stylesheets + self.param.stylesheets.rx(),
             sizing_mode="stretch_width",
-            css_classes=["footer"] + self.param.show_footer.rx().rx.pipe(
-                lambda x: ["show-on-hover"] if x == "hover" else []
-            ),
-            visible=self.param.show_footer.rx().rx.pipe(bool)
+            css_classes=["footer"],
         )
+        self._update_footer_row()
         self._right_col = right_col = Column(
             header_row,
             self._center_row,
-            footer_row,
+            self._footer_row,
             css_classes=["right"],
             stylesheets=self._stylesheets + self.param.stylesheets.rx(),
             sizing_mode=None
@@ -625,6 +623,16 @@ class ChatMessage(PaneBase):
         else:
             self.chat_copy_icon.value = ""
             self.chat_copy_icon.visible = False
+
+    @param.depends("show_footer", watch=True)
+    def _update_footer_row(self):
+        self._footer_row.visible = bool(self.show_footer)
+        if self.show_footer == "hover" and "hover" not in self._footer_row.css_classes:
+            self._footer_row.css_classes += ["show-on-hover"]
+        else:
+            self._footer_row.css_classes = [
+                css for css in self._footer_row.css_classes if css != "show-on-hover"
+            ]
 
     def _cleanup(self, root=None) -> None:
         """

--- a/panel/chat/message.py
+++ b/panel/chat/message.py
@@ -203,6 +203,9 @@ class ChatMessage(PaneBase):
     show_activity_dot = param.Boolean(default=False, doc="""
         Whether to show the activity dot.""")
 
+    show_footer = param.ClassSelector(class_=(bool, str), default="hover", doc="""
+        Whether to show the footer.""")
+
     renderers = param.HookList(doc="""
         A callable or list of callables that accept the object and return a
         Panel object to render the object. If a list is provided, will
@@ -292,16 +295,17 @@ class ChatMessage(PaneBase):
         self._timestamp_html = HTML(
             self.param.timestamp.rx().strftime(self.param.timestamp_format),
             css_classes=["timestamp"],
-            visible=self.param.show_timestamp
+            visible=self.param.show_timestamp,
         )
-
         footer_row = Row(
             self._timestamp_html,
             stylesheets=self._stylesheets + self.param.stylesheets.rx(),
             sizing_mode="stretch_width",
-            css_classes=["footer"]
+            css_classes=["footer"] + self.param.show_footer.rx().rx.pipe(
+                lambda x: ["show-on-hover"] if x == "hover" else []
+            ),
+            visible=self.param.show_footer.rx().rx.pipe(bool)
         )
-
         self._right_col = right_col = Column(
             header_row,
             self._center_row,

--- a/panel/dist/css/chat_message.css
+++ b/panel/dist/css/chat_message.css
@@ -52,10 +52,6 @@
   width: fit-content;
 }
 
-.header:hover {
-  opacity: 1;
-}
-
 .name {
   font-size: 1em;
   margin-bottom: 0px;
@@ -89,10 +85,6 @@
   align-items: center;
   justify-content: center;
   overflow-wrap: anywhere;
-}
-
-.footer:hover {
-  opacity: 1;
 }
 
 .footer {

--- a/panel/dist/css/chat_message.css
+++ b/panel/dist/css/chat_message.css
@@ -11,9 +11,10 @@
   max-height: none;
 }
 
-.chat-message {
+:host(.chat-message) {
   display: flex;
   flex-direction: row;
+  margin-block: 0.5px;
 }
 
 .avatar {
@@ -22,7 +23,7 @@
   justify-content: center;
   align-items: center;
 
-  margin-top: calc(1em + 5px);
+  margin-top: 1em;
   min-width: 50px;
   width: 50px;
   min-height: 50px;
@@ -49,6 +50,10 @@
 
 .header {
   width: fit-content;
+}
+
+.header:hover {
+  opacity: 1;
 }
 
 .name {
@@ -86,11 +91,16 @@
   overflow-wrap: anywhere;
 }
 
+.footer:hover {
+  opacity: 1;
+}
+
 .footer {
   display: flex;
   flex-direction: row;
   align-items: center;
   justify-content: space-between;
+  transition: opacity 0.5s;
 }
 
 .timestamp {
@@ -113,8 +123,18 @@
   flex-direction: column;
   align-items: start;
   width: fit-content;
+  height: max-content;
   margin-block: 0px;
   margin-inline: 2px;
+}
+
+.show-on-hover {
+  opacity: 0;
+  transition: opacity 0.5s;
+}
+
+.show-on-hover:hover {
+  opacity: 1;
 }
 
 @keyframes fadeOut {

--- a/panel/tests/chat/test_message.py
+++ b/panel/tests/chat/test_message.py
@@ -223,6 +223,21 @@ class TestChatMessage:
         message.show_reaction_icons = False
         assert not message.reaction_icons.visible
 
+    def test_show_footer(self):
+        message = ChatMessage()
+        assert message.show_footer
+        message.show_footer = "hover"
+        message._footer_row.css_classes = ["footer", "show-on-hover"]
+        assert message._footer_row.visible
+
+        message.show_footer = False
+        assert message._footer_row.css_classes == ["footer"]
+        assert not message._footer_row.visible
+
+        message.show_footer = True
+        message._footer_row.css_classes = ["footer"]
+        assert message._footer_row.visible
+
     def test_default_avatars(self):
         assert isinstance(ChatMessage.default_avatars, dict)
         assert (


### PR DESCRIPTION
I wanted to do something like this:
```css
.chat-message:hover .reaction-icons,
.chat-message:hover .footer,
.chat-message:hover .header {
  opacity: 1;
}

.reaction-icons,
.footer,
.header {
  opacity: 0;
  transition: opacity 0.2s;
}
```

To hide all elements until hover over the chat message

https://github.com/holoviz/panel/assets/15331990/3aadfede-b6ae-4031-8e24-4c898157f3fe

But shadow root only allows me to target one at a time I think:

https://github.com/holoviz/panel/assets/15331990/efdc09e1-b514-4f6a-ba29-d228fab8fee1

