### PR TITLE
Ensure ChatMessage is serialized to string

### DIFF
--- a/panel/chat/message.py
+++ b/panel/chat/message.py
@@ -342,7 +342,7 @@ class ChatMessage(Pane):
         """
         Serialize the message object to a string.
         """
-        return self.serialize()
+        return str(self.serialize())
 
     @property
     def _synced_params(self) -> list[str]:

--- a/panel/chat/utils.py
+++ b/panel/chat/utils.py
@@ -185,4 +185,8 @@ def serialize_recursively(
     if prefix_with_viewable_label and isinstance(obj, Viewable):
         label = get_obj_label(obj)
         string = f"{label}={string!r}"
+
+    if not isinstance(string, str):
+        string = str(string)
+
     return string

--- a/panel/tests/chat/test_feed.py
+++ b/panel/tests/chat/test_feed.py
@@ -1246,6 +1246,7 @@ class TestChatFeedSerializeForTransformers:
         assert chat_feed.serialize(limit=1) == [
             {"role": "assistant", "content": "I'm a bot"},
         ]
+
     def test_serialize_class(self, chat_feed):
         class Test():
 
@@ -1253,7 +1254,7 @@ class TestChatFeedSerializeForTransformers:
                 return "something"
 
         chat_feed.send(Test())
-        assert chat_feed.serialize() == {"role": "user", "assistant": "something"}
+        assert chat_feed.serialize() == [{"role": "user", "content": "something"}]
 
 
 @pytest.mark.xdist_group("chat")

--- a/panel/tests/chat/test_feed.py
+++ b/panel/tests/chat/test_feed.py
@@ -1246,6 +1246,15 @@ class TestChatFeedSerializeForTransformers:
         assert chat_feed.serialize(limit=1) == [
             {"role": "assistant", "content": "I'm a bot"},
         ]
+    def test_serialize_class(self, chat_feed):
+        class Test():
+
+            def __str__(self):
+                return "something"
+
+        chat_feed.send(Test())
+        assert chat_feed.serialize() == "something"
+
 
 @pytest.mark.xdist_group("chat")
 class TestChatFeedSerializeBase:

--- a/panel/tests/chat/test_feed.py
+++ b/panel/tests/chat/test_feed.py
@@ -1250,11 +1250,11 @@ class TestChatFeedSerializeForTransformers:
     def test_serialize_class(self, chat_feed):
         class Test():
 
-            def __str__(self):
-                return "something"
+            def __repr__(self):
+                return "Test()"
 
         chat_feed.send(Test())
-        assert chat_feed.serialize() == [{"role": "user", "content": "something"}]
+        assert chat_feed.serialize() == [{"role": "user", "content": "Test()"}]
 
 
 @pytest.mark.xdist_group("chat")

--- a/panel/tests/chat/test_feed.py
+++ b/panel/tests/chat/test_feed.py
@@ -1253,7 +1253,7 @@ class TestChatFeedSerializeForTransformers:
                 return "something"
 
         chat_feed.send(Test())
-        assert chat_feed.serialize() == "something"
+        assert chat_feed.serialize() == {"role": "user", "assistant": "something"}
 
 
 @pytest.mark.xdist_group("chat")


### PR DESCRIPTION
This previously would crash.
```python
from lumen.ai.views import LumenOutput
from panel.chat.feed import ChatFeed

class Test():

    def __str__(self):
        return "something"


chat_feed = ChatFeed()
chat_feed.send(Test())
chat_feed.serialize()
```

```python
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
Cell In[2], line 12
     10 chat_feed = ChatFeed()
     11 chat_feed.send(Test())
---> 12 chat_feed.serialize()
     14 # def custom_serializer(message):
     15 #     if isinstance(message, LumenOutput):
     16 #         return message._tabs[0].objects[0].value
   (...)
     19 
     20 # chat.serialize()

File ~/repos/panel/panel/chat/feed.py:953, in ChatFeed.serialize(self, exclude_users, filter_by, format, custom_serializer, limit, **serialize_kwargs)
    950     messages = filter_by(messages)
    952 if format == "transformers":
--> 953     return self._serialize_for_transformers(
    954         messages, custom_serializer=custom_serializer, **serialize_kwargs
    955     )
    956 raise NotImplementedError(f"Format {format!r} is not supported.")

File ~/repos/panel/panel/chat/feed.py:870, in ChatFeed._serialize_for_transformers(self, messages, role_names, default_role, custom_serializer)
    865             raise ValueError(
    866                 f"The provided custom_serializer must return a string; "
    867                 f"it returned a {type(content)} type"
    868             )
    869     else:
--> 870         content = str(message)
    872     serialized_messages.append({"role": role, "content": content})
    873 return serialized_messages

TypeError: __str__ returned non-string (type Test)
```