### PR TITLE
Replace typeof with bokehjs' type queries

### DIFF
--- a/panel/models/data.ts
+++ b/panel/models/data.ts
@@ -1,4 +1,5 @@
 import type {ColumnDataSource} from "@bokehjs/models/sources/column_data_source"
+import {isNumber} from "@bokehjs/core/util/types"
 
 export function transform_cds_to_records(cds: ColumnDataSource, addId: boolean = false, start: number = 0): any {
   const data: any = []
@@ -13,7 +14,7 @@ export function transform_cds_to_records(cds: ColumnDataSource, addId: boolean =
     for (const column of columns) {
       const array: any = cds.get_array(column)
       const shape = (array[0] == null || array[0].shape == null) ? null : array[0].shape
-      if ((shape != null) && (shape.length > 1) && (typeof shape[0] == "number")) {
+      if (shape != null && shape.length > 1 && isNumber(shape[0])) {
         item[column] = array.slice(i*shape[1], i*shape[1]+shape[1])
       } else if (array.length != cdsLength && (array.length % cdsLength === 0)) {
         const offset = array.length / cdsLength

--- a/panel/models/deckgl.ts
+++ b/panel/models/deckgl.ts
@@ -1,5 +1,6 @@
 import {div} from "@bokehjs/core/dom"
 import type * as p from "@bokehjs/core/properties"
+import {isNumber} from "@bokehjs/core/util/types"
 import {ColumnDataSource} from "@bokehjs/models/sources/column_data_source"
 
 import {debounce} from  "debounce"
@@ -91,7 +92,7 @@ export class DeckGLPlotView extends LayoutDOMView {
       n += 1
       if ((n-1) in this._layer_map) {
         cds = this.model.data_sources[this._layer_map[n-1]]
-      } else if (typeof layer.data != "number") {
+      } else if (!isNumber(layer.data)) {
         continue
       } else {
         this._layer_map[n-1] = layer.data

--- a/panel/models/plotly.ts
+++ b/panel/models/plotly.ts
@@ -1,11 +1,12 @@
 import {div} from "@bokehjs/core/dom"
 import type * as p from "@bokehjs/core/properties"
+import {isPlainObject} from "@bokehjs/core/util/types"
 import {clone} from "@bokehjs/core/util/object"
 import {is_equal} from "@bokehjs/core/util/eq"
 import {ColumnDataSource} from "@bokehjs/models/sources/column_data_source"
 
 import {debounce} from  "debounce"
-import {deepCopy, isPlainObject, get, reshape, throttle} from "./util"
+import {deepCopy, get, reshape, throttle} from "./util"
 
 import {HTMLBox, HTMLBoxView, set_size} from "./layout"
 
@@ -27,7 +28,7 @@ function convertUndefined(obj: any): any {
   Object
     .entries(obj)
     .forEach(([key, value]) => {
-      if (!!value && (typeof value === "object")) {
+      if (isPlainObject(value)) {
         convertUndefined(value)
       } else if (value === undefined) {
         obj[key] = null

--- a/panel/models/reactive_html.ts
+++ b/panel/models/reactive_html.ts
@@ -3,7 +3,7 @@ import {useCallback} from "preact/hooks"
 import {html} from "htm/preact"
 
 import {div} from "@bokehjs/core/dom"
-import {isArray} from "@bokehjs/core/util/types"
+import {isArray, isString} from "@bokehjs/core/util/types"
 import type * as p from "@bokehjs/core/properties"
 import type {LayoutDOM} from "@bokehjs/models/layouts/layout_dom"
 
@@ -16,7 +16,7 @@ function serialize_attrs(attrs: any): any {
   const serialized: any = {}
   for (const attr in attrs) {
     let value = attrs[attr]
-    if (typeof value !== "string") {
+    if (!isString(value)) {
       value = value
     } else if (value !== "" && (value === "NaN" || !isNaN(Number(value)))) {
       value = Number(value)
@@ -237,7 +237,7 @@ export class ReactiveHTMLView extends HTMLBoxView {
     const models = []
     for (const parent in this.model.children) {
       for (const model of this.model.children[parent]) {
-        if (typeof model !== "string") {
+        if (!isString(model)) {
           models.push(model)
         }
       }
@@ -313,7 +313,7 @@ export class ReactiveHTMLView extends HTMLBoxView {
   private _render_children(): void {
     for (const node in this.model.children) {
       let children = this.model.children[node]
-      if (typeof children == "string") {
+      if (isString(children)) {
         children = this.model.data[children]
         if (!isArray(children)) {
           children = [children]
@@ -501,7 +501,7 @@ export class ReactiveHTMLView extends HTMLBoxView {
       let value = attr === "children" ? el.innerHTML : el[attr]
       if (tokens.length === 1 && (`{${tokens[0]}}` === template)) {
         attrs[tokens[0]] = value
-      } else if (typeof value === "string") {
+      } else if (isString(value)) {
         value = extractToken(template, value, tokens)
         if (value == null) {
           console.warn(`Could not resolve parameters in ${name} element ${attr} attribute value ${value}.`)

--- a/panel/models/tabulator.ts
+++ b/panel/models/tabulator.ts
@@ -1,5 +1,5 @@
 import {undisplay} from "@bokehjs/core/dom"
-import {isArray} from "@bokehjs/core/util/types"
+import {isArray, isBoolean, isString, isNumber} from "@bokehjs/core/util/types"
 import {ModelEvent} from "@bokehjs/core/bokeh_events"
 import {div} from "@bokehjs/core/dom"
 import {Enum} from "@bokehjs/core/kinds"
@@ -909,8 +909,7 @@ export class DataTabulatorView extends HTMLBoxView {
       tab_column.visible = (tab_column.visible != false && !this.model.hidden_columns.includes(column.field))
       tab_column.editable = () => (this.model.editable && (editor.default_view != null))
       if (tab_column.headerFilter) {
-        if ((typeof tab_column.headerFilter) === "boolean" &&
-            (typeof tab_column.editor) === "string") {
+        if (isBoolean(tab_column.headerFilter) && isString(tab_column.editor)) {
           tab_column.headerFilter = tab_column.editor
           tab_column.headerFilterParams = tab_column.editorParams
         }
@@ -1169,7 +1168,7 @@ export class DataTabulatorView extends HTMLBoxView {
     if (
       this._selection_updating ||
         this._initializing ||
-        (typeof this.model.select_mode) === "string" ||
+        isString(this.model.select_mode) ||
         this.model.select_mode === false ||  // selection disabled
         this.model.configuration.dataTree || // dataTree does not support selection
         e.srcElement?.innerText === "►"      // expand button
@@ -1223,7 +1222,7 @@ export class DataTabulatorView extends HTMLBoxView {
       indices.splice(indices.indexOf(index), 1)
     }
     // Remove the first selected indices when selectable is an int.
-    if (typeof this.model.select_mode === "number") {
+    if (isNumber(this.model.select_mode)) {
       while (indices.length > this.model.select_mode) {
         indices.shift()
       }
@@ -1251,8 +1250,8 @@ export class DataTabulatorView extends HTMLBoxView {
     if (
       this._selection_updating ||
         this._initializing ||
-        (typeof this.model.select_mode) === "boolean" ||
-        (typeof this.model.select_mode) === "number" ||
+        isBoolean(this.model.select_mode) ||
+        isNumber(this.model.select_mode) ||
         this.model.configuration.dataTree
     ) {
       return

--- a/panel/models/tooltips.ts
+++ b/panel/models/tooltips.ts
@@ -23,6 +23,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
+import {isBoolean, isString, isNumber, isPlainObject} from "@bokehjs/core/util/types"
+
 /* global document */
 let lastPickedObject: any
 let lastTooltip: any
@@ -117,9 +119,9 @@ export function toText(jsonValue: any) {
   let text
   if (Array.isArray(jsonValue) && jsonValue.length > 4) {
     text = `Array<${jsonValue.length}>`
-  } else if (typeof jsonValue === "string") {
+  } else if (isString(jsonValue)) {
     text = jsonValue
-  } else if (typeof jsonValue === "number") {
+  } else if (isNumber(jsonValue)) {
     text = String(jsonValue)
   } else {
     try {
@@ -138,7 +140,7 @@ export function toText(jsonValue: any) {
 export function substituteIn(template: any, json: any) {
   let output = template
   for (const key in json) {
-    if (typeof json[key] === "object") {
+    if (isPlainObject(json[key])) {
       for (const subkey in json[key]) {
         output = output.replace(`{${key}.${subkey}}`, json[key][subkey])
       }
@@ -164,7 +166,7 @@ export function makeTooltip(tooltips: any, layers: any[]) {
   for (let i = 0; i < layers.length; i++) {
     const layer = layers[i]
     const layer_id = (layer.id as string)
-    if (typeof tooltips !== "boolean" && (i.toString() in tooltips || layer_id in tooltips)) {
+    if (!isBoolean(tooltips) && (i.toString() in tooltips || layer_id in tooltips)) {
       layer_tooltips[layer_id] = layer_id in tooltips ? tooltips[layer_id]: tooltips[i.toString()]
       per_layer = true
     }
@@ -179,7 +181,7 @@ export function makeTooltip(tooltips: any, layers: any[]) {
       const tooltip = (per_layer) ? layer_tooltips[pickedInfo.layer.id]: tooltips
       if (tooltip == null) {
         return
-      } else if (typeof tooltip === "boolean") {
+      } else if (isBoolean(tooltip)) {
         return tooltip ? getTooltipDefault(pickedInfo) : null
       }
 

--- a/panel/models/util.ts
+++ b/panel/models/util.ts
@@ -53,10 +53,6 @@ export function deepCopy(obj: any): any {
   throw new Error("Unable to copy obj! Its type isn't supported.")
 }
 
-export function isPlainObject(obj: any) {
-  return Object.prototype.toString.call(obj) === "[object Object]"
-}
-
 export function reshape(arr: any[], dim: number[]) {
   let elemIndex = 0
 


### PR DESCRIPTION
Type queries can a bit tricky in JS, so it's better to use standardized APIs for this, so e.g. instead of `typeof x == "boolean"` use `isBoolean(x)` (from `@bokehjs/core/util/types`), etc.