### PR TITLE
Annotate Widget params as Any

### DIFF
--- a/panel/widgets/base.py
+++ b/panel/widgets/base.py
@@ -103,7 +103,7 @@ class Widget(Reactive, WidgetBase):
 
     __abstract = True
 
-    def __init__(self, **params):
+    def __init__(self, **params: Any):
         if 'name' not in params:
             params['name'] = ''
         if '_supports_embed' in params:


### PR DESCRIPTION
Part of https://github.com/holoviz/panel/issues/7078

Users who run their own code in Mypy strict mode require that all calls they make are to typed interfaces.

I did initially explore the possibility of annotating these `**params` as `Unpack[TypedDict]` (see [PEP 692](https://peps.python.org/pep-0692/)) but it was not readily apparent from the source code what all the possibilities were, and until [PEP 728](https://peps.python.org/pep-0728/) is accepted this had the potential to break perfectly valid code that were using parameters that I did not anticipate. So I dropped this idea pretty quickly.

But to solve the basic issue in user code, all this needs is an annotation - of any kind. So I went ahead and added an `Any`.

Here is some sample code, run on Mypy strict:

```python
from panel.widgets.input import StaticText

t1 = StaticText()
```

**Before**:

```
>> mypy panel_test_code.py --follow-imports=silent --strict
panel_test_code.py:3: error: Call to untyped function "StaticText" in typed context  [no-untyped-call]
```

**After**:
```
>> mypy panel_test_code.py --follow-imports=silent --strict
Success: no issues found in 1 source file
```

@MarcSkovMadsen 