### PR TITLE
Allow Tabulator HTMLTemplateFormatter to reference multiple columns

### DIFF
--- a/panel/models/tabulator.ts
+++ b/panel/models/tabulator.ts
@@ -853,7 +853,7 @@ export class DataTabulatorView extends HTMLBoxView {
           tab_column.formatter = "tickCross"
         } else {
           tab_column.formatter = (cell: any) => {
-	    const row = cell.getRow()
+            const row = cell.getRow()
             const formatted = column.formatter.doFormat(cell.getRow(), cell, cell.getValue(), null, row.getData())
             if (column.formatter.type === "HTMLTemplateFormatter") {
               return formatted

--- a/panel/models/tabulator.ts
+++ b/panel/models/tabulator.ts
@@ -853,7 +853,8 @@ export class DataTabulatorView extends HTMLBoxView {
           tab_column.formatter = "tickCross"
         } else {
           tab_column.formatter = (cell: any) => {
-            const formatted = column.formatter.doFormat(cell.getRow(), cell, cell.getValue(), null, null)
+	    const row = cell.getRow()
+            const formatted = column.formatter.doFormat(cell.getRow(), cell, cell.getValue(), null, row.getData())
             if (column.formatter.type === "HTMLTemplateFormatter") {
               return formatted
             }

--- a/panel/tests/ui/widgets/test_tabulator.py
+++ b/panel/tests/ui/widgets/test_tabulator.py
@@ -383,6 +383,23 @@ def test_tabulator_formatters_bokeh_string(page, df_mixed):
     )
 
 
+def test_tabulator_formatters_bokeh_html_multiple_columns(page, df_mixed):
+    htmlfmt = HTMLTemplateFormatter(
+        template='<p class="html-format"><%= str %> <%= bool %></p>'
+    )
+    widget = Tabulator(df_mixed, formatters={'str': htmlfmt})
+
+    serve_component(page, widget)
+
+    # The BooleanFormatter renders with svg icons.
+    cells = page.locator(".tabulator-cell .html-format")
+    expect(cells).to_have_count(len(df_mixed))
+
+    for i, (_, row) in enumerate(df_mixed.iterrows()):
+
+        expect(cells.nth(i)).to_have_text(f"{row['str']} {str(row['bool']).lower()}")
+
+
 def test_tabulator_formatters_bokeh_html(page, df_mixed):
     widget = Tabulator(
         df_mixed,


### PR DESCRIPTION
Fixes https://github.com/holoviz/panel/issues/6654