### PR TITLE
Fixes for layout caching and sizing

### DIFF
--- a/panel/layout/accordion.py
+++ b/panel/layout/accordion.py
@@ -78,6 +78,7 @@ class Accordion(NamedListPanel):
 
     def __init__(self, *objects, **params):
         super().__init__(*objects, **params)
+        self._panels = {}
         self._updating_active = False
         self.param.watch(self._update_active, ['active'])
         self.param.watch(self._update_cards, self._synced_properties)
@@ -104,7 +105,7 @@ class Accordion(NamedListPanel):
             self.objects[i] = pane
 
         for obj in old_objects:
-            if obj not in self.objects:
+            if obj not in self.objects and id(obj) in self._panels:
                 self._panels[id(obj)]._cleanup(root)
                 del self._panels[id(obj)]
 

--- a/panel/layout/base.py
+++ b/panel/layout/base.py
@@ -160,7 +160,7 @@ class Panel(Reactive):
         current_objects = list(self.objects)
         ref = root.ref['id']
         for i, pane in enumerate(self.objects):
-            if pane in old_objects and ref in pane._models:
+            if ref in pane._models:
                 child, _ = pane._models[root.ref['id']]
                 old_models.append(child)
             else:

--- a/panel/layout/base.py
+++ b/panel/layout/base.py
@@ -293,7 +293,7 @@ class Panel(Reactive):
         properties = {'sizing_mode': sizing_mode}
         if (sizing_mode.endswith(("_width", "_both")) and
             widths and 'min_width' not in properties):
-            width_op = max if self._direction == 'vertical' else sum
+            width_op = max if self._direction in ('vertical', None) else sum
             min_width = width_op(widths)
             op_widths = [min_width]
             if 'max_width' in properties:
@@ -301,7 +301,7 @@ class Panel(Reactive):
             properties['min_width'] = min(op_widths)
         if (sizing_mode.endswith(("_height", "_both")) and
             heights and 'min_height' not in properties):
-            height_op = max if self._direction == 'horizontal' else sum
+            height_op = max if self._direction in ('horizontal', None) else sum
             min_height = height_op(heights)
             op_heights = [min_height]
             if 'max_height' in properties:

--- a/panel/layout/feed.py
+++ b/panel/layout/feed.py
@@ -136,7 +136,7 @@ class Feed(Column):
         ref = root.ref['id']
         for i in range(*self._last_synced):
             pane = current_objects[i]
-            if pane in old_objects and ref in pane._models:
+            if ref in pane._models:
                 child, _ = pane._models[root.ref['id']]
                 old_models.append(child)
             else:

--- a/panel/layout/tabs.py
+++ b/panel/layout/tabs.py
@@ -55,7 +55,7 @@ class Tabs(NamedListPanel):
 
     _bokeh_model: ClassVar[Type[Model]] = BkTabs
 
-    _direction: ClassVar[str | None] = 'vertical'
+    _direction: ClassVar[str | None] = None
 
     _js_transforms: ClassVar[Mapping[str, str]] = {'tabs': """
     var ids = [];


### PR DESCRIPTION
Layouts use various approaches for caching internal bokeh models and panes. This PR ensures that we use that cache if available, even if the object isn't currently displayed.