### PR TITLE
Do not include ReactiveHTML resources if not loaded

### DIFF
--- a/panel/io/notebook.py
+++ b/panel/io/notebook.py
@@ -305,7 +305,7 @@ def require_components():
 
     skip_import = {}
     for model in js_requires:
-        if issubclass(model, ReactiveHTML) and not model._loaded():
+        if not isinstance(model, dict) and issubclass(model, ReactiveHTML) and not model._loaded():
             continue
 
         if hasattr(model, '__js_skip__'):

--- a/panel/io/notebook.py
+++ b/panel/io/notebook.py
@@ -305,6 +305,9 @@ def require_components():
 
     skip_import = {}
     for model in js_requires:
+        if issubclass(model, ReactiveHTML) and not model._loaded():
+            continue
+
         if hasattr(model, '__js_skip__'):
             skip_import.update(model.__js_skip__)
 


### PR DESCRIPTION
Generally we do not load the resources for ReactiveHTML components until they have been loaded with `pn.extension`. However the codepath using require.js did not check if the component was loaded so in classic notebook and certain other notebook environments we would always load `jsPanel`, `gridstack` and `Notyf`. This adds the missing `loaded` check.

Fixes https://github.com/holoviz/panel/issues/6550