### PR TITLE
Add `context_exception` to ChatStep

### DIFF
--- a/examples/reference/chat/ChatStep.ipynb
+++ b/examples/reference/chat/ChatStep.ipynb
@@ -27,6 +27,7 @@
     "##### Core\n",
     "\n",
     "* **`collapsed_on_success`** (`bool`): Whether to collapse the card on completion. Defaults to `True`.\n",
+    "* **`context_exception`** (`str`): How to handle exceptions raised upon exiting the context manager. If \"raise\", the exception will be raised. If \"summary\", a summary will be sent to the chat step. If \"verbose\", the full traceback will be sent to the chat step. If \"ignore\", the exception will be ignored.\n",
     "* **`success_title`** (`str`): Title to display when status is success; if not provided and `collapsed_on_success` uses the last object's string. Defaults to `None`.\n",
     "* **`default_title`** (`str`): The default title to display if the other title params are unset. Defaults to an empty string `\"\"`.\n",
     "* **`failed_title`** (`str`): Title to display when status is failed. Defaults to `None`.\n",

--- a/panel/chat/feed.py
+++ b/panel/chat/feed.py
@@ -739,6 +739,8 @@ class ChatFeed(ListPanel):
                 )
                 for obj in step
             ]
+            if "context_exception" not in step_params:
+                step_params["context_exception"] = self.callback_exception
             step = ChatStep(**step_params)
         steps_column = None
         if append:

--- a/panel/chat/step.py
+++ b/panel/chat/step.py
@@ -78,7 +78,7 @@ class ChatStep(Card):
         After, it cannot be set directly; instead use the *_title params.""")
 
     context_exception = param.ObjectSelector(
-        default="summary", objects=["raise", "summary", "verbose", "ignore"], doc="""
+        default="verbose", objects=["raise", "summary", "verbose", "ignore"], doc="""
         How to handle exceptions raised upon exiting the context manager.
         If "raise", the exception will be raised.
         If "summary", a summary will be sent to the chat feed.

--- a/panel/chat/step.py
+++ b/panel/chat/step.py
@@ -44,7 +44,7 @@ class ChatStep(Card):
         Whether to collapse the card on completion.""")
 
     context_exception = param.ObjectSelector(
-        default="verbose", objects=["raise", "summary", "verbose", "ignore"], doc="""
+        default="raise", objects=["raise", "summary", "verbose", "ignore"], doc="""
         How to handle exceptions raised upon exiting the context manager.
         If "raise", the exception will be raised.
         If "summary", a summary will be sent to the chat feed.

--- a/panel/chat/step.py
+++ b/panel/chat/step.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import traceback
+
 from typing import ClassVar, Literal, Mapping
 
 import param
@@ -41,6 +43,15 @@ class ChatStep(Card):
     collapsed_on_success = param.Boolean(default=True, doc="""
         Whether to collapse the card on completion.""")
 
+    context_exception = param.ObjectSelector(
+        default="verbose", objects=["raise", "summary", "verbose", "ignore"], doc="""
+        How to handle exceptions raised upon exiting the context manager.
+        If "raise", the exception will be raised.
+        If "summary", a summary will be sent to the chat feed.
+        If "verbose", the full traceback will be sent to the chat feed.
+        If "ignore", the exception will be ignored.
+        """)
+
     success_title = param.String(default=None, doc="""
         Title to display when status is success.""")
 
@@ -77,17 +88,9 @@ class ChatStep(Card):
         The title of the chat step. Will redirect to default_title on init.
         After, it cannot be set directly; instead use the *_title params.""")
 
-    context_exception = param.ObjectSelector(
-        default="verbose", objects=["raise", "summary", "verbose", "ignore"], doc="""
-        How to handle exceptions raised upon exiting the context manager.
-        If "raise", the exception will be raised.
-        If "summary", a summary will be sent to the chat feed.
-        If "verbose", the full traceback will be sent to the chat feed.
-        If "ignore", the exception will be ignored.
-        """)
-
     _rename: ClassVar[Mapping[str, str | None]] = {
         "collapsed_on_success": None,
+        "context_exception": None,
         "default_badges": None,
         "default_title": None,
         "pending_title": None,
@@ -131,26 +134,27 @@ class ChatStep(Card):
         self.status = "running"
         return self
 
-    def __exit__(self, exc_type, exc_value, traceback):
+    def __exit__(self, exc_type, exc_value, tb):
         if exc_type is not None and self.context_exception != "ignore":
             if self.failed_title is None:
                 # convert to str to wrap repr in apostrophes
                 self._failed_title = f"Error: {exc_type.__name__!r}"
-                if self.context_exception == "summary":
+                if self.context_exception == "summary" or self.context_exception == "raise":
                     exc_msg = f"{exc_value}"
                 elif self.context_exception == "verbose":
-                    exc_msg = f"{exc_value}\n{traceback}"
+                    exc_msg = "```python\n" + "\n".join(traceback.format_exception(exc_type, exc_value, tb)) + "\n```"
                 else:
                     exc_msg = None
 
                 if len(self.objects) == 1:
                     exc_msg = f"\n{exc_msg}"
                 self.stream(exc_msg)
-
             self.status = "failed"
             if self.context_exception == "raise":
-                raise exc_value
-        self.status = "success"
+                return False
+        else:
+            self.status = "success"
+        return True  # suppress exception if any
 
     @param.depends("status", "default_badges", watch=True)
     def _render_avatar(self):

--- a/panel/chat/step.py
+++ b/panel/chat/step.py
@@ -47,8 +47,8 @@ class ChatStep(Card):
         default="raise", objects=["raise", "summary", "verbose", "ignore"], doc="""
         How to handle exceptions raised upon exiting the context manager.
         If "raise", the exception will be raised.
-        If "summary", a summary will be sent to the chat feed.
-        If "verbose", the full traceback will be sent to the chat feed.
+        If "summary", a summary will be sent to the chat step.
+        If "verbose", the full traceback will be sent to the chat step.
         If "ignore", the exception will be ignored.
         """)
 

--- a/panel/tests/chat/test_feed.py
+++ b/panel/tests/chat/test_feed.py
@@ -290,6 +290,13 @@ class TestChatFeed:
         assert len(steps2[0].objects) == 1
         assert steps2[0].objects[0].object == "Object 2"
 
+    def test_add_step_inherits_callback_exception(self, chat_feed):
+        chat_feed.callback_exception = "verbose"
+        with chat_feed.add_step("Object", title="Title") as step:
+            assert step.callback_exception == "verbose"
+            raise ValueError("Testing")
+        assert "Traceback" in step.objects[0].object
+
     def test_stream_with_user_avatar(self, chat_feed):
         user = "Bob"
         avatar = "👨"

--- a/panel/tests/chat/test_step.py
+++ b/panel/tests/chat/test_step.py
@@ -94,6 +94,31 @@ class TestChatStep:
         assert step.title == "Error: 'RuntimeError'", "Title should update to 'Error: 'RuntimeError'' on failure again"
         assert step.objects[0].object == "Testing\nSecond Testing", "Error message should be streamed to the message pane"
 
+    def test_context_exception_ignore(self):
+        step = ChatStep(context_exception="ignore")
+        with step:
+            raise ValueError("Testing")
+        assert step.objects == []
+
+    def test_context_exception_raise(self):
+        step = ChatStep(context_exception="raise")
+        with pytest.raises(ValueError, match="Testing"):
+            with step:
+                raise ValueError("Testing")
+        assert step.objects[0].object == "Testing"
+
+    def test_context_exception_summary(self):
+        step = ChatStep(context_exception="summary")
+        with step:
+            raise ValueError("Testing")
+        assert step.objects[0].object == "Testing"
+
+    def test_context_exception_verbose(self):
+        step = ChatStep(context_exception="verbose")
+        with step:
+            raise ValueError("Testing")
+        assert "Traceback" in step.objects[0].object
+
     def test_stream_none(self):
         step = ChatStep()
         step.stream(None)


### PR DESCRIPTION
It was really frustrating to see a summary of the exception

<img width="646" alt="image" src="https://github.com/user-attachments/assets/ba8dadf5-8f5d-4421-a263-173473f112cc">

But have no idea where it came from while debugging; this PR makes it so that the ChatStep exception handling inherits `callback_exception` from ChatFeed. 

I'm not sure if `ChatStep` should also call it `callback_exception` since it's not really a callback, so I went with `context_exception`.

