### PR TITLE
Ensure perspective-viewer is loaded before rendering

### DIFF
--- a/panel/_templates/autoload_panel_js.js
+++ b/panel/_templates/autoload_panel_js.js
@@ -119,7 +119,7 @@ calls it with the rendered model.
     }
 
     {%- for lib, urls in skip_imports.items() %}
-    if (((window['{{ lib }}'] !== undefined) && (!(window['{{ lib }}'] instanceof HTMLElement))) || window.requirejs) {
+    if (((window.{{ lib }} !== undefined) && (!(window.{{ lib }} instanceof HTMLElement))) || window.requirejs) {
       var urls = {{ urls }};
       for (var i = 0; i < urls.length; i++) {
         skip.push(urls[i])

--- a/panel/_templates/doc_nb_js.js
+++ b/panel/_templates/doc_nb_js.js
@@ -34,7 +34,7 @@
   }
   function is_loaded(root) {
     var Bokeh = get_bokeh(root)
-    return (Bokeh != null && Bokeh.Panel !== undefined{% for reqs in requirements %} && ({% for req in reqs %}{% if loop.index0 > 0 %}||{% endif %} root['{{ req }}'] !== undefined{% endfor %}){% endfor %}{% if ipywidget %}&& Bokeh.Models._known_models.has("ipywidgets_bokeh.widget.IPyWidget") {% endif %})
+    return (Bokeh != null && Bokeh.Panel !== undefined{% for reqs in requirements %} && ({% for req in reqs %}{% if loop.index0 > 0 %}||{% endif %} root.{{ req }} !== undefined{% endfor %}){% endfor %}{% if ipywidget %}&& Bokeh.Models._known_models.has("ipywidgets_bokeh.widget.IPyWidget") {% endif %})
   }
   if (is_loaded(root)) {
     embed_document(root);

--- a/panel/config.py
+++ b/panel/config.py
@@ -683,7 +683,7 @@ class panel_extension(_pyviz_extension):
         'gridstack': ['GridStack'],
         'katex': ['katex'],
         'mathjax': ['MathJax'],
-        'perspective': ['perspective.worker'],
+        'perspective': ["customElements.get('perspective-viewer')"],
         'plotly': ['Plotly'],
         'tabulator': ['Tabulator'],
         'terminal': ['Terminal', 'xtermjs'],

--- a/panel/config.py
+++ b/panel/config.py
@@ -32,7 +32,11 @@ from .util import param_watchers
 __version__ = str(param.version.Version(
     fpath=__file__, archive_commit="$Format:%h$", reponame="panel"))
 
-_LOCAL_DEV_VERSION = any(v in __version__ for v in ('post', 'dirty')) and not state._is_pyodide
+_LOCAL_DEV_VERSION = (
+    any(v in __version__ for v in ('post', 'dirty'))
+    and not state._is_pyodide
+    and 'PANEL_DOC_BUILD' not in os.environ
+)
 
 #---------------------------------------------------------------------
 # Public API

--- a/panel/models/perspective.py
+++ b/panel/models/perspective.py
@@ -101,12 +101,13 @@ class Perspective(HTMLBox):
     @classproperty
     def __js_skip__(cls):
         return {
-            "perspective": cls.__javascript_modules__
+            "customElements.get('perspective-viewer')": cls.__javascript_modules__
         }
 
     __js_require__ = {
         "paths": {
             "perspective": f"{config.npm_cdn}/@finos/perspective@{PERSPECTIVE_VERSION}/dist/cdn/perspective",
+            "perspective-worker": f"{config.npm_cdn}/@finos/perspective@{PERSPECTIVE_VERSION}/dist/cdn/perspective.worker",
             "perspective-viewer": f"{config.npm_cdn}/@finos/perspective-viewer@{PERSPECTIVE_VERSION}/dist/cdn/perspective-viewer",
             "perspective-viewer-datagrid": f"{config.npm_cdn}/@finos/perspective-viewer-datagrid@{PERSPECTIVE_VERSION}/dist/cdn/perspective-viewer-datagrid",
             "perspective-viewer-d3fc": f"{config.npm_cdn}/@finos/perspective-viewer-d3fc@{PERSPECTIVE_VERSION}/dist/cdn/perspective-viewer-d3fc",


### PR DESCRIPTION
Changes the logic for testing whether Perspective is fully loaded to ensure we do not start rendering before it is.