### PR TITLE
Disable sync scroll position

### DIFF
--- a/examples/reference/layouts/Column.ipynb
+++ b/examples/reference/layouts/Column.ipynb
@@ -22,7 +22,7 @@
     "\n",
     "* **``objects``** (list): The list of objects to display in the Column, should not generally be modified directly except when replaced in its entirety.\n",
     "* **``scroll``** (boolean): Enable scrollbars if the content overflows the size of the container.\n",
-    "* **``scroll_position``** (int): Current scroll position of the Column. Setting this value will update the scroll position of the Column. Setting to 0 will scroll to the top.\n",
+    "* **``scroll_position``** (int): Setting this value will update the scroll position of the Column; set to 0 to scroll to the top. This does NOT get the current scroll position.\n",
     "* **``auto_scroll_limit``** (int): Max pixel distance from the latest object in the Column to activate automatic scrolling upon update. Setting to 0 disables auto-scrolling\n",
     "* **``scroll_button_threshold``** (int): Min pixel distance from the latest object in the Column to display the scroll button. Setting to 0 disables the scroll button.\n",
     "* **``view_latest``** (bool): Whether to scroll to the latest object on init. If not enabled the view will be on the first object.\n",

--- a/panel/layout/base.py
+++ b/panel/layout/base.py
@@ -960,8 +960,6 @@ class Column(ListPanel):
 
     _bokeh_model: ClassVar[Type[Model]] = PnColumn
 
-    _busy__ignore = ['scroll_position']
-
     _direction = 'vertical'
 
     _stylesheets: ClassVar[list[str]] = [f'{CDN_DIST}css/listpanel.css']

--- a/panel/layout/base.py
+++ b/panel/layout/base.py
@@ -950,9 +950,9 @@ class Column(ListPanel):
         disables the scroll button.""")
 
     scroll_position = param.Integer(default=0, doc="""
-        Current scroll position of the Column. Setting this value
-        will update the scroll position of the Column. Setting to
-        0 will scroll to the top.""")
+        Setting this value will update the scroll position of the Column;
+        set to 0 to scroll to the top. This does NOT get the current
+        scroll position.""")
 
     view_latest = param.Boolean(default=False, doc="""
         Whether to scroll to the latest object on init. If not

--- a/panel/models/column.ts
+++ b/panel/models/column.ts
@@ -59,7 +59,7 @@ export class ColumnView extends BkColumnView {
     this.scroll_down_button_el = DOM.createElement("div", {class: "scroll-button"})
     this.shadow_el.appendChild(this.scroll_down_button_el)
     this.el.addEventListener("scroll", () => {
-        this.toggle_scroll_button()
+      this.toggle_scroll_button()
     })
     this.scroll_down_button_el.addEventListener("click", () => {
       this.scroll_to_latest()

--- a/panel/models/column.ts
+++ b/panel/models/column.ts
@@ -6,7 +6,6 @@ export class ColumnView extends BkColumnView {
   declare model: Column
 
   scroll_down_button_el: HTMLElement
-  _scroll_position: number
 
   override connect_signals(): void {
     super.connect_signals()

--- a/panel/models/column.ts
+++ b/panel/models/column.ts
@@ -6,6 +6,7 @@ export class ColumnView extends BkColumnView {
   declare model: Column
 
   scroll_down_button_el: HTMLElement
+  _scroll_position: number
 
   override connect_signals(): void {
     super.connect_signals()
@@ -22,6 +23,7 @@ export class ColumnView extends BkColumnView {
   }
 
   scroll_to_position(): void {
+    console.log(this.model.scroll_position)
     requestAnimationFrame(() => {
       this.el.scrollTo({top: this.model.scroll_position, behavior: "instant"})
     })
@@ -44,10 +46,6 @@ export class ColumnView extends BkColumnView {
     this.scroll_to_latest()
   }
 
-  record_scroll_position(): void {
-    this.model.scroll_position = Math.round(this.el.scrollTop)
-  }
-
   toggle_scroll_button(): void {
     const threshold = this.model.scroll_button_threshold
     const exceeds_threshold = this.distance_from_latest >= threshold
@@ -63,8 +61,7 @@ export class ColumnView extends BkColumnView {
     this.scroll_down_button_el = DOM.createElement("div", {class: "scroll-button"})
     this.shadow_el.appendChild(this.scroll_down_button_el)
     this.el.addEventListener("scroll", () => {
-      this.record_scroll_position()
-      this.toggle_scroll_button()
+        this.toggle_scroll_button()
     })
     this.scroll_down_button_el.addEventListener("click", () => {
       this.scroll_to_latest()

--- a/panel/models/column.ts
+++ b/panel/models/column.ts
@@ -23,7 +23,6 @@ export class ColumnView extends BkColumnView {
   }
 
   scroll_to_position(): void {
-    console.log(this.model.scroll_position)
     requestAnimationFrame(() => {
       this.el.scrollTo({top: this.model.scroll_position, behavior: "instant"})
     })

--- a/panel/tests/ui/layout/test_column.py
+++ b/panel/tests/ui/layout/test_column.py
@@ -204,22 +204,6 @@ def test_column_scroll_position_init(page):
     expect(column).to_have_js_property('scrollTop', 100)
 
 
-def test_column_scroll_position_recorded(page):
-    col = Column(
-        Spacer(styles=dict(background='red'), width=200, height=200),
-        Spacer(styles=dict(background='green'), width=200, height=200),
-        Spacer(styles=dict(background='blue'), width=200, height=200),
-        scroll=True, height=420
-    )
-
-    serve_component(page, col)
-
-    column = page.locator(".bk-panel-models-layout-Column")
-
-    column.evaluate('(el) => el.scrollTop = 150')
-    expect(column).to_have_js_property('scrollTop', 150)
-
-
 def test_column_scroll_position_param_updated(page):
     col = Column(
         Spacer(styles=dict(background='red'), width=200, height=200),


### PR DESCRIPTION
Closes https://github.com/holoviz/panel/issues/6585

https://github.com/holoviz/panel/assets/15331990/e12f2e3c-9b82-4507-8dc9-0d76c8ea1e23

Tested this with the changes
```
import panel as pn

obj = pn.Column(
    pn.pane.Markdown(height=2000, sizing_mode="stretch_width"),
    styles={"overflow-y": "auto", "height": "100%"},
    sizing_mode="stretch_both",
)

pn.template.BootstrapTemplate(main=[obj]).show()
```

Is a breaking change, but should have minimal impact.

<img width="342" alt="image" src="https://github.com/holoviz/panel/assets/15331990/2b65fef6-b14c-4a52-9e83-934d6b61d60e">

The only thing depending on scroll_position was this, and perhaps was triggering event.
<img width="346" alt="image" src="https://github.com/holoviz/panel/assets/15331990/eff81f41-3a03-454a-bc62-9febffcafb6b">
