### PR TITLE
Update plotly.js to 2.31.1

### DIFF
--- a/panel/models/plotly.py
+++ b/panel/models/plotly.py
@@ -18,7 +18,7 @@ class PlotlyPlot(LayoutDOM):
 
     __javascript_raw__ = [
         JS_URLS['jQuery'],
-        'https://cdn.plot.ly/plotly-2.25.2.min.js'
+        'https://cdn.plot.ly/plotly-2.31.1.min.js'
     ]
 
     @classproperty
@@ -31,7 +31,7 @@ class PlotlyPlot(LayoutDOM):
 
     __js_require__ = {
         'paths': {
-            'plotly': 'https://cdn.plot.ly/plotly-2.25.2.min'
+            'plotly': 'https://cdn.plot.ly/plotly-2.31.1.min'
         },
         'exports': {'plotly': 'Plotly'}
     }


### PR DESCRIPTION
Closing #6741

## Manual Test Steps

- [x] Bundle assets
- [x] Panel Serve Examples from plotly reference guide. Check that they work as expected, that the 2.31.1 version of Plotly is loaded and that there are no errors in browser console.
- [x] Panel Serve Examples discourse Polars plot that created original issue. Check that they work as expected, that the 2.31.1 version of Plotly is loaded and that there are no errors in browser console.

I don't know how this is normally tested?