### PR TITLE
Prevent overriding the existing message user/avatar

### DIFF
--- a/panel/chat/interface.py
+++ b/panel/chat/interface.py
@@ -710,7 +710,7 @@ class ChatInterface(ChatFeed):
         -------
         The message that was updated.
         """
-        if not isinstance(value, ChatMessage):
+        if not isinstance(value, ChatMessage) and not message:
             # ChatMessage cannot set user or avatar when explicitly streaming
             # so only set to the default when not a ChatMessage
             user = user or self.user

--- a/panel/tests/chat/test_interface.py
+++ b/panel/tests/chat/test_interface.py
@@ -458,6 +458,12 @@ class TestChatInterface:
         await asyncio.sleep(0.2)  # give a little time for enabling
         assert not chat_interface.disabled
 
+    def test_prevent_stream_override_message_user_avatar(self, chat_interface):
+        msg = chat_interface.send("Hello", user="Welcoming User", avatar="👋")
+        chat_interface.stream("New Hello", message=msg)
+        assert msg.user == "Welcoming User"
+        assert msg.avatar == "👋"
+
 class TestChatInterfaceWidgetsSizingMode:
     def test_none(self):
         chat_interface = ChatInterface()


### PR DESCRIPTION
Closes https://github.com/holoviz/panel/issues/6957
```python
import panel as pn
pn.extension()

chat = pn.chat.ChatInterface()
chat.show()
msg = chat.send("Hello", user="Hello")
chat.stream("New Hello", message=msg)
assert msg.user == "Hello"  # not true here previously
```