### PR TITLE
Add linting rule to error on console.log

### DIFF
--- a/doc/how_to/custom_components/index.md
+++ b/doc/how_to/custom_components/index.md
@@ -132,6 +132,7 @@ Build custom components wrapping Material UI using `ReactComponent`.
 :hidden:
 :maxdepth: 2
 
+esm/build
 esm/callbacks
 esm/custom_widgets
 esm/custom_layout

--- a/panel/.eslintrc.js
+++ b/panel/.eslintrc.js
@@ -48,6 +48,7 @@ module.exports = {
     "@typescript-eslint/no-unnecessary-type-assertion": ["error"],
     "@typescript-eslint/no-unnecessary-type-constraint": ["error"],
     "@typescript-eslint/switch-exhaustiveness-check": ["error"],
+    "no-console": ["error", { "allow": ["warn", "error"] }],
     "no-self-assign": ["error", {"props": false}],
     "brace-style": ["error", "1tbs", {"allowSingleLine": true}],
     "comma-dangle": ["off"],

--- a/panel/models/comm_manager.ts
+++ b/panel/models/comm_manager.ts
@@ -52,7 +52,7 @@ export class CommManager extends Model {
     this._blocked = false
     this._timeout = Date.now()
     if (((window as any).PyViz == undefined) || (!(window as any).PyViz.comm_manager)) {
-      console.log("Could not find comm manager on window.PyViz, ensure the extension is loaded.")
+      console.warn("Could not find comm manager on window.PyViz, ensure the extension is loaded.")
     } else {
       this.ns = (window as any).PyViz
       this.ns.comm_manager.register_target(this.plot_id, this.comm_id, (msg: any) => {
@@ -163,9 +163,10 @@ export class CommManager extends Model {
       this._blocked = false
     }
     if ((metadata.msg_type == "Ready") && metadata.content) {
+      // eslint-disable-next-line no-console
       console.log("Python callback returned following output:", metadata.content)
     } else if (metadata.msg_type == "Error") {
-      console.log("Python failed with the following traceback:", metadata.traceback)
+      console.warn("Python failed with the following traceback:", metadata.traceback)
     }
   }
 
@@ -176,9 +177,10 @@ export class CommManager extends Model {
     const plot_id = this.plot_id
     if ((metadata.msg_type == "Ready")) {
       if (metadata.content) {
+        // eslint-disable-next-line no-console
         console.log("Python callback returned following output:", metadata.content)
       } else if (metadata.msg_type == "Error") {
-        console.log("Python failed with the following traceback:", metadata.traceback)
+        console.warn("Python failed with the following traceback:", metadata.traceback)
       }
     } else if (plot_id != null) {
       let plot = null

--- a/panel/models/deckgl.ts
+++ b/panel/models/deckgl.ts
@@ -20,7 +20,6 @@ function extractClasses() {
     classesDict[cls] = deck[cls]
   }
   const carto = (window as any).CartoLibrary
-  console.log(carto)
   const layers = Object.keys(carto.CARTO_LAYERS).filter(x => x.endsWith("Layer"))
   for (const layer of layers) {
     classesDict[layer] = carto.CARTO_LAYERS[layer]

--- a/panel/models/player.ts
+++ b/panel/models/player.ts
@@ -378,7 +378,6 @@ export class PlayerView extends WidgetView {
         break
       case "end":
         this.titleEl.style.textAlign = "right"
-        console.log(this.titleEl)
         break
     }
   }

--- a/panel/models/reactive_esm.ts
+++ b/panel/models/reactive_esm.ts
@@ -574,7 +574,6 @@ export class ReactiveESM extends HTMLBox {
       // @ts-ignore
       this.compiled_module = importShim(url)
       const mod = await this.compiled_module
-      console.log(mod)
       let initialize
       if (mod.initialize) {
         initialize = mod.initialize

--- a/panel/models/reactive_html.ts
+++ b/panel/models/reactive_html.ts
@@ -200,7 +200,7 @@ export class ReactiveHTMLView extends HTMLBoxView {
     const script_fn = this._script_fns.get(property)
     if (script_fn === undefined) {
       if (!silent) {
-        console.log(`Script '${property}' could not be found.`)
+        console.warn(`Script '${property}' could not be found.`)
       }
       return
     }
@@ -532,7 +532,7 @@ export class ReactiveHTMLView extends HTMLBoxView {
       this._changing = true
       this.model.data.setv(serialize_attrs(attrs))
     } catch {
-      console.log("Could not serialize", attrs)
+      console.error("Could not serialize", attrs)
     } finally {
       this._changing = false
     }

--- a/panel/models/speech_to_text.ts
+++ b/panel/models/speech_to_text.ts
@@ -86,12 +86,10 @@ export class SpeechToTextView extends HTMLBoxView {
       this.model.results = serializeResults(event.results)
     }
     this.recognition.onerror = (event: any) => {
-      console.log("SpeechToText Error")
-      console.log(event)
+      console.error(`SpeechToText Error: ${event}`)
     }
     this.recognition.onnomatch = (event: any) => {
-      console.log("SpeechToText No Match")
-      console.log(event)
+      console.warn(`SpeechToText No Match: ${event}`)
     }
 
     this.recognition.onaudiostart = () => this.model.audio_started = true


### PR DESCRIPTION
Had a couple of stray `console.log` statements so decided to enable linting to disallow everything but `console.warn` and `console.error`.