### PR TITLE
Add placeholder while loading to ChatFeed

### DIFF
--- a/panel/chat/feed.py
+++ b/panel/chat/feed.py
@@ -337,6 +337,13 @@ class ChatFeed(ListPanel):
             **self.placeholder_params
         )
 
+    @param.depends("loading", watch=True, on_init=True)
+    def _show_placeholder(self):
+        if self.loading:
+            self.append(self._placeholder)
+        else:
+            self._replace_placeholder(None)
+
     def _replace_placeholder(self, message: ChatMessage | None = None) -> None:
         """
         Replace the placeholder from the chat log with the message
@@ -348,6 +355,8 @@ class ChatFeed(ListPanel):
                 self.append(message)
 
             try:
+                if self.loading:
+                    return
                 self.remove(self._placeholder)
             except ValueError:
                 pass

--- a/panel/tests/chat/test_feed.py
+++ b/panel/tests/chat/test_feed.py
@@ -40,6 +40,12 @@ class TestChatFeed:
         assert message.object == "Instructions"
         assert message.user == "Help"
 
+    def test_init_with_loading(self):
+        chat_feed = ChatFeed(loading=True)
+        assert chat_feed._placeholder in chat_feed._chat_log
+        chat_feed.loading = False
+        assert chat_feed._placeholder not in chat_feed._chat_log
+
     def test_update_header(self):
         chat_feed = ChatFeed(header="1")
         assert chat_feed._card.header == "1"
@@ -1135,6 +1141,17 @@ class TestChatFeedCallback:
         chat_feed.send("Message", respond=True)
         wait_until(lambda: len(chat_feed.objects) == 2)
         assert chat_feed.objects[1].object == "User: Message"
+
+    def test_persist_placeholder_while_loading(self, chat_feed):
+        def callback(contents):
+            assert chat_feed._placeholder in chat_feed._chat_log
+            return "hey testing"
+
+        chat_feed.loading = True
+        chat_feed.callback = callback
+        chat_feed.send("Message", respond=True)
+        assert chat_feed._placeholder in chat_feed._chat_log
+
 
 @pytest.mark.xdist_group("chat")
 class TestChatFeedSerializeForTransformers:


### PR DESCRIPTION
To indicate activity while some callbacks are blocking, I've been wanting to have some control over the loading spinner, and have it persist.

https://github.com/user-attachments/assets/7bdd4855-4cc3-4a17-8379-c1ce7806a32f

```python
import asyncio
import panel as pn

pn.extension()

async def callback(message):
    await asyncio.sleep(2)
    return message


chat = pn.chat.ChatInterface(callback=callback, callback_exception="verbose", loading=True)
chat.servable()
```