### PR TITLE
Do not reset Tabulator selection if there was no selection

### DIFF
--- a/panel/widgets/tables.py
+++ b/panel/widgets/tables.py
@@ -1598,7 +1598,7 @@ class Tabulator(BaseTable):
             self._apply_update([], {'max_page': max_page}, model, ref)
 
     def _clear_selection_remote_pagination(self, event):
-        if event.new is not event.old and self.pagination == 'remote':
+        if self.selection and event.new is not event.old and self.pagination == 'remote':
             self.selection = []
 
     def _update_selected(self, *events: param.parameterized.Event, indices=None):


### PR DESCRIPTION
Ensures we do not send a selection reset event if not required.