### PR TITLE
Default to one row for ChatAreaInput

### DIFF
--- a/panel/chat/input.py
+++ b/panel/chat/input.py
@@ -42,6 +42,9 @@ class ChatAreaInput(_PnTextAreaInput):
         accommodate the current text.""",
     )
 
+    rows = param.Integer(default=1, doc="""
+        Number of rows in the text input field.""")
+
     max_rows = param.Integer(
         default=10,
         doc="""


### PR DESCRIPTION
It aligns better

<img width="1496" alt="image" src="https://github.com/holoviz/panel/assets/15331990/944b8da7-813a-40bb-bb0b-0ca98eef9db2">
