### PR TITLE
Align Param docstring

### DIFF
--- a/panel/param.py
+++ b/panel/param.py
@@ -131,6 +131,23 @@ class Param(Pane):
     """
     Param panes render a Parameterized class to a set of widgets which
     are linked to the parameter values on the class.
+
+    Reference: https://panel.holoviz.org/reference/panes/Param.html
+
+    :Example:
+
+    >>> import param
+    >>> import panel as pn
+    >>> pn.extension()
+
+    >>> class App(param.Parameterized):
+    >>>     some_text = param.String(default="Hello")
+    >>>     some_float = param.Number(default=1, bounds=(0, 10), step=0.1)
+    >>>     some_boolean = param.Boolean(default=True)
+
+    >>> app = App()
+
+    >>> pn.Param(app, parameters=["some_text", "some_float"], show_name=False).servable()
     """
 
     display_threshold = param.Number(default=0, precedence=-10, doc="""


### PR DESCRIPTION
Adds "missing" reference link and example.