### PR TITLE
Allow rendering raw IPython.display output in dashboard builder

### DIFF
--- a/panel/io/mime_render.py
+++ b/panel/io/mime_render.py
@@ -238,6 +238,12 @@ def render_pdf(value, meta, mime):
     src = f"data:application/pdf;base64,{base64_pdf}"
     return f'<embed src="{src}" width="100%" height="100%" type="application/pdf">', 'text/html'
 
+def render_plotly(value, meta, mime):
+    from ..pane import Plotly
+
+    config = value.pop('config', {})
+    return Plotly(value, config=config)
+
 def identity(value, meta, mime):
     return value, mime
 
@@ -251,6 +257,7 @@ MIME_RENDERERS = {
     "text/html": identity,
     "text/markdown": render_markdown,
     "text/plain": identity,
+    "application/vnd.plotly.v1+json": render_plotly
 }
 
 def eval_formatter(obj, print_method):


### PR DESCRIPTION
This PR adds a few improvements to the dashboard builder UI:

- We now patch the `IPython.display.display` utility (in addition to the `display` utility) with our custom handler
- We add handling for raw mimebundles in our patched utility
- We add a mime renderer for the Plotly mime type
- We add a minimum height for Plotly output since the initial sizing may not work

As an example, this allows us to do stuff like this:

<img width="2206" alt="Screenshot 2024-04-03 at 14 57 33" src="https://github.com/holoviz/panel/assets/1550771/5cfd6f30-85c9-454a-b592-27d45bba16a2">
