### PR TITLE
Fix nested disabled state for ChatFeed

### DIFF
--- a/panel/chat/feed.py
+++ b/panel/chat/feed.py
@@ -203,6 +203,9 @@ class ChatFeed(ListPanel):
 
         super().__init__(*objects, **params)
 
+        if self.help_text:
+            self.objects = [ChatMessage(self.help_text, user="Help"), *self.objects]
+
         # instantiate the card's column
         linked_params = dict(
             design=self.param.design,
@@ -214,7 +217,7 @@ class ChatFeed(ListPanel):
         )
         # we separate out chat log for the auto scroll feature
         self._chat_log = Feed(
-            *objects,
+            *self.objects,
             load_buffer=self.load_buffer,
             auto_scroll_limit=self.auto_scroll_limit,
             scroll_button_threshold=self.scroll_button_threshold,
@@ -259,9 +262,6 @@ class ChatFeed(ListPanel):
         # handle async callbacks using this trick
         self._callback_trigger = Button(visible=False)
         self._callback_trigger.on_click(self._prepare_response)
-
-        if self.help_text:
-            self.objects = [ChatMessage(self.help_text, user="Help"), *self.objects]
 
     def _get_model(
         self, doc: Document, root: Model | None = None,

--- a/panel/chat/feed.py
+++ b/panel/chat/feed.py
@@ -203,9 +203,6 @@ class ChatFeed(ListPanel):
 
         super().__init__(*objects, **params)
 
-        if self.help_text:
-            self.objects = [ChatMessage(self.help_text, user="Help"), *self.objects]
-
         # instantiate the card's column
         linked_params = dict(
             design=self.param.design,
@@ -262,6 +259,9 @@ class ChatFeed(ListPanel):
         # handle async callbacks using this trick
         self._callback_trigger = Button(visible=False)
         self._callback_trigger.on_click(self._prepare_response)
+
+        if self.help_text:
+            self.objects = [ChatMessage(self.help_text, user="Help"), *self.objects]
 
     def _get_model(
         self, doc: Document, root: Model | None = None,

--- a/panel/chat/feed.py
+++ b/panel/chat/feed.py
@@ -181,7 +181,7 @@ class ChatFeed(ListPanel):
     _callback_state = param.ObjectSelector(objects=list(CallbackState), doc="""
         The current state of the callback.""")
 
-    _was_disabled = param.Boolean(default=False, doc="""
+    _disabled_stack = param.List(doc="""
         The previous disabled state of the feed.""")
 
     _stylesheets: ClassVar[List[str]] = [f"{CDN_DIST}css/chat_feed.css"]
@@ -499,7 +499,7 @@ class ChatFeed(ListPanel):
         if self.callback is None:
             return
 
-        self._was_disabled = self.disabled
+        self._disabled_stack.append(self.disabled)
         try:
             with param.parameterized.batch_call_watchers(self):
                 self.disabled = True
@@ -543,7 +543,7 @@ class ChatFeed(ListPanel):
         with param.parameterized.batch_call_watchers(self):
             self._replace_placeholder(None)
             self._callback_state = CallbackState.IDLE
-            self.disabled = self._was_disabled
+            self.disabled = self._disabled_stack.pop() if self._disabled_stack else False
 
     # Public API
 
@@ -678,7 +678,7 @@ class ChatFeed(ListPanel):
             cancelled = self._callback_future.cancel()
 
         if cancelled:
-            self.disabled = self._was_disabled
+            self.disabled = self._disabled_stack.pop() if self._disabled_stack else False
             self._replace_placeholder(None)
         return cancelled
 

--- a/panel/chat/interface.py
+++ b/panel/chat/interface.py
@@ -586,6 +586,8 @@ class ChatInterface(ChatFeed):
     @param.depends("_callback_state", watch=True)
     async def _update_input_disabled(self):
         busy_states = (CallbackState.RUNNING, CallbackState.GENERATING)
+        if isinstance(self.active_widget, ChatAreaInput):
+            self.active_widget.disabled = self.disabled
         if not self.show_stop or self._callback_state not in busy_states or self._callback_future is None:
             with param.parameterized.batch_call_watchers(self):
                 self._buttons["send"].visible = True

--- a/panel/chat/interface.py
+++ b/panel/chat/interface.py
@@ -586,8 +586,6 @@ class ChatInterface(ChatFeed):
     @param.depends("_callback_state", watch=True)
     async def _update_input_disabled(self):
         busy_states = (CallbackState.RUNNING, CallbackState.GENERATING)
-        if isinstance(self.active_widget, ChatAreaInput):
-            self.active_widget.disabled = self.disabled
         if not self.show_stop or self._callback_state not in busy_states or self._callback_future is None:
             with param.parameterized.batch_call_watchers(self):
                 self._buttons["send"].visible = True

--- a/panel/tests/ui/chat/test_chat_interface_ui.py
+++ b/panel/tests/ui/chat/test_chat_interface_ui.py
@@ -1,0 +1,18 @@
+import pytest
+
+pytest.importorskip("playwright")
+
+from panel.chat import ChatInterface
+from panel.tests.util import serve_component
+
+pytestmark = pytest.mark.ui
+
+
+def test_chat_interface_help(page):
+    chat_interface = ChatInterface(
+        help_text="This is a test help text"
+    )
+    serve_component(page, chat_interface)
+    message = page.locator("p")
+    message_text = message.inner_text()
+    assert message_text == "This is a test help text"


### PR DESCRIPTION
Previously, nested callbacks left the ChatInterface disabled. Here, we implement a stack instead of a single boolean to track the original disabled state.