### PR TITLE
Define GridSpec.objects as ChildDict parameter

### DIFF
--- a/panel/layout/grid.py
+++ b/panel/layout/grid.py
@@ -19,6 +19,7 @@ from bokeh.models import FlexBox as BkFlexBox, GridBox as BkGridBox
 from ..io.document import freeze_doc
 from ..io.model import hold
 from ..io.resources import CDN_DIST
+from ..viewable import ChildDict
 from .base import (
     ListPanel, Panel, _col, _row,
 )
@@ -257,7 +258,7 @@ class GridSpec(Panel):
     >>> gspec
     """
 
-    objects = param.Dict(default={}, doc="""
+    objects = ChildDict(default={}, doc="""
         The dictionary of child objects that make up the grid.""")
 
     mode = param.ObjectSelector(default='warn', objects=['warn', 'error', 'override'], doc="""
@@ -503,7 +504,6 @@ class GridSpec(Panel):
             return list(subgrid)[0][1]
 
     def __setitem__(self, index, obj):
-        from ..pane.base import panel
         if not isinstance(index, tuple):
             raise IndexError('Must supply a 2D index for GridSpec assignment.')
 
@@ -536,7 +536,7 @@ class GridSpec(Panel):
         overlap = key in self.objects
         clone = self.clone(objects=dict(self.objects), mode='override')
         if not overlap:
-            clone.objects[key] = panel(obj)
+            clone.objects[key] = obj
             clone._update_grid_size()
             grid = clone.grid
         else:
@@ -576,5 +576,5 @@ class GridSpec(Panel):
                     del new_objects[dkey]
                 except KeyError:
                     continue
-        new_objects[key] = panel(obj)
+        new_objects[key] = obj
         self.objects = new_objects

--- a/panel/viewable.py
+++ b/panel/viewable.py
@@ -1121,16 +1121,6 @@ class Children(param.List):
     by calling the ``panel`` utility.
     """
 
-    @typing.overload
-    def __init__(
-        self,
-        default=[], *, instantiate=True, bounds=(0, None),
-        allow_None=False, doc=None, label=None, precedence=None,
-        constant=False, readonly=False, pickle_default_value=True, per_instance=True,
-        allow_refs=False, nested_refs=False
-    ):
-        ...
-
     def __init__(
         self, /, default=Undefined, instantiate=Undefined, bounds=Undefined,
         item_type=Viewable, **params
@@ -1158,6 +1148,30 @@ class Children(param.List):
                 v if isinstance(v, Viewable) else panel(v)
                 for v in val
             ]
+        return val
+
+    @instance_descriptor
+    def __set__(self, obj, val):
+        super().__set__(obj, self._transform_value(val))
+
+
+class ChildDict(param.Dict):
+
+    def __init__(
+        self, /, default=Undefined, instantiate=Undefined, **params
+    ):
+        default = self._transform_value(default)
+        super().__init__(
+            default=default, instantiate=instantiate, **params
+        )
+
+    def _transform_value(self, val):
+        if isinstance(val, dict) and val:
+            from .pane import panel
+            val.update({
+                k: v if isinstance(v, Viewable) else panel(v)
+                for k, v in val.items()
+            })
         return val
 
     @instance_descriptor


### PR DESCRIPTION
Aligns grids with other layouts that now use Child parameter types and avoids potential multiple conversion of objects on grid.

- Fixes https://github.com/holoviz/panel/issues/6810