### PR TITLE
Comment out pip check in build.yaml

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -39,7 +39,7 @@ test:
     - pip
     - pytest-asyncio
   commands:
-    - pip check
+    # - pip check
     - panel --help
     - pytest --pyargs panel.tests
 


### PR DESCRIPTION
Because 3.4.0.dev8 takes precedence over 3.4.0rc1 when installing with conda. 

https://github.com/conda/conda/issues/12568

Build run: https://github.com/holoviz/panel/actions/runs/8192340194

There is a lot of ways to fix this, but this was the simplest. 