### PR TITLE
Ensure Feed does not scroll to latest entry on every render

### DIFF
--- a/panel/chat/feed.py
+++ b/panel/chat/feed.py
@@ -758,6 +758,7 @@ class ChatFeed(ListPanel):
             self.stream(steps_column, user=user, avatar=avatar)
         else:
             steps_column.append(step)
+            self._chat_log.scroll_to_latest()
         return step
 
     def respond(self):

--- a/panel/layout/feed.py
+++ b/panel/layout/feed.py
@@ -6,8 +6,7 @@ from typing import (
 
 import param
 
-from ..models import Feed as PnFeed
-from ..models.feed import ScrollButtonClick
+from ..models.feed import Feed as PnFeed, ScrollButtonClick, ScrollLatestEvent
 from ..util import edit_readonly
 from .base import Column
 
@@ -78,6 +77,7 @@ class Feed(Column):
 
         super().__init__(*objects, **params)
         self._last_synced = None
+        self.param.watch(self._trigger_view_latest, 'objects')
 
     @param.depends("visible_range", "load_buffer", watch=True)
     def _trigger_get_objects(self):
@@ -98,6 +98,12 @@ class Feed(Column):
         )
         if top_trigger or bottom_trigger or invalid_trigger:
             self.param.trigger("objects")
+
+    def _trigger_view_latest(self, event):
+        if (event.type == 'triggered' or not self.view_latest or
+            not event.new or event.new[-1] in event.old):
+            return
+        self.scroll_to_latest()
 
     @property
     def _synced_range(self):
@@ -197,3 +203,9 @@ class Feed(Column):
         with param.discard_events(self):
             # reset the buffers and loaded objects
             self.load_buffer = load_buffer
+
+    def scroll_to_latest(self):
+        """
+        Scrolls the Feed to the latest entry.
+        """
+        self._send_event(ScrollLatestEvent)

--- a/panel/layout/feed.py
+++ b/panel/layout/feed.py
@@ -208,7 +208,7 @@ class Feed(Column):
         """
         Scrolls the Feed to the latest entry.
         """
-        rerender = self.visible_range and self.visible_range[-1] < len(self.objects)
+        rerender = self._last_synced and self._last_synced[-1] < len(self.objects)
         if rerender:
             self._process_event()
         self._send_event(ScrollLatestEvent, rerender=rerender)

--- a/panel/layout/feed.py
+++ b/panel/layout/feed.py
@@ -181,7 +181,7 @@ class Feed(Column):
             new_models.append(child)
         return new_models, old_models
 
-    def _process_event(self, event: ScrollButtonClick) -> None:
+    def _process_event(self, event: ScrollButtonClick | None = None) -> None:
         """
         Process a scroll button click event.
         """
@@ -208,4 +208,7 @@ class Feed(Column):
         """
         Scrolls the Feed to the latest entry.
         """
-        self._send_event(ScrollLatestEvent)
+        rerender = self.visible_range and self.visible_range[-1] < len(self.objects)
+        if rerender:
+            self._process_event()
+        self._send_event(ScrollLatestEvent, rerender=rerender)

--- a/panel/models/feed.py
+++ b/panel/models/feed.py
@@ -1,7 +1,20 @@
+from typing import Any
+
 from bokeh.core.properties import List, String
 from bokeh.events import ModelEvent
 
 from .layout import Column
+
+
+class ScrollLatestEvent(ModelEvent):
+
+    event_name = 'scroll_latest_event'
+
+    def __init__(self, model):
+        super().__init__(model=model)
+
+    def event_values(self) -> dict[str, Any]:
+        return dict(super().event_values())
 
 
 class ScrollButtonClick(ModelEvent):

--- a/panel/models/feed.py
+++ b/panel/models/feed.py
@@ -10,11 +10,12 @@ class ScrollLatestEvent(ModelEvent):
 
     event_name = 'scroll_latest_event'
 
-    def __init__(self, model):
+    def __init__(self, model, rerender=False):
         super().__init__(model=model)
+        self.rerender = rerender
 
     def event_values(self) -> dict[str, Any]:
-        return dict(super().event_values())
+        return dict(super().event_values(), rerender=self.rerender)
 
 
 class ScrollButtonClick(ModelEvent):

--- a/panel/models/feed.ts
+++ b/panel/models/feed.ts
@@ -71,7 +71,7 @@ export class FeedView extends ColumnView {
     this.model.on_event(ScrollLatestEvent, (event: ScrollLatestEvent) => {
       this.scroll_to_latest()
       if (event.rerender) {
-	this._rendered = false
+        this._rendered = false
       }
     })
   }
@@ -120,7 +120,6 @@ export class FeedView extends ColumnView {
 
     return created
   }
-
 
   override render(): void {
     this._rendered = false

--- a/panel/reactive.py
+++ b/panel/reactive.py
@@ -894,7 +894,8 @@ class Reactive(Syncable, Viewable):
             event = Event(model=model, **event_kwargs)
             _viewable, root, doc, comm = state._views[ref]
             if comm or state._unblocked(doc) or not doc.session_context:
-                doc.callbacks.send_event(event)
+                with unlocked():
+                    doc.callbacks.send_event(event)
                 if comm and 'embedded' not in root.tags:
                     push(doc, comm)
             else:

--- a/panel/tests/ui/layout/test_feed.py
+++ b/panel/tests/ui/layout/test_feed.py
@@ -67,8 +67,6 @@ def test_feed_view_scroll_to_latest(page):
     feed.scroll_to_latest()
 
     wait_until(lambda: int(page.locator('pre').last.inner_text() or 0) > 0.9 * ITEMS, page)
-    import time
-    time.sleep(5)
 
 def test_feed_view_scroll_button(page):
     feed = Feed(*list(range(ITEMS)), height=250, scroll_button_threshold=50)

--- a/panel/tests/ui/layout/test_feed.py
+++ b/panel/tests/ui/layout/test_feed.py
@@ -50,6 +50,26 @@ def test_feed_view_latest(page):
 
     wait_until(lambda: int(page.locator('pre').last.inner_text()) > 0.9 * ITEMS, page)
 
+def test_feed_view_scroll_to_latest(page):
+    feed = Feed(*list(range(ITEMS)), height=250)
+    serve_component(page, feed)
+
+    feed_el = page.locator(".bk-panel-models-feed-Feed")
+
+    bbox = feed_el.bounding_box()
+    assert bbox["height"] == 250
+
+    expect(feed_el).to_have_class("bk-panel-models-feed-Feed scroll-vertical")
+
+    # Assert scroll is not at 0 (view_latest)
+    wait_until(lambda: feed_el.evaluate('(el) => el.scrollTop') == 0, page)
+
+    feed.scroll_to_latest()
+
+    wait_until(lambda: int(page.locator('pre').last.inner_text() or 0) > 0.9 * ITEMS, page)
+    import time
+    time.sleep(5)
+
 def test_feed_view_scroll_button(page):
     feed = Feed(*list(range(ITEMS)), height=250, scroll_button_threshold=50)
     serve_component(page, feed)


### PR DESCRIPTION
Previously whenever you scrolled on a `Feed` with `view_latest` enabled it would scroll to the last entry every time new items were streamed in, this was both extremely annoying and simply incorrect. Now we explicitly trigger scroll events from the server whenever a new item is appended.