### PR TITLE
Fix test-CI

### DIFF
--- a/panel/pane/holoviews.py
+++ b/panel/pane/holoviews.py
@@ -37,6 +37,12 @@ if TYPE_CHECKING:
     from pyviz_comms import Comm
 
 
+def check_holoviews(version):
+    import holoviews as hv
+
+    return Version(Version(hv.__version__).base_version) >= Version(version)
+
+
 class HoloViews(PaneBase):
     """
     `HoloViews` panes render any `HoloViews` object using the
@@ -487,8 +493,6 @@ class HoloViews(PaneBase):
         return pane_type(state, **kwargs)
 
     def _render(self, doc, comm, root):
-        import holoviews as hv
-
         from holoviews import Store, renderer as load_renderer
 
         if self.renderer:
@@ -516,7 +520,7 @@ class HoloViews(PaneBase):
                 renderer = renderer.instance(**params)
 
         kwargs = {'margin': self.margin}
-        if backend == 'bokeh' or Version(str(hv.__version__)) >= Version('1.13.0'):
+        if backend == 'bokeh' or check_holoviews('1.13.0'):
             kwargs['doc'] = doc
             kwargs['root'] = root
             if comm:
@@ -807,7 +811,8 @@ def find_links(root_view, root_model):
     plots = [(plot, root_plot) for root_plot in root_plots
              for plot in root_plot.traverse(lambda x: x, [is_bokeh_element_plot])]
 
-    potentials = [(LinkCallback.find_link(plot), root_plot)
+    link_kwargs = {'target': True} if check_holoviews('1.19') else {}
+    potentials = [(LinkCallback.find_link(plot, **link_kwargs), root_plot)
                   for plot, root_plot in plots]
 
     source_links = [p for p in potentials if p[0] is not None]
@@ -818,7 +823,7 @@ def find_links(root_view, root_model):
                 # If link has no target don't look further
                 found.append((link, plot, None))
                 continue
-            potentials = [LinkCallback.find_link(plot, link) for plot, inner_root in plots
+            potentials = [LinkCallback.find_link(plot, link, **link_kwargs) for plot, inner_root in plots
                           if inner_root is not root_plot]
             tgt_links = [p for p in potentials if p is not None]
             if tgt_links:

--- a/panel/tests/conftest.py
+++ b/panel/tests/conftest.py
@@ -12,6 +12,7 @@ import socket
 import tempfile
 import time
 import unittest
+import warnings
 
 from contextlib import contextmanager
 from subprocess import PIPE, Popen
@@ -39,6 +40,13 @@ config.apply_signatures = False
 JUPYTER_PORT = 8887
 JUPYTER_TIMEOUT = 15 # s
 JUPYTER_PROCESS = None
+
+try:
+    with warnings.catch_warnings():
+        warnings.filterwarnings("error", category=DeprecationWarning)
+        asyncio.get_event_loop()
+except (RuntimeError, DeprecationWarning):
+    asyncio.set_event_loop(asyncio.new_event_loop())
 
 def port_open(port):
     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)

--- a/panel/tests/ui/layout/test_feed.py
+++ b/panel/tests/ui/layout/test_feed.py
@@ -46,7 +46,7 @@ def test_feed_view_latest(page):
     expect(feed_el).to_have_class("bk-panel-models-feed-Feed scroll-vertical")
 
     # Assert scroll is not at 0 (view_latest)
-    assert feed_el.evaluate('(el) => el.scrollTop') > 0
+    wait_until(lambda: feed_el.evaluate('(el) => el.scrollTop') > 0, page)
 
     wait_until(lambda: int(page.locator('pre').last.inner_text()) > 0.9 * ITEMS, page)
 

--- a/panel/tests/ui/widgets/test_select.py
+++ b/panel/tests/ui/widgets/test_select.py
@@ -30,4 +30,4 @@ def test_multi_select_double_click(page):
 
     page.locator('option').nth(1).dblclick()
 
-    wait_until(lambda: clicks and clicks[0].option == 'B')
+    wait_until(lambda: bool(clicks) and clicks[0].option == 'B')

--- a/pixi.toml
+++ b/pixi.toml
@@ -127,7 +127,7 @@ nbval = "*"
 channels = ["pyviz/label/dev", "bokeh", "microsoft", "conda-forge"]
 
 [feature.test-ui.dependencies]
-playwright = "*"
+playwright = { version = "*", channel = "microsoft" }
 pytest-playwright = "*"
 jupyter_server = "*"
 


### PR DESCRIPTION
Conda-forge now has `playwright`, though they patched it to remove the download option, and it only works on the UNIX system for now. For now, I will keep using the one from the Microsoft channel. It does seem like the conda-forge equivalent is called `python-playwright`. 

Also, fixing the error shown in https://github.com/holoviz/panel/issues/6902

I think the failing test in `test_param_generator` is because we don't have an event loop, which takes time to start on CI, therefore missing the `wait_until` time. 