### PR TITLE
Enable test of types in CI

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -270,4 +270,4 @@ jobs:
           environments: ${{ matrix.environment }}
       - name: Test Type
         run: |
-          pixi run -e ${{ matrix.environment }} test-type || echo "Failed"
+          pixi run -e ${{ matrix.environment }} test-type

--- a/panel/io/cache.py
+++ b/panel/io/cache.py
@@ -15,7 +15,6 @@ import sys
 import threading
 import time
 import unittest.mock
-import weakref
 
 from contextlib import contextmanager
 from typing import (
@@ -50,7 +49,7 @@ _FFI_TYPE_NAMES = ("_cffi_backend.FFI", "builtins.CompiledFFI",)
 
 _HASH_MAP: dict[Hashable, str] = {}
 
-_HASH_STACKS = weakref.WeakKeyDictionary()
+# _HASH_STACKS = weakref.WeakKeyDictionary()
 
 _INDETERMINATE = type('INDETERMINATE', (object,), {})()
 
@@ -187,7 +186,7 @@ _hash_funcs = {
 }
 
 for name in _FFI_TYPE_NAMES:
-    _hash_funcs[name] = b'0'
+    _hash_funcs[name] = lambda obj: b'0'
 
 def _find_hash_func(obj):
     fqn_type = _get_fqn(obj)

--- a/panel/io/profile.py
+++ b/panel/io/profile.py
@@ -194,7 +194,7 @@ def profiling_tabs(state, allow=None, deny=[]):
 
 
 @contextmanager
-def profile_ctx(engine: ProfilingEngine = 'pyinstrument') -> Iterator[list[Profile | bytes]]:
+def profile_ctx(engine: ProfilingEngine | None = 'pyinstrument') -> Iterator[list[Profile | bytes]]:
     """
     A context manager which profiles the body of the with statement
     with the supplied profiling engine and returns the profiling object

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -223,7 +223,7 @@ filterwarnings = [
 [tool.mypy]
 files = ["panel/"]
 
-strict = true
+# strict = true
 
 pretty = true
 show_column_numbers = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -221,12 +221,36 @@ filterwarnings = [
 ]
 
 [tool.mypy]
+files = ["panel/"]
+
+strict = true
+
+pretty = true
+show_column_numbers = true
+show_error_codes = true
+show_error_context = true
+
+disallow_any_unimported = true
+implicit_reexport = true
 namespace_packages = true
-explicit_package_bases = true
-mypy_path = ""
-exclude = []
+warn_return_any = false
+warn_unreachable = true
 
 [[tool.mypy.overrides]]
+ignore_errors = true
+module = [
+    "panel.*",
+]
+
+[[tool.mypy.overrides]]
+ignore_errors = false
+module = [
+    "panel.io.cache",
+    "panel.io.profile",
+]
+
+[[tool.mypy.overrides]]
+ignore_missing_imports = true
 module = [
     "altair.*",
     "bokeh_django.*",
@@ -271,4 +295,3 @@ module = [
     "tranquilizer.*",
     "vtk.*",
 ]
-ignore_missing_imports = true


### PR DESCRIPTION
Currently, we just ran `mypy`, this will make it so it fails if type testing fails. I have, set it up so you manually have to enable modules. 

Copied settings from: https://github.com/bokeh/bokeh/blob/bba83ab0db6986f5b8e82ab01e2ad2d09b877cea/pyproject.toml

Commented out strict for now, as it have many failing tests. Currently, I see two failing tests.  

Currently two errors, the changes in the codebase is to fix other errors. 

```
panel/io/cache.py: note: In function "cache":
panel/io/cache.py:472:23: error: Incompatible types in "await" (actual type "_R", expected type "Awaitable[Any]")  [misc]
                    ret = await func(*args, **kwargs)
                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~
panel/io/cache.py:515:12: error: Incompatible return value type (got "_Wrapped[_P, _R, _P, Coroutine[Any, Any, _R]]", expected "_CachedFunc[Callable[_P, _R]] | Callable[[Callable[_P, _R]], _CachedFunc[Callable[_P, _R]]]")  [return-value]
        return wrapped_func
               ^~~~~~~~~~~~
Found 2 errors in 1 file (checked 341 source files)
```