### PR TITLE
Catch a ValueError in order to load custom templates

### DIFF
--- a/panel/template/base.py
+++ b/panel/template/base.py
@@ -677,7 +677,7 @@ class BasicTemplate(BaseTemplate):
         tmpl_string = self._template.read_text(encoding='utf-8')
         try:
             template = _env.get_template(str(self._template.relative_to(Path(__file__).parent)))
-        except jinja2.exceptions.TemplateNotFound:
+        except (jinja2.exceptions.TemplateNotFound, ValueError):
             template = parse_template(tmpl_string)
 
         if 'header' not in params:


### PR DESCRIPTION
Solves issue #6275 

When a custom template is created (for example, based on `BootstrapTemplate`), a bunch of files could be saved in some sub-folder on the disk (the `.html` template file, the `.css` file, the `__init__.py` file).

Latest version of panel is unable to load them, raising a `ValueError`.

This PR catches that `ValueError`, forcing the load to occur with `parse_template`. This makes custom templates working again.