### PR TITLE
Enhance Plotly documentation

### DIFF
--- a/examples/reference/panes/Plotly.ipynb
+++ b/examples/reference/panes/Plotly.ipynb
@@ -1,38 +1,51 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The Plotly pane displays [Plotly plots](https://plotly.com/python/) within a Panel application. It enhances the speed of plot updates by using binary serialization for array data contained in the Plotly object. \n",
+    "\n",
+    "Please remember that to use the Plotly pane in a Jupyter notebook, you must activate the Panel extension and include `\"plotly\"` as an argument. This step ensures that plotly.js is properly set up."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "import panel as pn\n",
-    "pn.extension('plotly')"
+    "\n",
+    "pn.extension(\"plotly\")"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The ``Plotly`` pane renders Plotly plots inside a panel. It optimizes the plot rendering by using binary serialization for any array data found on the Plotly object, providing efficient updates. Note that to use the Plotly pane in a Jupyter notebook, the Panel extension has to be loaded with 'plotly' as an argument to ensure that Plotly.js is initialized.\n",
-    "\n",
-    "#### Parameters:\n",
+    "## Parameters:\n",
     "\n",
     "For details on other options for customizing the component see the [layout](../../how_to/layout/index.md) and [styling](../../how_to/styling/index.md) how-to guides.\n",
     "\n",
-    "* **``object``** (object): The Plotly figure being displayed\n",
+    "### Core\n",
+    "\n",
+    "* **``object``** (object): The Plotly `Figure` or dictionary object being displayed.\n",
+    "* **``config``** (dict): Additional configuration of the plot. See [Plotly configuration options](https://plotly.com/javascript/configuration-options/).\n",
+    "\n",
+    "### Callbacks\n",
+    "\n",
     "* **``click_data``** (dict): Click callback data\n",
     "* **``clickannotation_data``** (dict): Clickannotation callback data\n",
-    "* **``config``** (dict): Config data\n",
     "* **``hover_data``** (dict): Hover callback data\n",
     "* **``link_figure``** (bool): Attach callbacks to the Plotly figure to update output when it is modified in place.\n",
     "* **``relayout_data``** (dict): Relayout callback data\n",
     "* **``restyle_data``** (dict): Restyle callback data\n",
     "* **``selected_data``** (dict): Selected callback data\n",
-    "* **``viewport``** (dict): Current viewport state\n",
+    "* **``viewport``** (dict): Current viewport state, i.e. the x- and y-axis limits of the displayed plot.\n",
     "* **``viewport_update_policy``** (str, default = 'mouseup'): Policy by which the viewport parameter is updated during user interactions\n",
     "    * ``mouseup``: updates are synchronized when mouse button is released after panning\n",
-    "    * ``continuoius``: updates are synchronized continually while panning\n",
+    "    * ``continuous``: updates are synchronized continually while panning\n",
     "    * ``throttle``: updates are synchronized while panning, at intervals determined by the viewport_update_throttle parameter\n",
     "* **``viewport_update_throttle``** (int, default = 200, bounds = (0, None)): Time interval in milliseconds at which viewport updates are synchronized when viewport_update_policy is \"throttle\".\n",
     "\n",
@@ -43,7 +56,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "As with most other types ``Panel`` will automatically convert a Plotly figure to a ``Plotly`` pane if it is passed to the ``pn.panel`` function or a panel layout, but a ``Plotly`` pane can be constructed directly using the ``pn.pane.Plotly`` constructor:"
+    "As with most other types ``Panel`` will automatically convert a Plotly `Figure` to a `Plotly` pane if it is passed to the `pn.panel` function or a Panel layout, but a `Plotly` pane can also be constructed directly using the `pn.pane.Plotly` constructor:"
    ]
   },
   {
@@ -55,10 +68,97 @@
     "import numpy as np\n",
     "import plotly.graph_objs as go\n",
     "\n",
+    "import panel as pn\n",
+    "\n",
+    "pn.extension(\"plotly\")\n",
+    "\n",
     "xx = np.linspace(-3.5, 3.5, 100)\n",
     "yy = np.linspace(-3.5, 3.5, 100)\n",
     "x, y = np.meshgrid(xx, yy)\n",
-    "z = np.exp(-(x-1)**2-y**2)-(x**3+y**4-x/5)*np.exp(-(x**2+y**2))\n",
+    "z = np.exp(-((x - 1) ** 2) - y**2) - (x**3 + y**4 - x / 5) * np.exp(-(x**2 + y**2))\n",
+    "\n",
+    "surface=go.Surface(z=z)\n",
+    "fig = go.Figure(data=[surface])\n",
+    "\n",
+    "fig.update_layout(\n",
+    "    title=\"Plotly 3D Plot\",\n",
+    "    width=500,\n",
+    "    height=500,\n",
+    "    margin=dict(t=50, b=50, r=50, l=50),\n",
+    ")\n",
+    "\n",
+    "plotly_pane = pn.pane.Plotly(fig)\n",
+    "plotly_pane"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Once created `Plotly` pane can be updated by assigning a new figure object"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "new_fig = go.Figure(data=[go.Surface(z=np.sin(z+1))])\n",
+    "new_fig.update_layout(\n",
+    "    title=\"Plotly 3D Plot\",\n",
+    "    width=500,\n",
+    "    height=500,\n",
+    "    margin=dict(t=50, b=50, r=50, l=50),\n",
+    ")\n",
+    "\n",
+    "plotly_pane.object = new_fig"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Lets reset the Plotly pane"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plotly_pane.object = fig"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Efficient Updates with Dictionaries\n",
+    "\n",
+    "Instead of updating the entire Figure you can efficiently update specific traces or the layout if you use a dictionary instead of a Plotly Figure.\n",
+    "\n",
+    "Note updates will only be fast if the ``Figure`` is defined as a dictionary, since Plotly will make copies of the traces, which means that modifying them in place has no effect. Modifying an array will send just the array using a binary protocol, leading to fast and efficient updates."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import plotly.graph_objs as go\n",
+    "\n",
+    "import panel as pn\n",
+    "\n",
+    "pn.extension(\"plotly\")\n",
+    "\n",
+    "xx = np.linspace(-3.5, 3.5, 100)\n",
+    "yy = np.linspace(-3.5, 3.5, 100)\n",
+    "x, y = np.meshgrid(xx, yy)\n",
+    "z = np.exp(-((x - 1) ** 2) - y**2) - (x**3 + y**4 - x / 5) * np.exp(-(x**2 + y**2))\n",
     "\n",
     "surface = go.Surface(z=z)\n",
     "layout = go.Layout(\n",
@@ -73,13 +173,6 @@
     "\n",
     "plotly_pane = pn.pane.Plotly(fig)\n",
     "plotly_pane"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Once created the plot can be updated by modifying the Plotly traces and then triggering an update by setting or triggering an event on the pane ``object``. Note that this only works if the ``Figure`` is defined as a dictionary, since Plotly will make copies of the traces, which means that modifying them in place has no effect. Modifying an array will send just the array using a binary protocol, leading to fast and efficient updates."
    ]
   },
   {
@@ -114,7 +207,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The Plotly pane supports layouts and subplots of arbitrary complexity, allowing even deeply nested Plotly figures to be displayed:"
+    "Lets reset the Plotly pane"
    ]
   },
   {
@@ -123,7 +216,31 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "surface.z = z\n",
+    "fig['layout']['width'] = 500\n",
+    "\n",
+    "plotly_pane.object = fig"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Plotly Layouts\n",
+    "\n",
+    "The `Plotly` pane supports layouts and subplots of arbitrary complexity, allowing even deeply nested Plotly figures to be displayed:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import panel as pn\n",
     "from plotly import subplots\n",
+    "\n",
+    "pn.extension(\"plotly\")\n",
     "\n",
     "heatmap = go.Heatmap(\n",
     "    z=[[1, 20, 30],\n",
@@ -148,6 +265,8 @@
     "fig.append_trace(heatmap, 2, 1)\n",
     "\n",
     "fig['layout'].update(height=600, width=600, title='i <3 subplots')\n",
+    "\n",
+    "# Conversion to dictionary only necessary if you want efficient updates\n",
     "fig = fig.to_dict()\n",
     "\n",
     "subplot_panel = pn.pane.Plotly(fig)\n",
@@ -175,7 +294,31 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Lastly, Plotly plots can be made responsive using the `autosize` option on a Plotly layout:"
+    "Lets reset the plot"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig['layout']['title']['text'] = 'i <3 subplots'\n",
+    "subplot_panel.object = fig"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Responsive Plots"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Plotly plots can be made responsive using the `autosize` option on a Plotly layout and a responsive `sizing_mode` argument to the `Plotly` pane:"
    ]
   },
   {
@@ -185,7 +328,10 @@
    "outputs": [],
    "source": [
     "import pandas as pd\n",
+    "import panel as pn\n",
     "import plotly.express as px\n",
+    "\n",
+    "pn.extension(\"plotly\")\n",
     "\n",
     "data = pd.DataFrame([\n",
     "    ('Monday', 7), ('Tuesday', 4), ('Wednesday', 9), ('Thursday', 4),\n",
@@ -196,16 +342,36 @@
     "fig.update_traces(mode=\"lines+markers\", marker=dict(size=10), line=dict(width=4))\n",
     "fig.layout.autosize = True\n",
     "\n",
-    "responsive = pn.pane.Plotly(fig)\n",
+    "responsive = pn.pane.Plotly(fig, height=300)\n",
     "\n",
-    "pn.Column('# A responsive plot', responsive, sizing_mode='stretch_width')"
+    "pn.Column('## A responsive plot', responsive, sizing_mode='stretch_width')"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Controls\n",
+    "## Plot Configuration\n",
+    "\n",
+    "You can set the [Plotly configuration options](https://plotly.com/javascript/configuration-options/) via the `config` parameter. Lets try to configure `scrollZoom`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "responsive = pn.pane.Plotly(fig, config={\"scrollZoom\": True}, height=300)\n",
+    "\n",
+    "pn.Column('## A responsive and zoomable plot', responsive, sizing_mode='stretch_width')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Controls\n",
     "\n",
     "The `Plotly` pane exposes a number of options which can be changed from both Python and Javascript try out the effect of these parameters interactively:"
    ]

--- a/panel/pane/plotly.py
+++ b/panel/pane/plotly.py
@@ -48,7 +48,8 @@ class Plotly(ModelPane):
 
     clickannotation_data = param.Dict(doc="Clickannotation callback data")
 
-    config = param.Dict(nested_refs=True, doc="Config data")
+    config = param.Dict(nested_refs=True, doc="""
+        Plotly configuration options. See https://plotly.com/javascript/configuration-options/""")
 
     hover_data = param.Dict(doc="Hover callback data")
 
@@ -62,7 +63,7 @@ class Plotly(ModelPane):
 
     selected_data = param.Dict(nested_refs=True, doc="Selected callback data")
 
-    viewport = param.Dict(nested_refs=True, doc="Current viewport state")
+    viewport = param.Dict(nested_refs=True, doc="Current viewport state, i.e. the x- and y-axis limits of the displayed plot.")
 
     viewport_update_policy = param.Selector(default="mouseup", doc="""
         Policy by which the viewport parameter is updated during user interactions.


### PR DESCRIPTION
The Plotly reference guide does not explain the Plotly pane to a great extent. I believe more is needed. This PR adresses that.

In most of the sections I try to start from a working example. I've always found it hard using the reference guides across the HoloViz ecosystem when I have to compose a working example from something at the top of a notebook, something from the middle, something from the next cell and then finally what I have further down. So if you don't like me to write sections starting from a working example its time to tell me.

I would have liked to also describe how to use the callbacks. But it seems the `click_data` is not working. So it does not make sense to do now. See https://github.com/holoviz/panel/issues/5096.