### PR TITLE
Add missing FloatPanel docstring 

### DIFF
--- a/panel/layout/float.py
+++ b/panel/layout/float.py
@@ -34,6 +34,14 @@ STATUS = [
 class FloatPanel(ListLike, ReactiveHTML):
     """
     Float provides a floating panel layout.
+
+    Reference: https://panel.holoviz.org/reference/layouts/FloatPanel.html
+
+    :Example:
+
+    >>> import panel as pn
+    >>> pn.extension("floatpanel")
+    >>> pn.layout.FloatPanel("**I can float**!", position="center", width=300).servable()
     """
 
     config = param.Dict({}, doc="""


### PR DESCRIPTION
This PR adds the missing docstring details to the `FloatPanel` docstring.

I saw it was missing while helping https://discourse.holoviz.org/t/how-to-center-text-and-title-in-float-panel/7538.