### PR TITLE
Fix stream ChatMessage for ChatInterface and mention `serialize`

### DIFF
--- a/examples/reference/chat/ChatFeed.ipynb
+++ b/examples/reference/chat/ChatFeed.ipynb
@@ -65,6 +65,7 @@
     "##### Core\n",
     "\n",
     "* **`send`**: Sends a value and creates a new message in the chat log. If `respond` is `True`, additionally executes the callback, if provided.\n",
+    "* **`serialize`**: Exports the chat log as a dict; primarily for use with `transformers`.\n",
     "* **`stream`**: Streams a token and updates the provided message, if provided. Otherwise creates a new message in the chat log, so be sure the returned message is passed back into the method, e.g. `message = chat.stream(token, message=message)`. This method is primarily for outputs that are not generators--notably LangChain. For most cases, use the send method instead.\n",
     "\n",
     "##### Other\n",

--- a/examples/reference/chat/ChatFeed.ipynb
+++ b/examples/reference/chat/ChatFeed.ipynb
@@ -701,6 +701,63 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "If the output is complex, you can pass a `custom_serializer` to only keep the text part."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "complex_output = pn.Tabs((\"Code\", \"`print('Hello World)`\"), (\"Output\", \"Hello World\"))\n",
+    "chat_feed = pn.chat.ChatFeed(pn.chat.ChatMessage(complex_output))\n",
+    "chat_feed"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Here's the output without:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "chat_feed.serialize()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Here's the output with a `custom_serializer`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def custom_serializer(obj):\n",
+    "    if isinstance(obj, pn.Tabs):\n",
+    "        # only keep the first tab's content\n",
+    "        return obj[0].object\n",
+    "    # fall back to the default serialization\n",
+    "    return obj.serialize()\n",
+    "\n",
+    "chat_feed.serialize(custom_serializer=custom_serializer)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "It can be fun to watch bots talking to each other. Beware of the token usage!\n",
     "\n",
     "```python\n",

--- a/panel/chat/feed.py
+++ b/panel/chat/feed.py
@@ -593,7 +593,7 @@ class ChatFeed(ListPanel):
 
     def stream(
         self,
-        value: str,
+        value: str | dict | ChatMessage,
         user: str | None = None,
         avatar: str | bytes | BytesIO | None = None,
         message: ChatMessage | None = None,

--- a/panel/chat/interface.py
+++ b/panel/chat/interface.py
@@ -641,7 +641,7 @@ class ChatInterface(ChatFeed):
 
     def stream(
         self,
-        value: str,
+        value: str | dict | ChatMessage,
         user: str | None = None,
         avatar: str | bytes | BytesIO | None = None,
         message: ChatMessage | None = None,
@@ -675,4 +675,9 @@ class ChatInterface(ChatFeed):
         -------
         The message that was updated.
         """
-        return super().stream(value, user=user or self.user, avatar=avatar or self.avatar, message=message, replace=replace)
+        if not isinstance(value, ChatMessage):
+            # ChatMessage cannot set user or avatar when explicitly streaming
+            # so only set to the default when not a ChatMessage
+            user = user or self.user
+            avatar = avatar or self.avatar
+        return super().stream(value, user=user, avatar=avatar, message=message, replace=replace)

--- a/panel/tests/chat/test_feed.py
+++ b/panel/tests/chat/test_feed.py
@@ -227,7 +227,7 @@ class TestChatFeed:
         assert chat_feed.objects[0].user == user
         assert chat_feed.objects[0].avatar == avatar
 
-    def test_stream_entry(self, chat_feed):
+    def test_stream_message(self, chat_feed):
         message = ChatMessage("Streaming message", user="Person", avatar="P")
         chat_feed.stream(message)
         wait_until(lambda: len(chat_feed.objects) == 1)
@@ -235,6 +235,11 @@ class TestChatFeed:
         assert chat_feed.objects[0].object == "Streaming message"
         assert chat_feed.objects[0].user == "Person"
         assert chat_feed.objects[0].avatar == "P"
+
+    def test_stream_message_error_passed_user_avatar(self, chat_feed):
+        message = ChatMessage("Streaming message", user="Person", avatar="P")
+        with pytest.raises(ValueError, match="Cannot set user or avatar"):
+            chat_feed.stream(message, user="Bob", avatar="👨")
 
     def test_stream_replace(self, chat_feed):
         message = chat_feed.stream("Hello")

--- a/panel/tests/chat/test_interface.py
+++ b/panel/tests/chat/test_interface.py
@@ -7,6 +7,7 @@ import requests
 
 from panel.chat.input import ChatAreaInput
 from panel.chat.interface import ChatInterface
+from panel.chat.message import ChatMessage
 from panel.layout import Row, Tabs
 from panel.pane import Image
 from panel.tests.util import async_wait_until, wait_until
@@ -378,6 +379,25 @@ class TestChatInterface:
         assert chat_interface.user == "New User"
         chat_interface.send("Test")
         assert chat_interface.objects[0].user == "New User"
+
+    def test_stream_chat_message(self, chat_interface):
+        chat_interface.stream(ChatMessage("testeroo", user="useroo", avatar="avataroo"))
+        chat_message = chat_interface.objects[0]
+        assert chat_message.user == "useroo"
+        assert chat_message.avatar == "avataroo"
+        assert chat_message.object == "testeroo"
+
+    def test_stream_chat_message_error_passed_user(self, chat_interface):
+        with pytest.raises(ValueError, match="Cannot set user or avatar"):
+            chat_interface.stream(ChatMessage(
+                "testeroo", user="useroo", avatar="avataroo",
+            ), user="newuser")
+
+    def test_stream_chat_message_error_passed_avatar(self, chat_interface):
+        with pytest.raises(ValueError, match="Cannot set user or avatar"):
+            chat_interface.stream(ChatMessage(
+                "testeroo", user="useroo", avatar="avataroo",
+            ), avatar="newavatar")
 
 class TestChatInterfaceWidgetsSizingMode:
     def test_none(self):


### PR DESCRIPTION
Allows doing this:
```
    def test_stream_chat_message(self, chat_interface):
        chat_interface.stream(ChatMessage("testeroo", user="useroo", avatar="avataroo"))
        chat_message = chat_interface.objects[0]
        assert chat_message.user == "useroo"
        assert chat_message.avatar == "avataroo"
        assert chat_message.object == "testeroo"
```

Previously, since it defaulted to `self.user` it would raise an error.

Also, fixes the typing of the `stream`; ChatMessage was already supported, just not documented properly.

Lastly, sneaks in a docs mention of the `serialize` + `custom_serializer` method in Feed