### PR TITLE
Update pn_panel.md: replace mention of 'dice' with ' wind turbine' in the tutorial.

### DIFF
--- a/doc/tutorials/basic/pn_panel.md
+++ b/doc/tutorials/basic/pn_panel.md
@@ -318,7 +318,7 @@ print(component)
 component.servable()
 ```
 
-Please notice that the image of the dice is very tall. To fine-tune the way it is displayed, we can use `pn.panel` with arguments.
+Please notice that the image of the wind turbine is quite large. To fine-tune the way it is displayed, we can use `pn.panel` with arguments.
 
 Run the code below:
 


### PR DESCRIPTION
There is a mention of 'dice' in this tutorial, which uses wind turbines as an example. Replaced 'dice' with 'wind turbine'.