### PR TITLE
support custom vizzu backend

### DIFF
--- a/panel/pane/holoviews.py
+++ b/panel/pane/holoviews.py
@@ -385,6 +385,9 @@ class HoloViews(Pane):
                 'width': None,
                 'height': None
             }
+        else:
+            params = {}
+
         self._syncing_props = True
         try:
             self.param.update({k: v for k, v in params.items() if k not in self._overrides})


### PR DESCRIPTION
Inspired by https://discourse.holoviz.org/t/how-to-create-a-custom-holoviews-plotting-backend/7555 I was trying to create a minimal Vizzu HoloViews backend.

This PR fixes issues in Panel discovered when trying to use a custom backend.

## Example

I would like to end up with a working example. My current example is below. Next step is to figure out what to return in the `generate_plot`. The problem is that the `fig` is given to the `Vizzu.object`. Instead is should be split into two and given to `Vizzu.object` and `Vizzu.config`. **How do to that?**

```python
import holoviews as hv
import panel as pn
import param

from holoviews.plotting.plot import GenericElementPlot, DimensionedPlot, CallbackPlot
from holoviews.plotting.renderer import Renderer

class VizzuRenderer(Renderer):

    backend = param.String(default='vizzu', doc="The backend name.")

    
    mode_formats = {'fig': ['html', ],
                    'holomap': ['widgets', 'scrubber', 'gif', 'auto']}
    
    _render_with_panel = True

    @classmethod
    def load_nb(cls, inline=True):
        """
        Loads the vizzu notebook resources.
        """
        import panel.models.vizzu # noqa
        cls._loaded = True
        if 'vizzu' not in getattr(pn.extension, '_loaded_extensions', ['vizzu']):
            pn.extension._loaded_extensions.append('vizzu')

    @classmethod
    def plot_options(cls, obj, percent_size):
        return {}

    
    def _figure_data(self, plot, fmt, as_script=False, **kwargs):
        return plot.handles['fig']


class VizzuPlot(DimensionedPlot, CallbackPlot):

    backend = 'vizzu'

    def initialize_plot(self, ranges=None, is_geo=False):
        return self.generate_plot(self.keys[-1], ranges, is_geo=is_geo)


    def update_frame(self, key, ranges=None, is_geo=False):
        return self.generate_plot(key, ranges, is_geo=is_geo)
    
    @property
    def state(self):
        """
        The plotting state that gets updated via the update method and
        used by the renderer to generate output.
        """
        return self.handles['fig']


class CurvePlot(VizzuPlot, GenericElementPlot):

    def generate_plot(self, key, ranges, element=None, is_geo=False):
        if element is None:
            element = self._get_frame(key)
        else:
            self.current_frame = element

        xdim, ydim = element.dimensions()[:2]
        
        import numpy as np
        data = {
            'Name': ['Alice', 'Bob', 'Ted', 'Patrick', 'Jason', 'Teresa', 'John'],
            'Weight': 50+np.random.randint(0, 10, 7)*10
        }
        config={'geometry': 'rectangle', 'x': 'Name', 'y': 'Weight', 'title': 'Weight by person'}
        
        
        self.handles['fig'] = fig = {
            "data": data,
            "config": config,
        }
        return fig
        

pn.pane.HoloViews.param.backend.objects.append('vizzu')
pn.pane.HoloViews._panes['vizzu'] = pn.pane.Vizzu

hv.Store.renderers['vizzu'] = VizzuRenderer.instance()
hv.Store.register({hv.Curve: CurvePlot}, backend='vizzu')

# Needs a fix in hv.util.__init__.py
# hv.extension._backends['vizzu'] = 'vizzu'
hv.extension('vizzu')
hv.Store.current_backend = 'vizzu'


# Need another fix in the HoloViews pane


import panel as pn

pn.extension("vizzu")
plot = hv.Curve([1, 2, 3])

pn.panel(plot).servable()
```
