### PR TITLE
Avoid overeager garbage collection

### DIFF
--- a/panel/io/application.py
+++ b/panel/io/application.py
@@ -24,7 +24,7 @@ from .logging import LOG_SESSION_DESTROYED, LOG_SESSION_LAUNCHING
 from .state import set_curdoc, state
 
 if TYPE_CHECKING:
-    from boekh.application.application import SessionContext
+    from bokeh.application.application import SessionContext
     from bokeh.application.handlers.handler import Handler
 
 log = logging.getLogger('panel.io.application')

--- a/panel/io/document.py
+++ b/panel/io/document.py
@@ -50,7 +50,7 @@ DISPATCH_EVENTS = (
 GC_DEBOUNCE = 5
 WRITE_LOCK = asyncio.Lock()
 
-_last_cleanup = None
+_panel_last_cleanup = None
 _write_tasks = []
 
 @dataclasses.dataclass
@@ -180,7 +180,7 @@ async def _dispatch_msgs(doc, msgs):
     _dispatch_write_task(doc, _dispatch_msgs, doc, remaining)
 
 def _garbage_collect():
-    if (new_time:= time.monotonic()-_last_cleanup) < GC_DEBOUNCE:
+    if (new_time:= time.monotonic()-_panel_last_cleanup) < GC_DEBOUNCE:
         at = dt.datetime.now() + dt.timedelta(seconds=new_time)
         state.schedule_task('gc.collect', _garbage_collect, at=at)
         return
@@ -229,8 +229,8 @@ def _destroy_document(self, session):
             del state_obj[self]
 
     # Schedule GC
-    global _last_cleanup
-    _last_cleanup = time.monotonic()
+    global _panel_last_cleanup
+    _panel_last_cleanup = time.monotonic()
     at = dt.datetime.now() + dt.timedelta(seconds=GC_DEBOUNCE)
     state.schedule_task('gc.collect', _garbage_collect, at=at)
 

--- a/panel/io/document.py
+++ b/panel/io/document.py
@@ -7,7 +7,9 @@ import gc
 import inspect
 import json
 import logging
+import sys
 import threading
+import time
 import weakref
 
 from contextlib import contextmanager
@@ -45,9 +47,11 @@ DISPATCH_EVENTS = (
     ColumnDataChangedEvent, ColumnsPatchedEvent, ColumnsStreamedEvent,
     ModelChangedEvent
 )
-
-WRITE_TASKS = []
+GC_DEBOUNCE = 5
 WRITE_LOCK = asyncio.Lock()
+
+_last_cleanup = None
+_write_tasks = []
 
 @dataclasses.dataclass
 class Request:
@@ -74,8 +78,8 @@ class MockSessionContext(SessionContext):
         return Request(headers={}, cookies={}, arguments={})
 
 def _cleanup_task(task):
-    if task in WRITE_TASKS:
-        WRITE_TASKS.remove(task)
+    if task in _write_tasks:
+        _write_tasks.remove(task)
 
 def _dispatch_events(doc: Document, events: List[DocumentChangedEvent]) -> None:
     """
@@ -148,7 +152,7 @@ def _dispatch_write_task(doc, func, *args, **kwargs):
     """
     try:
         task = asyncio.ensure_future(func(*args, **kwargs))
-        WRITE_TASKS.append(task)
+        _write_tasks.append(task)
         task.add_done_callback(_cleanup_task)
     except RuntimeError:
         doc.add_next_tick_callback(partial(func, *args, **kwargs))
@@ -175,6 +179,13 @@ async def _dispatch_msgs(doc, msgs):
     await asyncio.sleep(0.01)
     _dispatch_write_task(doc, _dispatch_msgs, doc, remaining)
 
+def _garbage_collect():
+    if (new_time:= time.monotonic()-_last_cleanup) < GC_DEBOUNCE:
+        at = dt.datetime.now() + dt.timedelta(seconds=new_time)
+        state.schedule_task('gc.collect', _garbage_collect, at=at)
+        return
+    gc.collect()
+
 def _destroy_document(self, session):
     """
     Override for Document.destroy() without calling gc.collect directly.
@@ -192,7 +203,17 @@ def _destroy_document(self, session):
 
     self.callbacks.destroy()
     self.models.destroy()
-    self.modules.destroy()
+
+    # Module cleanup without trawling through referrers (as self.modules.destroy() does)
+    for module in self.modules._modules:
+        # remove the reference from sys.modules
+        if module.__name__ in sys.modules:
+            del sys.modules[module.__name__]
+
+        # explicitly clear the module contents and the module here itself
+        module.__dict__.clear()
+        del module
+    self.modules._modules = []
 
     # Clear periodic callbacks
     for cb in state._periodic.get(self, []):
@@ -208,8 +229,10 @@ def _destroy_document(self, session):
             del state_obj[self]
 
     # Schedule GC
-    at = dt.datetime.now() + dt.timedelta(seconds=5)
-    state.schedule_task('gc.collect', gc.collect, at=at)
+    global _last_cleanup
+    _last_cleanup = time.monotonic()
+    at = dt.datetime.now() + dt.timedelta(seconds=GC_DEBOUNCE)
+    state.schedule_task('gc.collect', _garbage_collect, at=at)
 
     del self.destroy
 


### PR DESCRIPTION
As part of https://github.com/holoviz/panel/issues/6502 I discovered that we still run garbage collection whenever a session is destroyed. Previously we had set up scheduled tasks to run garbage collection AFTER a session is destroyed ensuring that if multiple sessions are closed in succession we only run the task once. In this PR we do two things:

1. Replace the `_on_session_destroyed` handler on `DocumentLifecycleHandler` overriding the default handler which runs garbage collection
2. Add debouncing to the `Document.destroy` garbage collection task so it runs 5 seconds after the last session was destroyed, i.e. if multiple sessions are destroyed in quick succession we only run the garbage collection cycle 5 seconds after the last session is destroyed.