### PR TITLE
Add support for logout from OAuth provider

### DIFF
--- a/panel/_templates/logout.html
+++ b/panel/_templates/logout.html
@@ -84,6 +84,9 @@
         <p> Successfully logged out.</p>
       </div>
       <div class="form-group">
+        {% if SIGNOUT_ENDPOINT -%}
+	<button class="form-button" onclick="location.href = '{{ SIGNOUT_ENDPOINT }}'">Sign out of SSO</button>
+	{% endif %}
         <button class="form-button" type="submit">Login</button>
       </div>
       <div><small></small></div>


### PR DESCRIPTION
Until now we never logged the user out of the OAuth provider we simply cleared the cookies. This is "usually" the desirable behavior since often the OAuth provider is part of a larger SSO system and you don't want to log someone out of Google/GitHub/Gitlab/Azure/Okta when you're simply wanting to log out of the app. Here we make it possible to log the user out of Okta and make the logout endpoint configurable for the `GenericLoginHandler`.

- [ ] Add tests
- [ ] Update docs