### PR TITLE
Ensure no content warning is not displayed when template is added

### DIFF
--- a/panel/io/handlers.py
+++ b/panel/io/handlers.py
@@ -277,7 +277,7 @@ def run_app(handler, module, doc, post_run=None, allow_empty=False):
                             handler._runner.run(module, post_check)
                             if post_run:
                                 post_run()
-                if not doc.roots and not allow_empty and config.autoreload:
+                if not doc.roots and not allow_empty and config.autoreload and doc not in state._templates:
                     from ..pane import Alert
                     Alert(
                         ('<b>Application did not publish any contents</b>\n\n<span>'


### PR DESCRIPTION
Skips content warning if global template is registered.