### PR TITLE
Fix and improve Plotly event handling

### DIFF
--- a/panel/models/plotly.py
+++ b/panel/models/plotly.py
@@ -4,10 +4,20 @@ Defines a custom PlotlyPlot bokeh model to render Plotly plots.
 from bokeh.core.properties import (
     Any, Dict, Either, Enum, Instance, Int, List, Null, Nullable, String,
 )
+from bokeh.events import ModelEvent
 from bokeh.models import ColumnDataSource, LayoutDOM
 
 from ..io.resources import JS_URLS, bundled_files
 from ..util import classproperty
+
+
+class PlotlyEvent(ModelEvent):
+
+    event_name = 'plotly_event'
+
+    def __init__(self, model, data=None):
+        self.data = data
+        super().__init__(model=model)
 
 
 class PlotlyPlot(LayoutDOM):
@@ -53,10 +63,6 @@ class PlotlyPlot(LayoutDOM):
     # Callback properties
     relayout_data = Dict(String, Any)
     restyle_data = List(Any)
-    click_data = Either(Dict(String, Any), Null)
-    hover_data = Either(Dict(String, Any), Null)
-    clickannotation_data = Either(Dict(String, Any), Null)
-    selected_data = Either(Dict(String, Any), Null)
     viewport = Either(Dict(String, Any), Null)
     viewport_update_policy = Enum( "mouseup", "continuous", "throttle")
     viewport_update_throttle = Int()

--- a/panel/models/plotly.ts
+++ b/panel/models/plotly.ts
@@ -1,9 +1,11 @@
+import {ModelEvent} from "@bokehjs/core/bokeh_events"
 import type {StyleSheetLike} from "@bokehjs/core/dom"
 import {div} from "@bokehjs/core/dom"
 import type * as p from "@bokehjs/core/properties"
-import {isPlainObject} from "@bokehjs/core/util/types"
+import {isPlainObject, isArray} from "@bokehjs/core/util/types"
 import {clone} from "@bokehjs/core/util/object"
 import {is_equal} from "@bokehjs/core/util/eq"
+import type {Attrs} from "@bokehjs/core/types"
 import {ColumnDataSource} from "@bokehjs/models/sources/column_data_source"
 
 import {debounce} from  "debounce"
@@ -13,8 +15,23 @@ import {HTMLBox, HTMLBoxView, set_size} from "./layout"
 
 import plotly_css from "styles/models/plotly.css"
 
+export class PlotlyEvent extends ModelEvent {
+  constructor(readonly data: any) {
+    super()
+  }
+
+  protected override get event_values(): Attrs {
+    return {model: this.origin, data: this.data}
+  }
+
+  static {
+    this.prototype.event_name = "plotly_event"
+  }
+}
+
 interface PlotlyHTMLElement extends HTMLDivElement {
   _fullLayout: any
+  _hoverdata: any
   layout: any
   on(event: "plotly_relayout", callback: (eventData: any) => void): void
   on(event: "plotly_relayouting", callback: (eventData: any) => void): void
@@ -28,15 +45,19 @@ interface PlotlyHTMLElement extends HTMLDivElement {
 }
 
 function convertUndefined(obj: any): any {
-  Object
-    .entries(obj)
-    .forEach(([key, value]) => {
-      if (isPlainObject(value)) {
-        convertUndefined(value)
-      } else if (value === undefined) {
-        obj[key] = null
-      }
-    })
+  if (isArray(obj)) {
+    return obj.map(convertUndefined)
+  } else if (isPlainObject(obj)) {
+    Object
+      .entries(obj)
+      .forEach(([key, value]) => {
+        if (isPlainObject(value) || isArray(value)) {
+          convertUndefined(value)
+        } else if (value === undefined) {
+          obj[key] = null
+        }
+      })
+  }
   return obj
 }
 
@@ -130,6 +151,7 @@ export class PlotlyPlotView extends HTMLBoxView {
   _rendered: boolean = false
   _reacting: boolean = false
   _relayouting: boolean = false
+  _hoverdata: any = null
   container: PlotlyHTMLElement
   _watched_sources: string[]
   _end_relayouting = debounce(() => {
@@ -279,37 +301,46 @@ export class PlotlyPlotView extends HTMLBoxView {
 
     //  - plotly_click
     this.container.on("plotly_click", (eventData: any) => {
-      this.model.click_data = filterEventData(
-        this.container, eventData, "click")
+      const data = filterEventData(this.container, eventData, "click")
+      console.trace('click', data)
+      this.model.trigger_event(new PlotlyEvent({type: 'click', data}))
     })
 
     //  - plotly_hover
     this.container.on("plotly_hover", (eventData: any) => {
-      this.model.hover_data = filterEventData(
-        this.container, eventData, "hover")
+      const data = filterEventData(this.container, eventData, "hover")
+      this.model.trigger_event(new PlotlyEvent({type: "hover", data}))
+      // Override hoverdata to ensure click event has context
+      this._hoverdata = this.container._hoverdata = eventData.points
     })
 
     //  - plotly_selected
     this.container.on("plotly_selected", (eventData: any) => {
-      this.model.selected_data = filterEventData(
-        this.container, eventData, "selected")
+      const data = filterEventData(this.container, eventData, "selected")
+      this.model.trigger_event(new PlotlyEvent({type: "selected", data}))
     })
 
     //  - plotly_clickannotation
     this.container.on("plotly_clickannotation", (eventData: any) => {
       delete eventData.event
       delete eventData.fullAnnotation
-      this.model.clickannotation_data = eventData
+      this.model.trigger_event(new PlotlyEvent({type: "clickannotation", data: eventData}))
     })
 
     //  - plotly_deselect
     this.container.on("plotly_deselect", () => {
-      this.model.selected_data = null
+      this.model.trigger_event(new PlotlyEvent({type: "selected", data: null}))
     })
 
     //  - plotly_unhover
     this.container.on("plotly_unhover", () => {
-      this.model.hover_data = null
+      // Override hoverdata to ensure click event has context
+      this.container._hoverdata = this._hoverdata
+      this.model.trigger_event(new PlotlyEvent({type: "hover", data: null}))
+      setTimeout(() => {
+        // Remove hoverdata once events have been processed
+        delete this.container._hoverdata
+      }, 0)
     })
   }
 
@@ -441,10 +472,6 @@ export namespace PlotlyPlot {
     restyle: p.Property<any>
     relayout_data: p.Property<any>
     restyle_data: p.Property<any>
-    click_data: p.Property<any>
-    hover_data: p.Property<any>
-    clickannotation_data: p.Property<any>
-    selected_data: p.Property<any>
     viewport: p.Property<any>
     viewport_update_policy: p.Property<string>
     viewport_update_throttle: p.Property<number>
@@ -476,10 +503,6 @@ export class PlotlyPlot extends HTMLBox {
       restyle: [ Nullable(Any), {} ],
       relayout_data: [ Any, {} ],
       restyle_data: [ List(Any), [] ],
-      click_data: [ Any, {} ],
-      hover_data: [ Any, {} ],
-      clickannotation_data: [ Any, {} ],
-      selected_data: [ Any, {} ],
       viewport: [ Any, {} ],
       viewport_update_policy: [ Str, "mouseup" ],
       viewport_update_throttle: [ Float, 200 ],


### PR DESCRIPTION
After a ton of investigation I found that click event handling depends on the following sequence of events, which for some reason does not occur in the right sequence in our case (likely due to the shadow DOM):

1. Hover event data is captured and set on the Plotly container element
2. The click event handler checks if the hoverdata is present and only dispatches a click event if that's the case
3. On unhover the hoverdata is reset.

In our case steps 2 and 3 were switched causing click events not to be dispatched. In this PR we do a few things:

1. Temporarily patch the hoverdata to ensure it is present when the click handler expects it
2. Convert the various `<event_data>` bokeh properties into bokeh events, ensuring that the same event can be sent multiple times. 

Fixes https://github.com/holoviz/panel/issues/5096