### PR TITLE
Annotate pn.io.cache decorator

### DIFF
--- a/panel/io/cache.py
+++ b/panel/io/cache.py
@@ -320,7 +320,7 @@ def cache(
     policy: Literal['FIFO', 'LRU', 'LFU'] = ...,
     ttl: float | None = ...,
     to_disk: bool = ...,
-    cache_path: str = ...,
+    cache_path: str | os.PathLike = ...,
     per_session: bool = ...,
 ) -> Callable[[Callable[P, R]], Callable[P, R]]:
     ...
@@ -333,7 +333,7 @@ def cache(
     policy: Literal['FIFO', 'LRU', 'LFU'] = ...,
     ttl: float | None = ...,
     to_disk: bool = ...,
-    cache_path: str = ...,
+    cache_path: str | os.PathLike = ...,
     per_session: bool = ...,
 ) -> Callable[P, R]:
     ...
@@ -345,7 +345,7 @@ def cache(
     policy: Literal['FIFO', 'LRU', 'LFU'] = 'LRU',
     ttl: float | None = None,
     to_disk: bool = False,
-    cache_path: str = './cache',
+    cache_path: str | os.PathLike = './cache',
     per_session: bool = False
 ) -> Callable[P, R] | Callable[[Callable[P, R]], Callable[P, R]]:
     """

--- a/panel/io/cache.py
+++ b/panel/io/cache.py
@@ -1,6 +1,8 @@
 """
 Implements memoization for functions with arbitrary arguments
 """
+from __future__ import annotations
+
 import datetime as dt
 import functools
 import hashlib
@@ -18,7 +20,8 @@ import weakref
 
 from contextlib import contextmanager
 from typing import (
-    Any, Callable, Hashable, Literal, ParamSpec, Protocol, TypeVar, overload,
+    TYPE_CHECKING, Any, Callable, Hashable, Literal, ParamSpec, Protocol,
+    TypeVar, overload,
 )
 
 import param
@@ -31,15 +34,16 @@ from .state import state
 # Private API
 #---------------------------------------------------------------------
 
-_P = ParamSpec("_P")
-_R = TypeVar("_R")
-_CallableT = TypeVar("_CallableT", bound=Callable)
+if TYPE_CHECKING:
+    _P = ParamSpec("_P")
+    _R = TypeVar("_R")
+    _CallableT = TypeVar("_CallableT", bound=Callable)
 
-class _CachedFunc(Protocol[_CallableT]):
-    def clear(self, func_hashes: list[str | None]) -> None:
-        pass
+    class _CachedFunc(Protocol[_CallableT]):
+        def clear(self, func_hashes: list[str | None]) -> None:
+            pass
 
-    __call__: _CallableT
+        __call__: _CallableT
 
 _CYCLE_PLACEHOLDER = b"panel-93KZ39Q-floatingdangeroushomechose-CYCLE"
 

--- a/panel/io/cache.py
+++ b/panel/io/cache.py
@@ -387,15 +387,17 @@ def cache(
 
     hash_funcs = hash_funcs or {}
     if func is None:
-        return lambda f: cache(
-            func=f,
-            hash_funcs=hash_funcs,
-            max_items=max_items,
-            ttl=ttl,
-            to_disk=to_disk,
-            cache_path=cache_path,
-            per_session=per_session,
-        )
+        def decorator(func: Callable[P, R]) -> Callable[P, R]:
+            return cache(
+                func=func,
+                hash_funcs=hash_funcs,
+                max_items=max_items,
+                ttl=ttl,
+                to_disk=to_disk,
+                cache_path=cache_path,
+                per_session=per_session,
+            )
+        return decorator
     func_hashes = [None] # noqa
 
     lock = threading.RLock()

--- a/panel/io/cache.py
+++ b/panel/io/cache.py
@@ -494,7 +494,7 @@ def cache(
             cache = state._memoize_cache.get(func_hash, {})
         cache.clear()
 
-    wrapped_func.clear = clear
+    wrapped_func.clear = clear  # type: ignore[attr-defined]
 
     if per_session and state.curdoc and state.curdoc.session_context:
         def server_clear(session_context, clear=clear):

--- a/panel/io/cache.py
+++ b/panel/io/cache.py
@@ -374,7 +374,7 @@ def cache(
         the cache should not expire. The default is None.
     to_disk: bool
         Whether to cache to disk using diskcache.
-    cache_dir: str
+    cache_path: str
         Directory to cache to on disk.
     per_session: bool
         Whether to cache data only for the current session.

--- a/panel/io/cache.py
+++ b/panel/io/cache.py
@@ -18,7 +18,8 @@ import weakref
 
 from contextlib import contextmanager
 from typing import (
-    TYPE_CHECKING, Any, Callable, Literal, ParamSpec, TypeVar, overload,
+    TYPE_CHECKING, Any, Callable, Hashable, Literal, ParamSpec, TypeVar,
+    overload,
 )
 
 if TYPE_CHECKING:
@@ -40,7 +41,7 @@ _CYCLE_PLACEHOLDER = b"panel-93KZ39Q-floatingdangeroushomechose-CYCLE"
 
 _FFI_TYPE_NAMES = ("_cffi_backend.FFI", "builtins.CompiledFFI",)
 
-_HASH_MAP = {}
+_HASH_MAP: dict[Hashable, str] = {}
 
 _HASH_STACKS = weakref.WeakKeyDictionary()
 

--- a/panel/io/cache.py
+++ b/panel/io/cache.py
@@ -18,8 +18,13 @@ import weakref
 
 from contextlib import contextmanager
 from typing import (
-    Any, Callable, Literal, ParamSpec, TypeVar, overload,
+    TYPE_CHECKING, Any, Callable, Literal, ParamSpec, TypeVar, overload,
 )
+
+if TYPE_CHECKING:
+    P = ParamSpec("P")
+    R = TypeVar("R")
+    T = TypeVar("T")
 
 import param
 
@@ -307,10 +312,6 @@ def compute_hash(func, hash_funcs, args, kwargs):
     if _INDETERMINATE not in key:
         _HASH_MAP[key] = hash_value
     return hash_value
-
-P = ParamSpec("P")
-R = TypeVar("R")
-T = TypeVar("T")
 
 @overload
 def cache(


### PR DESCRIPTION
Part of https://github.com/holoviz/panel/issues/7078

In the docs I see that [minimum Python version is 3.9](https://panel.holoviz.org/developer_guide/index.html#create-a-development-environment), however in the `pyproject.toml` it states `requires-python = ">=3.10"`. Importing `ParamSpec` from `typing` instead of `typing_extensions` requires 3.10. This PR assumes the latter is correct and that `typing_extensions` is not required.

@MarcSkovMadsen 