### PR TITLE
Allow providing DataFrame as part of vega(-lite) spec

### DIFF
--- a/panel/pane/vega.py
+++ b/panel/pane/vega.py
@@ -8,6 +8,7 @@ from typing import (
 )
 
 import numpy as np
+import pandas as pd
 import param
 
 from bokeh.models import ColumnDataSource
@@ -26,6 +27,8 @@ def ds_as_cds(dataset):
     """
     Converts Vega dataset into Bokeh ColumnDataSource data
     """
+    if isinstance(dataset, pd.DataFrame):
+        return {k: dataset[k].values for k in dataset.columns}
     if len(dataset) == 0:
         return {}
     # create a list of unique keys from all items as some items may not include optional fields
@@ -237,7 +240,7 @@ class Vega(ModelPane):
         data = json.get('data', {})
         if isinstance(data, dict):
             data = data.pop('values', {})
-            if data:
+            if data is not None and not (isinstance(data, dict) and not data):
                 sources['data'] = ColumnDataSource(data=ds_as_cds(data))
         elif isinstance(data, list):
             for d in data:

--- a/panel/tests/pane/test_vega.py
+++ b/panel/tests/pane/test_vega.py
@@ -11,6 +11,7 @@ except Exception:
 altair_available = pytest.mark.skipif(alt is None, reason="requires altair")
 
 import numpy as np
+import pandas as pd
 
 import panel as pn
 
@@ -32,6 +33,18 @@ vega_example = {
                         {'x': 'C', 'y': 6},
                         {'x': 'D', 'y': 7},
                         {'x': 'E', 'y': 2}]},
+    'mark': 'bar',
+    'encoding': {'x': {'type': 'ordinal', 'field': 'x'},
+                 'y': {'type': 'quantitative', 'field': 'y'}},
+    '$schema': 'https://vega.github.io/schema/vega-lite/v3.2.1.json'
+}
+
+vega_df_example = {
+    'config': {
+        'mark': {'tooltip': None},
+        'view': {'height': 300, 'width': 400}
+    },
+    'data': {'values': pd.DataFrame({'x': ['A', 'B', 'C', 'D', 'E'], 'y': [5, 3, 6, 7, 2]})},
     'mark': 'bar',
     'encoding': {'x': {'type': 'ordinal', 'field': 'x'},
                  'y': {'type': 'quantitative', 'field': 'y'}},
@@ -194,8 +207,9 @@ def test_get_vega_pane_type_from_dict():
     assert PaneBase.get_pane_type(vega_example) is Vega
 
 
-def test_vega_pane(document, comm):
-    pane = pn.panel(vega_example)
+@pytest.mark.parametrize('example', [vega_example, vega_df_example])
+def test_vega_pane(document, comm, example):
+    pane = pn.panel(example)
 
     # Create pane
     model = pane.get_root(document, comm=comm)


### PR DESCRIPTION
Useful when generating vega(-lite) specs directly, e.g. in Lumen.ai.