### PR TITLE
prettier --cache-location=.prettier-cache

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,7 +42,7 @@ repos:
     rev: v4.0.0-alpha.8
     hooks:
       - id: prettier
-        entry: prettier --write --ignore-unknown --no-error-on-unmatched-pattern
+        entry: prettier --write --cache-location=.prettier-cache --ignore-unknown --no-error-on-unmatched-pattern
         types_or: [css]
   - repo: https://github.com/shssoichiro/oxipng
     rev: v8.0.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,7 +39,7 @@ repos:
         additional_dependencies:
           - tomli
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v4.0.0-alpha.8
+    rev: v3.1.0
     hooks:
       - id: prettier
         entry: prettier --write --cache-location=.prettier-cache --ignore-unknown --no-error-on-unmatched-pattern


### PR DESCRIPTION
I had a second node_modules folder which I found confusing.

Apparently not possible to get rid of it yet ( see https://github.com/prettier/prettier/issues/13032 ) but hopefully this will hide it by default.

```
(panel_dev) panel $ find node_modules 
node_modules
node_modules/.cache
node_modules/.cache/prettier
node_modules/.cache/prettier/.prettier-caches
node_modules/.cache/prettier/.prettier-caches/04d07533a4dc0e8ecb9ce9c6af0f582956b2ce4e.json
(panel_dev) panel $ cat node_modules/.cache/prettier/.prettier-caches/04d07533a4dc0e8ecb9ce9c6af0f582956b2ce4e.json
{"94c70838f6582b402d2ca1fde8f428df7f5e08cd":{"files":{"panel/template/editable/editable.css":["yz8jN6B7lUkpjFh2nKEVy+9iT/4=",true],"panel/template/golden/golden.css":["SiKhDdTeMkMO8hoeFeehET9DBRw=",true],"panel/template/slides/slides.css":["SciHvduYS0tsgK2nOAcWTGctA10=",true],"panel/dist/css/notifications.css":["7aqHRKysbj5sZpqC+y6wRnFeqA8=",true],"panel/dist/css/button.css":["NZEetSRtHRh437lV1n9GDfk9k1U=",true],"panel/template/react/react.css":["wFSSv4cOY+Svl4xCqIZUV6KYnVI=",true],"panel/dist/css/markdown.css":["GQcbnFTW6AU99sTXYMpmGKdb+24=",true]},"modified":1711986814648}}%                                                                                                                                                                             
```