### PR TITLE
Update CrossSelector.ipynb

### DIFF
--- a/examples/reference/widgets/CrossSelector.ipynb
+++ b/examples/reference/widgets/CrossSelector.ipynb
@@ -26,7 +26,7 @@
     "##### Core\n",
     "\n",
     "* **`definition_order`** (boolean, default=True): Whether to preserve definition order after filtering. Disable to allow the order of selection to define the order of the selected list.\n",
-    "* **`filter_fn`** (function): The function used for filtering the options when searching using the text fields. The supplied function must allow two arguments; the user supplied search pattern and the label from the list of suplied `options`. The default is [`re.search`](https://docs.python.org/3/library/re.html#re.search), which matches options using a standard regular expression.",
+    "* **`filter_fn`** (function): The function used for filtering the options when searching using the text fields. The supplied function must allow two arguments; the user supplied search pattern and the label from the list of suplied `options`. The default is [`re.search`](https://docs.python.org/3/library/re.html#re.search), which matches options using a standard regular expression.\n",
     "* **`options`** (list or dict): List or dictionary of available options\n",
     "* **`value`** (list): Currently selected options\n",
     "\n",

--- a/examples/reference/widgets/CrossSelector.ipynb
+++ b/examples/reference/widgets/CrossSelector.ipynb
@@ -15,7 +15,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The ``CrossSelector`` widget allows selecting multiple values from a list of options by moving items between two lists. It falls into the broad category of multi-option selection widgets that provide a compatible API and include the [``MultiSelect``](MultiSelect.ipynb), [``CheckBoxGroup``](CheckBoxGroup.ipynb) and [``CheckButtonGroup``](CheckButtonGroup.ipynb) widgets.\n",
+    "The `CrossSelector` widget allows selecting multiple values from a list of options by moving items between two lists. It falls into the broad category of multi-option selection widgets that provide a compatible API and include the [`MultiSelect`](MultiSelect.ipynb), [`CheckBoxGroup`](CheckBoxGroup.ipynb) and [`CheckButtonGroup`](CheckButtonGroup.ipynb) widgets.\n",
     "\n",
     "Discover more on using widgets to add interactivity to your applications in the [how-to guides on interactivity](../how_to/interactivity/index.md). Alternatively, learn [how to set up callbacks and (JS-)links between parameters](../../how_to/links/index.md) or [how to use them as part of declarative UIs with Param](../../how_to/param/index.html).\n",
     "\n",
@@ -25,15 +25,15 @@
     "\n",
     "##### Core\n",
     "\n",
-    "* **``definition_order``** (boolean, default=True): Whether to preserve definition order after filtering. Disable to allow the order of selection to define the order of the selected list.\n",
-    "* **``filter_fn``** (function): The filter function applied when querying using the text fields, defaults to re.search. Function is two arguments, the query or pattern and the item label.\n",
-    "* **``options``** (list or dict): List or dictionary of available options\n",
-    "* **``value``** (list): Currently selected options\n",
+    "* **`definition_order`** (boolean, default=True): Whether to preserve definition order after filtering. Disable to allow the order of selection to define the order of the selected list.\n",
+    "* **`filter_fn`** (function): The function used for filtering the options when searching using the text fields. The supplied function must allow two arguments; the user supplied search pattern and the label from the list of suplied `options`. The default is [`re.search`](https://docs.python.org/3/library/re.html#re.search), which matches options using a standard regular expression.",
+    "* **`options`** (list or dict): List or dictionary of available options\n",
+    "* **`value`** (list): Currently selected options\n",
     "\n",
     "##### Display\n",
     "\n",
-    "* **``disabled``** (boolean): Whether the widget is editable\n",
-    "* **``name``** (str): The title of the widget\n",
+    "* **`disabled`** (boolean): Whether the widget is editable\n",
+    "* **`name`** (str): The title of the widget\n",
     "\n",
     "___"
    ]
@@ -42,11 +42,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The ``CrossSelector`` is made up of a number of components:\n",
+    "The `CrossSelector` is made up of a number of components:\n",
     "    \n",
     "* Two lists for the unselected (left) and selected (right) option values\n",
     "* Filter boxes that allow using a regex to match options in the list of values below\n",
-    "* Buttons to move values from the unselected to the selected list (``>>``) and vice versa (``<<``)"
+    "* Buttons to move values from the unselected to the selected list (`>>`) and vice versa (`<<`)"
    ]
   },
   {
@@ -65,7 +65,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "``CrossSelector.value`` returns a list of the currently selected options:"
+    "`CrossSelector.value` returns a list of the currently selected options:"
    ]
   },
   {

--- a/examples/reference/widgets/CrossSelector.ipynb
+++ b/examples/reference/widgets/CrossSelector.ipynb
@@ -28,7 +28,7 @@
     "* **``definition_order``** (boolean, default=True): Whether to preserve definition order after filtering. Disable to allow the order of selection to define the order of the selected list.\n",
     "* **``filter_fn``** (function): The filter function applied when querying using the text fields, defaults to re.search. Function is two arguments, the query or pattern and the item label.\n",
     "* **``options``** (list or dict): List or dictionary of available options\n",
-    "* **``value``** (boolean): Currently selected options\n",
+    "* **``value``** (list): Currently selected options\n",
     "\n",
     "##### Display\n",
     "\n",


### PR DESCRIPTION
Hi. Not a very experienced Github user, I hope I proposed the change in the right way (and that there is indeed an issue in the current documentation).

Line 31: says value of selected options is a boolean. That needs to be list instead though right? Value is stated as type list in similar selector widgets. Changed boolean to list in line 31 in the fork I made.

Also, the below seems unclear (for me). Defaults to re.search? Maybe insert a hyperlink to an explanation of re.search?

It states that Function has two arguments. Maybe insert or link to anexplanation / example(s) of a query with 2 arguments?

I get that you can put a (regex?) query in the search boxes, but doesn't that query search through  the list of item labels as shown  in the box?

What is the purpose of the 2nd argument 'item label'? Or does item label mean the labels in the search boxes that say 'Filter available options' and Filter selected options? A link or hover to what an item label is in this context would be nice.

 "* **``filter_fn``** (function): The filter function applied when querying using the text fields, defaults to re.search. Function is two arguments, the query or pattern and the item label.\n",
   
    "* **``value``** (list): Currently selected options\n",