### PR TITLE
Add warning about use of ipywidgets with Panel in Colab, and to upgrade Panel when using Anaconda Cloud other_nb.md

### DIFF
--- a/doc/how_to/notebook/other_nb.md
+++ b/doc/how_to/notebook/other_nb.md
@@ -8,6 +8,12 @@ This guide addresses how to develop apps in Google Colab, VSCode, nteract, and o
 
 In the Google Colaboratory notebook, first make sure to load the `pn.extension()`. Panel objects will then render themselves if they are the last item in a notebook cell. Please note that in Colab rendering for each notebook cell is isolated, which means that every cell must reload the Panel extension code separately. This will result in somewhat slower and larger notebook than with other notebook technologies.
 
+* Be aware: using Panel with ipywidgets in Colab does not work, due to Colab's architecture constraints.
+
+### Anaconda Cloud
+
+When using Anaconda Coud, make sure to upgrade the Panel package to the latest version using !pip install
+
 ### VSCode notebook
 
 Visual Studio Code (VSCode) versions 2020.4.74986 and later support ipywidgets, and Panel objects can be used as ipywidgets since Panel 0.10 thanks to `jupyter_bokeh`, which means that you can now use Panel components interactively in VSCode. Ensure you install `jupyter_bokeh` with `pip install jupyter_bokeh` or `conda install -c bokeh jupyter_bokeh` and then enable the extension with `pn.extension()`.

--- a/doc/how_to/notebook/other_nb.md
+++ b/doc/how_to/notebook/other_nb.md
@@ -12,7 +12,7 @@ In the Google Colaboratory notebook, first make sure to load the `pn.extension()
 
 ### Anaconda Cloud
 
-When using Anaconda Coud, make sure to upgrade the Panel package to the latest version using !pip install
+When using Anaconda Cloud, make sure to upgrade the Panel package to the latest version using !pip install
 
 ### VSCode notebook
 


### PR DESCRIPTION
Add a warning that ipywidgets + Panel does not work in Colab.

I think this should be pointed out in the documentation (I have wasted considerable time trying to get it to work, which is currently not possible due to Colab constraints regarding comms). 

Maybe even add a warning in the code that detects use of ipywidgets + Colab and provides a warning in the Cell output?

See Discord message by @jbednar and surrounding messages here: https://discord.com/channels/1075331058024861767/1088157184489164831/1206732316513271818

And Github issue here: https://github.com/holoviz/panel/issues/6298

Added mention of Anaconda Cloud as a Notebook environment, and mention that users should upgrade Panel when using it. I am not sure what the correct / optimal !pip install command is. The specific command should probably be added, but at least this gives users a heads-up.

Should Panel have code that checks its own version, and produces  a warning if  the latest version is not being used?

That would seem sensible, also to alert users in local environments that are currently on the latest version, but might not be when the next version comes out. So this would provide them with a heads-up.