### PR TITLE
Ensure redraw does not error out if tabulator undefined

### DIFF
--- a/panel/models/tabulator.ts
+++ b/panel/models/tabulator.ts
@@ -444,7 +444,7 @@ export class DataTabulatorView extends HTMLBoxView {
   }
 
   redraw(columns: boolean = true, rows: boolean = true): void {
-    if (this._building) {
+    if (this._building || this.tabulator != null) {
       return
     }
     if (columns && (this.tabulator.columnManager.element != null)) {


### PR DESCRIPTION
Should address some issues when tabulator is resized before it has actually been rendered.