### PR TITLE
Make ChatMessage reaction_icons reactive

### DIFF
--- a/panel/chat/message.py
+++ b/panel/chat/message.py
@@ -288,7 +288,7 @@ class ChatMessage(PaneBase):
         self._update_chat_copy_icon()
         self._center_row = Row(
             self._object_panel,
-            self.reaction_icons,
+            self.param.reaction_icons.rx(),
             css_classes=["center"],
             stylesheets=self._stylesheets + self.param.stylesheets.rx(),
             sizing_mode=None

--- a/panel/tests/chat/test_message.py
+++ b/panel/tests/chat/test_message.py
@@ -51,7 +51,7 @@ class TestChatMessage:
         assert isinstance(object_pane, Markdown)
         assert object_pane.object == "ABC"
 
-        icons = center_row[1]
+        icons = center_row[1][0][0].object()
         assert isinstance(icons, ChatReactionIcons)
 
         footer_col = columns[1][2]


### PR DESCRIPTION
Closes https://github.com/holoviz/panel/issues/6804
```python
import panel as pn
pn.extension()

chat = pn.chat.ChatMessage("Hey")
chat

chat.reaction_icons = pn.chat.ChatReactionIcons(options={"like": "thumb-up"})
```


<img width="636" alt="image" src="https://github.com/holoviz/panel/assets/15331990/eae5a664-861c-4e24-aad9-6605dce7a021">

