### PR TITLE
Patch to make tabulator work offline in jupyter notebook in "pn.config.inline" mode

### DIFF
--- a/panel/models/layout.ts
+++ b/panel/models/layout.ts
@@ -47,7 +47,7 @@ export class PanelMarkupView extends WidgetView {
       }
     }
     if (Object.keys(this._initialized_stylesheets).length === 0) {
-      this.style_redraw()
+      setTimeout(() => { this.style_redraw() }, 1)
     }
   }
 
@@ -174,6 +174,9 @@ export abstract class HTMLBoxView extends LayoutDOMView {
           }
         })
       }
+    }
+    if (Object.keys(this._initialized_stylesheets).length === 0) {
+      setTimeout(() => { this.style_redraw() }, 1)
     }
   }
 


### PR DESCRIPTION
- io/notebook.py `render_mimebundle` defaults to resources=inline when pn.config.inline=True instead of always using cdn
- In this mode, we patch the doc json to replace ImportedStyleSheet with InlineStyleSheet
- io/resources.py patches loading of inlined js file to make require defines work in cases where the define() call has the module name not specified
- layout.ts: watch_stylesheets() makes sure to call "style_redraw()" in case no css link needs to be loaded. This is done after a timeout since some models (eg Tabulator) aren't completely setup when the watch_stylesheets() call is made.

Testing:
In jupyter notebook (I'm using classic notebook):
```
import panel as pn
print(pn, pn.__version__)
pn.extension('tabulator', 'plotly', inline=True)
import pandas as pd
df = pd.DataFrame({'a':range(10), 'b':[chr(ord('A')+i) for i in range(10)]})
pn.widgets.Tabulator(df)
```

Fixes #3959 
xref: #5167

Note: This is a POC code to share the minimal conceptual changes needed to make panel tabulator work offline in notebook. Took me a while to get this working, so posting it here for review and "inspiration" to get a proper fix in panel, as it seems we have quite a few github issues about problems working offline