### PR TITLE
Support `value` key for ChatFeed.callback generators

### DIFF
--- a/panel/chat/message.py
+++ b/panel/chat/message.py
@@ -632,6 +632,11 @@ class ChatMessage(Pane):
                 updates["user"] = user
             if avatar:
                 updates["avatar"] = avatar
+            if "value" in updates and "object" in updates:
+                raise ValueError(
+                    "Cannot set both 'value' and 'object' in the update dict."
+                )
+            updates["object"] = updates.pop("value", updates.get("object"))
         elif isinstance(value, ChatMessage):
             if user is not None or avatar is not None:
                 raise ValueError(

--- a/panel/tests/chat/test_feed.py
+++ b/panel/tests/chat/test_feed.py
@@ -699,6 +699,20 @@ class TestChatFeedCallback:
         assert chat_feed.objects[1].object == "Message"
         assert not chat_feed.objects[-1].show_activity_dot
 
+    @pytest.mark.parametrize("key", ["value", "object"])
+    def test_generator_dict(self, chat_feed, key):
+        def echo(contents, user, instance):
+            message = ""
+            for char in contents:
+                message += char
+                yield {key: message}
+
+        chat_feed.callback = echo
+        chat_feed.send("Message", respond=True)
+        wait_until(lambda: len(chat_feed.objects) == 2)
+        assert chat_feed.objects[1].object == "Message"
+        assert chat_feed.objects[-1].object == "Message"
+
     @pytest.mark.asyncio
     async def test_async_generator(self, chat_feed):
         async def async_gen(contents):
@@ -717,6 +731,25 @@ class TestChatFeedCallback:
         await async_wait_until(lambda: len(chat_feed.objects) == 2)
         assert chat_feed.objects[1].object == "Message"
         assert not chat_feed.objects[-1].show_activity_dot
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("key", ["value", "object"])
+    async def test_async_generator_dict(self, chat_feed, key):
+        async def async_gen(contents):
+            for char in contents:
+                yield char
+
+        async def echo(contents, user, instance):
+            message = ""
+            async for char in async_gen(contents):
+                message += char
+                yield {key: message}
+
+        chat_feed.callback = echo
+        chat_feed.send("Message", respond=True)
+        await async_wait_until(lambda: len(chat_feed.objects) == 2)
+        assert chat_feed.objects[1].object == "Message"
+        assert chat_feed.objects[-1].object == "Message"
 
     def test_placeholder_text_params(self, chat_feed):
         def echo(contents, user, instance):


### PR DESCRIPTION
Closes https://github.com/holoviz/panel/issues/6954

We have handling for `value` in `_build_message`, but not for generators.
```

    def _build_message(
        self,
        value: dict,
        user: str | None = None,
        avatar: str | bytes | BytesIO | None = None,
        **input_message_params
    ) -> ChatMessage | None:
        """
        Builds a ChatMessage from the value.
        """
        if "value" in value and "object" in value:
            raise ValueError(f"Cannot pass both 'value' and 'object' together; got {value!r}")
        elif "value" in value:
            value["object"] = value.pop("value")
        elif "object" not in value:
            raise ValueError(
                f"If 'value' is a dict, it must contain an 'object' key, "
                f"e.g. {{'object': 'Hello World'}}; got {value!r}"
            )
```