### PR TITLE
Fixes ability to serve notebook with string which contains #

### DIFF
--- a/doc/how_to/callbacks/examples/streaming_tabulator.md
+++ b/doc/how_to/callbacks/examples/streaming_tabulator.md
@@ -27,7 +27,7 @@ def color_negative_red(val):
     color = 'red' if val < 0 else 'green'
     return 'color: %s' % color
 
-tabulator.style.applymap(color_negative_red)
+tabulator.style.map(color_negative_red)
 
 def stream():
     data = df.iloc[-1] + np.random.randn(4)

--- a/doc/how_to/param/examples/precedence.md
+++ b/doc/how_to/param/examples/precedence.md
@@ -44,9 +44,9 @@ class Precedence(param.Parameterized):
             self.param,
             parameters=["x", "y", "z"],
             widgets={
-                "x": {"background": "#fac400"},
-                "y": {"background": "#07d900"},
-                "z": {"background": "#00c0d9"},
+                "x": {"styles": {"background": "#fac400"}},
+                "y": {"styles": {"background": "#07d900"}},
+                "z": {"styles": {"background": "#00c0d9"}},
             },
             show_name=False
         )

--- a/examples/gallery/iris_kmeans.ipynb
+++ b/examples/gallery/iris_kmeans.ipynb
@@ -55,7 +55,7 @@
     "    pn.WidgetBox(\n",
     "        '# Iris K-Means Clustering',\n",
     "        pn.Column(\n",
-    "            \"This app provides an example of **building a simple dashboard using Panel**.\\n\\nIt demonstrates how to take the output of **k-means clustering on the Iris dataset** using scikit-learn, parameterizing the number of clusters and the variables to plot.\\n\\nThe entire clustering and plotting pipeline is expressed as a **single reactive function** that responsively returns an updated plot when one of the widgets changes.\\n\\n The **`x` marks the center** of the cluster.\"\"\",\n",
+    "            \"\"\"This app provides an example of **building a simple dashboard using Panel**.\\n\\nIt demonstrates how to take the output of **k-means clustering on the Iris dataset** using scikit-learn, parameterizing the number of clusters and the variables to plot.\\n\\nThe entire clustering and plotting pipeline is expressed as a **single reactive function** that responsively returns an updated plot when one of the widgets changes.\\n\\n The **`x` marks the center** of the cluster.\"\"\",\n",
     "            x, y, n_clusters\n",
     "        ).servable(target='sidebar')\n",
     "    ),\n",

--- a/examples/gallery/portfolio_analyzer.ipynb
+++ b/examples/gallery/portfolio_analyzer.ipynb
@@ -275,7 +275,7 @@
     "    \"\"\"Returns the css to apply to an 'action' cell depending on the val\"\"\"\n",
     "    return f'color: {colors[value]}' if value in colors else ''\n",
     "\n",
-    "summary_table.style.applymap(style_of_action_cell, subset=[\"action\"]).set_properties(\n",
+    "summary_table.style.map(style_of_action_cell, subset=[\"action\"]).set_properties(\n",
     "    **{\"background-color\": \"#444\"}, subset=[\"quantity\"]\n",
     ")"
    ]

--- a/panel/io/handlers.py
+++ b/panel/io/handlers.py
@@ -151,7 +151,13 @@ def capture_code_cell(cell):
 
     # Remove code comments
     if '#' in cell_out:
-        cell_out = cell_out[:cell_out.index('#')].rstrip()
+        try:
+            # To not remove "#000000"
+            cell_tmp = cell_out[:cell_out.index('#')].rstrip()
+            ast.parse(cell_tmp)
+            cell_out = cell_tmp
+        except SyntaxError:
+            pass
 
     # Use eval mode to check whether cell ends in a statement or an
     # expression that will be rendered


### PR DESCRIPTION
Noticed when running `panel convert examples/gallery/*.ipynb doc/how_to/*/examples/*.md --to pyodide-worker --out ./builtdocs/pyodide/ --pwa --index --requirements doc/pyodide_dependencies.json`

I could recreate in a notebook with a cell `dict(**{"background-color": "#444"})`  and running `panel serve notebook.ipynb`

Also did some other fixes related to deprecations and one wrong string start `"` instead of `"""`. 