### PR TITLE
Enhancement/plotly review feedback

### DIFF
--- a/examples/reference/panes/Plotly.ipynb
+++ b/examples/reference/panes/Plotly.ipynb
@@ -149,6 +149,119 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## Layout Example\n",
+    "\n",
+    "The `Plotly` pane supports layouts and subplots of arbitrary complexity, allowing even deeply nested Plotly figures to be displayed:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import panel as pn\n",
+    "from plotly import subplots\n",
+    "\n",
+    "pn.extension(\"plotly\")\n",
+    "\n",
+    "heatmap = go.Heatmap(\n",
+    "    z=[[1, 20, 30],\n",
+    "       [20, 1, 60],\n",
+    "       [30, 60, 1]],\n",
+    "    showscale=False)\n",
+    "\n",
+    "y0 = np.random.randn(50)\n",
+    "y1 = np.random.randn(50)+1\n",
+    "\n",
+    "box_1 = go.Box(y=y0)\n",
+    "box_2 = go.Box(y=y1)\n",
+    "data = [heatmap, box_1, box_2]\n",
+    "\n",
+    "fig = subplots.make_subplots(\n",
+    "    rows=2, cols=2, specs=[[{}, {}], [{'colspan': 2}, None]],\n",
+    "    subplot_titles=('First Subplot','Second Subplot', 'Third Subplot')\n",
+    ")\n",
+    "\n",
+    "fig.append_trace(box_1, 1, 1)\n",
+    "fig.append_trace(box_2, 1, 2)\n",
+    "fig.append_trace(heatmap, 2, 1)\n",
+    "\n",
+    "fig['layout'].update(height=600, width=600, title='i <3 subplots')\n",
+    "\n",
+    "# Conversion to dictionary only necessary if you want efficient updates\n",
+    "fig = fig.to_dict()\n",
+    "\n",
+    "subplot_panel = pn.pane.Plotly(fig)\n",
+    "subplot_panel"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Responsive Plots\n",
+    "\n",
+    "Plotly plots can be made responsive using the `autosize` option on a Plotly layout and a responsive `sizing_mode` argument to the `Plotly` pane:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import panel as pn\n",
+    "import plotly.express as px\n",
+    "\n",
+    "pn.extension(\"plotly\")\n",
+    "\n",
+    "data = pd.DataFrame([\n",
+    "    ('Monday', 7), ('Tuesday', 4), ('Wednesday', 9), ('Thursday', 4),\n",
+    "    ('Friday', 4), ('Saturday', 4), ('Sunday', 4)], columns=['Day', 'Orders']\n",
+    ")\n",
+    "\n",
+    "fig = px.line(data, x=\"Day\", y=\"Orders\")\n",
+    "fig.update_traces(mode=\"lines+markers\", marker=dict(size=10), line=dict(width=4))\n",
+    "fig.layout.autosize = True\n",
+    "\n",
+    "responsive = pn.pane.Plotly(fig, height=300)\n",
+    "\n",
+    "pn.Column('## A responsive plot', responsive, sizing_mode='stretch_width')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Plot Configuration\n",
+    "\n",
+    "You can set the [Plotly configuration options](https://plotly.com/javascript/configuration-options/) via the `config` parameter. Lets try to configure `scrollZoom`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "responsive_with_zoom = pn.pane.Plotly(fig, config={\"scrollZoom\": True}, height=300)\n",
+    "\n",
+    "pn.Column('## A responsive and scroll zoomable plot', responsive_with_zoom, sizing_mode='stretch_width')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Try scrolling with the mouse!"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Patching\n",
     "\n",
     "Instead of updating the entire Figure you can efficiently patch traces or the layout if you use a dictionary instead of a Plotly Figure.\n",
@@ -415,7 +528,7 @@
     "pn.Column(\n",
     "    button,\n",
     "    plotly_pane,\n",
-    ").servable()"
+    ")"
    ]
   },
   {
@@ -425,158 +538,6 @@
     "This enables you to use the Plotly `Figure` in the same way as you would have been using the Plotly [`FigureWidget`](https://plotly.com/python/figurewidget/).\n",
     "\n",
     "If you for some reason want to disable in place updates, you can set `link_figure=False` when you create the `Plotly` pane. You cannot change this when the pane has been created."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Layouts\n",
-    "\n",
-    "The `Plotly` pane supports layouts and subplots of arbitrary complexity, allowing even deeply nested Plotly figures to be displayed:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import panel as pn\n",
-    "from plotly import subplots\n",
-    "\n",
-    "pn.extension(\"plotly\")\n",
-    "\n",
-    "heatmap = go.Heatmap(\n",
-    "    z=[[1, 20, 30],\n",
-    "       [20, 1, 60],\n",
-    "       [30, 60, 1]],\n",
-    "    showscale=False)\n",
-    "\n",
-    "y0 = np.random.randn(50)\n",
-    "y1 = np.random.randn(50)+1\n",
-    "\n",
-    "box_1 = go.Box(y=y0)\n",
-    "box_2 = go.Box(y=y1)\n",
-    "data = [heatmap, box_1, box_2]\n",
-    "\n",
-    "fig = subplots.make_subplots(\n",
-    "    rows=2, cols=2, specs=[[{}, {}], [{'colspan': 2}, None]],\n",
-    "    subplot_titles=('First Subplot','Second Subplot', 'Third Subplot')\n",
-    ")\n",
-    "\n",
-    "fig.append_trace(box_1, 1, 1)\n",
-    "fig.append_trace(box_2, 1, 2)\n",
-    "fig.append_trace(heatmap, 2, 1)\n",
-    "\n",
-    "fig['layout'].update(height=600, width=600, title='i <3 subplots')\n",
-    "\n",
-    "# Conversion to dictionary only necessary if you want efficient updates\n",
-    "fig = fig.to_dict()\n",
-    "\n",
-    "subplot_panel = pn.pane.Plotly(fig)\n",
-    "subplot_panel"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Just like in the single-subplot case we can modify just certain aspects of a plot and then trigger an update. E.g. here we replace the overall title text:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "fig['layout']['title']['text'] = 'i <3 updating subplots'\n",
-    "subplot_panel.object = fig"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Lets reset the plot"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "fig['layout']['title']['text'] = 'i <3 subplots'\n",
-    "subplot_panel.object = fig"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Responsive Plots"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Plotly plots can be made responsive using the `autosize` option on a Plotly layout and a responsive `sizing_mode` argument to the `Plotly` pane:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import pandas as pd\n",
-    "import panel as pn\n",
-    "import plotly.express as px\n",
-    "\n",
-    "pn.extension(\"plotly\")\n",
-    "\n",
-    "data = pd.DataFrame([\n",
-    "    ('Monday', 7), ('Tuesday', 4), ('Wednesday', 9), ('Thursday', 4),\n",
-    "    ('Friday', 4), ('Saturday', 4), ('Sunday', 4)], columns=['Day', 'Orders']\n",
-    ")\n",
-    "\n",
-    "fig = px.line(data, x=\"Day\", y=\"Orders\")\n",
-    "fig.update_traces(mode=\"lines+markers\", marker=dict(size=10), line=dict(width=4))\n",
-    "fig.layout.autosize = True\n",
-    "\n",
-    "responsive = pn.pane.Plotly(fig, height=300)\n",
-    "\n",
-    "pn.Column('## A responsive plot', responsive, sizing_mode='stretch_width')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Plot Configuration\n",
-    "\n",
-    "You can set the [Plotly configuration options](https://plotly.com/javascript/configuration-options/) via the `config` parameter. Lets try to configure `scrollZoom`:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "responsive = pn.pane.Plotly(fig, config={\"scrollZoom\": True}, height=300)\n",
-    "\n",
-    "pn.Column('## A responsive and zoomable plot', responsive, sizing_mode='stretch_width')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Try scrolling with the mouse!"
    ]
   },
   {
@@ -664,6 +625,105 @@
    "metadata": {},
    "source": [
     "In the plot above, try hovering, clicking, selecting and changing the viewport by panning. Watch how the parameter values just above changes."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "\r\n",
+    "\r\n",
+    "### Parent-Child Views\r\n",
+    "\r\n",
+    "A common technique for exploring higher-dimensional datasets is the use of Parent-Child views. This approach allows you to employ a top-down method to initially explorthree most important dimensions in the parent plot. You can then select a subset of the data points and examine them in greater detail and across additional dimensions.\r\n",
+    "\r\n",
+    "Let's create a plot where Box or Lasso selections in the parent plot update a child plot. We will also customize the action bars using the `config` pa your guide."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import plotly.express as px\n",
+    "\n",
+    "import panel as pn\n",
+    "\n",
+    "pn.extension(\"plotly\")\n",
+    "df = (\n",
+    "    pd.read_csv(\"https://datasets.holoviz.org/penguins/v1/penguins.csv\")\n",
+    "    .dropna()\n",
+    "    .reset_index(drop=True)\n",
+    ")\n",
+    "df[\"index\"] = df.index # Used to filter rows for child view\n",
+    "\n",
+    "color_map = {\"Adelie\": \"blue\", \"Chinstrap\": \"red\", \"Gentoo\": \"green\"}\n",
+    "\n",
+    "fig_parent = px.scatter(\n",
+    "    df,\n",
+    "    x=\"flipper_length_mm\",\n",
+    "    y=\"body_mass_g\",\n",
+    "    color_discrete_map=color_map,\n",
+    "    custom_data=\"index\",  # Used to filter rows for child view\n",
+    "    color=\"species\",\n",
+    "    title=\"<b>Parent Plot</b>: Box or Lasso Select Points\",\n",
+    ")\n",
+    "\n",
+    "\n",
+    "def fig_child(selectedData):\n",
+    "    if selectedData:\n",
+    "        indices = [point[\"customdata\"][0] for point in selectedData[\"points\"]]\n",
+    "        filtered_df = df.iloc[indices]\n",
+    "        title = f\"<b>Child Plot</b>: Selected Points({len(indices)})\"\n",
+    "    else:\n",
+    "        filtered_df = df\n",
+    "        title = f\"<b>Child Plot</b>: All Points ({len(filtered_df)})\"\n",
+    "\n",
+    "    fig = px.scatter(\n",
+    "        filtered_df,\n",
+    "        x=\"bill_length_mm\",\n",
+    "        y=\"bill_depth_mm\",\n",
+    "        color_discrete_map=color_map,\n",
+    "        color=\"species\",\n",
+    "        hover_data={\"flipper_length_mm\": True, \"body_mass_g\": True},\n",
+    "        title=title,\n",
+    "    )\n",
+    "    return fig\n",
+    "\n",
+    "\n",
+    "parent_config = {\n",
+    "    \"modeBarButtonsToAdd\": [\"select2d\", \"lasso2d\"],\n",
+    "    \"modeBarButtonsToRemove\": [\n",
+    "        \"zoomIn2d\",\n",
+    "        \"zoomOut2d\",\n",
+    "        \"pan2d\",\n",
+    "        \"zoom2d\",\n",
+    "        \"autoScale2d\",\n",
+    "    ],\n",
+    "    \"displayModeBar\": True,\n",
+    "    \"displaylogo\": False,\n",
+    "}\n",
+    "parent_pane = pn.pane.Plotly(fig_parent, config=parent_config)\n",
+    "\n",
+    "ifig_child = pn.bind(fig_child, parent_pane.param.selected_data)\n",
+    "child_config = {\n",
+    "    \"modeBarButtonsToRemove\": [\n",
+    "        \"select2d\",\n",
+    "        \"lasso2d\",\n",
+    "        \"zoomIn2d\",\n",
+    "        \"zoomOut2d\",\n",
+    "        \"pan2d\",\n",
+    "        \"zoom2d\",\n",
+    "        \"autoScale2d\",\n",
+    "    ],\n",
+    "    \"displayModeBar\": True,\n",
+    "    \"displaylogo\": False,\n",
+    "}\n",
+    "child_pane = pn.pane.Plotly(ifig_child, config=child_config)\n",
+    "\n",
+    "pn.FlexBox(parent_pane, child_pane)"
    ]
   },
   {

--- a/examples/reference/panes/Plotly.ipynb
+++ b/examples/reference/panes/Plotly.ipynb
@@ -52,8 +52,6 @@
     "    * ``throttle``: updates are synchronized while panning, at intervals determined by the viewport_update_throttle parameter\n",
     "* **``viewport_update_throttle``** (int, default = 200, bounds = (0, None)): Time interval in milliseconds at which viewport updates are synchronized when viewport_update_policy is \"throttle\".\n",
     "\n",
-    "### Other\n",
-    "\n",
     "___"
    ]
   },

--- a/examples/reference/panes/Plotly.ipynb
+++ b/examples/reference/panes/Plotly.ipynb
@@ -634,7 +634,7 @@
     "\r\n",
     "A common technique for exploring higher-dimensional datasets is the use of Parent-Child views. This approach allows you to employ a top-down method to initially exing thehree most important dimensions in the parent plot. You can then select a subset of the data points and examine them in greater detail and across additional dimensions.\r\n",
     "\r\n",
-    "Let's create a plot where Box or Lasso selections in the parent plot update a child plot. We will also customize the action bars using the `conframeter.guide."
+    "Let's create a plot where Box or Lasso selections in the parent plot update a child plot. We will also customize the action bars using the `config` parameter."
    ]
   },
   {

--- a/examples/reference/panes/Plotly.ipynb
+++ b/examples/reference/panes/Plotly.ipynb
@@ -515,8 +515,8 @@
     "        fig.layout = {\"title\": \"\"}\n",
     "        button.name = \"Create\"\n",
     "\n",
-    "\n",
     "pn.bind(handle_click, button.param.clicks, watch=True)\n",
+    "button.clicks=1\n",
     "\n",
     "plotly_pane = pn.pane.Plotly(\n",
     "    fig,\n",
@@ -569,7 +569,7 @@
     "df = pd.DataFrame({'x': x, 'y': y})\n",
     "\n",
     "# Create scatter plot\n",
-    "fig = px.scatter(df, x='x', y='y', title='Click on Points', hover_name='x',)\n",
+    "fig = px.scatter(df, x='x', y='y', title='Click on a Point!', hover_name='x',)\n",
     "fig.update_traces(marker=dict(size=20))\n",
     "fig.update_layout(autosize=True, hovermode='closest')\n",
     "\n",
@@ -614,10 +614,7 @@
    "source": [
     "event_parameters = [\"click_data\", \"click_annotation_data\", \"hover_data\", \"relayout_data\", \"restyle_data\", \"selected_data\", \"viewport\"]\n",
     "\n",
-    "with pn.config.set(sizing_mode=\"stretch_width\"):\n",
-    "    pane = pn.Param(plotly_pane, parameters=event_parameters, max_width=1100, name=\"Plotly Event Parameters\")\n",
-    "\n",
-    "pane"
+    "pn.Param(plotly_pane, parameters=event_parameters, max_width=1100, name=\"Plotly Event Parameters\")"
    ]
   },
   {
@@ -635,9 +632,9 @@
     "\r\n",
     "### Parent-Child Views\r\n",
     "\r\n",
-    "A common technique for exploring higher-dimensional datasets is the use of Parent-Child views. This approach allows you to employ a top-down method to initially explorthree most important dimensions in the parent plot. You can then select a subset of the data points and examine them in greater detail and across additional dimensions.\r\n",
+    "A common technique for exploring higher-dimensional datasets is the use of Parent-Child views. This approach allows you to employ a top-down method to initially exing thehree most important dimensions in the parent plot. You can then select a subset of the data points and examine them in greater detail and across additional dimensions.\r\n",
     "\r\n",
-    "Let's create a plot where Box or Lasso selections in the parent plot update a child plot. We will also customize the action bars using the `config` pa your guide."
+    "Let's create a plot where Box or Lasso selections in the parent plot update a child plot. We will also customize the action bars using the `conframeter.guide."
    ]
   },
   {


### PR DESCRIPTION
I wanted to make a few improvements to the Plotly reference guide

- Change the order such that the simple things users are looking for are at the top
- It includes a Parent-Child plot example as this is an often sought for example I believe. II actually requires a few "tricks" to do. This also shows how powerful the `config` option is. I've never seen that in use before.