### PR TITLE
Rename eslint.js to .eslintrc.js

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -53,7 +53,7 @@ repos:
     rev: v8.56.0
     hooks:
       - id: eslint
-        args: ['-c', 'panel/eslint.js', 'panel/*.ts', 'panel/models/**/*.ts']
+        args: ['-c', 'panel/.eslintrc.js', 'panel/*.ts', 'panel/models/**/*.ts']
         additional_dependencies:
           - 'eslint@8.57.0'
           - '@stylistic/eslint-plugin@1.6.3'

--- a/panel/.eslintrc.js
+++ b/panel/.eslintrc.js
@@ -9,7 +9,7 @@ module.exports = {
   },
   "plugins": ["@typescript-eslint", "@stylistic/eslint-plugin"],
   "extends": [],
-  "ignorePatterns": ["*/dist", "*/theme/**/*.js", "eslint.js", "*/_templates/*.js", "*/template/**/*.js"],
+  "ignorePatterns": ["*/dist", "*/theme/**/*.js", ".eslintrc.js", "*/_templates/*.js", "*/template/**/*.js"],
   "rules": {
     "@typescript-eslint/ban-types": ["error", {
       "types": {

--- a/panel/package.json
+++ b/panel/package.json
@@ -32,6 +32,6 @@
   ],
   "main": "dist/panel.min.js",
   "scripts": {
-    "lint": "npx eslint -c eslint.js './*.ts' './models/**/*.ts'"
+    "lint": "npx eslint -c .eslintrc.js './*.ts' './models/**/*.ts'"
   }
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ select = [
 
 [tool.codespell]
 ignore-words-list = "nd,doubleclick,ser"
-skip = "doc/generate_modules.py,examples/reference/templates/FastGridTemplate.ipynb,panel/eslint.js,panel/package-lock.json,panel/package.json"
+skip = "doc/generate_modules.py,examples/reference/templates/FastGridTemplate.ipynb,panel/.eslintrc.js,panel/package-lock.json,panel/package.json"
 write-changes = true
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
`eslint.js` is not one of the default filenames for an ESLint config file [[ref](https://eslint.org/docs/latest/use/configure/configuration-files#configuration-file-formats)]. 

This adds unnecessary friction when setting it up with people's IDE of choice. 