### PR TITLE
Mention code highlighting in Markdown and Feed

### DIFF
--- a/examples/reference/chat/ChatFeed.ipynb
+++ b/examples/reference/chat/ChatFeed.ipynb
@@ -182,7 +182,24 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "message = chat_feed.send({\"object\": \"Overtaken!\", \"user\": \"Bot\"}, user=\"MegaBot\")"
+    "contents = \"\"\"\n",
+    "```python\n",
+    "import panel as pn\n",
+    "\n",
+    "pn.chat.ChatMessage(\"I'm a code block!\", avatar=\"🤖\")\n",
+    "```\n",
+    "\"\"\"\n",
+    "message = chat_feed.send({\"object\": contents, \"user\": \"Bot\"}, user=\"MegaBot\")\n",
+    "message"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "```{admonition} Code Highlighting\n",
+    "To enable code highlighting in `Markdown` panes, `pip install pygments`\n",
+    "```"
    ]
   },
   {

--- a/examples/reference/panes/Markdown.ipynb
+++ b/examples/reference/panes/Markdown.ipynb
@@ -255,6 +255,17 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## Code Highlighting\n",
+    "\n",
+    "```{admonition} Code Highlighting\n",
+    "To enable code highlighting in `Markdown` panes, `pip install pygments`\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Renderer\n",
     "\n",
     "Since the 1.0 release Panel uses [`markdown-it`](https://markdown-it-py.readthedocs.io/en/latest/) as the the default markdown renderer. If you want to restore the previous default `'markdown'` or switch to `MyST` flavored Markdown you can set it via the `renderer` parameter. As an example here we render a task list using 'markdown-it' and 'markdown':"


### PR DESCRIPTION
I'm not sure if admonitions can be used in Reference notebooks?