### PR TITLE
Remove Document lock in Jupyter Preview context

### DIFF
--- a/panel/io/jupyter_executor.py
+++ b/panel/io/jupyter_executor.py
@@ -7,7 +7,7 @@ import weakref
 
 from dataclasses import dataclass
 from typing import (
-    TYPING, Any, Dict, List, Union,
+    TYPE_CHECKING, Any, Dict, List, Union,
 )
 
 import tornado
@@ -31,7 +31,7 @@ from .resources import Resources
 from .server import server_html_page_for_session
 from .state import set_curdoc, state
 
-if TYPING:
+if TYPE_CHECKING:
     from bokeh.document.events import DocumentPatchedEvent
 
 

--- a/panel/io/state.py
+++ b/panel/io/state.py
@@ -135,7 +135,7 @@ class _state(param.Parameterized):
 
     # Jupyter communication
     _comm_manager: ClassVar[Type[_CommManager]] = _CommManager
-    _jupyter_kernel_context: ClassVar[bool] = False
+    _jupyter_kernel_context: ClassVar[BokehSessionContext | None] = None
     _kernels = {}
     _ipykernels: ClassVar[WeakKeyDictionary[Document, Any]] = WeakKeyDictionary()
 


### PR DESCRIPTION
The Jupyter server extension that runs apps inside a kernel had some issues with the document lock not being correctly set. Since only a single server and thread is running inside the kernel we can simply lift the document lock entirely and lock only the actual writes on the Jupyter comm.