### PR TITLE
Propagate serialize_kwargs to ChatMessage

### DIFF
--- a/panel/chat/feed.py
+++ b/panel/chat/feed.py
@@ -874,7 +874,8 @@ class ChatFeed(ListPanel):
         messages: list[ChatMessage],
         role_names: dict[str, str | list[str]] | None = None,
         default_role: str | None = "assistant",
-        custom_serializer: Callable = None
+        custom_serializer: Callable | None = None,
+        **serialize_kwargs
     ) -> list[dict[str, Any]]:
         """
         Exports the chat log for use with transformers.
@@ -914,7 +915,7 @@ class ChatFeed(ListPanel):
                         f"it returned a {type(content)} type"
                     )
             else:
-                content = str(message)
+                content = message.serialize(**serialize_kwargs)
 
             serialized_messages.append({"role": role, "content": content})
         return serialized_messages

--- a/panel/chat/interface.py
+++ b/panel/chat/interface.py
@@ -584,7 +584,8 @@ class ChatInterface(ChatFeed):
         messages: list[ChatMessage],
         role_names: dict[str, str | list[str]] | None = None,
         default_role: str | None = "assistant",
-        custom_serializer: Callable = None
+        custom_serializer: Callable = None,
+        **serialize_kwargs
     ) -> list[dict[str, Any]]:
         """
         Exports the chat log for use with transformers.
@@ -606,6 +607,8 @@ class ChatInterface(ChatFeed):
             A custom function to format the ChatMessage's object. The function must
             accept one positional argument, the ChatMessage object, and return a string.
             If not provided, uses the serialize method on ChatMessage.
+        serialize_kwargs : dict
+            Additional keyword arguments to pass to the serializer.
 
         Returns
         -------
@@ -616,7 +619,8 @@ class ChatInterface(ChatFeed):
                 "user": [self.user],
                 "assistant": [self.callback_user],
             }
-        return super()._serialize_for_transformers(messages, role_names, default_role, custom_serializer)
+        return super()._serialize_for_transformers(
+            messages, role_names, default_role, custom_serializer, **serialize_kwargs)
 
     @param.depends("_callback_state", watch=True)
     async def _update_input_disabled(self):

--- a/panel/tests/chat/test_feed.py
+++ b/panel/tests/chat/test_feed.py
@@ -1313,6 +1313,17 @@ class TestChatFeedSerializeForTransformers:
         chat_feed.send(Test())
         assert chat_feed.serialize() == [{"role": "user", "content": "Test()"}]
 
+    def test_serialize_kwargs(self, chat_feed):
+        chat_feed.send("Hello")
+        chat_feed.add_step("Hello", "World")
+        assert chat_feed.serialize(
+            prefix_with_container_label=False,
+            prefix_with_viewable_label=False
+        ) == [
+            {'role': 'user', 'content': 'Hello'},
+            {'role': 'user', 'content': '((Hello))'}
+        ]
+
 
 @pytest.mark.xdist_group("chat")
 class TestChatFeedSerializeBase:


### PR DESCRIPTION
Closes https://github.com/holoviz/panel/issues/7143

```python
import panel as pn

pn.extension()

ci = pn.chat.ChatInterface()
ci.send("Hello")
ci.add_step("Hello", "World")
ci.serialize(
    prefix_with_container_label=False,
    prefix_with_viewable_label=False
)
```

```
[{'role': 'user', 'content': 'Hello'},
 {'role': 'user', 'content': '((Hello))'}]
```