### PR TITLE
Fix 'dictionary chaged size during update' in panel/base

### DIFF
--- a/panel/pane/base.py
+++ b/panel/pane/base.py
@@ -420,7 +420,7 @@ class Pane(PaneBase, Reactive):
             view._preprocess(root, self)
 
     def _update_pane(self, *events) -> None:
-        for ref, (_, parent) in self._models.items():
+        for ref, (_, parent) in self._models.copy().items():
             if ref not in state._views or ref in state._fake_roots:
                 continue
             viewable, root, doc, comm = state._views[ref]


### PR DESCRIPTION
I've been using Panel to make and dashboard and have gotten periodic crashes.  This seems to be the exact same type of error in https://github.com/holoviz/panel/issues/2631 so I just copied its solution for the panel/base/_update_pane.