### PR TITLE
Update conf.py to dynamically show current release number in announcement text at top of Panel site.

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -44,7 +44,8 @@ html_theme = "pydata_sphinx_theme"
 html_favicon = "_static/icons/favicon.ico"
 
 current_release = panel.__version__  # Current release version variable
-announcement_text = f"Panel {current_release} has just been released! Checkout the <a href='https://panel.holoviz.org/about/releases.html#version-1-4-0'>release notes</a> and support Panel by giving it a 🌟 on <a href='https://github.com/holoviz/panel'>Github</a>."
+
+announcement_text = f"Panel {current_release} has just been released! Check out the <a href='https://panel.holoviz.org/about/releases.html#version-1-4-0'>release notes</a> and support Panel by giving it a 🌟 on <a href='https://github.com/holoviz/panel'>Github</a>."
 
 
 html_theme_options = {

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -43,6 +43,10 @@ html_css_files += [
 html_theme = "pydata_sphinx_theme"
 html_favicon = "_static/icons/favicon.ico"
 
+current_release = panel.__version__  # Current release version variable
+announcement_text = f"Panel {current_release} has just been released! Checkout the <a href='https://panel.holoviz.org/about/releases.html#version-1-4-0'>release notes</a> and support Panel by giving it a 🌟 on <a href='https://github.com/holoviz/panel'>Github</a>."
+}
+
 html_theme_options = {
     "logo": {
         "image_light": "_static/logo_horizontal_light_theme.png",
@@ -74,7 +78,7 @@ html_theme_options = {
         "panelitelink",
         "page-toc",
     ],
-    "announcement": "Panel 1.4 has just been released! Checkout the <a href='https://panel.holoviz.org/about/releases.html#version-1-4-0'>release notes</a> and support Panel by giving it a 🌟 on <a href='https://github.com/holoviz/panel'>Github</a>.",
+    "announcement": announcement_text,
 }
 
 extensions += [

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -45,7 +45,7 @@ html_favicon = "_static/icons/favicon.ico"
 
 current_release = panel.__version__  # Current release version variable
 announcement_text = f"Panel {current_release} has just been released! Checkout the <a href='https://panel.holoviz.org/about/releases.html#version-1-4-0'>release notes</a> and support Panel by giving it a 🌟 on <a href='https://github.com/holoviz/panel'>Github</a>."
-}
+
 
 html_theme_options = {
     "logo": {


### PR DESCRIPTION
Announcement at top of site now says: "Panel 1.4 has just been released. ..."

Introducing a variable that retrieves current version number , so it will say "Panel 1.4.x has just been released. ..."

This way the announcement will always show the actual latest release number to new and returning users. More accurate and more informative.

Also, it will more accurately reflect the fact that Panel has frequent releases. Now it says 1.4 just released for a very long period,.

The announcement is on every page of the website, so every site visitor sees this...

Thanks to @maximlt for pointing out line 77 of conf py .