### PR TITLE
Fix FileDownload with icon

### DIFF
--- a/panel/dist/css/button.css
+++ b/panel/dist/css/button.css
@@ -153,7 +153,3 @@
   justify-content: center;
   padding: 0px;
 }
-
-:host(.bk-panel-models-widgets-FileDownload) .bk-btn .bk-TablerIcon {
-  margin-left: 0.5em;
-}

--- a/panel/models/file_download.ts
+++ b/panel/models/file_download.ts
@@ -9,7 +9,7 @@ import {Icon} from "@bokehjs/models/ui/icons/icon"
 
 import buttons_css, * as buttons from "@bokehjs/styles/buttons.css"
 import type {StyleSheetLike} from "@bokehjs/core/dom"
-import {prepend, nbsp, text, button, input} from "@bokehjs/core/dom"
+import {nbsp, text, button, input} from "@bokehjs/core/dom"
 
 function dataURItoBlob(dataURI: string) {
   // convert base64 to raw binary data held in a string
@@ -97,7 +97,8 @@ export class FileDownloadView extends InputWidgetView {
     })
     if (this.icon_view != null) {
       const separator = this.model.label != "" ? nbsp() : text("")
-      prepend(this.button_el, this.icon_view.el, separator)
+      this.anchor_el.appendChild(this.icon_view.el)
+      this.anchor_el.appendChild(separator)
       this.icon_view.render()
     }
     this._update_button_style()
@@ -200,7 +201,8 @@ export class FileDownloadView extends InputWidgetView {
   }
 
   _update_label(): void {
-    this.anchor_el.textContent = this.model.label
+    const label = document.createTextNode(this.model.label);
+    this.anchor_el.appendChild(label)
   }
 
   _update_button_style(): void {

--- a/panel/models/file_download.ts
+++ b/panel/models/file_download.ts
@@ -201,7 +201,7 @@ export class FileDownloadView extends InputWidgetView {
   }
 
   _update_label(): void {
-    const label = document.createTextNode(this.model.label);
+    const label = document.createTextNode(this.model.label)
     this.anchor_el.appendChild(label)
   }
 


### PR DESCRIPTION
Closes #6972

## Manual Test

```python
import panel as pn

pn.extension()

download = pn.widgets.FileDownload(icon="cloud", file=" ", sizing_mode="stretch_width")
button = pn.widgets.Button(icon="cloud", name="Download", sizing_mode="stretch_width")

download_wo = pn.widgets.FileDownload(file=" ", sizing_mode="stretch_width")
button_wo = pn.widgets.Button(name="Download", sizing_mode="stretch_width")

pn.Column(download, button, download_wo, button_wo).servable()
```

![image](https://github.com/user-attachments/assets/463e04ca-90ba-4436-b021-41ecd24a138b)