### PR TITLE
Fix chat step stream none bug

### DIFF
--- a/panel/chat/step.py
+++ b/panel/chat/step.py
@@ -210,7 +210,7 @@ class ChatStep(Card):
             original = getattr(self, f"{status}_title") or ""
             setattr(self, f"{status}_title", original + token)
 
-    def stream(self, token: str, replace: bool = False):
+    def stream(self, token: str | None, replace: bool = False):
         """
         Stream a token to the last available string-like object.
 
@@ -226,6 +226,9 @@ class ChatStep(Card):
         Viewable
             The updated message pane.
         """
+        if token is None:
+            token = ""
+
         if (
             len(self.objects) == 0 or not isinstance(self.objects[-1], HTMLBasePane) or isinstance(self.objects[-1], ImageBase)
         ):

--- a/panel/tests/chat/test_step.py
+++ b/panel/tests/chat/test_step.py
@@ -93,3 +93,12 @@ class TestChatStep:
         assert step.status == "failed", "Status should be 'failed' after an exception"
         assert step.title == "Error: 'RuntimeError'", "Title should update to 'Error: 'RuntimeError'' on failure again"
         assert step.objects[0].object == "Testing\nSecond Testing", "Error message should be streamed to the message pane"
+
+    def test_stream_none(self):
+        step = ChatStep()
+        step.stream(None)
+        assert len(step) == 1
+        assert step[0].object == ""
+        step.stream("abc")
+        assert len(step) == 1
+        assert step[0].object == "abc"


### PR DESCRIPTION
Casts None to "".

Without these changes, it would hang indefinitely on `self.append(Markdown(None))`.