### PR TITLE
Update conf.py with corrected hyperlink

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -45,7 +45,7 @@ html_favicon = "_static/icons/favicon.ico"
 
 current_release = panel.__version__  # Current release version variable
 
-announcement_text = f"Panel {current_release} has just been released! Check out the <a href='https://panel.holoviz.org/about/releases.html#version-1-4-0'>release notes</a> and support Panel by giving it a 🌟 on <a href='https://github.com/holoviz/panel'>Github</a>."
+announcement_text = f"Panel {current_release} has just been released! Check out the <a href='https://panel.holoviz.org/about/releases.html'>release notes</a> and support Panel by giving it a 🌟 on <a href='https://github.com/holoviz/panel'>Github</a>."
 
 
 html_theme_options = {


### PR DESCRIPTION
Aa discussed with @Maximlt, In the below section, the url:

https://panel.holoviz.org/about/releases.html#version-1-4-0

Was changed to:

https://panel.holoviz.org/about/releases.html

See below for comment and explanation:

https://github.com/holoviz/panel/pull/6903#pullrequestreview-2108660028




announcement_text = f"Panel {current_release} has just been released! Check out the <a href='https://panel.holoviz.org/about/releases.html#version-1-4-0'>release notes</a> and support Panel by giving it a 🌟 on <a href='https://github.com/holoviz/panel'>Github</a>."