### PR TITLE
Hide icon names in ChatReactionIcons

### DIFF
--- a/panel/chat/icon.py
+++ b/panel/chat/icon.py
@@ -64,6 +64,7 @@ class ChatReactionIcons(CompositeWidget):
                 icon=icon,
                 active_icon=active_icon,
                 value=option in self.value,
+                margin=0,
             )
             icon._reaction = option
             icon.param.watch(self._update_value, "value")

--- a/panel/chat/icon.py
+++ b/panel/chat/icon.py
@@ -64,9 +64,8 @@ class ChatReactionIcons(CompositeWidget):
                 icon=icon,
                 active_icon=active_icon,
                 value=option in self.value,
-                name=option,
-                margin=0,
             )
+            icon._reaction = option
             icon.param.watch(self._update_value, "value")
             self._rendered_icons[option] = icon
         self._composite[:] = list(self._rendered_icons.values())
@@ -82,7 +81,7 @@ class ChatReactionIcons(CompositeWidget):
             icon.active_icon = self.active_icons.get(option, "")
 
     def _update_value(self, event):
-        reaction = event.obj.name
+        reaction = event.obj._reaction
         icon_value = event.new
         reactions = self.value.copy()
         if icon_value and reaction not in self.value:


### PR DESCRIPTION
With https://github.com/holoviz/panel/pull/6411, if a name is set, the icon will show a name on the side, and ChatReactionIcons uses that attribute to store its reactions initially.

This PR instead sets reaction on `_reaction`, but unsure if this is the best way to approach this.

Before:

<img width="432" alt="image" src="https://github.com/holoviz/panel/assets/15331990/e848a049-6f70-4302-a8d9-5bd106697f2c">

After:

<img width="424" alt="image" src="https://github.com/holoviz/panel/assets/15331990/caa27fec-b97b-4da2-affa-1453c42ce58a">


