### PR TITLE
Document how display full html document in iframe

### DIFF
--- a/examples/reference/panes/HTML.ipynb
+++ b/examples/reference/panes/HTML.ipynb
@@ -141,7 +141,7 @@
     "hvplot.save(plot, plot_file)\n",
     "plot_file.seek(0)  # Move to the beginning of the StringIO object\n",
     "\n",
-    "# Read the HTML content\n",
+    "# Read the HTML content and escape it\n",
     "html_content = plot_file.read()\n",
     "escaped_html = html.escape(html_content)\n",
     "\n",

--- a/examples/reference/panes/HTML.ipynb
+++ b/examples/reference/panes/HTML.ipynb
@@ -106,7 +106,7 @@
     "\r\n",
     "The `HTML` pane is designed to display *basic* HTML content. It is not suitable for rendering full HTML documents that include JavaScript or other dynamic elements.\r\n",
     "\r\n",
-    "To display complete HTML documents, you can escape the HTML content and embed it within an [`iframe`](https://www.w3schools.com/html/html_iframe.asp). Here's how you can achieve this:cture."
+    "To display complete HTML documents, you can escape the HTML content and embed it within an [`iframe`](https://www.w3schools.com/html/html_iframe.asp). Here's how you can achieve this:"
    ]
   },
   {

--- a/examples/reference/panes/HTML.ipynb
+++ b/examples/reference/panes/HTML.ipynb
@@ -97,6 +97,67 @@
    "source": [
     "html_pane.styles = dict(html_pane.styles, border='2px solid red')"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "\r\n",
+    "\r\n",
+    "## HTML Documents\r\n",
+    "\r\n",
+    "The `HTML` pane is designed to display *basic* HTML content. It is not suitable for rendering full HTML docuwith head and body elementsements.\r\n",
+    "\r\n",
+    "To display complete HTML documents, you can escape the HTML content and embed it wi[thin an ](https://www.w3schools.com/html/html_iframe.asp)`iframe`. Here's how you can achie that requires its own separate HTML structure."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import html\n",
+    "import hvplot.pandas\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "import panel as pn\n",
+    "from io import StringIO\n",
+    "\n",
+    "pn.extension()\n",
+    "\n",
+    "# Set seed for reproducibility\n",
+    "np.random.seed(1)\n",
+    "\n",
+    "# Create a time-series data frame\n",
+    "idx = pd.date_range(\"1/1/2000\", periods=1000)\n",
+    "df = pd.DataFrame(np.random.randn(1000, 4), index=idx, columns=list(\"ABCD\")).cumsum()\n",
+    "\n",
+    "# Plot the data using hvplot\n",
+    "plot = df.hvplot()\n",
+    "\n",
+    "# Save the plot. We use a StringIO object in the reference guide to avoid saving to disk.\n",
+    "plot_file = StringIO()\n",
+    "hvplot.save(plot, plot_file)\n",
+    "plot_file.seek(0)  # Move to the beginning of the StringIO object\n",
+    "\n",
+    "# Read the HTML content\n",
+    "html_content = plot_file.read()\n",
+    "escaped_html = html.escape(html_content)\n",
+    "\n",
+    "# Create iframe embedding the escaped HTML and display it\n",
+    "iframe_html = f'<iframe srcdoc=\"{escaped_html}\" style=\"height:100%; width:100%\" frameborder=\"0\"></iframe>'\n",
+    "\n",
+    "# Display iframe in a Panel HTML pane\n",
+    "pn.pane.HTML(iframe_html, height=350, sizing_mode=\"stretch_width\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This method ensures that the embedded HTML is safely isolated within an iframe, preventing any script execution that might otherwise occur directly within the Panel environment. This approach is particularly useful for embedding rich content, such as interactive visualizations, that requires its own separate HTML structure."
+   ]
   }
  ],
  "metadata": {

--- a/examples/reference/panes/HTML.ipynb
+++ b/examples/reference/panes/HTML.ipynb
@@ -102,13 +102,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "\r\n",
-    "\r\n",
     "## HTML Documents\r\n",
     "\r\n",
-    "The `HTML` pane is designed to display *basic* HTML content. It is not suitable for rendering full HTML docuwith head and body elementsements.\r\n",
+    "The `HTML` pane is designed to display *basic* HTML content. It is not suitable for rendering full HTML documents that include JavaScript or other dynamic elements.\r\n",
     "\r\n",
-    "To display complete HTML documents, you can escape the HTML content and embed it wi[thin an ](https://www.w3schools.com/html/html_iframe.asp)`iframe`. Here's how you can achie that requires its own separate HTML structure."
+    "To display complete HTML documents, you can escape the HTML content and embed it within an [`iframe`](https://www.w3schools.com/html/html_iframe.asp). Here's how you can achieve this:cture."
    ]
   },
   {


### PR DESCRIPTION
Closing #6737 by adding an example of displaying a full html document in an iframe using the `HTML` pane.