### PR TITLE
Raise on ChatReactionIcons instance in ChatFeed.message_params

### DIFF
--- a/panel/chat/feed.py
+++ b/panel/chat/feed.py
@@ -213,7 +213,7 @@ class ChatFeed(ListPanel):
         super().__init__(*objects, **params)
 
         if self.help_text:
-            self.objects = [ChatMessage(self.help_text, user="Help"), *self.objects]
+            self.objects = [ChatMessage(self.help_text, user="Help", **message_params), *self.objects]
 
         # instantiate the card's column
         linked_params = dict(
@@ -350,6 +350,11 @@ class ChatFeed(ListPanel):
                 f"e.g. {{'object': 'Hello World'}}; got {value!r}"
             )
         message_params = dict(value, renderers=self.renderers, **self.message_params)
+        for param_key, param_value in message_params.items():
+            if hasattr(param_value, "clone"):
+                # fixes chat reaction icons being linked across all messages
+                message_params[param_key] = param_value.clone()
+
         if user:
             message_params["user"] = user
         if avatar:

--- a/panel/tests/chat/test_feed.py
+++ b/panel/tests/chat/test_feed.py
@@ -443,14 +443,10 @@ class TestChatFeed:
         assert chat_message.reactions == ["like"]
         assert chat_message.reaction_icons.options == {"like": "thumb-up"}
 
-    def test_message_params_cloned(self, chat_feed):
-        chat_feed.reaction_icons = ChatReactionIcons(options={"like": "thumb-up", "dislike": "thumb-down"})
-        msg1 = chat_feed.send("Hello")
-        msg2 = chat_feed.send("Hey")
-
-        msg1.reactions = ["like"]
-        assert msg1.reactions == ["like"]
-        assert msg2.reactions == []
+    def test_message_params_no_chat_reaction_icons_instance(self, chat_feed):
+        with pytest.raises(ValueError, match="Cannot pass"):
+            chat_feed.message_params = {"reaction_icons": ChatReactionIcons(
+                options={"like": "thumb-up", "dislike": "thumb-down"})}
 
     def test_update_chat_log_params(self, chat_feed):
         chat_feed = ChatFeed(load_buffer=5, scroll_button_threshold=5, auto_scroll_limit=5)

--- a/panel/tests/chat/test_feed.py
+++ b/panel/tests/chat/test_feed.py
@@ -4,6 +4,7 @@ import time
 import pytest
 
 from panel.chat.feed import ChatFeed
+from panel.chat.icon import ChatReactionIcons
 from panel.chat.message import ChatMessage
 from panel.layout import Column, Row
 from panel.pane.image import Image
@@ -441,6 +442,15 @@ class TestChatFeed:
         assert chat_message.object == "Hey!"
         assert chat_message.reactions == ["like"]
         assert chat_message.reaction_icons.options == {"like": "thumb-up"}
+
+    def test_message_params_cloned(self, chat_feed):
+        chat_feed.reaction_icons = ChatReactionIcons(options={"like": "thumb-up", "dislike": "thumb-down"})
+        msg1 = chat_feed.send("Hello")
+        msg2 = chat_feed.send("Hey")
+
+        msg1.reactions = ["like"]
+        assert msg1.reactions == ["like"]
+        assert msg2.reactions == []
 
     def test_update_chat_log_params(self, chat_feed):
         chat_feed = ChatFeed(load_buffer=5, scroll_button_threshold=5, auto_scroll_limit=5)


### PR DESCRIPTION
```python
import panel as pn

pn.extension()

chat_feed = pn.chat.ChatFeed(reaction_icons=pn.chat.ChatReactionIcons(options={"like": "thumb-up", "dislike": "thumb-down"}))
msg1 = chat_feed.send("Hello")
msg2 = chat_feed.send("Hey")

msg1.reactions = ["like"]

chat_feed
```

No longer linked

<img width="486" alt="image" src="https://github.com/holoviz/panel/assets/15331990/904de50a-da85-45d1-87ad-a02acab40c65">
