### PR TITLE
Ensure refreshed tokens can be accessed across processes

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -145,7 +145,7 @@ jobs:
         with:
           name: unit_test_suite
           python-version: ${{ matrix.python-version }}
-          channels: pyviz/label/dev,numba,bokeh/label/dev,conda-forge,nodefaults
+          channels: pyviz/label/dev,numba,conda-forge,nodefaults
           conda-update: true
           nodejs: true
           nodejs-version: "20.9"  #  https://github.com/bokeh/bokeh/pull/13851

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -233,7 +233,7 @@ jobs:
         with:
           name: ui_test_suite
           python-version: 3.9
-          channels: pyviz/label/dev,bokeh/label/dev,conda-forge,nodefaults
+          channels: pyviz/label/dev,conda-forge,nodefaults
           envs: "-o recommended -o tests -o build"
           cache: ${{ github.event.inputs.cache || github.event.inputs.cache == '' }}
           nodejs: true

--- a/panel/auth.py
+++ b/panel/auth.py
@@ -414,7 +414,7 @@ class OAuthLoginHandler(tornado.web.RequestHandler, OAuth2Mixin):
                           type(handler).__name__, user_key)
                 raise HTTPError(401, "OAuth token payload missing user information")
             handler.clear_cookie('is_guest')
-            handler.set_secure_cookie('user', user, expires_days=config.oauth_expiry)
+            handler.set_secure_cookie('user', user, expires_days=config.oauth_expiry, httponly=True)
         else:
             user = None
 
@@ -424,14 +424,14 @@ class OAuthLoginHandler(tornado.web.RequestHandler, OAuth2Mixin):
                 id_token = state.encryption.encrypt(id_token.encode('utf-8'))
             if refresh_token:
                 refresh_token = state.encryption.encrypt(refresh_token.encode('utf-8'))
-        handler.set_secure_cookie('access_token', access_token, expires_days=config.oauth_expiry)
+        handler.set_secure_cookie('access_token', access_token, expires_days=config.oauth_expiry, httponly=True)
         if id_token:
-            handler.set_secure_cookie('id_token', id_token, expires_days=config.oauth_expiry)
+            handler.set_secure_cookie('id_token', id_token, expires_days=config.oauth_expiry, httponly=True)
         if expires_in:
             now_ts = dt.datetime.now(dt.timezone.utc).timestamp()
-            handler.set_secure_cookie('oauth_expiry', str(int(now_ts + expires_in)), expires_days=config.oauth_expiry)
+            handler.set_secure_cookie('oauth_expiry', str(int(now_ts + expires_in)), expires_days=config.oauth_expiry, httponly=True)
         if refresh_token:
-            handler.set_secure_cookie('refresh_token', refresh_token, expires_days=config.oauth_expiry)
+            handler.set_secure_cookie('refresh_token', refresh_token, expires_days=config.oauth_expiry, httponly=True)
         if user and user in state._oauth_user_overrides:
             state._oauth_user_overrides.pop(user, None)
         return user
@@ -849,11 +849,11 @@ class BasicLoginHandler(RequestHandler):
             self.clear_cookie("user")
             return
         self.clear_cookie("is_guest")
-        self.set_secure_cookie("user", user, expires_days=config.oauth_expiry)
+        self.set_secure_cookie("user", user, expires_days=config.oauth_expiry, httponly=True)
         id_token = base64url_encode(json.dumps({'user': user}))
         if state.encryption:
             id_token = state.encryption.encrypt(id_token.encode('utf-8'))
-        self.set_secure_cookie('id_token', id_token, expires_days=config.oauth_expiry)
+        self.set_secure_cookie('id_token', id_token, expires_days=config.oauth_expiry, httponly=True)
 
 
 class LogoutHandler(tornado.web.RequestHandler):

--- a/panel/auth.py
+++ b/panel/auth.py
@@ -994,7 +994,11 @@ class OAuthProvider(BasicAuthProvider):
                 _, token = protocol_header.split(', ')
                 payload = get_token_payload(token)
                 if 'user_data' in payload:
-                    state._oauth_user_overrides[user] = payload['user_data']
+                    user_data = payload['user_data']
+                    if state.encryption:
+                        user_data = state.encryption.decrypt(user_data).decode('utf-8')
+                    user_data = json.loads(user_data)
+                    state._oauth_user_overrides[user] = user_data
 
             now_ts = dt.datetime.now(dt.timezone.utc).timestamp()
             expiry = None

--- a/panel/io/application.py
+++ b/panel/io/application.py
@@ -3,6 +3,7 @@ Extensions for Bokeh application handling.
 """
 from __future__ import annotations
 
+import json
 import logging
 import os
 
@@ -101,7 +102,10 @@ class Application(BkApplication):
             from tornado.web import decode_signed_value
             user = decode_signed_value(config.cookie_secret, 'user', user.value).decode('utf-8')
             if user in state._oauth_user_overrides:
-                request_data['user_data'] = state._oauth_user_overrides[user]
+                user_data = json.dumps(state._oauth_user_overrides[user])
+                if state.encryption:
+                    user_data = state.encryption.encrypt(user_data.encode('utf-8'))
+                request_data['user_data'] = user_data
         return request_data
 
 bokeh.command.util.Application = Application # type: ignore


### PR DESCRIPTION
When a user enables token refreshing and horizontally scales the application (either with `--num-procs` or with a load balancer) it is possible to get into a situation where the initial HTTP request arrives on one server, triggers a token refresh, but the subsequent WS request arrives on a different server, which does not have access to the refreshed token. The problem that will then occur is that it will once again try to make a request to refresh the tokens but by that point the `refresh_token` will have expired since they are single use.

This PR mitigates this issue by including the refreshed token information in the token, such that we can decode it on the server that opens the WS connection.