### PR TITLE
Use assert_allclose in test_svg_native_size

### DIFF
--- a/panel/tests/ui/pane/test_image.py
+++ b/panel/tests/ui/pane/test_image.py
@@ -1,5 +1,7 @@
 import pytest
 
+from numpy.testing import assert_allclose
+
 pytestmark = pytest.mark.ui
 
 from panel.layout import Row
@@ -108,7 +110,7 @@ def test_png_stretch_both(embed, page):
 def test_svg_native_size(embed, page):
     svg = SVG(SVG_FILE, embed=embed)
     bbox = get_bbox(page, svg)
-    assert bbox['width'] == 507.203125
+    assert_allclose(bbox['width'], 507.21, atol=0.01)
     assert int(bbox['height']) == 427
 
 @pytest.mark.parametrize('embed', [False, True])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,9 +68,6 @@ norecursedirs = "doc .git dist build _build .ipynb_checkpoints panel/examples"
 asyncio_mode = "auto"
 xfail_strict = true
 filterwarnings = [
-    # 2023-11: ChatBox and ChatRow are deprecated
-    "ignore:'pn.widgets.ChatBox' is deprecated and will be removed in version 1.4",
-    "ignore:'pn.widgets.ChatRow' is deprecated and will be removed in version 1.4",
     # 2023-11: `pkg_resources` is deprecated
     "ignore:Deprecated call to `pkg_resources.+?'zope:DeprecationWarning",  # https://github.com/zopefoundation/meta/issues/194
     "ignore: pkg_resources is deprecated as an API:DeprecationWarning:streamz.plugins", # https://github.com/python-streamz/streamz/issues/460


### PR DESCRIPTION
This makes test_svg_native_size robust by using assert_allclose for the float check.

When I run `doit test_ui` locally I see 4 fails:
```
FAILED panel/tests/ui/pane/test_image.py::test_svg_native_size[False] - assert 507.2109375 == 507.203125
FAILED panel/tests/ui/pane/test_image.py::test_svg_native_size[True] - assert 507.2109375 == 507.203125
FAILED panel/tests/ui/io/test_jupyterlite.py::test_jupyterlite_execution - playwright._impl._errors.TimeoutError: Timeout 20000ms exceeded.
FAILED panel/tests/ui/widgets/test_tabulator.py::test_tabulator_patch_no_height_resize - TimeoutError: wait_until timed out in 5000 milliseconds
```

The other two I can run like this:
```
pytest -v panel/tests/ui/io/test_jupyterlite.py --ui
pytest -v panel/tests/ui/widgets/test_tabulator.py --ui
```
and see that this is the problem:
```
OSError: [Errno 24] Too many open files
```
But I'm not sure why Panel opens so many files or how to fix this.