### PR TITLE
Ensure Perspective is fully loaded before attempting render

### DIFF
--- a/panel/config.py
+++ b/panel/config.py
@@ -683,7 +683,7 @@ class panel_extension(_pyviz_extension):
         'gridstack': ['GridStack'],
         'katex': ['katex'],
         'mathjax': ['MathJax'],
-        'perspective': ['perspective'],
+        'perspective': ['perspective.worker'],
         'plotly': ['Plotly'],
         'tabulator': ['Tabulator'],
         'terminal': ['Terminal', 'xtermjs'],


### PR DESCRIPTION
Previously Perspective would attempt rendering even if it was only half loaded, which could result in rendering errors in the notebook and in the docs.