### PR TITLE
Improve Tabulator editor text color in Fast theme

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,6 +42,7 @@ repos:
     rev: v4.0.0-alpha.8
     hooks:
       - id: prettier
+        entry: prettier --write --ignore-unknown --no-error-on-unmatched-pattern
         types_or: [css]
   - repo: https://github.com/shssoichiro/oxipng
     rev: v8.0.0

--- a/panel/dist/bundled/datatabulator/tabulator-tables@5.5.0/dist/css/tabulator_fast.min.css
+++ b/panel/dist/bundled/datatabulator/tabulator-tables@5.5.0/dist/css/tabulator_fast.min.css
@@ -572,6 +572,14 @@
 .tabulator-row.tabulator-selectable:hover a {
   color: var(--foreground-on-accent-rest);
 }
+.tabulator-row.tabulator-selectable:hover .tabulator-cell.tabulator-editing input,
+.tabulator-row.tabulator-selectable:hover .tabulator-cell.tabulator-editing select {
+  color: var(--foreground-on-accent-rest);
+}
+.tabulator-row.tabulator-selected .tabulator-cell.tabulator-editing input,
+.tabulator-row.tabulator-selected .tabulator-cell.tabulator-editing select {
+  color: var(--foreground-on-accent-rest);
+}
 .tabulator-row.tabulator-row-moving {
   border: 1px solid #000;
   background: #fff;


### PR DESCRIPTION
Previously the text would be black, and not show up well on the selected background color:

<img width="884" alt="Screenshot 2024-03-16 at 13 34 40" src="https://github.com/holoviz/panel/assets/1550771/04e8b06a-273d-431c-b78f-af23508c777c">
