### PR TITLE
Fix issue detecting PyScript worker

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -197,6 +197,9 @@ jobs:
         with:
           environments: ${{ matrix.environment }}
         id: install
+      - name: Build pyodide wheels
+        shell: pixi run -e test-ui bash -el {0}
+        run: python ./scripts/build_pyodide_wheels.py
       - name: Launch JupyterLab
         shell: pixi run -e test-ui bash -el {0}
         run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -198,8 +198,7 @@ jobs:
           environments: ${{ matrix.environment }}
         id: install
       - name: Build pyodide wheels
-        shell: pixi run -e test-ui bash -el {0}
-        run: python ./scripts/build_pyodide_wheels.py
+        run: pixi run -e test-ui "python ./scripts/build_pyodide_wheels.py"
       - name: Launch JupyterLab
         shell: pixi run -e test-ui bash -el {0}
         run: |

--- a/panel/__version.py
+++ b/panel/__version.py
@@ -17,7 +17,7 @@ try:
 
         # This will fail with LookupError if the package is not installed in
         # editable mode or if Git is not installed.
-        __version__ = get_version(root="..", relative_to=__file__)
+        __version__ = get_version(root="..", relative_to=__file__, version_scheme="post-release")
     else:
         raise FileNotFoundError
 except (ImportError, LookupError, FileNotFoundError):

--- a/panel/io/convert.py
+++ b/panel/io/convert.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import base64
 import concurrent.futures
 import dataclasses
 import json
@@ -42,8 +43,9 @@ BOKEH_VERSION = base_version(bokeh.__version__)
 PY_VERSION = base_version(__version__)
 PYODIDE_VERSION = 'v0.25.0'
 PYSCRIPT_VERSION = '2024.2.1'
-PANEL_LOCAL_WHL = DIST_DIR / 'wheels' / f'panel-{__version__.replace("-dirty", "")}-py3-none-any.whl'
-BOKEH_LOCAL_WHL = DIST_DIR / 'wheels' / f'bokeh-{BOKEH_VERSION}-py3-none-any.whl'
+WHL_PATH = DIST_DIR / 'wheels'
+PANEL_LOCAL_WHL = WHL_PATH / f'panel-{__version__.replace("-dirty", "")}-py3-none-any.whl'
+BOKEH_LOCAL_WHL = WHL_PATH / f'bokeh-{BOKEH_VERSION}-py3-none-any.whl'
 PANEL_CDN_WHL = f'{CDN_DIST}wheels/panel-{PY_VERSION}-py3-none-any.whl'
 BOKEH_CDN_WHL = f'{CDN_ROOT}wheels/bokeh-{BOKEH_VERSION}-py3-none-any.whl'
 PYODIDE_URL = f'https://cdn.jsdelivr.net/pyodide/{PYODIDE_VERSION}/full/pyodide.js'
@@ -342,7 +344,14 @@ def script_to_html(
     if template in (BASE_TEMPLATE, FILE):
         # Add loading.css if not served from Panel template
         if inline:
-            loading_base = (DIST_DIR / "css" / "loading.css").read_text(encoding='utf-8')
+            svg_name = f'{config.loading_spinner}_spinner.svg'
+            svg_b64 = base64.b64encode((DIST_DIR / 'assets' / svg_name).read_bytes()).decode('utf-8')
+            loading_base = (
+                DIST_DIR / "css" / "loading.css"
+            ).read_text(encoding='utf-8').replace(
+                f'../assets/{svg_name}', f'data:image/svg+xml;base64,{svg_b64}'
+            )
+            print(loading_base)
             loading_style = f'<style type="text/css">\n{loading_base}\n</style>'
         else:
             loading_style = f'<link rel="stylesheet" href="{CDN_DIST}css/loading.css" type="text/css" />'

--- a/panel/io/convert.py
+++ b/panel/io/convert.py
@@ -351,7 +351,6 @@ def script_to_html(
             ).read_text(encoding='utf-8').replace(
                 f'../assets/{svg_name}', f'data:image/svg+xml;base64,{svg_b64}'
             )
-            print(loading_base)
             loading_style = f'<style type="text/css">\n{loading_base}\n</style>'
         else:
             loading_style = f'<link rel="stylesheet" href="{CDN_DIST}css/loading.css" type="text/css" />'

--- a/panel/io/pyodide.py
+++ b/panel/io/pyodide.py
@@ -48,10 +48,10 @@ try:
         if _IN_PYSCRIPT_WORKER:
             from pyscript import window
             js.window = window
-        _IN_WORKER = True
+        _IN_WORKER = False
     except Exception:
         _IN_PYSCRIPT_WORKER = False
-        _IN_WORKER = False
+        _IN_WORKER = True
 except Exception:
     try:
         # Initial version of PyScript Next Worker support did not patch js.document

--- a/panel/io/pyodide.py
+++ b/panel/io/pyodide.py
@@ -59,9 +59,10 @@ except Exception:
             from pyscript import document, window
             js.document = document
             js.window = window
+        _IN_WORKER = False
     except Exception:
         _IN_PYSCRIPT_WORKER = False
-    _IN_WORKER = True
+        _IN_WORKER = True
 
 # Ensure we don't try to load MPL WASM backend in worker
 if _IN_WORKER:

--- a/panel/io/pyodide.py
+++ b/panel/io/pyodide.py
@@ -48,10 +48,9 @@ try:
         if _IN_PYSCRIPT_WORKER:
             from pyscript import window
             js.window = window
-        _IN_WORKER = False
     except Exception:
         _IN_PYSCRIPT_WORKER = False
-        _IN_WORKER = True
+    _IN_WORKER = False
 except Exception:
     try:
         # Initial version of PyScript Next Worker support did not patch js.document

--- a/panel/io/resources.py
+++ b/panel/io/resources.py
@@ -747,7 +747,9 @@ class Resources(BkResources):
 
         # Add loading spinner
         if config.global_loading_spinner:
-            loading_base = (DIST_DIR / "css" / "loading.css").read_text(encoding='utf-8')
+            loading_base = (DIST_DIR / "css" / "loading.css").read_text(encoding='utf-8').replace(
+                '../assets', self.dist_dir
+            )
             raw.extend([loading_base, loading_css(
                 config.loading_spinner, config.loading_color, config.loading_max_height
             )])

--- a/panel/tests/ui/io/test_convert.py
+++ b/panel/tests/ui/io/test_convert.py
@@ -34,6 +34,7 @@ else:
 
 _worker_id = os.environ.get("PYTEST_XDIST_WORKER", "0")
 HTTP_PORT = 50000 + int(re.sub(r"\D", "", _worker_id))
+RUNTIMES = ['pyodide', 'pyscript', 'pyodide-worker', 'pyscript-worker']
 
 button_app = """
 import panel as pn
@@ -174,7 +175,7 @@ def test_pyodide_test_error_handling_worker(http_serve, page):
     expect(page.locator('.pn-loading-msg')).to_have_text('RuntimeError: This app is broken', timeout=TIMEOUT)
 
 
-@pytest.mark.parametrize('runtime', ['pyodide', 'pyscript', 'pyodide-worker'])
+@pytest.mark.parametrize('runtime', RUNTIMES)
 def test_pyodide_test_convert_button_app(http_serve, page, runtime):
     msgs = wait_for_app(http_serve, button_app, page, runtime)
 
@@ -187,7 +188,7 @@ def test_pyodide_test_convert_button_app(http_serve, page, runtime):
     assert [msg for msg in msgs if msg.type == 'error' and 'favicon' not in msg.location['url']] == []
 
 
-@pytest.mark.parametrize('runtime', ['pyodide', 'pyscript', 'pyodide-worker'])
+@pytest.mark.parametrize('runtime', RUNTIMES)
 def test_pyodide_test_convert_template_button_app(http_serve, page, runtime):
     msgs = wait_for_app(http_serve, button_app, page, runtime)
 
@@ -200,7 +201,7 @@ def test_pyodide_test_convert_template_button_app(http_serve, page, runtime):
     assert [msg for msg in msgs if msg.type == 'error' and 'favicon' not in msg.location['url']] == []
 
 
-@pytest.mark.parametrize('runtime', ['pyodide', 'pyscript', 'pyodide-worker'])
+@pytest.mark.parametrize('runtime', RUNTIMES)
 def test_pyodide_test_convert_slider_app(http_serve, page, runtime):
     msgs = wait_for_app(http_serve, slider_app, page, runtime)
 
@@ -214,7 +215,7 @@ def test_pyodide_test_convert_slider_app(http_serve, page, runtime):
     assert [msg for msg in msgs if msg.type == 'error' and 'favicon' not in msg.location['url']] == []
 
 
-@pytest.mark.parametrize('runtime', ['pyodide', 'pyscript', 'pyodide-worker'])
+@pytest.mark.parametrize('runtime', RUNTIMES)
 def test_pyodide_test_convert_custom_config(http_serve, page, runtime):
     wait_for_app(http_serve, config_app, page, runtime)
 

--- a/panel/tests/ui/io/test_convert.py
+++ b/panel/tests/ui/io/test_convert.py
@@ -2,12 +2,9 @@ import os
 import pathlib
 import re
 import shutil
-import sys
 import tempfile
 import time
 import uuid
-
-from subprocess import PIPE, Popen
 
 import pytest
 
@@ -17,6 +14,7 @@ from playwright.sync_api import expect
 
 from panel.config import config
 from panel.io.convert import BOKEH_LOCAL_WHL, PANEL_LOCAL_WHL, convert_apps
+from panel.tests.util import http_serve_directory
 
 if not (PANEL_LOCAL_WHL.is_file() and BOKEH_LOCAL_WHL.is_file()):
     pytest.skip(
@@ -27,6 +25,7 @@ if not (PANEL_LOCAL_WHL.is_file() and BOKEH_LOCAL_WHL.is_file()):
 
 pytestmark = pytest.mark.ui
 
+
 if os.name == "wt":
     TIMEOUT = 150_000
 else:
@@ -34,6 +33,7 @@ else:
 
 _worker_id = os.environ.get("PYTEST_XDIST_WORKER", "0")
 HTTP_PORT = 50000 + int(re.sub(r"\D", "", _worker_id))
+HTTP_URL = f"http://localhost:{HTTP_PORT}/"
 RUNTIMES = ['pyodide', 'pyscript', 'pyodide-worker', 'pyscript-worker']
 
 button_app = """
@@ -129,10 +129,10 @@ def http_serve():
     except shutil.SameFileError:
         pass
 
-    process = Popen(
-        [sys.executable, "-m", "http.server", str(HTTP_PORT), "--directory", str(temp_path)], stdout=PIPE,
-    )
-    time.sleep(10)  # Wait for server to start
+    httpd, _ = http_serve_directory(str(temp_path), port=HTTP_PORT)
+
+
+    time.sleep(1)
 
     def write(app):
         app_name = uuid.uuid4().hex
@@ -143,8 +143,7 @@ def http_serve():
 
     yield write
 
-    process.terminate()
-    process.wait()
+    httpd.shutdown()
 
 
 def wait_for_app(http_serve, app, page, runtime, wait=True, **kwargs):
@@ -152,13 +151,14 @@ def wait_for_app(http_serve, app, page, runtime, wait=True, **kwargs):
 
     convert_apps(
         [app_path], app_path.parent, runtime=runtime, build_pwa=False,
-        prerender=False, panel_version='local', inline=True, **kwargs
+        prerender=False, panel_version='local', inline=True,
+        local_prefix=HTTP_URL, **kwargs
     )
 
     msgs = []
     page.on("console", lambda msg: msgs.append(msg))
 
-    page.goto(f"http://127.0.0.1:{HTTP_PORT}/{app_path.name[:-3]}.html")
+    page.goto(f"{HTTP_URL}{app_path.name[:-3]}.html")
 
     cls = f'pn-loading pn-{config.loading_spinner}'
     expect(page.locator('body')).to_have_class(cls)
@@ -185,6 +185,8 @@ def test_pyodide_test_convert_button_app(http_serve, page, runtime):
 
     expect(page.locator('pre:not([class])')).to_have_text('1')
 
+    import pdb
+    pdb.set_trace()
     assert [msg for msg in msgs if msg.type == 'error' and 'favicon' not in msg.location['url']] == []
 
 

--- a/panel/tests/ui/io/test_convert.py
+++ b/panel/tests/ui/io/test_convert.py
@@ -185,8 +185,6 @@ def test_pyodide_test_convert_button_app(http_serve, page, runtime):
 
     expect(page.locator('pre:not([class])')).to_have_text('1')
 
-    import pdb
-    pdb.set_trace()
     assert [msg for msg in msgs if msg.type == 'error' and 'favicon' not in msg.location['url']] == []
 
 

--- a/pixi.toml
+++ b/pixi.toml
@@ -135,6 +135,7 @@ channels = ["pyviz/label/dev", "bokeh", "microsoft", "conda-forge"]
 playwright = { version = "*", channel = "microsoft" }
 pytest-playwright = "*"
 jupyter_server = "*"
+packaging = "*"
 
 [feature.test-ui.tasks]
 _install-ui = 'playwright install chromium'


### PR DESCRIPTION
This fixes an issue that @antocuni and @WebReflection heroically tracked down. Specifically the issue is that Panel makes various assumptions on which JS APIs it can use in a pyodide context based on whether `js.document` is defined. These assumptions do not hold when we are in a PyScript worker because there [`coincident`](https://github.com/WebReflection/coincident) is used to automatically proxy various JS APIs without having to rely on the custom JS <-> JS Worker message-passing implementation that Panel ships.  The logic was incorrectly setting `IN_WORKER=True` when we were in a PyScript worker, which in turn causes Panel to make incorrect assumptions on how to pass messages and access DOM APIs.

Fixes https://github.com/holoviz/panel/issues/6995