### PR TITLE
Ensure Design is applied globally when using global templates

### DIFF
--- a/panel/io/state.py
+++ b/panel/io/state.py
@@ -1102,6 +1102,8 @@ class _state(param.Parameterized):
         elif self.curdoc is None and self._template:
             return self._template
         template = config.template(theme=config.theme)
+        if not config.design:
+            config.design = template.design
         if self.curdoc is None:
             self._template = template
         else:

--- a/panel/reactive.py
+++ b/panel/reactive.py
@@ -213,7 +213,11 @@ class Syncable(Renderable):
             wrapped = []
             for stylesheet in stylesheets:
                 if isinstance(stylesheet, str) and stylesheet.split('?')[0].endswith('.css'):
-                    stylesheet = ImportedStyleSheet(url=stylesheet)
+                    cache = state._stylesheets.get(state.curdoc, {})
+                    if stylesheet in cache:
+                        stylesheet = cache[stylesheet]
+                    else:
+                        cache[stylesheet] = stylesheet = ImportedStyleSheet(url=stylesheet)
                 wrapped.append(stylesheet)
             properties['stylesheets'] = wrapped
         return properties

--- a/panel/reactive.py
+++ b/panel/reactive.py
@@ -213,7 +213,7 @@ class Syncable(Renderable):
             wrapped = []
             for stylesheet in stylesheets:
                 if isinstance(stylesheet, str) and stylesheet.split('?')[0].endswith('.css'):
-                    cache = state._stylesheets.get(state.curdoc, {})
+                    cache = (state._stylesheets if state.curdoc else {}).get(state.curdoc, {})
                     if stylesheet in cache:
                         stylesheet = cache[stylesheet]
                     else:

--- a/panel/template/base.py
+++ b/panel/template/base.py
@@ -209,7 +209,7 @@ class BaseTemplate(param.Parameterized, MimeRenderMixin, ServableMixin, Resource
         # Initialize fake root. This is needed to ensure preprocessors
         # which assume that all models are owned by a single root can
         # link objects across multiple roots in a template.
-        col = Column()
+        col = Column(design=self.design)
         preprocess_root = col.get_root(document, comm, preprocess=False)
         col._hooks.append(self._design._apply_hooks)
         ref = preprocess_root.ref['id']
@@ -220,7 +220,8 @@ class BaseTemplate(param.Parameterized, MimeRenderMixin, ServableMixin, Resource
         tracked_models = set()
         for name, (obj, tags) in self._render_items.items():
             # Render root without pre-processing
-            model = obj.get_root(document, comm, preprocess=False)
+            with config.set(design=self.design):
+                model = obj.get_root(document, comm, preprocess=False)
             model.name = name
             model.tags = model.tags + [tag for tag in tags if tag not in model.tags]
             mref = model.ref['id']

--- a/panel/template/base.py
+++ b/panel/template/base.py
@@ -209,7 +209,7 @@ class BaseTemplate(param.Parameterized, MimeRenderMixin, ServableMixin, Resource
         # Initialize fake root. This is needed to ensure preprocessors
         # which assume that all models are owned by a single root can
         # link objects across multiple roots in a template.
-        col = Column(design=self.design)
+        col = Column()
         preprocess_root = col.get_root(document, comm, preprocess=False)
         col._hooks.append(self._design._apply_hooks)
         ref = preprocess_root.ref['id']

--- a/panel/theme/base.py
+++ b/panel/theme/base.py
@@ -121,15 +121,18 @@ class Design(param.Parameterized, ResourceComponent):
         isolated: bool=True, cache=None, document=None
     ) -> None:
         ref = root.ref['id']
+        seen = set()
         for o in viewable.select():
             if o.design and not isolated:
                 continue
             elif not o.design and not isolated:
                 o._design = self
 
-            if old_models and ref in o._models:
-                if o._models[ref][0] in old_models:
+            if ref in o._models:
+                model = o._models[ref][0]
+                if (old_models and model in old_models) or model in seen:
                     continue
+                seen.add(model)
             self._apply_modifiers(o, ref, self.theme, isolated, cache, document)
 
     def _apply_hooks(self, viewable: Viewable, root: Model, changed: Viewable, old_models=None) -> None:
@@ -285,8 +288,8 @@ class Design(param.Parameterized, ResourceComponent):
                 del props['stylesheets']
             else:
                 props['stylesheets'] = stylesheets
-
-        model.update(**props)
+        if props:
+            model.update(**props)
         if hasattr(viewable, '_synced_properties') and 'objects' in viewable._property_mapping:
             obj_key = viewable._property_mapping['objects']
             child_props = {

--- a/panel/viewable.py
+++ b/panel/viewable.py
@@ -302,7 +302,6 @@ class Layoutable(param.Parameterized):
         super().__init__(**params)
 
 
-
 class ServableMixin:
     """
     Mixin to define methods shared by objects which can served.
@@ -385,6 +384,9 @@ class ServableMixin:
                 assert template is not None
                 if template.title == template.param.title.default and title:
                     template.title = title
+                for obj in self.select():
+                    if not obj.design:
+                        obj.design = template.design
                 if area == 'main':
                     template.main.append(self)
                 elif area == 'sidebar':


### PR DESCRIPTION
Includes a number of optimizations and fixes when applying a `Design`, specifically:

- Always cache the creation of `ImportedStyleSheet`
- If an app uses `pn.state.template` the template's design is applied globally (for the session)
- Design modifiers are only applied once per model (e.g. ensuring that wrapper components have final say on the themes applied to the model)