### PR TITLE
Reset ChatAreaInput's textarea rows after send

### DIFF
--- a/panel/models/chatarea_input.ts
+++ b/panel/models/chatarea_input.ts
@@ -21,6 +21,14 @@ export class ChatMessageEvent extends ModelEvent {
 export class ChatAreaInputView extends PnTextAreaInputView {
   declare  model: ChatAreaInput;
 
+  override connect_signals(): void {
+    super.connect_signals()
+
+    const {value_input} = this.model.properties
+
+    this.on_change(value_input, () => this.update_rows())
+  }
+
   override render(): void {
     super.render()
 
@@ -28,10 +36,10 @@ export class ChatAreaInputView extends PnTextAreaInputView {
       if (event.key === 'Enter' && !event.shiftKey) {
         this.model.trigger_event(new ChatMessageEvent(this.model.value_input))
         this.model.value_input = ""
-        this.update_rows()
         event.preventDefault();
       }
     });
+
   }
 }
 

--- a/panel/models/chatarea_input.ts
+++ b/panel/models/chatarea_input.ts
@@ -28,6 +28,7 @@ export class ChatAreaInputView extends PnTextAreaInputView {
       if (event.key === 'Enter' && !event.shiftKey) {
         this.model.trigger_event(new ChatMessageEvent(this.model.value_input))
         this.model.value_input = ""
+        this.update_rows()
         event.preventDefault();
       }
     });

--- a/panel/tests/ui/chat/test_input_ui.py
+++ b/panel/tests/ui/chat/test_input_ui.py
@@ -44,3 +44,28 @@ def test_chat_area_input_enter(page):
     wait_until(lambda: chat_area_input.value_input == "", page)
     assert chat_area_input.value == ""
     assert output_markdown.object == "Try again now!"
+
+
+def test_chat_area_input_resets_to_row(page):
+
+    chat_area_input = ChatAreaInput(rows=2)
+    serve_component(page, chat_area_input)
+
+    # find chat area input and type a message
+    textbox = page.locator(".bk-input")
+    textbox.fill("Hello World!")
+    # click shift_enter 3 times
+    textbox.press("Shift+Enter")
+    textbox.press("Shift+Enter")
+    textbox.press("Shift+Enter")
+    wait_until(lambda: chat_area_input.value_input == "Hello World!\n\n\n", page)
+    assert chat_area_input.value == ""
+    textbox_rows = textbox.evaluate("el => el.rows")
+    assert textbox_rows == 4
+
+    # Click enter with textbox having focus
+    textbox.press("Enter")
+    wait_until(lambda: chat_area_input.value_input == "", page)
+    assert chat_area_input.value == ""
+    textbox_rows = textbox.evaluate("el => el.rows")
+    assert textbox_rows == 2


### PR DESCRIPTION
Makes text area el rows reset after enter/clicking send.


https://github.com/holoviz/panel/assets/15331990/b2701b56-0de0-4017-85e6-6b22f51edb9e


Reported from https://discourse.holoviz.org/t/chatinterface-bug-automatically-enters-text-in-textbox-if-you-leave-the-panel-app-page/6916/11?u=ahuang11