### PR TITLE
Avoid events boomeranging from frontend

### DIFF
--- a/panel/reactive.py
+++ b/panel/reactive.py
@@ -330,13 +330,17 @@ class Syncable(Renderable):
         ref = root.ref['id']
         self._changing[ref] = attrs = []
         for attr, value in dict(msg).items():
-            # Do not apply model change that is in flight
             if attr in self._in_process__events and value is self._in_process__events[attr]:
+                # Do not apply change that originated directly from
+                # the frontend since this may cause boomerang if a
+                # new property value is already in-flight
                 del self._in_process__events[attr]
                 del msg[attr]
                 continue
             elif attr in self._events:
-                del msg[attr]
+                # Do not override a property value that was just changed
+                # on the frontend
+                del self._events[attr]
                 continue
 
             # Bokeh raises UnsetValueError if the value is Undefined.

--- a/panel/reactive.py
+++ b/panel/reactive.py
@@ -331,7 +331,11 @@ class Syncable(Renderable):
         self._changing[ref] = attrs = []
         for attr, value in dict(msg).items():
             # Do not apply model change that is in flight
-            if attr in self._events or (attr in self._in_process__events and value is self._in_process__events[attr]):
+            if attr in self._in_process__events and value is self._in_process__events[attr]:
+                del self._in_process__events[attr]
+                del msg[attr]
+                continue
+            elif attr in self._events:
                 del msg[attr]
                 continue
 

--- a/panel/reactive.py
+++ b/panel/reactive.py
@@ -334,7 +334,6 @@ class Syncable(Renderable):
                 # Do not apply change that originated directly from
                 # the frontend since this may cause boomerang if a
                 # new property value is already in-flight
-                del self._in_process__events[attr]
                 del msg[attr]
                 continue
             elif attr in self._events:
@@ -455,6 +454,7 @@ class Syncable(Renderable):
             log.exception(f'Callback failed for object named {self.name!r} {msg_end}')
             raise
         finally:
+            self._in_process_events = {}
             self._log('finished processing events %s', events)
             if any(e for e in events if e not in self._busy__ignore):
                 with edit_readonly(state):

--- a/panel/reactive.py
+++ b/panel/reactive.py
@@ -427,7 +427,7 @@ class Syncable(Renderable):
         if any(e for e in events if e not in self._busy__ignore):
             with edit_readonly(state):
                 state._busy_counter += 1
-        self._in_process__events = events = dict(events)
+        self._in_process__events.update(events)
         params = self._process_property_change(events)
         try:
             with edit_readonly(self):
@@ -454,7 +454,7 @@ class Syncable(Renderable):
             log.exception(f'Callback failed for object named {self.name!r} {msg_end}')
             raise
         finally:
-            self._in_process_events = {}
+            self._in_process__events.clear()
             self._log('finished processing events %s', events)
             if any(e for e in events if e not in self._busy__ignore):
                 with edit_readonly(state):

--- a/panel/reactive.py
+++ b/panel/reactive.py
@@ -307,21 +307,36 @@ class Syncable(Renderable):
                 else:
                     cb()
 
+    def _scheduled_update_model(
+        self, events: dict[str, param.parameterized.Event], msg: dict[str, Any],
+        root: Model, model: Model, doc: Document, comm: Optional[Comm],
+        curdoc_events: dict[str, Any]
+    ) -> None:
+        #
+        self._in_process__events[doc] = curdoc_events
+        try:
+            self._update_model(events, msg, root, model, doc, comm)
+        finally:
+            del self._in_process__events[doc]
+
     def _apply_update(
         self, events: dict[str, param.parameterized.Event], msg: dict[str, Any],
         model: Model, ref: str
-    ) -> None:
+    ) -> bool:
         if ref not in state._views or ref in state._fake_roots:
-            return
+            return True
         viewable, root, doc, comm = state._views[ref]
         if comm or not doc.session_context or state._unblocked(doc):
             with unlocked():
                 self._update_model(events, msg, root, model, doc, comm)
             if comm and 'embedded' not in root.tags:
                 push(doc, comm)
+            return True
         else:
-            cb = partial(self._update_model, events, msg, root, model, doc, comm)
+            curdoc_events = self._in_process__events.pop(doc, {})
+            cb = partial(self._scheduled_update_model, events, msg, root, model, doc, comm, curdoc_events)
             doc.add_next_tick_callback(cb)
+            return False
 
     def _update_model(
         self, events: dict[str, param.parameterized.Event], msg: dict[str, Any],
@@ -329,8 +344,9 @@ class Syncable(Renderable):
     ) -> None:
         ref = root.ref['id']
         self._changing[ref] = attrs = []
-        for attr, value in dict(msg).items():
-            if attr in self._in_process__events and value is self._in_process__events[attr]:
+        curdoc_events = self._in_process__events.get(doc, {})
+        for attr, value in msg.copy().items():
+            if attr in curdoc_events and value is curdoc_events[attr]:
                 # Do not apply change that originated directly from
                 # the frontend since this may cause boomerang if a
                 # new property value is already in-flight
@@ -416,18 +432,25 @@ class Syncable(Renderable):
 
     def _param_change(self, *events: param.parameterized.Event) -> None:
         named_events = {event.name: event for event in events}
+        applied = False
         for ref, (model, _) in self._models.copy().items():
             properties = self._update_properties(*events, doc=model.document)
             if not properties:
                 return
-            self._apply_update(named_events, properties, model, ref)
+            applied &= self._apply_update(named_events, properties, model, ref)
+            if ref not in state._views:
+                continue
+            doc = state._views[ref][2]
+            if applied and doc in self._in_process__events:
+                del self._in_process__events[doc]
 
     def _process_events(self, events: dict[str, Any]) -> None:
         self._log('received events %s', events)
         if any(e for e in events if e not in self._busy__ignore):
             with edit_readonly(state):
                 state._busy_counter += 1
-        self._in_process__events.update(events)
+        if events:
+            self._in_process__events[state.curdoc] = events
         params = self._process_property_change(events)
         try:
             with edit_readonly(self):
@@ -454,7 +477,6 @@ class Syncable(Renderable):
             log.exception(f'Callback failed for object named {self.name!r} {msg_end}')
             raise
         finally:
-            self._in_process__events.clear()
             self._log('finished processing events %s', events)
             if any(e for e in events if e not in self._busy__ignore):
                 with edit_readonly(state):

--- a/panel/tests/test_param.py
+++ b/panel/tests/test_param.py
@@ -574,7 +574,7 @@ def test_param_throttled(document, comm):
     assert mb.value != 3
     assert test.b == 3
 
-    test_pane._widgets['b']._process_events({'value': 4})
+    mb.value = 4
     assert test.b == 3
     assert mb.value == 4
 
@@ -616,7 +616,7 @@ def test_param_onkeyup(document, comm):
     assert mb.value != '3'
     assert test.b == '3'
 
-    test_pane._widgets['b']._process_events({'value': '4'})
+    mb.value = '4'
     assert test.b == '3'
     assert mb.value == '4'
 
@@ -873,7 +873,7 @@ def test_set_widgets_throttled(document, comm):
     assert number.value != 3
     assert test.a == 3
 
-    pane._widgets['a']._process_events({'value': 4})
+    number.value = 4
     assert test.a == 3
     assert number.value == 4
 

--- a/panel/tests/test_reactive.py
+++ b/panel/tests/test_reactive.py
@@ -15,6 +15,7 @@ from bokeh.io.doc import patch_curdoc
 from bokeh.models import Div
 
 from panel.depends import bind, depends
+from panel.io.state import set_curdoc
 from panel.layout import Tabs, WidgetBox
 from panel.pane import Markdown
 from panel.reactive import Reactive, ReactiveHTML
@@ -369,6 +370,19 @@ def test_text_input_controls_explicit():
 
     text_input.placeholder = "Test placeholder..."
     assert placeholder.value == "Test placeholder..."
+
+def test_property_change_does_not_boomerang(document, comm):
+    text_input = TextInput(value='A')
+
+    model = text_input.get_root(document, comm)
+
+    assert model.value == 'A'
+    model.value = 'B'
+    with set_curdoc(document):
+        text_input._process_events({'value': 'C'})
+
+    assert model.value == 'B'
+    assert text_input.value == 'C'
 
 def test_reactive_html_basic():
 


### PR DESCRIPTION
This adds a long overdue change which ensures that events arriving from the frontend do not boomerang. There was a previous attempt at doing this but instead of skipping events being applied that originated on the frontend it cancelled the processing of new events after a property change was made. These approaches have potentially similar effects but in fact are quite different, since the old change effectively would potentially cause a property to revert to an older value.

Fixes https://github.com/holoviz/panel/issues/7096
Fixes https://github.com/holoviz/panel/issues/6738
Fixes https://github.com/holoviz/panel/issues/6414