### PR TITLE
Hide typing constructs behind TYPE_CHECKING guard

### DIFF
--- a/panel/io/profile.py
+++ b/panel/io/profile.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import io
 import os
 import re
@@ -8,15 +10,16 @@ from contextlib import contextmanager
 from cProfile import Profile
 from functools import wraps
 from typing import (
-    Callable, Iterator, Literal, ParamSpec, TypeVar,
+    TYPE_CHECKING, Callable, Iterator, Literal, ParamSpec, TypeVar,
 )
 
 from ..config import config
 from ..util import escape
 from .state import state
 
-_P = ParamSpec("_P")
-_R = TypeVar("_R")
+if TYPE_CHECKING:
+    _P = ParamSpec("_P")
+    _R = TypeVar("_R")
 
 ProfilingEngine = Literal["pyinstrument", "snakeviz", "memray"]
 


### PR DESCRIPTION
@philippjfr Clean up to adopt @hoxbro feedback on the other PR

I deliberately left `ProfilingEngine` public as I didn't want to preclude the possibility of someone actually using this type themselves in their own code.