### PR TITLE
[docs] Remove extraneous cell from Param Component Gallery example

### DIFF
--- a/examples/reference/panes/Param.ipynb
+++ b/examples/reference/panes/Param.ipynb
@@ -298,26 +298,6 @@
    },
    "outputs": [],
    "source": [
-    "sections = {'InputFiles': ['dirs', 'files'], 'Field': ['grps', 'varns']}\n",
-    "\n",
-    "def update(target, event):\n",
-    "    target.param.update(options=sections[event.new], value=sections[event.new][0])\n",
-    "\n",
-    "sel = pn.widgets.Select(options=list(sections.keys()))\n",
-    "rad = pn.widgets.RadioButtonGroup(options=sections[sel.value])\n",
-    "sel.link(rad, callbacks={'value': update})\n",
-    "\n",
-    "pn.Column(sel, rad)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
     "power_curve_view = pn.Row(\n",
     "    power_curve_columns_view,\n",
     "    athlete.power_curve.plot,\n",


### PR DESCRIPTION
The cell with `Select` and `RadioButtonGroup` seems to be there by mistake. Its variables etc aren't used elsewhere, and it doesn't relate to the rest of the Athlete/Power Curve example. (Noticed this looking here https://panel.holoviz.org/reference/panes/Param.html)