### PR TITLE
Docs: remove Google Analytics

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -66,7 +66,6 @@ html_theme_options = {
             "icon": "fa-brands fa-discord",
         },
     ],
-    "analytics": {"google_analytics_id": "G-L0C8PGT2LM"},
     "pygment_light_style": "material",
     "pygment_dark_style": "material",
     "header_links_before_dropdown": 5,


### PR DESCRIPTION
GoatCounter was already in place, and we've seen that the metrics both services provide are close enough.