### PR TITLE
Simplify and generalize JSComponent child re-rendering

### DIFF
--- a/panel/models/reactive_esm.ts
+++ b/panel/models/reactive_esm.ts
@@ -326,7 +326,7 @@ Promise.resolve(output).then((out) => {
         const parent = view.el.parentNode
         if (parent && !this._child_rendered.has(view)) {
           view.render()
-	  this._child_rendered.set(view, true)
+          this._child_rendered.set(view, true)
         }
       }
     }
@@ -391,7 +391,7 @@ Promise.resolve(output).then((out) => {
 
     for (const view of this._child_rendered.keys()) {
       if (!all_views.includes(view)) {
-	this._child_rendered.delete(view)
+        this._child_rendered.delete(view)
       }
     }
 

--- a/panel/models/reactive_esm.ts
+++ b/panel/models/reactive_esm.ts
@@ -148,13 +148,13 @@ export class ReactiveESMView extends HTMLBoxView {
   model_proxy: any
   _changing: boolean = false
   _child_callbacks: Map<string, ((new_views: UIElementView[]) => void)[]>
+  _child_rendered: Map<UIElementView, boolean> = new Map()
   _event_handlers: ((event: ESMEvent) => void)[] = []
   _lifecycle_handlers: Map<string, (() => void)[]> =  new Map([
     ["after_render", []],
     ["after_resize", []],
     ["remove", []],
   ])
-  _parent_map: Map<string, ParentNode> = new Map()
   _rendered: boolean = false
 
   override initialize(): void {
@@ -257,6 +257,7 @@ export class ReactiveESMView extends HTMLBoxView {
     this._apply_visible()
 
     this._child_callbacks = new Map()
+    this._child_rendered.clear()
 
     this._rendered = false
     set_size(this.el, this.model)
@@ -292,8 +293,7 @@ Promise.resolve(output).then((out) => {
       cb()
     }
     this.render_children()
-    const rerender = this.accessed_children.filter((child) => !this._parent_map.has(child))
-    this.model_proxy.on(rerender, () => this.render_esm())
+    this.model_proxy.on(this.accessed_children, () => this.render_esm())
     this._rendered = true
   }
 
@@ -302,7 +302,6 @@ Promise.resolve(output).then((out) => {
       return
     }
     this.accessed_properties = []
-    this._parent_map.clear()
     for (const lf of this._lifecycle_handlers.keys()) {
       (this._lifecycle_handlers.get(lf) || []).splice(0)
     }
@@ -319,33 +318,19 @@ Promise.resolve(output).then((out) => {
     for (const child of this.model.children) {
       const child_model = this.model.data[child]
       const children = isArray(child_model) ? child_model : [child_model]
-      const nodes = []
       for (const subchild of children) {
         const view = this._child_views.get(subchild)
         if (!view) {
           continue
         }
         const parent = view.el.parentNode
-        nodes.push(parent)
-        if (parent) {
+        if (parent && !this._child_rendered.has(view)) {
           view.render()
-          view.after_render()
-        }
-      }
-      if ((new Set(nodes)).size === 1 && nodes[0] != null) {
-        const parent = nodes[0]
-        let in_sequence = true
-        for (let i=0; i<nodes.length; i++) {
-          if (parent.children[i] !== this._child_views.get(children[i])?.el) {
-            in_sequence = false
-            break
-          }
-        }
-        if (in_sequence && parent) {
-          this._parent_map.set(child, parent)
+	  this._child_rendered.set(view, true)
         }
       }
     }
+    this.r_after_render()
   }
 
   override remove(): void {
@@ -353,6 +338,8 @@ Promise.resolve(output).then((out) => {
     for (const cb of (this._lifecycle_handlers.get("remove") || [])) {
       cb()
     }
+    this._child_callbacks.clear()
+    this._child_rendered.clear()
   }
 
   override after_resize(): void {
@@ -380,7 +367,8 @@ Promise.resolve(output).then((out) => {
   override async update_children(): Promise<void> {
     const created_children = new Set(await this.build_child_views())
 
-    for (const child_view of this.child_views) {
+    const all_views = this.child_views
+    for (const child_view of all_views) {
       child_view.el.remove()
     }
 
@@ -394,17 +382,16 @@ Promise.resolve(output).then((out) => {
         continue
       }
 
-      if (this._parent_map.has(child)) {
-        const parent = this._parent_map.get(child)
-        child_view.render()
-        // @ts-ignore
-        parent.append(child_view.el)
-      }
-
       if (new_views.has(child)) {
         new_views.get(child).push(child_view)
       } else {
         new_views.set(child, [child_view])
+      }
+    }
+
+    for (const view of this._child_rendered.keys()) {
+      if (!all_views.includes(view)) {
+	this._child_rendered.delete(view)
       }
     }
 

--- a/panel/tests/ui/test_custom.py
+++ b/panel/tests/ui/test_custom.py
@@ -291,6 +291,22 @@ class JSChildren(JSComponent):
     }"""
 
 
+class JSChildrenNoReturn(JSComponent):
+
+    children = Children()
+
+    render_count = param.Integer(default=0)
+
+    _esm = """
+    export function render({ model, view }) {
+      const div = document.createElement('div')
+      div.id = "container"
+      div.append(...model.get_child('children'))
+      view.container.replaceChildren(div)
+      model.render_count += 1
+    }"""
+
+
 class ReactChildren(ReactComponent):
 
     children = Children()
@@ -304,7 +320,7 @@ class ReactChildren(ReactComponent):
     }"""
 
 
-@pytest.mark.parametrize('component', [JSChildren, ReactChildren])
+@pytest.mark.parametrize('component', [JSChildren, JSChildrenNoReturn, ReactChildren])
 def test_children(page, component):
     example = component(children=['A Markdown pane!'])
 
@@ -326,7 +342,7 @@ def test_children(page, component):
     assert example.render_count == (1 if component is JSChildren else 2)
 
 
-@pytest.mark.parametrize('component', [JSChildren, ReactChildren])
+@pytest.mark.parametrize('component', [JSChildren, JSChildrenNoReturn, ReactChildren])
 def test_children_append_without_rerender(page, component):
     child = JSChild(child=Markdown(
         'A Markdown pane!', css_classes=['first']

--- a/panel/tests/ui/test_custom.py
+++ b/panel/tests/ui/test_custom.py
@@ -291,11 +291,7 @@ class JSChildren(JSComponent):
     }"""
 
 
-class JSChildrenNoReturn(JSComponent):
-
-    children = Children()
-
-    render_count = param.Integer(default=0)
+class JSChildrenNoReturn(JSChildren):
 
     _esm = """
     export function render({ model, view }) {
@@ -339,7 +335,7 @@ def test_children(page, component):
 
     page.wait_for_timeout(400)
 
-    assert example.render_count == (1 if component is JSChildren else 2)
+    assert example.render_count == (3 if issubclass(component, JSChildren) else 2)
 
 
 @pytest.mark.parametrize('component', [JSChildren, JSChildrenNoReturn, ReactChildren])


### PR DESCRIPTION
Reverts https://github.com/holoviz/panel/pull/7109 and finds a general solution to avoid unnecessary re-rendering of children.