### PR TITLE
Avoid opening ipywidgets comm twice

### DIFF
--- a/panel/io/ipywidget.py
+++ b/panel/io/ipywidget.py
@@ -80,7 +80,8 @@ def _on_widget_constructed(widget, doc=None):
         'buffers': buffers,
         'metadata': {
             'version': __protocol_version__
-        }
+        },
+        'kernel': kernel
     }
     if widget._model_id is not None:
         args['comm_id'] = widget._model_id
@@ -213,7 +214,6 @@ class PanelKernel(Kernel):
         comm = widget.comm
         comm.kernel = self
         self.comm_manager.register_comm(comm)
-        comm.open()
 
     def _wrap_handler(self, msg_type, handler):
         doc = self.session._document


### PR DESCRIPTION
Together with https://github.com/bokeh/ipywidgets_bokeh/pull/104 this appears to fix https://github.com/holoviz/panel/issues/6439 