### PR TITLE
Extend dev docs how to use pixi and pytest

### DIFF
--- a/doc/developer_guide/index.md
+++ b/doc/developer_guide/index.md
@@ -146,11 +146,11 @@ If you haven't set the environment flag in the command, a menu will help you sel
 Here's an example how you can pick a Python version and run some tests passing some pytest options through a pixi task:
 
 ```bash
-$ pixi run -e test-312 test-unit panel/tests/widgets/test_button.py -v --dist no -n 0
-✨ Pixi task (test-unit in test-312): pytest panel/tests -n logical --dist loadgroup panel/tests/widgets/test_button.py -v --dist no -n 0
+$ pixi run -e test-312 --verbose
+✨ Pixi task (test-unit in test-312): pytest panel/tests -n logical --dist loadgroup --verbose
 ```
 
-If you prefer you can also run `pytest` directly not using the pixi task:
+For more complicated options, you can run `pytest` directly, not using the pixi task:
 
 ```bash
 pixi run -e test-312 pytest panel/tests/widgets/test_button.py

--- a/doc/developer_guide/index.md
+++ b/doc/developer_guide/index.md
@@ -65,7 +65,6 @@ The version number of the package depends on [`git tags`](https://git-scm.com/bo
 ```bash
 git remote add upstream https://github.com/holoviz/panel.git
 git fetch --tags upstream
-git push --tags
 ```
 
 ## Start developing
@@ -78,7 +77,19 @@ pixi install
 
 The first time you run it, it will create a `pixi.lock` file with information for all available environments. This command will take a minute or so to run.
 
-All available tasks can be found by running `pixi task list`, the following sections will give a brief introduction to the most common tasks.
+All available tasks can be found by running
+
+```bash
+pixi task list
+```
+
+To list the pixi environments you have installed:
+
+```bash
+ls .pixi/envs/
+```
+
+The following sections will give a brief introduction to the most common tasks.
 
 ### Editable install
 
@@ -132,6 +143,21 @@ The task is available in the following environments: `test-310`, `test-311`, `te
 
 If you haven't set the environment flag in the command, a menu will help you select which one of the environments to use.
 
+Here's an example how you can pick a Python version and run some tests passing some pytest options through a pixi task:
+
+```bash
+$ pixi run -e test-312 test-unit panel/tests/widgets/test_button.py -v --dist no -n 0
+✨ Pixi task (test-unit in test-312): pytest panel/tests -n logical --dist loadgroup panel/tests/widgets/test_button.py -v --dist no -n 0
+```
+
+If you prefer you can also run `pytest` directly not using the pixi task:
+
+```bash
+pixi run -e test-312 pytest panel/tests/widgets/test_button.py
+```
+
+So the full power of pytest to select tests and configure the test run and reporting is available to you.
+
 ### Example tests
 
 Panel's documentation consists mainly of Jupyter Notebooks. The example tests execute all the notebooks and fail if an error is raised. Example tests are possible thanks to [nbval](https://nbval.readthedocs.io/) and can be found in the `examples/` folder.
@@ -161,11 +187,17 @@ The documentation can be built with the command:
 pixi run docs-build
 ```
 
+To open the generated HTML docs:
+
+```bash
+open builtdocs/index.html
+```
+
 As Panel uses notebooks for much of the documentation, this will take significant time to run (around an hour).
 
 A development version of Panel can be found [here](https://holoviz-dev.github.io/panel/). You can ask a maintainer if they want to make a dev release for your PR, but there is no guarantee they will say yes.
 
-To be able to run cells interactively you need `pyodide` server, this can be ran with:
+To be able to run cells interactively you need `pyodide` server, this can be run with:
 
 ```bash
 pixi run docs-server


### PR DESCRIPTION
This PR tries to improve the dev guide a bit for people (like me) that are new to pixi.

The most common gotcha (not improved here yet) I ran into was that I forgot to run the editable install for each env:
https://github.com/holoviz/panel/issues/7116#issuecomment-2282197706

@hoxbro  - thanks for pointing this out. Yes, it's mentioned at the top, but then it's easy to forget to do it for each env.

IMO ideal would be to have one full-featured Python 3.12 env for any development, testing, docs locally and set up in my IDE (PyCharm) without needing to maintain 5 envs and switch back and forth constantly. The other envs could remain as-is, but I would just let Github CI run those or use them rarely locally. But that's a matter of taste of course.

Otherwise I found that a handful of UI tests are flaky (see #7118) and it would be great to have advice in the dev docs how to debug that.

Similarly with the docs build (see #7119) it would be great to have advice in the dev docs how to get a faster edit & incremental build cycle.

Just to give one example - presumably that's some RST formatting issue:
```
/Users/cdeil/code/oss/panel/doc/api/panel.chat.rst:114: WARNING: No classes found for inheritance diagram
/Users/cdeil/code/oss/panel/doc/api/panel.chat.rst:5: ERROR: Document or section may not begin with a transition.
/Users/cdeil/code/oss/panel/doc/api/panel.chat.rst:122: ERROR: Document may not end with a transition.
```

But I don't know (a) how to localise it and (b) how after an edit what docs build command to run to check if I fixed it properly.