### PR TITLE
Update Image.ipynb 02 with added explanation that it selects another, sp…

### DIFF
--- a/examples/reference/panes/Image.ipynb
+++ b/examples/reference/panes/Image.ipynb
@@ -37,8 +37,19 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The ``Image`` pane can be pointed at any local or remote image file. If given a URL starting with ``http`` or ``https``, the ``embed`` parameter determines whether the image will be embedded or linked to:"
+    "The ``Image`` pane embeds any known image format file in panel if provided a local path, or will link to a remote image if provided with a URL.\n",
+    "\n",
+    "The Image pane functions as a sort of \"macro\" pane that selects one of the more specific image panes to display the image (whichever one first recognizes this particular image format).\n",
+    "\n",
+    "Please refer to the [API](https://panel.holoviz.org/api/panel.pane.html#image-module) and [source code](https://github.com/holoviz/panel/blob/main/panel/pane/image.py).\n",
+     "\n",
+     "The classmethod get_pane_type returns the pane_type that was selected.\n",
+     "\n",
+     "\n",
+     "Please consult the documentation of each specific pane (JPG, PNG, SVG, etc.) for the options that particular pane will support.\n",
+     "\n",
    ]
+
   },
   {
    "cell_type": "code",


### PR DESCRIPTION
…ecific image pane to display an image


New commit, with added text explaining that image is a "macro" pane that selects a more specific image pane to display an image. Includes links to the API and source code of the pane.