### PR TITLE
Change ChatStep error display

### DIFF
--- a/panel/chat/step.py
+++ b/panel/chat/step.py
@@ -126,7 +126,9 @@ class ChatStep(Card):
         if exc_type is not None:
             if self.failed_title is None:
                 # convert to str to wrap repr in apostrophes
-                self._failed_title = f"Error: {str(exc_value)!r}"
+                self._failed_title = f"Error: {exc_type.__name__!r}"
+                exc_msg = f"{exc_value}" if len(self.objects) == 0 else f"\n{exc_value}"
+                self.stream(exc_msg)
             self.status = "failed"
             raise exc_value
         self.status = "success"

--- a/panel/tests/chat/test_step.py
+++ b/panel/tests/chat/test_step.py
@@ -81,12 +81,15 @@ class TestChatStep:
         with pytest.raises(ValueError):
             with step:
                 raise ValueError("Testing")
+
         assert step.status == "failed", "Status should be 'failed' after an exception"
-        assert step.title == "Error: 'Testing'", "Title should update to 'Error: 'Testing'' on failure"
+        assert step.title == "Error: 'ValueError'", "Title should update to 'Error: 'ValueError'' on failure"
+        assert step.objects[0].object == "Testing", "Error message should be streamed to the message pane"
 
         with pytest.raises(RuntimeError):
             with step:
                 raise RuntimeError("Second Testing")
 
         assert step.status == "failed", "Status should be 'failed' after an exception"
-        assert step.title == "Error: 'Second Testing'", "Title should update to 'Error: 'Second Testing'' on failure again"
+        assert step.title == "Error: 'RuntimeError'", "Title should update to 'Error: 'RuntimeError'' on failure again"
+        assert step.objects[0].object == "Testing\nSecond Testing", "Error message should be streamed to the message pane"


### PR DESCRIPTION
Moves the exc_value into the body of the card, and type into the title.

Before:
<img width="991" alt="image" src="https://github.com/holoviz/panel/assets/15331990/1859e4eb-d303-413a-b53b-1be3d74a5a03">

After:
<img width="990" alt="image" src="https://github.com/holoviz/panel/assets/15331990/97486b0d-c734-495c-a952-9b86263c593b">
