### PR TITLE
Add ParamRef baseclass for ParamFunction and ParamMethod

### DIFF
--- a/panel/param.py
+++ b/panel/param.py
@@ -1049,6 +1049,10 @@ class ParamFunction(ParamRef):
             return None
         return False
 
+    @classmethod
+    def eval(self, ref):
+        return eval_function_with_deps(ref)
+
 
 class ReactiveExpr(PaneBase):
     """

--- a/panel/param.py
+++ b/panel/param.py
@@ -967,8 +967,6 @@ class ParamMethod(ParamRef):
 
     priority: ClassVar[float | bool | None] = 0.6
 
-    _applies_kw: ClassVar[bool] = True
-
     @classmethod
     def applies(cls, obj: Any) -> float | bool | None:
         return inspect.ismethod(obj) and isinstance(get_method_owner(obj), param.Parameterized)

--- a/panel/param.py
+++ b/panel/param.py
@@ -25,8 +25,8 @@ from typing import (
 import param
 
 from param.parameterized import (
-    classlist, discard_events, get_method_owner, iscoroutinefunction,
-    resolve_ref, resolve_value,
+    classlist, discard_events, eval_function_with_deps, get_method_owner,
+    iscoroutinefunction, resolve_ref, resolve_value,
 )
 from param.reactive import rx
 
@@ -965,7 +965,7 @@ class ParamMethod(ParamRef):
     return any object which itself can be rendered as a Pane.
     """
 
-    priority: ClassVar[float | bool | None] = 0.6
+    priority: ClassVar[float | bool | None] = 0.5
 
     @classmethod
     def applies(cls, obj: Any) -> float | bool | None:
@@ -1012,6 +1012,10 @@ class ParamMethod(ParamRef):
                     pobj.jslink(self._inner_layout, **props)
             watcher = pobj.param.watch(update_pane, ps, p.what)
             self._internal_callbacks.append(watcher)
+
+    @classmethod
+    def eval(self, ref):
+        return eval_function_with_deps(ref)
 
 
 class ParamFunction(ParamRef):

--- a/panel/param.py
+++ b/panel/param.py
@@ -799,7 +799,7 @@ class ParamRef(ReplacementPane):
 
     @param.depends('object', watch=True)
     def _validate_object(self):
-        dependencies = getattr(self.object, '_dinfo', None)
+        dependencies = getattr(self.object, '_dinfo', {})
         if not dependencies or not dependencies.get('watch'):
             return
         fn_type = 'method' if type(self) is ParamMethod else 'function'

--- a/panel/param.py
+++ b/panel/param.py
@@ -25,8 +25,8 @@ from typing import (
 import param
 
 from param.parameterized import (
-    classlist, discard_events, eval_function_with_deps, get_method_owner,
-    iscoroutinefunction,
+    classlist, discard_events, get_method_owner, iscoroutinefunction,
+    resolve_ref, resolve_value,
 )
 from param.reactive import rx
 
@@ -761,14 +761,11 @@ class Param(PaneBase):
         return super().select(selector) + self.layout.select(selector)
 
 
-class ParamMethod(ReplacementPane):
+class ParamRef(ReplacementPane):
     """
-    ParamMethod panes wrap methods on parameterized classes and
-    rerenders the plot when any of the method's parameters change. By
-    default ParamMethod will watch all parameters on the class owning
-    the method or can be restricted to certain parameters by annotating
-    the method using the param.depends decorator. The method may
-    return any object which itself can be rendered as a Pane.
+    ParamRef wraps any valid parameter reference and resolves it
+    dynamically, re-rendering the output. If enabled it will attempt
+    to update the previously rendered component inplace.
     """
 
     defer_load = param.Boolean(default=None, doc="""
@@ -822,8 +819,8 @@ class ParamMethod(ReplacementPane):
     #----------------------------------------------------------------
 
     @classmethod
-    def eval(self, function):
-        return eval_function_with_deps(function)
+    def eval(self, ref):
+        return resolve_value(ref)
 
     async def _eval_async(self, awaitable):
         if self._async_task:
@@ -895,6 +892,72 @@ class ParamMethod(ReplacementPane):
         self._link_object_params()
         self._replace_pane()
 
+    def _get_model(
+        self, doc: Document, root: Optional[Model] = None,
+        parent: Optional[Model] = None, comm: Optional[Comm] = None
+    ) -> Model:
+        if not self._evaled:
+            deferred = self.defer_load and not state.loaded
+            if deferred:
+                state.onload(
+                    partial(self._replace_pane, force=True),
+                    threaded=bool(state._thread_pool)
+                )
+            self._replace_pane(force=not deferred)
+        return super()._get_model(doc, root, parent, comm)
+
+    def _link_object_params(self):
+        dep_params = resolve_ref(self.object)
+        if not dep_params and not self.lazy and not self.defer_load and not iscoroutinefunction(self.object):
+            fn = getattr(self.object, '__bound_function__', self.object)
+            fn_name = getattr(fn, '__name__', repr(self.object))
+            self.param.warning(
+                f"The function {fn_name!r} does not have any dependencies "
+                "and will never update. Are you sure you did not intend "
+                "to depend on or bind a parameter or widget to this function? "
+                "If not simply call the function before passing it to Panel. "
+                "Otherwise, when passing a parameter as an argument, "
+                "ensure you pass at least one parameter and reference the "
+                "actual parameter object not the current value, i.e. use "
+                "object.param.parameter not object.parameter."
+            )
+        grouped = defaultdict(list)
+        for dep in dep_params:
+            grouped[id(dep.owner)].append(dep)
+        for group in grouped.values():
+            pobj = group[0].owner
+            watcher = pobj.param.watch(self._replace_pane, [dep.name for dep in group])
+            if isinstance(pobj, Reactive) and self.loading_indicator:
+                props = {dep.name: 'loading' for dep in group
+                         if dep.name in pobj._linkable_params}
+                if props:
+                    pobj.jslink(self._inner_layout, **props)
+            self._internal_callbacks.append(watcher)
+
+
+@param.depends(config.param.defer_load, watch=True)
+def _update_defer_load_default(default_value):
+    ParamRef.param.defer_load.default = default_value
+
+@param.depends(config.param.loading_indicator, watch=True)
+def _update_loading_indicator_default(default_value):
+    ParamRef.param.loading_indicator.default = default_value
+
+
+class ParamMethod(ParamRef):
+    """
+    ParamMethod panes wrap methods on parameterized classes and
+    rerenders the plot when any of the method's parameters change. By
+    default ParamMethod will watch all parameters on the class owning
+    the method or can be restricted to certain parameters by annotating
+    the method using the param.depends decorator. The method may
+    return any object which itself can be rendered as a Pane.
+    """
+
+    @classmethod
+    def applies(cls, obj: Any) -> float | bool | None:
+        return inspect.ismethod(obj) and isinstance(get_method_owner(obj), param.Parameterized)
+
     def _link_object_params(self):
         parameterized = get_method_owner(self.object)
         params = parameterized.param.method_dependencies(self.object.__name__)
@@ -937,37 +1000,8 @@ class ParamMethod(ReplacementPane):
             watcher = pobj.param.watch(update_pane, ps, p.what)
             self._internal_callbacks.append(watcher)
 
-    def _get_model(
-        self, doc: Document, root: Optional[Model] = None,
-        parent: Optional[Model] = None, comm: Optional[Comm] = None
-    ) -> Model:
-        if not self._evaled:
-            deferred = self.defer_load and not state.loaded
-            if deferred:
-                state.onload(
-                    partial(self._replace_pane, force=True),
-                    threaded=bool(state._thread_pool)
-                )
-            self._replace_pane(force=not deferred)
-        return super()._get_model(doc, root, parent, comm)
 
-    #----------------------------------------------------------------
-    # Public API
-    #----------------------------------------------------------------
-
-    @classmethod
-    def applies(cls, obj: Any) -> float | bool | None:
-        return inspect.ismethod(obj) and isinstance(get_method_owner(obj), param.Parameterized)
-
-@param.depends(config.param.defer_load, watch=True)
-def _update_defer_load_default(default_value):
-    ParamMethod.param.defer_load.default = default_value
-
-@param.depends(config.param.loading_indicator, watch=True)
-def _update_loading_indicator_default(default_value):
-    ParamMethod.param.loading_indicator.default = default_value
-
-class ParamFunction(ParamMethod):
+class ParamFunction(ParamRef):
     """
     ParamFunction panes wrap functions decorated with the param.depends
     decorator and rerenders the output when any of the function's
@@ -979,35 +1013,6 @@ class ParamFunction(ParamMethod):
     priority: ClassVar[float | bool | None] = 0.6
 
     _applies_kw: ClassVar[bool] = True
-
-    def _link_object_params(self):
-        deps = getattr(self.object, '_dinfo', {})
-        dep_params = list(deps.get('dependencies', [])) + list(deps.get('kw', {}).values())
-        if not dep_params and not self.lazy and not self.defer_load and not iscoroutinefunction(self.object):
-            fn = getattr(self.object, '__bound_function__', self.object)
-            fn_name = getattr(fn, '__name__', repr(self.object))
-            self.param.warning(
-                f"The function {fn_name!r} does not have any dependencies "
-                "and will never update. Are you sure you did not intend "
-                "to depend on or bind a parameter or widget to this function? "
-                "If not simply call the function before passing it to Panel. "
-                "Otherwise, when passing a parameter as an argument, "
-                "ensure you pass at least one parameter and reference the "
-                "actual parameter object not the current value, i.e. use "
-                "object.param.parameter not object.parameter."
-            )
-        grouped = defaultdict(list)
-        for dep in dep_params:
-            grouped[id(dep.owner)].append(dep)
-        for group in grouped.values():
-            pobj = group[0].owner
-            watcher = pobj.param.watch(self._replace_pane, [dep.name for dep in group])
-            if isinstance(pobj, Reactive) and self.loading_indicator:
-                props = {dep.name: 'loading' for dep in group
-                         if dep.name in pobj._linkable_params}
-                if props:
-                    pobj.jslink(self._inner_layout, **props)
-            self._internal_callbacks.append(watcher)
 
     #----------------------------------------------------------------
     # Public API
@@ -1157,6 +1162,12 @@ class ReactiveExpr(PaneBase):
                 if w not in widgets:
                     widgets.append(w)
         return self.widget_layout(*widgets)
+
+    def _get_model(
+        self, doc: Document, root: Optional['Model'] = None,
+        parent: Optional['Model'] = None, comm: Optional[Comm] = None
+    ) -> 'Model':
+        return self.layout._get_model(doc, root, parent, comm)
 
     def _generate_layout(self):
         panel = ParamFunction(self.object._callback)

--- a/panel/param.py
+++ b/panel/param.py
@@ -830,7 +830,7 @@ class ParamRef(ReplacementPane):
     #----------------------------------------------------------------
 
     @classmethod
-    def eval(self, ref):
+    def eval(cls, ref):
         return resolve_value(ref)
 
     async def _eval_async(self, awaitable):
@@ -1014,7 +1014,7 @@ class ParamMethod(ParamRef):
             self._internal_callbacks.append(watcher)
 
     @classmethod
-    def eval(self, ref):
+    def eval(cls, ref):
         return eval_function_with_deps(ref)
 
 

--- a/panel/tests/pane/test_base.py
+++ b/panel/tests/pane/test_base.py
@@ -13,13 +13,16 @@ from panel.pane import (
     Bokeh, HoloViews, Interactive, IPyWidget, Markdown, PaneBase, RGGPlot,
     Vega,
 )
-from panel.param import Param, ParamMethod, ReactiveExpr
+from panel.param import (
+    Param, ParamFunction, ParamMethod, ParamRef, ReactiveExpr,
+)
 from panel.tests.util import check_layoutable_properties
 from panel.util import param_watchers
 
 SKIP_PANES = (
-    Bokeh, HoloViews, Interactive, IPyWidget, Param, ParamMethod, RGGPlot,
-    ReactiveExpr, Vega, interactive, ChatMessage
+    Bokeh, ChatMessage, HoloViews, Interactive, IPyWidget, Param,
+    ParamFunction, ParamMethod, ParamRef, RGGPlot, ReactiveExpr, Vega,
+    interactive
 )
 
 all_panes = [w for w in param.concrete_descendents(PaneBase).values()


### PR DESCRIPTION
The class hierarchy for ParamFunction and ParamMethod has been quite confusing since their inception. Specifically `ParamMethod` was a subclass of `ParamFunction`, which conceptually makes no sense. Additionally, since we added generalized support and the concept of non-function references, there was no component in Panel that could take a generic reference and resolve it. Therefore we introduce the new `ParamRef` component in the class hierarchy, which forms a base class for both `ParamMethod` and `ParamFunction`. Not only is this organization now conceptually correct, but it also patches a hole in the Panel API which is to provide a component that can simply render the current value of a reference such as a parameter, widget, or reactive expression. Unlike `ParamFunction`, `ParamRef` will not have any display priority, i.e. a parameter will still be rendered using the `Param` pane, i.e. as a widget, but if e.g. we want to display the output of a widget or reactive expression the `ParamRef` pane comes in helpful.

Let's see an example:

```python
ticker = pn.widgets.Select(name='Ticker', options=tickers)
window = pn.widgets.IntSlider(name='Window Size', value=6, start=1, end=51, step=5)

plots = {
    'altair': pn.pane.Vega(pn.bind(get_altair, ticker, window)),
    'hvplot': pn.pane.HoloViews(pn.bind(get_hvplot, ticker, window)),
    'matplotlib': pn.pane.Matplotlib(pn.bind(get_mpl, ticker, window), format='svg', sizing_mode='stretch_width'),
    'plotly': pn.pane.Plotly(pn.bind(get_plotly, ticker, window))
}

backend = pn.widgets.Select(name='Backend', options=plots)

pn.Row(
    pn.Column(backend, ticker, window),
    pn.param.ParamRef(backend)
).servable()
```
<img width="1236" alt="Screenshot 2024-02-26 at 15 06 23" src="https://github.com/holoviz/panel/assets/1550771/92f3e601-3404-4d41-8f15-a230f6c2a666">

Here the `backend` widget allows selecting between a few values while the `ParamRef` pane can be used to resolve and render the currently selected component.

## Alternatives

Currently there are some alternatives to this new API but they are either not general enough or cumbersome to use.

### 1. Reference binding

One alternative is passing the reference to some other pane to resolve, e.g. this works well if the type of the object is well defined, e.g.:

```python
pn.pane.DataFrame(df_parameter)
``` 

Here the `DataFrame` pane will resolve the value and correctly and efficiently update the output but in our example above there is no pane that can render `Vega`, `HoloViews` etc. types.

### 2. Layout reference binding

In the case where the return value is a list of components we can once again use reference binding to render multiple objects, e.g.:

```python
multi_select = pn.widgets.MultiSelect(options=plots, value=[plots['altair'], plots['hvplot']])

pn.Row(multi_select, pn.FlexBox(objects=multi_select))
```

<img width="1267" alt="Screenshot 2024-02-26 at 15 27 42" src="https://github.com/holoviz/panel/assets/1550771/2994179b-a360-4672-b22b-3fe9c8ad1b6a">

### 3. Reactive Expression pane

Lastly we do have the option of rendering the component as a reactive expression using the existing `ReactiveExpr` pane. This works but requires a few workarounds for the simpler cases, e.g. to render the value of a select widget we have to call `.rx()` to turn our valid reference into a reactive expression and we also then have to disable rendering of the widgets:

```python
pn.Row(
    pn.Column(backend, ticker, window),
    pn.param.ReactiveExpr(backend.rx(), show_widgets=False)
).servable()
```

## Future work

As I finish writing https://github.com/holoviz/panel/pull/6289 and the remaining tutorials mentioned in https://github.com/holoviz/panel/issues/6390 I will also finally try to work out how to correctly document this important, but as of yet under-explained portion of the Panel API.