### PR TITLE
ChatMessage word break on long continuous words

### DIFF
--- a/panel/dist/css/chat_message.css
+++ b/panel/dist/css/chat_message.css
@@ -84,6 +84,7 @@
   align-items: center;
   justify-content: center;
   overflow-wrap: anywhere;
+  word-break: break-word;
 }
 
 .footer {


### PR DESCRIPTION
With it:
<img width="638" alt="image" src="https://github.com/holoviz/panel/assets/15331990/f4db32f2-7a1b-413a-88c9-eb9131fd2b70">

Without it:
<img width="506" alt="image" src="https://github.com/holoviz/panel/assets/15331990/1ffc540f-4f03-4da4-9924-a5f57a3b689c">
