### PR TITLE
Fix dynamically setting header in ChatFeed

### DIFF
--- a/panel/chat/feed.py
+++ b/panel/chat/feed.py
@@ -228,7 +228,7 @@ class ChatFeed(ListPanel):
         card_params.update(
             margin=self.param.margin,
             align=self.param.align,
-            header=self.header,
+            header=self.param.header,
             height=self.param.height,
             hide_header=self.param.header.rx().rx.in_((None, "")),
             collapsible=False,

--- a/panel/tests/chat/test_feed.py
+++ b/panel/tests/chat/test_feed.py
@@ -37,6 +37,14 @@ class TestChatFeed:
         assert message.object == "Instructions"
         assert message.user == "Help"
 
+    def test_update_header(self):
+        chat_feed = ChatFeed(header="1")
+        assert chat_feed._card.header == "1"
+        chat_feed.header = "2"
+        assert chat_feed._card.header == "2"
+        chat_feed.header = HTML("<b>3</b>")
+        assert chat_feed._card.header.object == "<b>3</b>"
+
     def test_hide_header(self, chat_feed):
         assert chat_feed.header is None
 


### PR DESCRIPTION
Allow dynamically setting header.