### PR TITLE
Ensure pending writes are dispatched in order and only from correct thread

### DIFF
--- a/panel/io/document.py
+++ b/panel/io/document.py
@@ -289,7 +289,7 @@ def unlocked() -> Iterator:
     curdoc = state.curdoc
     session_context = getattr(curdoc, 'session_context', None)
     session = getattr(session_context, 'session', None)
-    if state._current_thread != state._thread_id:
+    if state._current_thread != state._thread_id and state.loaded:
         logger.error(
             "Using the unlocked decorator when running inside a thread "
             "is not safe! Ensure you check that pn.state._current_thread "

--- a/panel/io/document.py
+++ b/panel/io/document.py
@@ -297,7 +297,8 @@ def unlocked() -> Iterator:
         )
         yield
         return
-    elif curdoc is None or session_context is None or session is None or state._jupyter_kernel_context:
+    elif (curdoc is None or session_context is None or session is None or
+          not state.loaded or state._jupyter_kernel_context):
         yield
         return
     elif curdoc.callbacks.hold_value:

--- a/panel/io/document.py
+++ b/panel/io/document.py
@@ -289,7 +289,15 @@ def unlocked() -> Iterator:
     curdoc = state.curdoc
     session_context = getattr(curdoc, 'session_context', None)
     session = getattr(session_context, 'session', None)
-    if curdoc is None or session_context is None or session is None or state._jupyter_kernel_context:
+    if state._current_thread != state._thread_id:
+        logger.error(
+            "Using the unlocked decorator when running inside a thread "
+            "is not safe! Ensure you check that pn.state._current_thread "
+            "matches the current thread id."
+        )
+        yield
+        return
+    elif curdoc is None or session_context is None or session is None or state._jupyter_kernel_context:
         yield
         return
     elif curdoc.callbacks.hold_value:

--- a/panel/io/state.py
+++ b/panel/io/state.py
@@ -245,9 +245,7 @@ class _state(param.Parameterized):
 
     @property
     def _current_thread(self) -> str | None:
-        thread = threading.current_thread()
-        thread_id = thread.ident if thread else None
-        return thread_id
+        return threading.get_ident()
 
     @property
     def _is_launching(self) -> bool:
@@ -270,7 +268,7 @@ class _state(param.Parameterized):
             self._thread_id_[self.curdoc] = thread_id
 
     def _unblocked(self, doc: Document) -> bool:
-        return doc is self.curdoc and self._thread_id in (self._current_thread, None)
+        return doc is self.curdoc and self.loaded and self._thread_id in (self._current_thread, None)
 
     @param.depends('_busy_counter', watch=True)
     def _update_busy_counter(self):

--- a/panel/io/state.py
+++ b/panel/io/state.py
@@ -268,7 +268,7 @@ class _state(param.Parameterized):
             self._thread_id_[self.curdoc] = thread_id
 
     def _unblocked(self, doc: Document) -> bool:
-        return doc is self.curdoc and self.loaded and self._thread_id in (self._current_thread, None)
+        return doc is self.curdoc and self._thread_id in (self._current_thread, None)
 
     @param.depends('_busy_counter', watch=True)
     def _update_busy_counter(self):


### PR DESCRIPTION
As usual with this corner of the code this was a tough one to pin down. Here we had multiple issues involving threaded dispatching. In particular the `ChatInterface` now uses threads quite extensively, this, combined with the fact that Lumen was incorrectly using the `unlocked` decorator resulted in threads pushing across the websocket in indeterministic order (particularly when a lot of stuff was pushed at the same time).

To avoid this we do two things:

1. We keep a global `_pending_writes` dict ensuring that writes are always processed in the order they were created
2. We make sure that `unlocked` does not unlock if we're not on the expected, i.e. usually the main, thread 

I still have to confirm that 1. is actually needed, and I think I should also handle potential attempts at writing to a closed session.