### PR TITLE
Improvements for ChatInterface

### DIFF
--- a/panel/chat/feed.py
+++ b/panel/chat/feed.py
@@ -705,6 +705,7 @@ class ChatFeed(ListPanel):
         append: bool = True,
         user: str | None = None,
         avatar: str | bytes | BytesIO | None = None,
+        steps_column: Column | None = None,
         **step_params
     ) -> ChatStep:
         """
@@ -723,6 +724,9 @@ class ChatFeed(ListPanel):
         avatar : str | bytes | BytesIO | None
             The avatar to use; overrides the message's avatar if provided.
             Will default to the avatar parameter. Only applicable if steps is "new".
+        steps_column : Column | None
+            An existing Column of steps to stream to, if None is provided
+            it will default to the last Column of steps or create a new one.
         step_params : dict
             Parameters to pass to the ChatStep.
         """
@@ -740,7 +744,6 @@ class ChatFeed(ListPanel):
                 for obj in step
             ]
             step = ChatStep(**step_params)
-        steps_column = None
         if append:
             last = self._chat_log[-1] if self._chat_log else None
             if last is not None and isinstance(last.object, Column) and (

--- a/panel/chat/interface.py
+++ b/panel/chat/interface.py
@@ -681,6 +681,7 @@ class ChatInterface(ChatFeed):
         avatar: str | bytes | BytesIO | None = None,
         message: ChatMessage | None = None,
         replace: bool = False,
+        **message_params
     ) -> ChatMessage | None:
         """
         Streams a token and updates the provided message, if provided.
@@ -715,4 +716,4 @@ class ChatInterface(ChatFeed):
             # so only set to the default when not a ChatMessage
             user = user or self.user
             avatar = avatar or self.avatar
-        return super().stream(value, user=user, avatar=avatar, message=message, replace=replace)
+        return super().stream(value, user=user, avatar=avatar, message=message, replace=replace, **message_params)


### PR DESCRIPTION
- `ChatInterface.stream` did not pass through the message params to the superclass method
- `ChatFeed.add_step` now accepts the `steps_column` to add a step to