### PR TITLE
Ensure Perspective loads in notebooks

### DIFF
--- a/panel/models/perspective.py
+++ b/panel/models/perspective.py
@@ -98,9 +98,11 @@ class Perspective(HTMLBox):
     def __javascript_modules__(cls):
         return [js for js in bundled_files(cls, 'javascript_modules') if 'wasm' not in js and 'worker' not in js]
 
-    __js_skip__ = {
-        "perspective": __javascript_modules__,
-    }
+    @classproperty
+    def __js_skip__(cls):
+        return {
+            "perspective": cls.__javascript_modules__
+        }
 
     __js_require__ = {
         "paths": {


### PR DESCRIPTION
Small oversight that led to Perspective not loading in notebooks (and notebook exports, which includes the docs).

Fixes https://github.com/holoviz/panel/issues/6612