### PR TITLE
Fix ChatInterface send with widget with no value_input

### DIFF
--- a/panel/chat/interface.py
+++ b/panel/chat/interface.py
@@ -369,7 +369,10 @@ class ChatInterface(ChatFeed):
         active_widget = self.active_widget
         # value_input for ChatAreaInput because value is unsynced until "Enter",
         # value for TextInput and others
-        value = active_widget.value or active_widget.value_input
+        value = active_widget.value
+        if not value and hasattr(active_widget, "value_input"):
+            value = active_widget.value_input
+
         if value:
             if isinstance(active_widget, FileInput):
                 value = _FileInputMessage(

--- a/panel/tests/chat/test_interface.py
+++ b/panel/tests/chat/test_interface.py
@@ -13,6 +13,7 @@ from panel.pane import Image
 from panel.tests.util import async_wait_until, wait_until
 from panel.widgets.button import Button
 from panel.widgets.input import FileInput, TextAreaInput, TextInput
+from panel.widgets.select import RadioButtonGroup
 
 ChatInterface.callback_exception = "raise"
 
@@ -90,6 +91,12 @@ class TestChatInterface:
         assert len(chat_interface.objects) == 0
         chat_interface._click_send(None)
         assert len(chat_interface.objects) == 1
+
+    def test_click_send_with_no_value_input(self, chat_interface: ChatInterface):
+        chat_interface.widgets = [RadioButtonGroup(options=["A", "B"])]
+        chat_interface.active_widget.value = "A"
+        chat_interface._click_send(None)
+        assert chat_interface.objects[0].object == "A"
 
     def test_show_stop_disabled(self, chat_interface: ChatInterface):
         async def callback(msg, user, instance):


### PR DESCRIPTION
Fixes this:
```python
  File "/Users/ahuang/miniconda3/envs/panel-chat-examples/lib/python3.10/site-packages/panel/chat/interface.py", line 372, in _click_send
    value = active_widget.value or active_widget.value_input
AttributeError: 'RadioButtonGroup' object has no attribute 'value_input'
```