### PR TITLE
Verfiy the tag contains v for gallery workflow

### DIFF
--- a/.github/workflows/gallery.yaml
+++ b/.github/workflows/gallery.yaml
@@ -64,7 +64,7 @@ jobs:
       - name: Upload and deploy prod gallery
         if: |
           (github.event_name == 'workflow_dispatch' && github.event.inputs.target == 'main') ||
-          (github.event_name == 'workflow_run' && !(contains(steps.vars.outputs.tag, 'a') || contains(steps.vars.outputs.tag, 'b') || contains(steps.vars.outputs.tag, 'rc')))
+          (github.event_name == 'workflow_run' && !(contains(steps.vars.outputs.tag, 'a') || contains(steps.vars.outputs.tag, 'b') || contains(steps.vars.outputs.tag, 'rc')) && contains(steps.vars.outputs.tag, 'v'))
         run: |
           conda activate test
           ae5 login --hostname holoviz.dsp.anaconda.com --username ${{ secrets.AE5_USERNAME }} --password ${{ secrets.AE5_PASSWORD }}


### PR DESCRIPTION
I noticed that manually running the build workflow would kick off a gallery workflow automatically, which pushed to prod. 

This adds a check to see if `v` is in the tag. 