### PR TITLE
When refreshing tokens ignore id_token and user_info

### DIFF
--- a/panel/auth.py
+++ b/panel/auth.py
@@ -236,6 +236,8 @@ class OAuthLoginHandler(tornado.web.RequestHandler, OAuth2Mixin):
         expires_in = body.get('expires_in')
         if expires_in:
             expires_in = int(expires_in)
+        if refresh_token:
+            return None, access_token, refresh_token, expires_in
         if id_token:= body.get('id_token'):
             try:
                 user = self._on_auth(id_token, access_token, refresh_token, expires_in)

--- a/panel/auth.py
+++ b/panel/auth.py
@@ -198,8 +198,11 @@ class OAuthLoginHandler(tornado.web.RequestHandler, OAuth2Mixin):
         if code:
             params['code'] = code
         if refresh_token:
+            refreshing = True
             params['refresh_token'] = refresh_token
             params['grant_type'] = 'refresh_token'
+        else:
+            refreshing = False
         if client_secret:
             params['client_secret'] = client_secret
         elif username:
@@ -232,11 +235,12 @@ class OAuthLoginHandler(tornado.web.RequestHandler, OAuth2Mixin):
                 return None, None, None
             self._raise_error(response, body, status=401)
 
-        access_token, refresh_token = body['access_token'], body.get('refresh_token')
         expires_in = body.get('expires_in')
         if expires_in:
             expires_in = int(expires_in)
-        if refresh_token:
+
+        access_token, refresh_token = body['access_token'], body.get('refresh_token')
+        if refreshing:
             # When refreshing the tokens we do not need to re-fetch the id_token or user info
             return None, access_token, refresh_token, expires_in
         elif id_token:= body.get('id_token'):


### PR DESCRIPTION
An issue we are seeing in some OAuth setups was that when refreshing the `access_token` we were running into issues because the code expects that the token endpoint returns an `id_token` OR we make a separate request to an OpenID user info endpoint. The problem with this is that at least some OAuth providers do not reissue a `id_token` when making a refresh request and the code ends up erroring out if no OpenID endpoint is provided. In the case of a token refresh request we already have all the user info we need so we can simply skip the `id_token` decoding or user info requests.