### PR TITLE
Ensure binary buffers are correctly extracted in CommManager

### DIFF
--- a/panel/models/comm_manager.ts
+++ b/panel/models/comm_manager.ts
@@ -4,6 +4,7 @@ import {View} from "@bokehjs/core/view"
 import {Model} from "@bokehjs/model"
 import {Message} from "@bokehjs/protocol/message"
 import {Receiver} from "@bokehjs/protocol/receiver"
+import {Buffer} from "@bokehjs/core/serialization/buffer"
 import type {Patch, DocumentChangedEvent} from "@bokehjs/document"
 import {isArray, isPlainObject} from "@bokehjs/core/util/types"
 import {values, size} from "@bokehjs/core/util/object"
@@ -108,17 +109,20 @@ export class CommManager extends Model {
       for (const val of value) {
         this._extract_buffers(val, buffers)
       }
+    } else if (value instanceof Map) {
+      for (const key of value.keys()) {
+	const v = value.get(key)
+	this._extract_buffers(v, buffers)
+      }
+    } else if (value instanceof Buffer) {
+      const {buffer} = value
+      delete value.buffer
+      const id = buffers.length
+      value.id = id
+      buffers.push(buffer)
     } else if (isPlainObject(value)) {
-      if (size(value) == 1 && value.buffer instanceof ArrayBuffer) {
-        const {buffer} = value
-        delete value.buffer
-        const id = buffers.length
-        value.id = id
-        buffers.push(buffer)
-      } else {
-        for (const val of values(value)) {
-          this._extract_buffers(val, buffers)
-        }
+      for (const val of values(value)) {
+        this._extract_buffers(val, buffers)
       }
     }
   }

--- a/panel/models/comm_manager.ts
+++ b/panel/models/comm_manager.ts
@@ -118,13 +118,13 @@ export class CommManager extends Model {
       const {buffer} = value
       const id = buffers.length
       buffers.push(buffer)
-      return {id: id}
+      return {id}
     } else if (isPlainObject(value)) {
       for (const key of keys(value)) {
         const replaced = this._extract_buffers(value[key], buffers)
-	if (replaced != null) {
-	  value[key] = replaced
-	}
+        if (replaced != null) {
+          value[key] = replaced
+        }
       }
     }
   }

--- a/panel/models/comm_manager.ts
+++ b/panel/models/comm_manager.ts
@@ -7,7 +7,7 @@ import {Receiver} from "@bokehjs/protocol/receiver"
 import {Buffer} from "@bokehjs/core/serialization/buffer"
 import type {Patch, DocumentChangedEvent} from "@bokehjs/document"
 import {isArray, isPlainObject} from "@bokehjs/core/util/types"
-import {values, size} from "@bokehjs/core/util/object"
+import {keys} from "@bokehjs/core/util/object"
 
 export const comm_settings: any = {
   debounce: true,

--- a/panel/models/comm_manager.ts
+++ b/panel/models/comm_manager.ts
@@ -111,8 +111,8 @@ export class CommManager extends Model {
       }
     } else if (value instanceof Map) {
       for (const key of value.keys()) {
-	const v = value.get(key)
-	this._extract_buffers(v, buffers)
+        const v = value.get(key)
+        this._extract_buffers(v, buffers)
       }
     } else if (value instanceof Buffer) {
       const {buffer} = value

--- a/panel/models/comm_manager.ts
+++ b/panel/models/comm_manager.ts
@@ -104,7 +104,7 @@ export class CommManager extends Model {
     }
   }
 
-  protected _extract_buffers(value: unknown, buffers: ArrayBuffer[]): void {
+  protected _extract_buffers(value: unknown, buffers: ArrayBuffer[]): any {
     if (isArray(value)) {
       for (const val of value) {
         this._extract_buffers(val, buffers)
@@ -116,13 +116,15 @@ export class CommManager extends Model {
       }
     } else if (value instanceof Buffer) {
       const {buffer} = value
-      delete value.buffer
       const id = buffers.length
-      value.id = id
       buffers.push(buffer)
+      return {id: id}
     } else if (isPlainObject(value)) {
-      for (const val of values(value)) {
-        this._extract_buffers(val, buffers)
+      for (const key of keys(value)) {
+        const replaced = this._extract_buffers(value[key], buffers)
+	if (replaced != null) {
+	  value[key] = replaced
+	}
       }
     }
   }


### PR DESCRIPTION
Binary buffers in Bokeh are now held in a `Buffer` object which means our old check for `isPlainObject` no longer works and we have to explicitly check for it.

- [ ] Add test