### PR TITLE
Do not trigger ScrollButtonClick event unless clicked

### DIFF
--- a/panel/layout/feed.py
+++ b/panel/layout/feed.py
@@ -192,7 +192,7 @@ class Feed(Column):
         n_visible = self.visible_range[-1] - self.visible_range[0]
         with edit_readonly(self):
             # plus one to center on the last object
-            self.visible_range = (max(n - n_visible + 1, 0), n)
+            self.visible_range = (min(max(n - n_visible + 1, 0), n), n)
 
         with param.discard_events(self):
             # reset the buffers and loaded objects

--- a/panel/models/column.ts
+++ b/panel/models/column.ts
@@ -1,6 +1,14 @@
-import {Column as BkColumn, ColumnView as BkColumnView} from "@bokehjs/models/layouts/column"
+import {ModelEvent} from "@bokehjs/core/bokeh_events"
 import {div} from "@bokehjs/core/dom"
 import type * as p from "@bokehjs/core/properties"
+import type {EventCallback} from "@bokehjs/model"
+import {Column as BkColumn, ColumnView as BkColumnView} from "@bokehjs/models/layouts/column"
+
+export class ScrollButtonClick extends ModelEvent {
+  static {
+    this.prototype.event_name = "scroll_button_click"
+  }
+}
 
 export class ColumnView extends BkColumnView {
   declare model: Column
@@ -70,6 +78,7 @@ export class ColumnView extends BkColumnView {
     })
     this.scroll_down_button_el.addEventListener("click", () => {
       this.scroll_to_latest()
+      this.model.trigger_event(new ScrollButtonClick())
     })
   }
 
@@ -117,5 +126,9 @@ export class Column extends BkColumn {
       scroll_button_threshold: [Int, 0],
       view_latest: [Bool, false],
     }))
+  }
+
+  on_click(callback: EventCallback<ScrollButtonClick>): void {
+    this.on_event(ScrollButtonClick, callback)
   }
 }

--- a/panel/models/feed.ts
+++ b/panel/models/feed.ts
@@ -2,14 +2,6 @@ import {Column, ColumnView} from "./column"
 import type * as p from "@bokehjs/core/properties"
 import {build_views} from "@bokehjs/core/build_views"
 import type {UIElementView} from "@bokehjs/models/ui/ui_element"
-import {ModelEvent} from "@bokehjs/core/bokeh_events"
-import type {EventCallback} from "@bokehjs/model"
-
-export class ScrollButtonClick extends ModelEvent {
-  static {
-    this.prototype.event_name = "scroll_button_click"
-  }
-}
 
 export class FeedView extends ColumnView {
   declare model: Feed
@@ -89,21 +81,13 @@ export class FeedView extends ColumnView {
     return created
   }
 
-  override scroll_to_latest(emit_event: boolean = true): void {
-    if (emit_event) {
-      this.model.trigger_event(new ScrollButtonClick())
-    }
-    super.scroll_to_latest()
-  }
-
   override trigger_auto_scroll(): void {
     const limit = this.model.auto_scroll_limit
     const within_limit = this.distance_from_latest <= limit
     if (limit == 0 || !within_limit) {
       return
     }
-
-    this.scroll_to_latest(false)
+    this.scroll_to_latest()
   }
 }
 
@@ -131,9 +115,5 @@ export class Feed extends Column {
     this.define<Feed.Props>(({List, Str}) => ({
       visible_children: [List(Str), []],
     }))
-  }
-
-  on_click(callback: EventCallback<ScrollButtonClick>): void {
-    this.on_event(ScrollButtonClick, callback)
   }
 }


### PR DESCRIPTION
The `ScrollButtonClick` event was being triggered a bunch due to some incorrect handling. We now move the event into our custom `Column` implementation and only trigger it when the button is actually clicked.