### PR TITLE
Fix stream None base message

### DIFF
--- a/panel/chat/message.py
+++ b/panel/chat/message.py
@@ -697,6 +697,9 @@ class ChatMessage(PaneBase):
         object_panel = self
         attr = "object"
         obj = self.object
+        if obj is None:
+            obj = ""
+
         while not isinstance(obj, str) or isinstance(object_panel, ImageBase):
             object_panel = obj
             if hasattr(obj, "objects"):

--- a/panel/tests/chat/test_feed.py
+++ b/panel/tests/chat/test_feed.py
@@ -252,6 +252,16 @@ class TestChatFeed:
         chat_feed.stream("Goodbye", message=message, replace=True)
         wait_until(lambda: chat_feed.objects[-1].object == "Goodbye")
 
+    @pytest.mark.parametrize("replace", [True, False])
+    def test_stream_originally_none_message(self, chat_feed, replace):
+        def callback(contents, user, instance):
+            for i in range(3):
+                chat_feed.stream(f"{i}.", message=base_message, replace=replace)
+        chat_feed.callback = callback
+        base_message = ChatMessage()
+        chat_feed.send(base_message, respond=True)
+        assert chat_feed.objects[0].object == "2." if replace else "0.1.2."
+
     @pytest.mark.parametrize(
         "obj",
         [


### PR DESCRIPTION
This didn't stream anything before (and was actually stuck in an infinite while loop)
```python
import panel as pn
chat_feed = pn.chat.ChatFeed()
message = pn.chat.ChatMessage(user="System")
chat_feed.send(message)
for i in range(0, 12):
    chat_feed.stream(f"new message {i}", message=message)
```

Originally discovered here:
https://discourse.holoviz.org/t/stream-text-to-chatinterface/6976/15?u=ahuang11