### PR TITLE
Don't install mkl in Windows

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -22,18 +22,20 @@ build = ["py311", "build"]
 lint = ["py311", "lint"]
 
 [dependencies]
+nodejs = ">=18"
+nomkl = "*"
+pip = "*"
+# Required
 bleach = "*"
 bokeh = ">=3.5.0,<3.6.0"
 linkify-it-py = "*"
 markdown = "*"
 markdown-it-py = "*"
 mdit-py-plugins = "*"
-nodejs = ">=18"
 numpy = "<2.0" # Temporary pin until panel release with support for bokeh 3.5.0 is available
 packaging = "*"
 pandas = ">=1.2"
 param = ">=2.1.0,<3.0"
-pip = "*"
 pyviz_comms = ">=2.0.0"
 requests = "*"
 tqdm = ">=4.48.0"


### PR DESCRIPTION
Notice we install mkl in Windows environments, which is likely why download is significantly slower on Windows. 