### PR TITLE
Fix docs pyodide code formatting

### DIFF
--- a/doc/how_to/components/add_remove.md
+++ b/doc/how_to/components/add_remove.md
@@ -167,7 +167,7 @@ gridspec
 
 Here is the complete code for this subsection in case you want to easily copy it:
 
-``` {pyodide}
+```{pyodide}
 import panel as pn
 pn.extension() # for notebook
 

--- a/doc/how_to/custom_components/esm/custom_widgets.md
+++ b/doc/how_to/custom_components/esm/custom_widgets.md
@@ -79,7 +79,7 @@ pn.Column(button, button.param.clicks,).servable()
 
 :::{tab-item} `ReactComponent`
 
-```pyodide
+```{pyodide}
 import panel as pn
 import param
 

--- a/examples/reference/custom_components/AnyWidget.md
+++ b/examples/reference/custom_components/AnyWidget.md
@@ -2,7 +2,7 @@
 
 Panel's `AnyWidgetComponent` class simplifies the creation of custom Panel components using the [`AnyWidget`](https://anywidget.dev/) JavaScript API.
 
-```pyodide
+```{pyodide}
 import panel as pn
 import param
 
@@ -70,7 +70,7 @@ For more detail, see [`AnyWidget`](https://anywidget.dev/).
 
 Include CSS within the `_stylesheets` attribute to style the component. The CSS is injected directly into the component's HTML.
 
-```pyodide
+```{pyodide}
 import panel as pn
 import param
 
@@ -121,7 +121,7 @@ StyledCounterButton().servable()
 
 JavaScript dependencies can be directly imported via URLs, such as those from [`esm.sh`](https://esm.sh/).
 
-```pyodide
+```{pyodide}
 import panel as pn
 from panel.custom import AnyWidgetComponent
 

--- a/examples/reference/custom_components/JSComponent.md
+++ b/examples/reference/custom_components/JSComponent.md
@@ -2,7 +2,7 @@
 
 `JSComponent` simplifies the creation of custom Panel components using JavaScript.
 
-```pyodide
+```{pyodide}
 import panel as pn
 import param
 
@@ -87,7 +87,7 @@ The following signatures are valid when listening to change events:
 
 Include CSS within the `_stylesheets` attribute to style the component. The CSS is injected directly into the component's HTML.
 
-```pyodide
+```{pyodide}
 import panel as pn
 import param
 
@@ -135,7 +135,7 @@ StyledCounterButton().servable()
 
 Events from JavaScript can be sent to Python using the `model.send_event` method. Define a *handler* in Python to manage these events. A *handler* is a method on the form `_handle_<name-of-event>(self, event)`:
 
-```pyodide
+```{pyodide}
 import panel as pn
 import param
 
@@ -167,7 +167,7 @@ pn.Column(
 
 You can also define and send your own custom events:
 
-```pyodide
+```{pyodide}
 import datetime
 
 import panel as pn
@@ -209,7 +209,7 @@ pn.Column(
 
 JavaScript dependencies can be directly imported via URLs, such as those from [`esm.sh`](https://esm.sh/).
 
-```pyodide
+```{pyodide}
 import panel as pn
 from panel.custom import JSComponent
 
@@ -235,7 +235,7 @@ ConfettiButton().servable()
 
 Use the `_importmap` attribute for more concise module references.
 
-```pyodide
+```{pyodide}
 import panel as pn
 
 from panel.custom import JSComponent
@@ -337,7 +337,7 @@ You can display Panel components (`Viewable`s) by defining a `Child` parameter.
 
 Lets start with the simplest example:
 
-```pyodide
+```{pyodide}
 import panel as pn
 
 from panel.custom import Child, JSComponent
@@ -358,13 +358,13 @@ Example(child=pn.panel("A **Markdown** pane!")).servable()
 
 If you provide a non-`Viewable` child it will automatically be converted to a `Viewable` by `pn.panel`:
 
-```pyodide
+```{pyodide}
 Example(child="A **Markdown** pane!").servable()
 ```
 
 If you want to allow a certain type of Panel components only you can specify the specific type in the `class_` argument.
 
-```pyodide
+```{pyodide}
 import panel as pn
 
 from panel.custom import Child, JSComponent
@@ -385,7 +385,7 @@ Example(child=pn.panel("A **Markdown** pane!")).servable()
 
 The `class_` argument also supports a tuple of types:
 
-```pyodide
+```{pyodide}
 import panel as pn
 
 from panel.custom import Child, JSComponent
@@ -408,7 +408,7 @@ Example(child=pn.panel("A **Markdown** pane!")).servable()
 
 You can also display a `List` of `Viewable` objects using the `Children` parameter type:
 
-```pyodide
+```{pyodide}
 import panel as pn
 
 from panel.custom import Children, JSComponent

--- a/examples/reference/custom_components/ReactComponent.md
+++ b/examples/reference/custom_components/ReactComponent.md
@@ -2,7 +2,7 @@
 
 `ReactComponent` simplifies the creation of custom Panel components by allowing you to write standard [React](https://react.dev/) code without the need to pre-compile or requiring a deep understanding of Javascript build tooling.
 
-```pyodide
+```{pyodide}
 import panel as pn
 import param
 
@@ -95,7 +95,7 @@ The following signatures are valid when listening to change events:
 
 Include CSS within the `_stylesheets` attribute to style the component. The CSS is injected directly into the component's HTML.
 
-```pyodide
+```{pyodide}
 import panel as pn
 import param
 
@@ -140,7 +140,7 @@ CounterButton().servable()
 
 Events from JavaScript can be sent to Python using the `model.send_event` method. Define a handler in Python to manage these events. A *handler* is a method on the form `_handle_<name-of-event>(self, event)`:
 
-```pyodide
+```{pyodide}
 import panel as pn
 import param
 
@@ -173,7 +173,7 @@ pn.Column(
 
 You can also define and send your own custom events:
 
-```pyodide
+```{pyodide}
 import datetime
 
 import panel as pn
@@ -218,7 +218,7 @@ pn.Column(
 
 JavaScript dependencies can be directly imported via URLs, such as those from [`esm.sh`](https://esm.sh/).
 
-```pyodide
+```{pyodide}
 import panel as pn
 
 from panel.custom import ReactComponent
@@ -244,7 +244,7 @@ ConfettiButton().servable()
 
 Use the `_importmap` attribute for more concise module references.
 
-```pyodide
+```{pyodide}
 import panel as pn
 
 from panel.custom import ReactComponent
@@ -342,7 +342,7 @@ You can display Panel components (`Viewable`s) by defining a `Child` parameter.
 
 Lets start with the simplest example
 
-```pyodide
+```{pyodide}
 import panel as pn
 
 from panel.custom import Child, ReactComponent
@@ -362,13 +362,13 @@ Example(child=pn.panel("A **Markdown** pane!")).servable()
 
 If you provide a non-`Viewable` child it will automatically be converted to a `Viewable` by `pn.panel`:
 
-```pyodide
+```{pyodide}
 Example(child="A **Markdown** pane!").servable()
 ```
 
 If you want to allow a certain type of Panel components only you can specify the specific type in the `class_` argument.
 
-```pyodide
+```{pyodide}
 import panel as pn
 
 from panel.custom import Child, ReactComponent
@@ -388,7 +388,7 @@ Example(child=pn.panel("A **Markdown** pane!")).servable()
 
 The `class_` argument also supports a tuple of types:
 
-```pyodide
+```{pyodide}
 import panel as pn
 
 from panel.custom import Child, ReactComponent
@@ -410,7 +410,7 @@ Example(child=pn.panel("A **Markdown** pane!")).servable()
 
 You can also display a `List` of `Viewable` objects using the `Children` parameter type:
 
-```pyodide
+```{pyodide}
 import panel as pn
 
 from panel.custom import Children, ReactComponent
@@ -441,7 +441,7 @@ You can change the `item_type` to a specific subtype of `Viewable` or a tuple of
 
 The global namespace also contains a `React` object that provides access to React hooks. Here is an example of a simple counter button using the `useState` hook:
 
-```pyodide
+```{pyodide}
 import panel as pn
 
 from panel.custom import ReactComponent

--- a/examples/reference/custom_components/Viewer.md
+++ b/examples/reference/custom_components/Viewer.md
@@ -2,7 +2,7 @@
 
 `Viewer` simplifies the creation of custom Panel components using Python and Panel components only.
 
-```pyodide
+```{pyodide}
 import panel as pn
 import param
 
@@ -58,7 +58,7 @@ None. The `Viewer` class does not have any special attributes. It is a simple `p
 
 You can style the component by styling the component(s) returned by `__panel__` using their `styles` or `stylesheets` attributes.
 
-```pyodide
+```{pyodide}
 import panel as pn
 import param
 
@@ -119,7 +119,7 @@ You can display Panel components (`Viewable`s) by defining a `Child` parameter.
 
 Let's start with the simplest example:
 
-```pyodide
+```{pyodide}
 import panel as pn
 
 from panel.custom import Child
@@ -144,25 +144,25 @@ The `_object` is a workaround to enable the `_layout` to replace the `object` co
 
 Let's replace the `object` with a `Button`:
 
-```pyodide
+```{pyodide}
 single_child.object = pn.widgets.Button(name="Click me")
 ```
 
 Let's change it back
 
-```pyodide
+```{pyodide}
 single_child.object = pn.pane.Markdown("A **Markdown** pane!")
 ```
 
 If you provide a non-`Viewable` child it will automatically be converted to a `Viewable` by `pn.panel`:
 
-```pyodide
+```{pyodide}
 SingleChild(object="A **Markdown** pane!").servable()
 ```
 
 If you want to allow a certain type of Panel components only, you can specify the specific type in the `class_` argument.
 
-```pyodide
+```{pyodide}
 import panel as pn
 
 from panel.custom import Child
@@ -184,7 +184,7 @@ SingleChild(object=pn.pane.Markdown("A **Markdown** pane!")).servable()
 
 The `class_` argument also supports a tuple of types:
 
-```pyodide
+```{pyodide}
 import panel as pn
 
 from panel.custom import Child
@@ -208,7 +208,7 @@ SingleChild(object=pn.pane.Markdown("A **Markdown** pane!")).servable()
 
 You can also display a `List` of `Viewable` objects using the `Children` parameter type:
 
-```pyodide
+```{pyodide}
 import panel as pn
 
 from panel.custom import Children


### PR DESCRIPTION
This PR changes all `pyodide` blocks to `{pyodide}` assuming that this is the recommended way to format Python code blocks in the docs.

Looking at https://holoviz-dev.github.io/panel/reference/custom_components/JSComponent.html it seems with the current `pyodide` without the curly braces the code formatting isn't applied:

<img width="500" alt="Screenshot 2024-06-30 at 14 12 04" src="https://github.com/holoviz/panel/assets/852409/6f80c32f-a26f-43ce-ad37-1428da425cc7">


```