### PR TITLE
Ensure Tabulator selection is updated when indexes change

### DIFF
--- a/panel/tests/ui/widgets/test_tabulator.py
+++ b/panel/tests/ui/widgets/test_tabulator.py
@@ -1968,7 +1968,6 @@ def test_tabulator_header_filters_default(page, df_mixed, cols):
         ([0, 1], 'input[type="number"]'),
         (np.array([0, 1], dtype=np.uint64), 'input[type="number"]'),
         ([0.1, 1.1], 'input[type="number"]'),
-        # ([True, False], 'input[type="checkbox"]'),  # Pandas cannot have boolean indexes apparently
     ),
 )
 def test_tabulator_header_filters_default_index(page, index, expected_selector):
@@ -3506,6 +3505,8 @@ def test_range_selection_on_sorted_data_downward(page, pagination):
 
     page.locator('.tabulator-col-title-holder').nth(2).click()
 
+    page.wait_for_timeout(100)
+
     page.locator('.tabulator-row').nth(0).click()
 
     page.keyboard.down('Shift')
@@ -3523,6 +3524,8 @@ def test_range_selection_on_sorted_data_upward(page, pagination):
     serve_component(page, table)
 
     page.locator('.tabulator-col-title-holder').nth(2).click()
+
+    page.wait_for_timeout(100)
 
     page.locator('.tabulator-row').nth(1).click()
 

--- a/panel/tests/widgets/test_tables.py
+++ b/panel/tests/widgets/test_tables.py
@@ -240,6 +240,15 @@ def test_none_table(document, comm):
     assert model.source.data == {}
 
 
+def test_tabulator_selection_resets():
+    df = makeMixedDataFrame()
+    table = Tabulator(df, selection=list(range(len(df))))
+
+    for i in reversed(range(len(df))):
+        table.value = df.iloc[:i]
+        assert table.selection == list(range(i))
+
+
 def test_tabulator_selected_dataframe():
     df = makeMixedDataFrame()
     table = Tabulator(df, selection=[0, 2])


### PR DESCRIPTION
A followup to https://github.com/holoviz/panel/pull/7058 to ensure that selections reset if rows are changed.