### PR TITLE
Auth: guard against user being removed

### DIFF
--- a/panel/auth.py
+++ b/panel/auth.py
@@ -1108,8 +1108,8 @@ class OAuthProvider(BasicAuthProvider):
         state._active_users[user] -= 1
         if not state._active_users[user]:
             del state._active_users[user]
-            # Don't remove the user when it's set to an empty dict in the
-            # overrides, as it means it is being refreshed.
+            # Don't remove the user override when it is set to None or
+            # is missing, as this means it is being refreshed.
             if state._oauth_user_overrides.get(user) is not None:
                 del state._oauth_user_overrides[user]
 

--- a/panel/auth.py
+++ b/panel/auth.py
@@ -1005,7 +1005,7 @@ class OAuthProvider(BasicAuthProvider):
             now_ts = dt.datetime.now(dt.timezone.utc).timestamp()
             expiry = None
             if user in state._oauth_user_overrides:
-                while not state._oauth_user_overrides[user]:
+                while not state._oauth_user_overrides.get(user):
                     await asyncio.sleep(0.1)
                 user_state = state._oauth_user_overrides[user]
                 access_token = user_state['access_token']
@@ -1149,7 +1149,7 @@ class OAuthProvider(BasicAuthProvider):
         if user in state._oauth_user_overrides:
             if not state._oauth_user_overrides[user]:
                 # Token is already being refreshed await it
-                while not state._oauth_user_overrides[user]:
+                while not state._oauth_user_overrides.get(user):
                     await asyncio.sleep(0.1)
                 return
             else:

--- a/panel/auth.py
+++ b/panel/auth.py
@@ -1108,7 +1108,9 @@ class OAuthProvider(BasicAuthProvider):
         state._active_users[user] -= 1
         if not state._active_users[user]:
             del state._active_users[user]
-            if user in state._oauth_user_overrides:
+            # Don't remove the user when it's set to an empty dict in the
+            # overrides, as it means it is being refreshed.
+            if state._oauth_user_overrides.get(user) is not None:
                 del state._oauth_user_overrides[user]
 
     def _schedule_refresh(self, expiry_ts, user, refresh_token, application, request):

--- a/panel/auth.py
+++ b/panel/auth.py
@@ -1005,7 +1005,7 @@ class OAuthProvider(BasicAuthProvider):
             now_ts = dt.datetime.now(dt.timezone.utc).timestamp()
             expiry = None
             if user in state._oauth_user_overrides:
-                while not state._oauth_user_overrides.get(user):
+                while not state._oauth_user_overrides[user]:
                     await asyncio.sleep(0.1)
                 user_state = state._oauth_user_overrides[user]
                 access_token = user_state['access_token']
@@ -1149,7 +1149,7 @@ class OAuthProvider(BasicAuthProvider):
         if user in state._oauth_user_overrides:
             if not state._oauth_user_overrides[user]:
                 # Token is already being refreshed await it
-                while not state._oauth_user_overrides.get(user):
+                while not state._oauth_user_overrides[user]:
                     await asyncio.sleep(0.1)
                 return
             else:


### PR DESCRIPTION
A user reported sometimes getting a `KeyError` at line 1008 in `auth.py`.