### PR TITLE
selection indices seem to be on _processed and not current view

### DIFF
--- a/panel/tests/ui/widgets/test_tabulator.py
+++ b/panel/tests/ui/widgets/test_tabulator.py
@@ -2948,7 +2948,6 @@ def test_tabulator_click_event_selection_integrations(page, sorter, python_filte
     assert widget.selected_dataframe.equals(expected_selected)
 
 
-@pytest.mark.xfail(reason='See https://github.com/holoviz/panel/issues/3664')
 def test_tabulator_selection_sorters_on_init(page, df_mixed):
     widget = Tabulator(df_mixed, sorters=[{'field': 'int', 'dir': 'desc'}])
 

--- a/panel/widgets/tables.py
+++ b/panel/widgets/tables.py
@@ -874,7 +874,7 @@ class BaseTable(ReactiveData, Widget):
         """
         if not self.selection:
             return self.current_view.iloc[:0]
-        return self.current_view.iloc[self.selection]
+        return self._processed.iloc[self.selection]
 
 
 class DataFrame(BaseTable):


### PR DESCRIPTION
The selecton indices seem to return the correct value after filtering and sorting on the _processed. I don't have indepth  knowledge of this code but making this change seems to return the correct rows.

My version of panel is 1.3.8, so will need @philippjfr and @Hoxbro to take a look. 

Fixes https://github.com/holoviz/panel/issues/3670