### PR TITLE
Add `message` into `css_classes` to ChatMessage's markup

### DIFF
--- a/panel/chat/message.py
+++ b/panel/chat/message.py
@@ -479,6 +479,20 @@ class ChatMessage(PaneBase):
             for o in obj.objects:
                 self._include_stylesheets_inplace(o)
 
+    def _include_message_css_class_inplace(self, obj):
+        if hasattr(obj, "objects"):
+            for o in obj.objects:
+                self._include_message_css_class_inplace(o)
+        elif isinstance(obj, str):
+            return self._include_message_css_class_inplace(Markdown(obj))
+
+        is_markup = isinstance(obj, HTMLBasePane) and not isinstance(obj, FileBase)
+        if obj.css_classes or not is_markup:
+            return
+        if len(str(obj.object)) > 0:  # only show a background if there is content
+            obj.css_classes = [*(css for css in obj.css_classes if css != "message"), "message"]
+        obj.sizing_mode = None
+
     def _set_params(self, obj, **params):
         """
         Set the sizing mode and height of the object.
@@ -486,9 +500,7 @@ class ChatMessage(PaneBase):
         self._include_stylesheets_inplace(obj)
         is_markup = isinstance(obj, HTMLBasePane) and not isinstance(obj, FileBase)
         if is_markup:
-            if len(str(obj.object)) > 0:  # only show a background if there is content
-                params['css_classes'] = [*(css for css in obj.css_classes if css != "message"), "message"]
-            params['sizing_mode'] = None
+            self._include_message_css_class_inplace(obj)
         else:
             if obj.sizing_mode is None and not obj.width:
                 params['sizing_mode'] = "stretch_width"
@@ -508,6 +520,7 @@ class ChatMessage(PaneBase):
         if isinstance(value, Viewable):
             self._internal = False
             self._include_stylesheets_inplace(value)
+            self._include_message_css_class_inplace(value)
             return value
 
         renderer = None

--- a/panel/chat/message.py
+++ b/panel/chat/message.py
@@ -484,7 +484,7 @@ class ChatMessage(PaneBase):
             for o in obj.objects:
                 self._include_message_css_class_inplace(o)
         elif isinstance(obj, str):
-            return self._include_message_css_class_inplace(Markdown(obj))
+            obj = Markdown(obj)
 
         is_markup = isinstance(obj, HTMLBasePane) and not isinstance(obj, FileBase)
         if obj.css_classes or not is_markup:

--- a/panel/tests/chat/test_message.py
+++ b/panel/tests/chat/test_message.py
@@ -214,6 +214,27 @@ class TestChatMessage:
         assert message.object.stylesheets == ChatMessage._stylesheets + ["chat.css", "row.css"]
         assert message.object.objects[0].stylesheets == ChatMessage._stylesheets + ["chat.css", "row2.css"]
 
+    def test_include_message_css_class_inplace(self):
+        # markdown
+        message = ChatMessage(object=Markdown("hello"))
+        assert message.object.css_classes == ["message"]
+
+        # custom css class; no message appended
+        message = ChatMessage(object=Markdown("hello", css_classes=["custom"]))
+        assert message.object.css_classes == ["custom"]
+
+        # nested in layout; message appended
+        message = ChatMessage(object=Row(Markdown("hello")))
+        assert message.object.objects[0].css_classes == ["message"]
+
+        # nested in layout as a string; message appended
+        message = ChatMessage(object=Row("hello"))
+        assert message.object.objects[0].css_classes == ["message"]
+
+        # nested in layout with custom css; no message appended
+        message = ChatMessage(object=Row(Markdown("hello", css_classes=["custom"])))
+        assert message.object.objects[0].css_classes == ["custom"]
+
     @mpl_available
     def test_can_display_any_python_object_that_panel_can_display(self):
         # For example matplotlib figures


### PR DESCRIPTION
Builds upon https://github.com/holoviz/panel/pull/6405

Text wrapped in pn.Row/pn.Column without the grey background looks extremely out of place; this alleviates it by attaching "message" into css_classes, unless the user provides their own `css_classes`.

Before:
![image](https://github.com/holoviz/panel/assets/15331990/90042a1d-02fd-4446-8238-8f6340391f4f)

After:
<img width="587" alt="image" src="https://github.com/holoviz/panel/assets/15331990/4c36b388-3480-4e82-bb9d-aadeace2659d">

Note, no need to pass `css_classes=["message"]`; simply pass `parts` (previously `pn.pane.Markdown(parts, css_classes=["message"])`)

```python
import panel as pn
from openai import AsyncOpenAI

pn.extension()


async def callback(contents: str, user: str, instance: pn.chat.ChatInterface):
    response = await aclient.chat.completions.create(
        model="gpt-3.5-turbo",
        messages=[{"role": "user", "content": contents}],
        stream=True,
    )
    message = None
    parts = ""
    indicator = pn.indicators.Dial(name="Length")
    async for chunk in response:
        part = chunk.choices[0].delta.content
        if part:
            parts += part
            indicator.value = len(parts)
            layout = pn.Row(
                parts,
                indicator,
            )
            yield layout


aclient = AsyncOpenAI()
chat_interface = pn.chat.ChatInterface(callback=callback, callback_user="ChatGPT")
chat_interface.send(
    "Send a message to get a reply from ChatGPT!", user="System", respond=False
)
chat_interface.servable()
```