### PR TITLE
Add limit to ChatFeed.serialize 

### DIFF
--- a/panel/chat/feed.py
+++ b/panel/chat/feed.py
@@ -885,6 +885,7 @@ class ChatFeed(ListPanel):
         filter_by: Callable | None = None,
         format: Literal["transformers"] = "transformers",
         custom_serializer: Callable | None = None,
+        limit: int | None = None,
         **serialize_kwargs
     ):
         """
@@ -905,9 +906,10 @@ class ChatFeed(ListPanel):
             A custom function to format the ChatMessage's object. The function must
             accept one positional argument, the ChatMessage object, and return a string.
             If not provided, uses the serialize method on ChatMessage.
+        limit : int
+            The number of messages to serialize at most, starting from the last message.
         **serialize_kwargs
             Additional keyword arguments to use for the specified format.
-
             - format="transformers"
               role_names : dict(str, str | list(str)) | None
                   A dictionary mapping the role to the ChatMessage's user name.
@@ -929,7 +931,7 @@ class ChatFeed(ListPanel):
             exclude_users = [user.lower() for user in exclude_users]
 
         messages = [
-            message for message in self._chat_log.objects
+            message for message in self._chat_log.objects[-limit:]
             if message.user.lower() not in exclude_users
             and message is not self._placeholder
         ]

--- a/panel/chat/feed.py
+++ b/panel/chat/feed.py
@@ -910,6 +910,7 @@ class ChatFeed(ListPanel):
             The number of messages to serialize at most, starting from the last message.
         **serialize_kwargs
             Additional keyword arguments to use for the specified format.
+
             - format="transformers"
               role_names : dict(str, str | list(str)) | None
                   A dictionary mapping the role to the ChatMessage's user name.
@@ -930,8 +931,11 @@ class ChatFeed(ListPanel):
         else:
             exclude_users = [user.lower() for user in exclude_users]
 
+        objects = self._chat_log.objects
+        if limit is not None:
+            objects = objects[-limit:]
         messages = [
-            message for message in self._chat_log.objects[-limit:]
+            message for message in objects
             if message.user.lower() not in exclude_users
             and message is not self._placeholder
         ]

--- a/panel/tests/chat/test_feed.py
+++ b/panel/tests/chat/test_feed.py
@@ -1224,7 +1224,6 @@ class TestChatFeedSerializeForTransformers:
             {"role": "assistant", "content": "I'm a bot"},
         ]
 
-
 @pytest.mark.xdist_group("chat")
 class TestChatFeedSerializeBase:
 

--- a/panel/tests/chat/test_feed.py
+++ b/panel/tests/chat/test_feed.py
@@ -1215,6 +1215,16 @@ class TestChatFeedSerializeForTransformers:
             {"role": "assistant", "content": "Hi User!"}
         ]
 
+    def test_serialize_limit(self):
+        chat_feed = ChatFeed()
+        chat_feed.send("I'm a user", user="user")
+        chat_feed.send("I'm the assistant", user="assistant")
+        chat_feed.send("I'm a bot", user="bot")
+        assert chat_feed.serialize(limit=1) == [
+            {"role": "assistant", "content": "I'm a bot"},
+        ]
+
+
 @pytest.mark.xdist_group("chat")
 class TestChatFeedSerializeBase:
 


### PR DESCRIPTION
Allows limiting the number of messages to serialize.