### PR TITLE
Implement Placeholder pane

### DIFF
--- a/examples/reference/panes/Placeholder.ipynb
+++ b/examples/reference/panes/Placeholder.ipynb
@@ -16,15 +16,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The `Placeholder` pane serves as a placeholder for other Panel components.\n",
-    "It can be used to display a message while a computation is running, for\n",
-    "example.\n",
+    "The `Placeholder` pane serves as a placeholder for other Panel components. It can be used to display a message while a computation is running, for example.\n",
     "\n",
     "#### Parameters:\n",
     "\n",
     "For details on other options for customizing the component see the [layout](../../how_to/layout/index.md) and [styling](../../how_to/styling/index.md) how-to guides.\n",
     "\n",
-    "* **``object``** (str or object): The PNG file to display. Can be a string pointing to a local or remote file, or an object with a ``_repr_png_`` method.\n",
+    "* **`object`** (Any): The Panel object to display, if object is not already a Panel object it will be converted with the `panel(...)` function.\n",
     "\n",
     "___"
    ]
@@ -50,7 +48,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The benefit of using a `Placeholder` is that it allows you to replace the content of the pane without being restricted to a specific type of component. This means you can replace the placeholder with any other pane type, including plots, images, and widgets."
+    "The benefit of using a `Placeholder` is that it allows you to replace the content of the pane without being restricted to a specific type of component. This means you can replace the placeholder with any other pane type, including plots, images, and widgets. You may either use the `update` method:"
    ]
   },
   {
@@ -59,14 +57,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "placeholder.object = pn.widgets.TextInput(value=\"Hello again!\")"
+    "placeholder.update(pn.widgets.TextInput(value=\"Hello again!\"))"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This is a better approach than using a layout, like `Column`, as a placeholder for single components."
+    "or set the `object` directly:"
    ]
   },
   {
@@ -75,17 +73,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "column = pn.Column(\"Hello\")\n",
-    "column"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "column.objects = [pn.widgets.TextInput(value=\"Hello again!\")]"
+    "placeholder.object = \"Hello once more!\""
    ]
   },
   {
@@ -119,11 +107,11 @@
    "outputs": [],
    "source": [
     "with placeholder:\n",
-    "    placeholder.object = \"🚀 Starting...\"\n",
+    "    placeholder.update(\"🚀 Starting...\")\n",
     "    await asyncio.sleep(1)\n",
-    "    placeholder.object = \"🏃 Running...\"\n",
+    "    placeholder.update(\"🏃 Running...\")\n",
     "    await asyncio.sleep(1)\n",
-    "    placeholder.object = \"✅ Complete!\"\n",
+    "    placeholder.update(\"✅ Complete!\")\n",
     "    await asyncio.sleep(1)"
    ]
   }

--- a/examples/reference/panes/Placeholder.ipynb
+++ b/examples/reference/panes/Placeholder.ipynb
@@ -1,0 +1,139 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import asyncio\n",
+    "import panel as pn\n",
+    "\n",
+    "pn.extension()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The `Placeholder` pane serves as a placeholder for other Panel components.\n",
+    "It can be used to display a message while a computation is running, for\n",
+    "example.\n",
+    "\n",
+    "#### Parameters:\n",
+    "\n",
+    "For details on other options for customizing the component see the [layout](../../how_to/layout/index.md) and [styling](../../how_to/styling/index.md) how-to guides.\n",
+    "\n",
+    "* **``object``** (str or object): The PNG file to display. Can be a string pointing to a local or remote file, or an object with a ``_repr_png_`` method.\n",
+    "\n",
+    "___"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The `Placeholder` pane can accept any Panel component as its argument, including other panes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "placeholder = pn.pane.Placeholder(\"Hello\")\n",
+    "placeholder"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The benefit of using a `Placeholder` is that it allows you to replace the content of the pane without being restricted to a specific type of component. This means you can replace the placeholder with any other pane type, including plots, images, and widgets."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "placeholder.object = pn.widgets.TextInput(value=\"Hello again!\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This is a better approach than using a layout, like `Column`, as a placeholder for single components."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "column = pn.Column(\"Hello\")\n",
+    "column"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "column.objects = [pn.widgets.TextInput(value=\"Hello again!\")]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If you'd like to temporarily replace the contents, you can use it as a context manager."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "placeholder = pn.pane.Placeholder(\"⏳ Idle\")\n",
+    "placeholder"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Upon execution of the cell below, the `Placeholder` pane will display `Starting...`, `Running...`, and `Complete!` in sequence, with a 1 second pause between each message, before finally displaying `Idle` again."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with placeholder:\n",
+    "    placeholder.object = \"🚀 Starting...\"\n",
+    "    await asyncio.sleep(1)\n",
+    "    placeholder.object = \"🏃 Running...\"\n",
+    "    await asyncio.sleep(1)\n",
+    "    placeholder.object = \"✅ Complete!\"\n",
+    "    await asyncio.sleep(1)"
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/panel/pane/__init__.py
+++ b/panel/pane/__init__.py
@@ -44,6 +44,7 @@ from .markup import (  # noqa
 )
 from .media import Audio, Video  # noqa
 from .perspective import Perspective  # noqa
+from .placeholder import Placeholder  # noqa
 from .plot import (  # noqa
     YT, Bokeh, Matplotlib, RGGPlot,
 )
@@ -84,6 +85,7 @@ __all__ = (
     "panel",
     "PDF",
     "Perspective",
+    "Placeholder",
     "Plotly",
     "PNG",
     "ReactiveExpr",

--- a/panel/pane/placeholder.py
+++ b/panel/pane/placeholder.py
@@ -46,3 +46,13 @@ class Placeholder(ReplacementPane):
         finally:
             self._temporary = False
         return False
+
+    def update(self, object):
+        """
+        Updates the object on the Placeholder.
+
+        Arguments
+        ---------
+        object: The object to update the Placeholder with.
+        """
+        self.object = object

--- a/panel/pane/placeholder.py
+++ b/panel/pane/placeholder.py
@@ -1,0 +1,48 @@
+"""
+Defines the Placeholder pane which serves as a placeholder for other Panel components.
+"""
+
+from __future__ import annotations
+
+import param
+
+from ..pane.base import ReplacementPane
+
+
+class Placeholder(ReplacementPane):
+    """
+    The `Placeholder` pane serves as a placeholder for other Panel components.
+    It can be used to display a message while a computation is running, for
+    example.
+
+    Reference: https://panel.holoviz.org/reference/panes/Placeholder.html
+
+    :Example:
+
+    >>> with Placeholder("⏳ Idle"):
+    ...     placeholder.object = "🏃 Running..."
+    """
+
+    def __init__(self, object=None, **params):
+        super().__init__(object=object, **params)
+        self._past_object = object  # used to restore object when Placeholder is exited
+        self._temporary = False
+        if object is not None:
+            self._replace_panel()
+
+    @param.depends("object", watch=True)
+    def _replace_panel(self):
+        if not self._temporary:
+            self._past_object = self.object
+        self._update_inner(self.object)
+
+    def __enter__(self):
+        self._temporary = True
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        try:
+            self.object = self._past_object
+        finally:
+            self._temporary = False
+        return False

--- a/panel/tests/pane/test_placeholder.py
+++ b/panel/tests/pane/test_placeholder.py
@@ -1,0 +1,28 @@
+import param
+
+from panel.pane.placeholder import Placeholder
+from panel.widgets import IntInput
+
+
+class TestPlaceholder:
+
+    def test_update_object(self):
+        placeholder = Placeholder("Idle")
+        placeholder.object = "Running..."
+        assert placeholder.object == "Running..."
+        placeholder.object = "New"
+        assert placeholder.object == "New"
+
+    def test_enter_exit(self):
+        placeholder = Placeholder("⏳ Idle")
+        with placeholder:
+            placeholder.object = "🏃 Running..."
+            assert placeholder.object == "🏃 Running..."
+            placeholder.object = "🚶 Walking..."
+            assert placeholder.object == "🚶 Walking..."
+        assert placeholder.object == "⏳ Idle"
+
+    def test_param_ref(self):
+        int_input = IntInput(name="IntInput", start=1, end=10, value=5)
+        placeholder = Placeholder(int_input.param.value)
+        assert isinstance(placeholder.object, param.Integer)


### PR DESCRIPTION
Philipp and I were discussing https://github.com/holoviz/panel/pull/6617 and thought it'd be useful to have a placeholder pane to easily replace the contents with any object.

Previously:
```python
column = pn.Column("Hello")
column

column.objects = [pn.widgets.TextInput(value="Hello again!")]
```

Now:
```python
placeholder = pn.pane.Placeholder("⏳ Idle")
placeholder

placeholder.object = pn.widgets.TextInput(value="Hello again!")
```

Additionally, it can be used as a context manager to replace objects and revert back to the original.

https://github.com/holoviz/panel/assets/15331990/fb0d5e57-16a0-4f15-a60c-3efddcf4c967

This could potentially be used to refactor `ChatMessage` too.
