### PR TITLE
Minify Player/DiscretePlayer with scale_buttons/visible_buttons/visible_loop_options

### DIFF
--- a/examples/reference/widgets/DiscretePlayer.ipynb
+++ b/examples/reference/widgets/DiscretePlayer.ipynb
@@ -37,9 +37,12 @@
     "\n",
     "* **``disabled``** (boolean): Whether the widget is editable\n",
     "* **``name``** (str): The title of the widget\n",
+    "* **``scale_buttons``** (float): The scaling factor to resize the buttons\n",
     "* **``show_loop_controls``** (boolean): Whether radio buttons allowing to switch between loop policies options are shown\n",
     "* **``show_value``** (boolean): Whether to display the value of the player\n",
     "* **``value_align``** (str): Where to display the value; must be one of 'start', 'center', 'end'\n",
+    "* **``visible_buttons``** (list[str]): The buttons to display on the player ('slower', 'first', 'previous', 'reverse', 'pause', 'play', 'next', 'last', 'faster')\n",
+    "* **``visible_loop_options``** (list[str]): The loop options to display on the player. ('once', 'loop', 'reflect')\n",
     "\n",
     "___"
    ]
@@ -105,6 +108,23 @@
     "discrete_player.reverse()\n",
     "time.sleep(2)\n",
     "discrete_player.pause()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The `DiscretePlayer` can be slimmed down by setting `scale_buttons`, `show_loop_controls`, `visible_buttons`, and/or `visible_loop_options`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "discrete_player = pn.widgets.DiscretePlayer(name='Player', visible_buttons=[\"play\", \"pause\"], scale_buttons=0.9, show_loop_controls=False, width=150)\n",
+    "discrete_player"
    ]
   },
   {

--- a/examples/reference/widgets/Player.ipynb
+++ b/examples/reference/widgets/Player.ipynb
@@ -39,9 +39,12 @@
     "\n",
     "* **``disabled``** (boolean): Whether the widget is editable\n",
     "* **``name``** (str): The title of the widget\n",
+    "* **``scale_buttons``** (float): The scaling factor to resize the buttons\n",
     "* **``show_loop_controls``** (boolean): Whether radio buttons allowing to switch between loop policies options are shown\n",
     "* **``show_value``** (boolean): Whether to display the value of the player\n",
     "* **``value_align``** (str): Where to display the value; must be one of 'start', 'center', 'end'\n",
+    "* **``visible_buttons``** (list[str]): The buttons to display on the player ('slower', 'first', 'previous', 'reverse', 'pause', 'play', 'next', 'last', 'faster')\n",
+    "* **``visible_loop_options``** (list[str]): The loop options to display on the player. ('once', 'loop', 'reflect')\n",
     "\n",
     "___"
    ]
@@ -107,6 +110,23 @@
     "player.reverse()\n",
     "time.sleep(2)\n",
     "player.pause()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The `Player` can be slimmed down by setting `scale_buttons`, `show_loop_controls`, `visible_buttons`, and/or `visible_loop_options`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "player = pn.widgets.Player(name='Player', visible_buttons=[\"play\", \"pause\"], scale_buttons=0.9, show_loop_controls=False, width=150)\n",
+    "player"
    ]
   },
   {

--- a/panel/models/player.ts
+++ b/panel/models/player.ts
@@ -5,56 +5,15 @@ import {Widget, WidgetView} from "@bokehjs/models/widgets/widget"
 import {to_string} from "@bokehjs/core/util/pretty"
 
 const SVG_STRINGS = {
-  slower: '<svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-minus" width="12" \
- height="12" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none"\
-  stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" \
-   fill="none"/><path d="M5 12l14 0" /></svg>',
-  first: '<svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-player-track-prev-filled" \
- width="12" height="12" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" \
-  stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/>\
-   <path d="M20.341 4.247l-8 7a1 1 0 0 0 0 1.506l8 7c.647 .565 1.659 .106 1.659 -.753v-14c0 -.86 \
-    -1.012 -1.318 -1.659 -.753z" stroke-width="0" fill="currentColor" /><path d="M9.341 4.247l-8 7a1 \
-     1 0 0 0 0 1.506l8 7c.647 .565 1.659 .106 1.659 -.753v-14c0 -.86 -1.012 -1.318 -1.659 -.753z" \
-      stroke-width="0" fill="currentColor" /></svg>',
-  previous: '<svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-player-skip-back-filled" \
- width="12" height="12" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" \
-  stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/> \
-   <path d="M19.496 4.136l-12 7a1 1 0 0 0 0 1.728l12 7a1 1 0 0 0 1.504 -.864v-14a1 1 0 0 0 -1.504 -.864z" \
-    stroke-width="0" fill="currentColor" /><path d="M4 4a1 1 0 0 1 .993 .883l.007 .117v14a1 1 0 0 1 -1.993 \
-     .117l-.007 -.117v-14a1 1 0 0 1 1 -1z" stroke-width="0" fill="currentColor" /></svg>',
-  reverse: '<svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-player-play-filled"\
- width="12" height="12" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none"\
-  stroke-linecap="round" stroke-linejoin="round" style="transform: scaleX(-1);"><path stroke="none"\
-   d="M0 0h24v24H0z" fill="none"/><path d="M6 4v16a1 1 0 0 0 1.524 .852l13 -8a1 1 0 0 0 0 -1.704l-13\
-    -8a1 1 0 0 0 -1.524 .852z" stroke-width="0" fill="currentColor" /></svg>',
-  pause: '<svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-player-pause-filled" \
- width="12" height="12" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" \
-  stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" \
-   fill="none"/><path d="M9 4h-2a2 2 0 0 0 -2 2v12a2 2 0 0 0 2 2h2a2 2 0 0 0 2 -2v-12a2 2 0 \
-    0 0 -2 -2z" stroke-width="0" fill="currentColor" /><path d="M17 4h-2a2 2 0 0 0 -2 2v12a2 \
-     2 0 0 0 2 2h2a2 2 0 0 0 2 -2v-12a2 2 0 0 0 -2 -2z" stroke-width="0" fill="currentColor" /></svg>',
-  play: '<svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-player-play-filled" \
- width="12" height="12" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" \
-  stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" \
-   fill="none"/><path d="M6 4v16a1 1 0 0 0 1.524 .852l13 -8a1 1 0 0 0 0 -1.704l-13 -8a1 \
-    1 0 0 0 -1.524 .852z" stroke-width="0" fill="currentColor" /></svg>',
-  next: '<svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-player-skip-forward-filled" \
- width="12" height="12" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" \
-  stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/> \
-  <path d="M3 5v14a1 1 0 0 0 1.504 .864l12 -7a1 1 0 0 0 0 -1.728l-12 -7a1 1 0 0 0 -1.504 .864z" \
-   stroke-width="0" fill="currentColor" /><path d="M20 4a1 1 0 0 1 .993 .883l.007 .117v14a1 1 0 0 \
-    1 -1.993 .117l-.007 -.117v-14a1 1 0 0 1 1 -1z" stroke-width="0" fill="currentColor" /></svg>',
-  last: '<svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-player-track-next-filled" \
- width="12" height="12" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" \
-  stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" \
-   fill="none"/><path d="M2 5v14c0 .86 1.012 1.318 1.659 .753l8 -7a1 1 0 0 0 0 -1.506l-8 \
-   -7c-.647 -.565 -1.659 -.106 -1.659 .753z" stroke-width="0" fill="currentColor" /><path \
-    d="M13 5v14c0 .86 1.012 1.318 1.659 .753l8 -7a1 1 0 0 0 0 -1.506l-8 -7c-.647 -.565 -1.659 \
-     -.106 -1.659 .753z" stroke-width="0" fill="currentColor" /></svg>',
-  faster: '<svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-plus" \
- width="12" height="12" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" \
-  stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" \
-   fill="none"/><path d="M12 5l0 14" /><path d="M5 12l14 0" /></svg>',
+  slower: '<svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-minus" width="12" height="12" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M5 12l14 0" /></svg>',
+  first: '<svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-player-track-prev-filled" width="12" height="12" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M20.341 4.247l-8 7a1 1 0 0 0 0 1.506l8 7c.647 .565 1.659 .106 1.659 -.753v-14c0 -.86 -1.012 -1.318 -1.659 -.753z" stroke-width="0" fill="currentColor" /><path d="M9.341 4.247l-8 7a1 1 0 0 0 0 1.506l8 7c.647 .565 1.659 .106 1.659 -.753v-14c0 -.86 -1.012 -1.318 -1.659 -.753z" stroke-width="0" fill="currentColor" /></svg>',
+  previous: '<svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-player-skip-back-filled" width="12" height="12" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M19.496 4.136l-12 7a1 1 0 0 0 0 1.728l12 7a1 1 0 0 0 1.504 -.864v-14a1 1 0 0 0 -1.504 -.864z" stroke-width="0" fill="currentColor" /><path d="M4 4a1 1 0 0 1 .993 .883l.007 .117v14a1 1 0 0 1 -1.993 .117l-.007 -.117v-14a1 1 0 0 1 1 -1z" stroke-width="0" fill="currentColor" /></svg>',
+  reverse: '<svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-player-play-filled" width="12" height="12" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round" style="transform: scaleX(-1);"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M6 4v16a1 1 0 0 0 1.524 .852l13 -8a1 1 0 0 0 0 -1.704l-13 -8a1 1 0 0 0 -1.524 .852z" stroke-width="0" fill="currentColor" /></svg>',
+  pause: '<svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-player-pause-filled" width="12" height="12" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M9 4h-2a2 2 0 0 0 -2 2v12a2 2 0 0 0 2 2h2a2 2 0 0 0 2 -2v-12a2 2 0 0 0 -2 -2z" stroke-width="0" fill="currentColor" /><path d="M17 4h-2a2 2 0 0 0 -2 2v12a2 2 0 0 0 2 2h2a2 2 0 0 0 2 -2v-12a2 2 0 0 0 -2 -2z" stroke-width="0" fill="currentColor" /></svg>',
+  play: '<svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-player-play-filled" width="12" height="12" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M6 4v16a1 1 0 0 0 1.524 .852l13 -8a1 1 0 0 0 0 -1.704l-13 -8a1 1 0 0 0 -1.524 .852z" stroke-width="0" fill="currentColor" /></svg>',
+  next: '<svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-player-skip-forward-filled" width="12" height="12" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M3 5v14a1 1 0 0 0 1.504 .864l12 -7a1 1 0 0 0 0 -1.728l-12 -7a1 1 0 0 0 -1.504 .864z" stroke-width="0" fill="currentColor" /><path d="M20 4a1 1 0 0 1 .993 .883l.007 .117v14a1 1 0 0 1 -1.993 .117l-.007 -.117v-14a1 1 0 0 1 1 -1z" stroke-width="0" fill="currentColor" /></svg>',
+  last: '<svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-player-track-next-filled" width="12" height="12" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M2 5v14c0 .86 1.012 1.318 1.659 .753l8 -7a1 1 0 0 0 0 -1.506l-8 -7c-.647 -.565 -1.659 -.106 -1.659 .753z" stroke-width="0" fill="currentColor" /><path d="M13 5v14c0 .86 1.012 1.318 1.659 .753l8 -7a1 1 0 0 0 0 -1.506l-8 -7c-.647 -.565 -1.659 -.106 -1.659 .753z" stroke-width="0" fill="currentColor" /></svg>',
+  faster: '<svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-plus" width="12" height="12" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M12 5l0 14" /><path d="M5 12l14 0" /></svg>',
 }
 
 function press(btn_list: HTMLButtonElement[]): void {
@@ -81,10 +40,20 @@ export class PlayerView extends WidgetView {
   protected slowerButton: HTMLButtonElement
   protected fasterButton: HTMLButtonElement
 
+  protected slower: HTMLButtonElement
+  protected first: HTMLButtonElement
+  protected previous: HTMLButtonElement
+  protected reverse: HTMLButtonElement
+  protected pause: HTMLButtonElement
+  protected play: HTMLButtonElement
+  protected next: HTMLButtonElement
+  protected last: HTMLButtonElement
+  protected faster: HTMLButtonElement
+
   override connect_signals(): void {
     super.connect_signals()
 
-    const {title, value_align, direction, value, loop_policy, disabled, show_loop_controls, show_value} = this.model.properties
+    const {title, value_align, direction, value, loop_policy, disabled, show_loop_controls, show_value, scale_buttons, visible_buttons} = this.model.properties
     this.on_change(title, () => this.update_title_and_value())
     this.on_change(value_align, () => this.set_value_align())
     this.on_change(direction, () => this.set_direction())
@@ -99,7 +68,9 @@ export class PlayerView extends WidgetView {
       }
     })
     this.on_change(show_value, () => this.update_title_and_value())
-
+    this.on_change(scale_buttons, () => this.update_css())
+    this.on_change(visible_buttons, () => this.update_css())
+    this.on_change(this.model.properties.visible_loop_options, () => this.update_css())
   }
 
   toggle_disable() {
@@ -119,6 +90,58 @@ export class PlayerView extends WidgetView {
 
   get_height(): number {
     return 250
+  }
+
+  update_css(): void {
+    const button_style_small = `text-align: center; flex-grow: 1; margin: 2px; transform: scale(${this.model.scale_buttons}); max-width: 50px;`
+    const button_style = `text-align: center; flex-grow: 2; margin: 2px; transform: scale(${this.model.scale_buttons}); max-width: 50px;`;
+
+    const buttons = {
+      slower: this.slower,
+      first: this.first,
+      previous: this.previous,
+      reverse: this.reverse,
+      pause: this.pause,
+      play: this.play,
+      next: this.next,
+      last: this.last,
+      faster: this.faster
+    };
+
+    for (const [name, button] of Object.entries(buttons)) {
+      if (button) {
+        if (this.model.visible_buttons.includes(name)) {
+          button.style.display = ''; // Reset to default display
+          if (name === 'slower' || name === 'faster') {
+            button.style.cssText += button_style_small;
+          } else {
+            button.style.cssText += button_style;
+          }
+        } else {
+          button.style.display = 'none'; // Hide the button completely
+        }
+      }
+    }
+
+
+    for (const el of this.loop_state.children) {
+      if (el.tagName.toLowerCase() == "input") {
+        const anyEl = el as any
+        if (this.model.visible_loop_options.includes(anyEl.value)) {
+          anyEl.style.display = ''
+        } else {
+          anyEl.style.display = 'none'
+        }
+      }
+      else if (el.tagName.toLowerCase() == "label") {
+        const anyEl = el as any
+        if (this.model.visible_loop_options.includes(anyEl.innerHTML.toLowerCase())) {
+          anyEl.style.display = ''
+        } else {
+          anyEl.style.display = 'none'
+        }
+      }
+    }
   }
 
   override render(): void {
@@ -162,86 +185,62 @@ export class PlayerView extends WidgetView {
     this.buttonEl = button_div
     button_div.style.cssText = "margin: 0 auto; display: flex; padding: 5px; align-items: stretch; justify-content: center; width: 100%;"
 
-    const button_style_small = `text-align: center; flex-grow: 1; margin: 2px; transform: scale(${this.model.button_scale})`
-    const button_style = `text-align: center; flex-grow: 2; margin: 2px; transform: scale(${this.model.button_scale})`;
+    this.slower = document.createElement("button")
+    this.slower.innerHTML = SVG_STRINGS.slower
+    this.slower.onclick = () => this.slower_speed()
+    button_div.appendChild(this.slower)
 
-    const slower = document.createElement("button")
-    slower.classList.add("slower")
-    slower.style.cssText = button_style_small
-    slower.innerHTML = SVG_STRINGS.slower
-    slower.onclick = () => this.slower()
-    this.slowerButton = slower
-    button_div.appendChild(slower)
+    this.first = document.createElement("button")
+    this.first.innerHTML = SVG_STRINGS.first
+    this.first.onclick = () => this.first_frame()
+    button_div.appendChild(this.first)
 
-    const first = document.createElement("button")
-    first.classList.add("first")
-    first.style.cssText = button_style
-    first.innerHTML = SVG_STRINGS.first
-    first.onclick = () => this.first_frame()
-    button_div.appendChild(first)
+    this.previous = document.createElement("button")
+    this.previous.innerHTML = SVG_STRINGS.previous
+    this.previous.onclick = () => this.previous_frame()
+    button_div.appendChild(this.previous)
 
-    const previous = document.createElement("button")
-    previous.classList.add("previous")
-    previous.style.cssText = button_style
-    previous.innerHTML = SVG_STRINGS.previous
-    previous.onclick = () => this.previous_frame()
-    button_div.appendChild(previous)
+    this.reverse = document.createElement("button")
+    this.reverse.innerHTML = SVG_STRINGS.reverse
+    this.reverse.onclick = () => this.reverse_animation()
+    button_div.appendChild(this.reverse)
 
-    const reverse = document.createElement("button")
-    reverse.classList.add("reverse")
-    reverse.style.cssText = button_style
-    reverse.innerHTML = SVG_STRINGS.reverse
-    reverse.onclick = () => this.reverse_animation()
-    button_div.appendChild(reverse)
+    this.pause = document.createElement("button")
+    this.pause.innerHTML = SVG_STRINGS.pause
+    this.pause.onclick = () => this.pause_animation()
+    button_div.appendChild(this.pause)
 
-    const pause = document.createElement("button")
-    pause.classList.add("pause")
-    pause.style.cssText = button_style
-    pause.innerHTML = SVG_STRINGS.pause
-    pause.onclick = () => this.pause_animation()
-    button_div.appendChild(pause)
+    this.play = document.createElement("button")
+    this.play.innerHTML = SVG_STRINGS.play
+    this.play.onclick = () => this.play_animation()
+    button_div.appendChild(this.play)
+    this.next = document.createElement("button")
+    this.next.innerHTML = SVG_STRINGS.next
+    this.next.onclick = () => this.next_frame()
+    button_div.appendChild(this.next)
 
-    const play = document.createElement("button")
-    play.classList.add("play")
-    play.style.cssText = button_style
-    play.innerHTML = SVG_STRINGS.play
-    play.onclick = () => this.play_animation()
-    button_div.appendChild(play)
+    this.last = document.createElement("button")
+    this.last.innerHTML = SVG_STRINGS.last
+    this.last.onclick = () => this.last_frame()
+    button_div.appendChild(this.last)
 
-    const next = document.createElement("button")
-    next.classList.add("next")
-    next.style.cssText = button_style
-    next.innerHTML = SVG_STRINGS.next
-    next.onclick = () => this.next_frame()
-    button_div.appendChild(next)
-
-    const last = document.createElement("button")
-    last.classList.add("last")
-    last.style.cssText = button_style
-    last.innerHTML = SVG_STRINGS.last
-    last.onclick = () => this.last_frame()
-    button_div.appendChild(last)
-
-    const faster = document.createElement("button")
-    faster.classList.add("faster")
-    faster.style.cssText = button_style_small
-    faster.innerHTML = SVG_STRINGS.faster
-    faster.onclick = () => this.faster()
-    this.fasterButton = faster
-    button_div.appendChild(faster)
+    this.faster = document.createElement("button")
+    this.faster.innerHTML = SVG_STRINGS.faster
+    this.faster.onclick = () => this.faster_speed()
+    button_div.appendChild(this.faster)
 
     // toggle
     this._toggle_reverse = () => {
-      unpress([pause, play])
-      press([reverse])
+      unpress([this.pause, this.play])
+      press([this.reverse])
     }
     this._toogle_pause = () => {
-      unpress([reverse, play])
-      press([pause])
+      unpress([this.reverse, this.play])
+      press([this.pause])
     }
     this._toggle_play = () => {
-      unpress([reverse, pause])
-      press([play])
+      unpress([this.reverse, this.pause])
+      press([this.play])
     }
 
     // Loop control
@@ -296,6 +295,7 @@ export class PlayerView extends WidgetView {
     }
 
     this.toggle_disable()
+    this.update_css()
     this.shadow_el.appendChild(this.groupEl)
   }
 
@@ -405,7 +405,7 @@ export class PlayerView extends WidgetView {
     }, this.model.preview_duration) // Show for 1.5 seconds
   }
 
-  slower(): void {
+  slower_speed(): void {
     this.model.interval = Math.round(this.model.interval / 0.7)
     this.updateSpeedButton(this.slowerButton, this.model.interval, SVG_STRINGS.slower)
     if (this.model.direction > 0) {
@@ -415,7 +415,7 @@ export class PlayerView extends WidgetView {
     }
   }
 
-  faster(): void {
+  faster_speed(): void {
     this.model.interval = Math.round(this.model.interval * 0.7)
     this.updateSpeedButton(this.fasterButton, this.model.interval, SVG_STRINGS.faster)
     if (this.model.direction > 0) {
@@ -524,6 +524,9 @@ export namespace Player {
     show_loop_controls: p.Property<boolean>
     show_value: p.Property<boolean>
     button_scale: p.Property<number>
+    scale_buttons: p.Property<number>
+    visible_buttons: p.Property<string[]>
+    visible_loop_options: p.Property<string[]>
   }
 }
 
@@ -542,7 +545,7 @@ export class Player extends Widget {
   static {
     this.prototype.default_view = PlayerView
 
-    this.define<Player.Props>(({Bool, Int, Str, Float}) => ({
+    this.define<Player.Props>(({Bool, Int, Float, List, Str}) => ({
       direction: [Int, 0],
       interval: [Int, 500],
       start: [Int, 0],
@@ -556,7 +559,10 @@ export class Player extends Widget {
       preview_duration: [Int, 1500],
       show_loop_controls: [Bool, true],
       show_value: [Bool, true],
-      button_scale: [Float, 1]
+      button_scale: [Float, 1],
+      scale_buttons: [Float, 1],
+      visible_buttons: [List(Str), ['slower', 'first', 'previous', 'reverse', 'pause', 'play', 'next', 'last', 'faster']],
+      visible_loop_options: [List(Str), ['once', 'loop', 'reflect']]
     }))
 
     this.override<Player.Props>({width: 400})

--- a/panel/models/player.ts
+++ b/panel/models/player.ts
@@ -37,8 +37,6 @@ export class PlayerView extends WidgetView {
   protected _toogle_pause: CallableFunction
   protected _toggle_play: CallableFunction
   protected _changing: boolean = false
-  protected slowerButton: HTMLButtonElement
-  protected fasterButton: HTMLButtonElement
 
   protected slower: HTMLButtonElement
   protected first: HTMLButtonElement
@@ -421,7 +419,7 @@ export class PlayerView extends WidgetView {
 
   slower_speed(): void {
     this.model.interval = Math.round(this.model.interval / 0.7)
-    this.updateSpeedButton(this.slowerButton, this.model.interval, SVG_STRINGS.slower)
+    this.updateSpeedButton(this.slower, this.model.interval, SVG_STRINGS.slower)
     if (this.model.direction > 0) {
       this.play_animation()
     } else if (this.model.direction < 0) {
@@ -431,7 +429,7 @@ export class PlayerView extends WidgetView {
 
   faster_speed(): void {
     this.model.interval = Math.round(this.model.interval * 0.7)
-    this.updateSpeedButton(this.fasterButton, this.model.interval, SVG_STRINGS.faster)
+    this.updateSpeedButton(this.faster, this.model.interval, SVG_STRINGS.faster)
     if (this.model.direction > 0) {
       this.play_animation()
     } else if (this.model.direction < 0) {

--- a/panel/models/player.ts
+++ b/panel/models/player.ts
@@ -53,7 +53,7 @@ export class PlayerView extends WidgetView {
   override connect_signals(): void {
     super.connect_signals()
 
-    const {title, value_align, direction, value, loop_policy, disabled, show_loop_controls, show_value, scale_buttons, visible_buttons} = this.model.properties
+    const {title, value_align, direction, value, loop_policy, disabled, show_loop_controls, show_value, scale_buttons, visible_buttons, visible_loop_options} = this.model.properties
     this.on_change(title, () => this.update_title_and_value())
     this.on_change(value_align, () => this.set_value_align())
     this.on_change(direction, () => this.set_direction())
@@ -70,7 +70,7 @@ export class PlayerView extends WidgetView {
     this.on_change(show_value, () => this.update_title_and_value())
     this.on_change(scale_buttons, () => this.update_css())
     this.on_change(visible_buttons, () => this.update_css())
-    this.on_change(this.model.properties.visible_loop_options, () => this.update_css())
+    this.on_change(visible_loop_options, () => this.update_css())
   }
 
   toggle_disable() {

--- a/panel/models/player.ts
+++ b/panel/models/player.ts
@@ -5,54 +5,54 @@ import {Widget, WidgetView} from "@bokehjs/models/widgets/widget"
 import {to_string} from "@bokehjs/core/util/pretty"
 
 const SVG_STRINGS = {
-  slower: '<svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-minus" width="24" \
- height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none"\
+  slower: '<svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-minus" width="12" \
+ height="12" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none"\
   stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" \
    fill="none"/><path d="M5 12l14 0" /></svg>',
   first: '<svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-player-track-prev-filled" \
- width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" \
+ width="12" height="12" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" \
   stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/>\
    <path d="M20.341 4.247l-8 7a1 1 0 0 0 0 1.506l8 7c.647 .565 1.659 .106 1.659 -.753v-14c0 -.86 \
     -1.012 -1.318 -1.659 -.753z" stroke-width="0" fill="currentColor" /><path d="M9.341 4.247l-8 7a1 \
      1 0 0 0 0 1.506l8 7c.647 .565 1.659 .106 1.659 -.753v-14c0 -.86 -1.012 -1.318 -1.659 -.753z" \
       stroke-width="0" fill="currentColor" /></svg>',
   previous: '<svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-player-skip-back-filled" \
- width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" \
+ width="12" height="12" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" \
   stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/> \
    <path d="M19.496 4.136l-12 7a1 1 0 0 0 0 1.728l12 7a1 1 0 0 0 1.504 -.864v-14a1 1 0 0 0 -1.504 -.864z" \
     stroke-width="0" fill="currentColor" /><path d="M4 4a1 1 0 0 1 .993 .883l.007 .117v14a1 1 0 0 1 -1.993 \
      .117l-.007 -.117v-14a1 1 0 0 1 1 -1z" stroke-width="0" fill="currentColor" /></svg>',
   reverse: '<svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-player-play-filled"\
- width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none"\
+ width="12" height="12" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none"\
   stroke-linecap="round" stroke-linejoin="round" style="transform: scaleX(-1);"><path stroke="none"\
    d="M0 0h24v24H0z" fill="none"/><path d="M6 4v16a1 1 0 0 0 1.524 .852l13 -8a1 1 0 0 0 0 -1.704l-13\
     -8a1 1 0 0 0 -1.524 .852z" stroke-width="0" fill="currentColor" /></svg>',
   pause: '<svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-player-pause-filled" \
- width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" \
+ width="12" height="12" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" \
   stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" \
    fill="none"/><path d="M9 4h-2a2 2 0 0 0 -2 2v12a2 2 0 0 0 2 2h2a2 2 0 0 0 2 -2v-12a2 2 0 \
     0 0 -2 -2z" stroke-width="0" fill="currentColor" /><path d="M17 4h-2a2 2 0 0 0 -2 2v12a2 \
      2 0 0 0 2 2h2a2 2 0 0 0 2 -2v-12a2 2 0 0 0 -2 -2z" stroke-width="0" fill="currentColor" /></svg>',
   play: '<svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-player-play-filled" \
- width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" \
+ width="12" height="12" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" \
   stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" \
    fill="none"/><path d="M6 4v16a1 1 0 0 0 1.524 .852l13 -8a1 1 0 0 0 0 -1.704l-13 -8a1 \
     1 0 0 0 -1.524 .852z" stroke-width="0" fill="currentColor" /></svg>',
   next: '<svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-player-skip-forward-filled" \
- width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" \
+ width="12" height="12" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" \
   stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/> \
   <path d="M3 5v14a1 1 0 0 0 1.504 .864l12 -7a1 1 0 0 0 0 -1.728l-12 -7a1 1 0 0 0 -1.504 .864z" \
    stroke-width="0" fill="currentColor" /><path d="M20 4a1 1 0 0 1 .993 .883l.007 .117v14a1 1 0 0 \
     1 -1.993 .117l-.007 -.117v-14a1 1 0 0 1 1 -1z" stroke-width="0" fill="currentColor" /></svg>',
   last: '<svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-player-track-next-filled" \
- width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" \
+ width="12" height="12" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" \
   stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" \
    fill="none"/><path d="M2 5v14c0 .86 1.012 1.318 1.659 .753l8 -7a1 1 0 0 0 0 -1.506l-8 \
    -7c-.647 -.565 -1.659 -.106 -1.659 .753z" stroke-width="0" fill="currentColor" /><path \
     d="M13 5v14c0 .86 1.012 1.318 1.659 .753l8 -7a1 1 0 0 0 0 -1.506l-8 -7c-.647 -.565 -1.659 \
      -.106 -1.659 .753z" stroke-width="0" fill="currentColor" /></svg>',
   faster: '<svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-plus" \
- width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" \
+ width="12" height="12" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" \
   stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" \
    fill="none"/><path d="M12 5l0 14" /><path d="M5 12l14 0" /></svg>',
 }
@@ -160,10 +160,10 @@ export class PlayerView extends WidgetView {
     // Buttons
     const button_div = div() as any
     this.buttonEl = button_div
-    button_div.style.cssText = "margin: 0 auto; display: flex; padding: 5px; align-items: stretch; width: 100%;"
+    button_div.style.cssText = "margin: 0 auto; display: flex; padding: 5px; align-items: stretch; justify-content: center; width: 100%;"
 
-    const button_style_small = "text-align: center; min-width: 50px; flex-grow: 1; margin: 2px"
-    const button_style = "text-align: center; min-width: 50px; flex-grow: 2; margin: 2px"
+    const button_style_small = `text-align: center; flex-grow: 1; margin: 2px; transform: scale(${this.model.button_scale})`
+    const button_style = `text-align: center; flex-grow: 2; margin: 2px; transform: scale(${this.model.button_scale})`;
 
     const slower = document.createElement("button")
     slower.classList.add("slower")
@@ -523,6 +523,7 @@ export namespace Player {
     preview_duration: p.Property<number>
     show_loop_controls: p.Property<boolean>
     show_value: p.Property<boolean>
+    button_scale: p.Property<number>
   }
 }
 
@@ -541,7 +542,7 @@ export class Player extends Widget {
   static {
     this.prototype.default_view = PlayerView
 
-    this.define<Player.Props>(({Bool, Int, Str}) => ({
+    this.define<Player.Props>(({Bool, Int, Str, Float}) => ({
       direction: [Int, 0],
       interval: [Int, 500],
       start: [Int, 0],
@@ -555,6 +556,7 @@ export class Player extends Widget {
       preview_duration: [Int, 1500],
       show_loop_controls: [Bool, true],
       show_value: [Bool, true],
+      button_scale: [Float, 1]
     }))
 
     this.override<Player.Props>({width: 400})

--- a/panel/models/player.ts
+++ b/panel/models/player.ts
@@ -94,7 +94,7 @@ export class PlayerView extends WidgetView {
 
   update_css(): void {
     const button_style_small = `text-align: center; flex-grow: 1; margin: 2px; transform: scale(${this.model.scale_buttons}); max-width: 50px;`
-    const button_style = `text-align: center; flex-grow: 2; margin: 2px; transform: scale(${this.model.scale_buttons}); max-width: 50px;`;
+    const button_style = `text-align: center; flex-grow: 2; margin: 2px; transform: scale(${this.model.scale_buttons}); max-width: 50px;`
 
     const buttons = {
       slower: this.slower,
@@ -105,40 +105,38 @@ export class PlayerView extends WidgetView {
       play: this.play,
       next: this.next,
       last: this.last,
-      faster: this.faster
-    };
+      faster: this.faster,
+    }
 
     for (const [name, button] of Object.entries(buttons)) {
       if (button) {
         if (this.model.visible_buttons.includes(name)) {
-          button.style.display = ''; // Reset to default display
-          if (name === 'slower' || name === 'faster') {
-            button.style.cssText += button_style_small;
+          button.style.display = "" // Reset to default display
+          if (name === "slower" || name === "faster") {
+            button.style.cssText += button_style_small
           } else {
-            button.style.cssText += button_style;
+            button.style.cssText += button_style
           }
         } else {
-          button.style.display = 'none'; // Hide the button completely
+          button.style.display = "none" // Hide the button completely
         }
       }
     }
-
 
     for (const el of this.loop_state.children) {
       if (el.tagName.toLowerCase() == "input") {
         const anyEl = el as any
         if (this.model.visible_loop_options.includes(anyEl.value)) {
-          anyEl.style.display = ''
+          anyEl.style.display = ""
         } else {
-          anyEl.style.display = 'none'
+          anyEl.style.display = "none"
         }
-      }
-      else if (el.tagName.toLowerCase() == "label") {
+      } else if (el.tagName.toLowerCase() == "label") {
         const anyEl = el as any
         if (this.model.visible_loop_options.includes(anyEl.innerHTML.toLowerCase())) {
-          anyEl.style.display = ''
+          anyEl.style.display = ""
         } else {
-          anyEl.style.display = 'none'
+          anyEl.style.display = "none"
         }
       }
     }
@@ -577,8 +575,8 @@ export class Player extends Widget {
       show_value: [Bool, true],
       button_scale: [Float, 1],
       scale_buttons: [Float, 1],
-      visible_buttons: [List(Str), ['slower', 'first', 'previous', 'reverse', 'pause', 'play', 'next', 'last', 'faster']],
-      visible_loop_options: [List(Str), ['once', 'loop', 'reflect']]
+      visible_buttons: [List(Str), ["slower", "first", "previous", "reverse", "pause", "play", "next", "last", "faster"]],
+      visible_loop_options: [List(Str), ["once", "loop", "reflect"]],
     }))
 
     this.override<Player.Props>({width: 400})

--- a/panel/models/player.ts
+++ b/panel/models/player.ts
@@ -186,45 +186,55 @@ export class PlayerView extends WidgetView {
     button_div.style.cssText = "margin: 0 auto; display: flex; padding: 5px; align-items: stretch; justify-content: center; width: 100%;"
 
     this.slower = document.createElement("button")
+    this.slower.classList.add("slower")
     this.slower.innerHTML = SVG_STRINGS.slower
     this.slower.onclick = () => this.slower_speed()
     button_div.appendChild(this.slower)
 
     this.first = document.createElement("button")
+    this.first.classList.add("first")
     this.first.innerHTML = SVG_STRINGS.first
     this.first.onclick = () => this.first_frame()
     button_div.appendChild(this.first)
 
     this.previous = document.createElement("button")
+    this.previous.classList.add("previous")
     this.previous.innerHTML = SVG_STRINGS.previous
     this.previous.onclick = () => this.previous_frame()
     button_div.appendChild(this.previous)
 
     this.reverse = document.createElement("button")
+    this.reverse.classList.add("reverse")
     this.reverse.innerHTML = SVG_STRINGS.reverse
     this.reverse.onclick = () => this.reverse_animation()
     button_div.appendChild(this.reverse)
 
     this.pause = document.createElement("button")
+    this.pause.classList.add("pause")
     this.pause.innerHTML = SVG_STRINGS.pause
     this.pause.onclick = () => this.pause_animation()
     button_div.appendChild(this.pause)
 
     this.play = document.createElement("button")
+    this.play.classList.add("play")
     this.play.innerHTML = SVG_STRINGS.play
     this.play.onclick = () => this.play_animation()
     button_div.appendChild(this.play)
+
     this.next = document.createElement("button")
+    this.next.classList.add("next")
     this.next.innerHTML = SVG_STRINGS.next
     this.next.onclick = () => this.next_frame()
     button_div.appendChild(this.next)
 
     this.last = document.createElement("button")
+    this.last.classList.add("last")
     this.last.innerHTML = SVG_STRINGS.last
     this.last.onclick = () => this.last_frame()
     button_div.appendChild(this.last)
 
     this.faster = document.createElement("button")
+    this.faster.classList.add("faster")
     this.faster.innerHTML = SVG_STRINGS.faster
     this.faster.onclick = () => this.faster_speed()
     button_div.appendChild(this.faster)
@@ -248,26 +258,32 @@ export class PlayerView extends WidgetView {
     this.loop_state.style.cssText = "margin: 0 auto; display: table"
 
     const once = document.createElement("input")
+    once.classList.add("once")
     once.type = "radio"
     once.value = "once"
     once.name = "state"
     const once_label = document.createElement("label")
     once_label.innerHTML = "Once"
+    once_label.classList.add("once-label")
     once_label.style.cssText = "padding: 0 10px 0 5px; user-select:none;"
 
     const loop = document.createElement("input")
+    loop.classList.add("loop")
     loop.setAttribute("type", "radio")
     loop.setAttribute("value", "loop")
     loop.setAttribute("name", "state")
     const loop_label = document.createElement("label")
+    loop_label.classList.add("loop-label")
     loop_label.innerHTML = "Loop"
     loop_label.style.cssText = "padding: 0 10px 0 5px; user-select:none;"
 
     const reflect = document.createElement("input")
+    reflect.classList.add("reflect")
     reflect.setAttribute("type", "radio")
     reflect.setAttribute("value", "reflect")
     reflect.setAttribute("name", "state")
     const reflect_label = document.createElement("label")
+    loop_label.classList.add("reflect-label")
     reflect_label.innerHTML = "Reflect"
     reflect_label.style.cssText = "padding: 0 10px 0 5px; user-select:none;"
 

--- a/panel/models/widgets.py
+++ b/panel/models/widgets.py
@@ -70,6 +70,8 @@ class Player(Widget):
 
     height = Override(default=250)
 
+    button_scale = Float(1, help="Percentage to scale the size of the buttons by")
+
 
 class DiscretePlayer(Player):
 

--- a/panel/models/widgets.py
+++ b/panel/models/widgets.py
@@ -70,8 +70,15 @@ class Player(Widget):
 
     height = Override(default=250)
 
-    button_scale = Float(1, help="Percentage to scale the size of the buttons by")
+    scale_buttons = Float(1, help="Percentage to scale the size of the buttons by")
 
+    visible_buttons = List(String, default=[
+        'slower', 'first', 'previous', 'reverse', 'pause', 'play', 'next', 'last', 'faster'
+    ], help="The buttons to display on the player.")
+
+    visible_loop_options = List(String, default=[
+        'once', 'loop', 'reflect'
+    ], help="The loop options to display on the player.")
 
 class DiscretePlayer(Player):
 

--- a/panel/tests/ui/widgets/test_player.py
+++ b/panel/tests/ui/widgets/test_player.py
@@ -95,7 +95,7 @@ def test_player_visible_buttons(page):
     assert not page.is_visible(".faster")
 
     player.visible_buttons = ["first"]
-    wait_until(lambda: page.is_visible(".first"))
+    expect(page.locator(".first")).to_be_visible()
     assert not page.is_visible(".play")
     assert not page.is_visible(".pause")
 
@@ -109,7 +109,7 @@ def test_player_visible_loop_options(page):
     assert not page.is_visible(".reflect")
 
     player.visible_loop_options = ["reflect"]
-    wait_until(lambda: page.is_visible(".reflect"))
+    expect(page.locator(".reflect")).to_be_visible()
     assert not page.is_visible(".loop")
     assert not page.is_visible(".once")
 

--- a/panel/tests/ui/widgets/test_player.py
+++ b/panel/tests/ui/widgets/test_player.py
@@ -80,3 +80,45 @@ def test_name_and_show_value(page):
 
     name = page.locator('.pn-player-title:has-text("test")')
     expect(name).to_have_count(1)
+def test_player_visible_buttons(page):
+    player = Player(visible_buttons=["play", "pause"])
+    serve_component(page, player)
+
+    assert page.is_visible(".play")
+    assert page.is_visible(".pause")
+    assert not page.is_visible(".reverse")
+    assert not page.is_visible(".first")
+    assert not page.is_visible(".previous")
+    assert not page.is_visible(".next")
+    assert not page.is_visible(".last")
+    assert not page.is_visible(".slower")
+    assert not page.is_visible(".faster")
+
+    player.visible_buttons = ["first"]
+    wait_until(lambda: page.is_visible(".first"))
+    assert not page.is_visible(".play")
+    assert not page.is_visible(".pause")
+
+
+def test_player_visible_loop_options(page):
+    player = Player(visible_loop_options=["loop", "once"])
+    serve_component(page, player)
+
+    assert page.is_visible(".loop")
+    assert page.is_visible(".once")
+    assert not page.is_visible(".reflect")
+
+    player.visible_loop_options = ["reflect"]
+    wait_until(lambda: page.is_visible(".reflect"))
+    assert not page.is_visible(".loop")
+    assert not page.is_visible(".once")
+
+
+def test_player_scale_buttons(page):
+    player = Player(scale_buttons=2)
+    serve_component(page, player)
+
+    expect(page.locator(".play")).to_have_attribute(
+        "style",
+        "text-align: center; flex-grow: 2; margin: 2px; transform: scale(2); max-width: 50px;",
+    )

--- a/panel/tests/widgets/test_player.py
+++ b/panel/tests/widgets/test_player.py
@@ -20,3 +20,15 @@ def test_discrete_player(document, comm):
 
     discrete_player.value = 100
     assert widget.value == 3
+
+
+def test_player_loop_policy_not_in_loop_options(document, comm):
+    player = DiscretePlayer(name='Player', loop_policy='once', visible_loop_options=['loop', 'reflect'])
+    assert player.loop_policy == 'loop'
+    assert player.visible_loop_options == ['loop', 'reflect']
+
+
+def test_player_loop_policy_with_no_loop_options(document, comm):
+    player = DiscretePlayer(name='Player', loop_policy='loop', visible_loop_options=[])
+    assert player.loop_policy == 'loop'
+    assert player.visible_loop_options == []

--- a/panel/widgets/player.py
+++ b/panel/widgets/player.py
@@ -59,7 +59,7 @@ class PlayerBase(Widget):
       or scale mode this will merely be used as a suggestion.""")
 
     scale_buttons = param.Number(default=1, doc="""
-        Percentage to scale the size of the buttons by.""")
+        The scaling factor to resize the buttons.""")
 
     visible_buttons = param.List(default=[
         'slower', 'first', 'previous', 'reverse', 'pause', 'play', 'next', 'last', 'faster'

--- a/panel/widgets/player.py
+++ b/panel/widgets/player.py
@@ -78,8 +78,8 @@ class PlayerBase(Widget):
     __abstract = True
 
     def __init__(self, **params):
-        if params.get("loop_policy", "once") not in params["visible_loop_options"]:
-            if loop_options := params.get("visible_loop_options", []):
+        if loop_options := params.get("visible_loop_options", []):
+            if params.get("loop_policy", "once") not in loop_options:
                 params["loop_policy"] = loop_options[0]
         if 'value' in params and 'value_throttled' in self.param:
             params['value_throttled'] = params['value']

--- a/panel/widgets/player.py
+++ b/panel/widgets/player.py
@@ -58,10 +58,18 @@ class PlayerBase(Widget):
       Width of this component. If sizing_mode is set to stretch
       or scale mode this will merely be used as a suggestion.""")
 
-    button_scale = param.Number(default=1, doc="""
+    scale_buttons = param.Number(default=1, doc="""
         Percentage to scale the size of the buttons by.""")
 
-    _rename: ClassVar[Mapping[str, str | None]] = {'name': 'title'}
+    visible_buttons = param.List(default=[
+        'slower', 'first', 'previous', 'reverse', 'pause', 'play', 'next', 'last', 'faster'
+    ], doc="""The buttons to display on the player.""")
+
+    visible_loop_options = param.List(default=[
+        'once', 'loop', 'reflect'
+    ], doc="The loop options to display on the player.")
+
+    _rename: ClassVar[Mapping[str, str | None]] = {'name': "title"}
 
     _widget_type: ClassVar[type[Model]] = _BkPlayer
 
@@ -70,6 +78,9 @@ class PlayerBase(Widget):
     __abstract = True
 
     def __init__(self, **params):
+        if params.get("loop_policy", "once") not in params["visible_loop_options"]:
+            if loop_options := params.get("visible_loop_options", []):
+                params["loop_policy"] = loop_options[0]
         if 'value' in params and 'value_throttled' in self.param:
             params['value_throttled'] = params['value']
         super().__init__(**params)

--- a/panel/widgets/player.py
+++ b/panel/widgets/player.py
@@ -58,6 +58,9 @@ class PlayerBase(Widget):
       Width of this component. If sizing_mode is set to stretch
       or scale mode this will merely be used as a suggestion.""")
 
+    button_scale = param.Number(default=1, doc="""
+        Percentage to scale the size of the buttons by.""")
+
     _rename: ClassVar[Mapping[str, str | None]] = {'name': 'title'}
 
     _widget_type: ClassVar[type[Model]] = _BkPlayer


### PR DESCRIPTION
Make it a little less bulky

```python
import panel as pn

pn.extension()
pn.widgets.Player(name='test', button_scale=0.8, width=300).servable()
```

<img width="323" alt="image" src="https://github.com/user-attachments/assets/dccaaa37-60b9-4366-85e3-031ca9b65355">

button_scale=1
<img width="322" alt="image" src="https://github.com/user-attachments/assets/55e42b04-7236-45b5-ac6b-a99aadc14f97">

```python
discrete_player = pn.widgets.DiscretePlayer(name='Player', visible_buttons=["play", "pause"], scale_buttons=0.9, show_loop_controls=False, width=150)
discrete_player
```

<img width="192" alt="image" src="https://github.com/user-attachments/assets/7040dd92-ab02-4659-9311-a499277c297a">
