### PR TITLE
Consistent page order in tutorials

### DIFF
--- a/doc/tutorials/basic/index.md
+++ b/doc/tutorials/basic/index.md
@@ -127,12 +127,12 @@ align
 widgets
 pn_bind
 pn_rx
-caching
-indicators_activity
-progressive_layouts
 templates
 design
 style
+caching
+indicators_activity
+progressive_layouts
 build_dashboard
 deploy
 build_report


### PR DESCRIPTION
Make page order and "next" button in basic tutorials consistent with the order in the overview page here:

https://github.com/cdeil/panel/blob/da9708385dcc47462ab50f6540266da2d0f52ff2/doc/tutorials/basic/index.md?plain=1#L63-L73

BTW: Thanks for the nice tutorials! :-)