### PR TITLE
Ensure BootstrapTemplate hamburger icon is actually white

### DIFF
--- a/panel/template/bootstrap/bootstrap.css
+++ b/panel/template/bootstrap/bootstrap.css
@@ -27,7 +27,6 @@
   --bokeh-base-font: system-ui, -apple-system, 'Segoe UI', Roboto,
     'Helvetica Neue', 'Noto Sans', 'Liberation Sans', Arial, sans-serif,
     'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
-  --bs-navbar-toggler-icon-bg: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='30' height='30' viewBox='0 0 30 30'%3E%3Cpath stroke='rgba(255, 255, 255, 1)' stroke-width='2' stroke-linecap='round' stroke-miterlimit='10' d='M4 7h22M4 15h22M4 23h22'/%3E%3C/svg%3E");
 }
 
 html {
@@ -74,10 +73,14 @@ body {
   color: var(--bs-primary-color);
 }
 
+.navbar {
+  --bs-navbar-toggler-icon-bg: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='30' height='30' viewBox='0 0 30 30'%3E%3Cpath stroke='rgba(255, 255, 255, 1)' stroke-width='2' stroke-linecap='round' stroke-miterlimit='10' d='M4 7h22M4 15h22M4 23h22'/%3E%3C/svg%3E");
+}
+
 .navbar-toggle {
   background: none;
   border: none;
-  padding-left: 10px;
+  margin-left: 10px;
 }
 
 a.navbar-brand {


### PR DESCRIPTION
Follow-up to https://github.com/holoviz/panel/pull/6111 which overrode the hamburger item but did not scope the class correctly so that the bootstrap variable still had precedence.

Fixes https://github.com/holoviz/panel/issues/5797