### PR TITLE
fix header input color

### DIFF
--- a/panel/theme/css/fast.css
+++ b/panel/theme/css/fast.css
@@ -307,7 +307,7 @@ table.panel-df {
   background-color: var(--neutral-fill-input-rest);
   border: 1px solid var(--accent-fill-rest);
   border-radius: calc(var(--control-corner-radius) * 1px);
-  color: var(--neutral-foreground-rest);
+  color: var(--foreground-on-accent-rest);
   font-size: var(--type-ramp-base-font-size);
   height: calc(
     (var(--base-height-multiplier) + var(--density)) * var(--design-unit) * 1px


### PR DESCRIPTION
Closes https://github.com/holoviz/panel/issues/6510

I couldn't actually get it to point to the updated stylesheet even with `panel build panel` and cache clear, but I'm fairly certain this is the change needed

<img width="943" alt="image" src="https://github.com/user-attachments/assets/4e837a54-0a07-4d51-8a97-f293ec9ef7e5">

Because if I change it in the browser

<img width="1299" alt="image" src="https://github.com/user-attachments/assets/ae8a060c-cba4-4a33-bae3-4f903939cbc4">

The CSS var is based off the theme toggle

<img width="1153" alt="image" src="https://github.com/user-attachments/assets/00a6f886-8b27-453e-8eb7-1b1d179a4f92">

