### PR TITLE
Implement support for multi-index columns in Tabulator

### DIFF
--- a/panel/models/tabulator.ts
+++ b/panel/models/tabulator.ts
@@ -307,7 +307,7 @@ function find_column(group: any, field: string): any {
     for (const col of group.columns) {
       const found = find_column(col, field)
       if (found) {
-	return found
+        return found
       }
     }
   } else {
@@ -873,7 +873,7 @@ export class DataTabulatorView extends HTMLBoxView {
     columns.push({field: "_index", frozen: true, visible: false})
     if (config_columns != null) {
       for (const column of config_columns) {
-	const new_column = clone_column(column)
+        const new_column = clone_column(column)
         if (column.formatter === "expand") {
           const expand = {
             hozAlign: "center",
@@ -901,7 +901,7 @@ export class DataTabulatorView extends HTMLBoxView {
       let tab_column: any = null
       if (config_columns != null) {
         for (const col of columns) {
-	  tab_column = find_column(col, column.field)
+          tab_column = find_column(col, column.field)
           if (tab_column != null) {
             break
           }

--- a/panel/tests/widgets/test_tables.py
+++ b/panel/tests/widgets/test_tables.py
@@ -310,6 +310,44 @@ def test_tabulator_multi_index_remote_pagination(document, comm):
     assert np.array_equal(model.source.data['C'], np.array(['foo1', 'foo2', 'foo3']))
 
 
+def test_tabulator_multi_index_columns(document, comm):
+    level_1 = ['A', 'A', 'A', 'B', 'B', 'B']
+    level_2 = ['one', 'one', 'two', 'two', 'three', 'three']
+    level_3 = ['X', 'Y', 'X', 'Y', 'X', 'Y']
+
+    # Combine these into a MultiIndex
+    multi_index = pd.MultiIndex.from_arrays([level_1, level_2, level_3], names=['Level 1', 'Level 2', 'Level 3'])
+
+    # Create a DataFrame with this MultiIndex as columns
+    df = pd.DataFrame(np.random.randn(4, 6), columns=multi_index)
+
+    table = Tabulator(df)
+
+    model = table.get_root(document, comm)
+
+    assert model.configuration['columns'] == [
+        {'field': 'index', 'sorter': 'number'},
+        {'title': 'A', 'columns': [
+            {'title': 'one', 'columns': [
+                {'field': 'A_one_X', 'sorter': 'number'},
+                {'field': 'A_one_Y', 'sorter': 'number'},
+            ]},
+            {'title': 'two', 'columns': [
+                {'field': 'A_two_X', 'sorter': 'number'}
+            ]},
+        ]},
+        {'title': 'B', 'columns': [
+            {'title': 'two', 'columns': [
+                {'field': 'B_two_Y', 'sorter': 'number'},
+            ]},
+            {'title': 'three', 'columns': [
+                {'field': 'B_three_X', 'sorter': 'number'},
+                {'field': 'B_three_Y', 'sorter': 'number'}
+            ]},
+        ]}
+    ]
+
+
 def test_tabulator_expanded_content(document, comm):
     df = makeMixedDataFrame()
 


### PR DESCRIPTION
Fixes https://github.com/holoviz/panel/issues/6794

Adds support for rendering arbitrarily deep column multi-indexes by using the column grouping feature of tabulator:

```python
import pandas as pd
import numpy as np
import panel as pn
pn.extension('tabulator')

# Define the three levels of column index
level_1 = ['A', 'A', 'A', 'B', 'B', 'B']
level_2 = ['one', 'one', 'two', 'two', 'three', 'three']
level_3 = ['X', 'Y', 'X', 'Y', 'X', 'Y']

# Combine these into a MultiIndex
multi_index = pd.MultiIndex.from_arrays([level_1, level_2, level_3], names=['Level 1', 'Level 2', 'Level 3'])

# Create a DataFrame with this MultiIndex as columns
df = pd.DataFrame(np.random.randn(4, 6), columns=multi_index)

pn.Column(df, pn.widgets.Tabulator(df))
```

<img width="517" alt="Screenshot 2024-08-09 at 10 56 47" src="https://github.com/user-attachments/assets/8601f737-8f0b-43c4-8823-da13ebf02ed1">
