### PR TITLE
Throttle updates to Boolean indicators

### DIFF
--- a/examples/reference/widgets/CrossSelector.ipynb
+++ b/examples/reference/widgets/CrossSelector.ipynb
@@ -26,7 +26,7 @@
     "##### Core\n",
     "\n",
     "* **`definition_order`** (boolean, default=True): Whether to preserve definition order after filtering. Disable to allow the order of selection to define the order of the selected list.\n",
-    "* **`filter_fn`** (function): The function used for filtering the options when searching using the text fields. The supplied function must allow two arguments; the user supplied search pattern and the label from the list of suplied `options`. The default is [`re.search`](https://docs.python.org/3/library/re.html#re.search), which matches options using a standard regular expression.\n",
+    "* **`filter_fn`** (function): The function used for filtering the options when searching using the text fields. The supplied function must allow two arguments; the user supplied search pattern and the label from the list of supplied `options`. The default is [`re.search`](https://docs.python.org/3/library/re.html#re.search), which matches options using a standard regular expression.\n",
     "* **`options`** (list or dict): List or dictionary of available options\n",
     "* **`value`** (list): Currently selected options\n",
     "\n",

--- a/panel/widgets/indicators.py
+++ b/panel/widgets/indicators.py
@@ -99,14 +99,20 @@ class BooleanIndicator(Indicator):
         self._reset__task = None
 
     def _throttle_events(self, events):
-        if not (io_loop:= asyncio.get_running_loop()) or not io_loop.is_running():
+        try:
+            io_loop = asyncio.get_running_loop()
+        except RuntimeError:
             return events
+        if not io_loop.is_running():
+            return events
+
         throttled_events = {}
         async def schedule_off():
             await asyncio.sleep(self.throttle/1000)
             if self._reset__task:
                 self.param.trigger('value')
             self._reset__task = None
+
         for k, e in events.items():
             if e.name != 'value':
                 throttled_events[k] = e


### PR DESCRIPTION
When working in a template the loading spinner is continuously updated to the point that it dominates Websocket traffic for many apps. By implementing simple throttling for boolean indicator events we can avoid a lot of that traffic and reduce the flicker of the indicator itself.