### PR TITLE
Fix Tabulator page size 0

### DIFF
--- a/panel/models/tabulator.ts
+++ b/panel/models/tabulator.ts
@@ -658,7 +658,7 @@ export class DataTabulatorView extends HTMLBoxView {
             const remaining = table_height - height
             page_size += Math.floor(remaining / Math.min(...heights))
           }
-          this.model.page_size = page_size
+          this.model.page_size = Math.max(page_size || 1, 1)
         }
       }
       this.setMaxPage()

--- a/panel/widgets/tables.py
+++ b/panel/widgets/tables.py
@@ -1308,6 +1308,8 @@ class Tabulator(BaseTable):
     def _process_events(self, events: dict[str, Any]) -> None:
         if 'expanded' in events:
             self._update_expanded(events.pop('expanded'))
+        if events.get('page_size') == 0:  # page_size can't be 0
+            events.pop('page_size')
         return super()._process_events(events)
 
     def _process_event(self, event) -> None:


### PR DESCRIPTION
Couldn't find a MRVE to add a test; I thought it was something related to sizing_mode + pagination. Also not sure if this is the proper place to fix or in TS.

```python
import pandas as pd
import panel as pn


pn.extension()

df = pd.DataFrame({
    "A": range(100),
    "B": range(100),
})

tabs = pn.Tabs()
tabs

tabs[:] = [pn.widgets.Tabulator(value=df, sizing_mode="stretch_both")]
```


```python
2024-08-19 16:23:11,445 ERROR: panel.reactive - Callback failed for object named '' changing property {'page_size': 0}
Traceback (most recent call last):
  File "/Users/ahuang/repos/panel/panel/reactive.py", line 459, in _process_events
    self.param.update(**self_params)
  File "/Users/ahuang/miniconda3/envs/lumen/lib/python3.10/site-packages/param/parameterized.py", line 2318, in update
    restore = dict(self_._update(arg, **kwargs))
  File "/Users/ahuang/miniconda3/envs/lumen/lib/python3.10/site-packages/param/parameterized.py", line 2344, in _update
    setattr(self_or_cls, k, v)
  File "/Users/ahuang/miniconda3/envs/lumen/lib/python3.10/site-packages/param/parameterized.py", line 528, in _f
    instance_param.__set__(obj, val)
  File "/Users/ahuang/miniconda3/envs/lumen/lib/python3.10/site-packages/param/parameterized.py", line 530, in _f
    return f(self, obj, val)
  File "/Users/ahuang/miniconda3/envs/lumen/lib/python3.10/site-packages/param/parameters.py", line 543, in __set__
    super().__set__(obj,val)
  File "/Users/ahuang/miniconda3/envs/lumen/lib/python3.10/site-packages/param/parameterized.py", line 530, in _f
    return f(self, obj, val)
  File "/Users/ahuang/miniconda3/envs/lumen/lib/python3.10/site-packages/param/parameterized.py", line 1497, in __set__
    self._validate(val)
  File "/Users/ahuang/miniconda3/envs/lumen/lib/python3.10/site-packages/param/parameters.py", line 830, in _validate
    self._validate_bounds(val, self.bounds, self.inclusive_bounds)
  File "/Users/ahuang/miniconda3/envs/lumen/lib/python3.10/site-packages/param/parameters.py", line 795, in _validate_bounds
    raise ValueError(
ValueError: Integer parameter 'Tabulator.page_size' must be at least 1, not 0.
Traceback (most recent call last):
  File "/Users/ahuang/repos/panel/panel/reactive.py", line 504, in _change_coroutine
    self._change_event(doc)
  File "/Users/ahuang/repos/panel/panel/reactive.py", line 522, in _change_event
    self._process_events(events)
  File "/Users/ahuang/repos/panel/panel/widgets/tables.py", line 1311, in _process_events
    return super()._process_events(events)
  File "/Users/ahuang/repos/panel/panel/reactive.py", line 1426, in _process_events
    super(ReactiveData, self)._process_events(events)
  File "/Users/ahuang/repos/panel/panel/reactive.py", line 459, in _process_events
    self.param.update(**self_params)
  File "/Users/ahuang/miniconda3/envs/lumen/lib/python3.10/site-packages/param/parameterized.py", line 2318, in update
    restore = dict(self_._update(arg, **kwargs))
  File "/Users/ahuang/miniconda3/envs/lumen/lib/python3.10/site-packages/param/parameterized.py", line 2344, in _update
    setattr(self_or_cls, k, v)
  File "/Users/ahuang/miniconda3/envs/lumen/lib/python3.10/site-packages/param/parameterized.py", line 528, in _f
    instance_param.__set__(obj, val)
  File "/Users/ahuang/miniconda3/envs/lumen/lib/python3.10/site-packages/param/parameterized.py", line 530, in _f
    return f(self, obj, val)
  File "/Users/ahuang/miniconda3/envs/lumen/lib/python3.10/site-packages/param/parameters.py", line 543, in __set__
    super().__set__(obj,val)
  File "/Users/ahuang/miniconda3/envs/lumen/lib/python3.10/site-packages/param/parameterized.py", line 530, in _f
    return f(self, obj, val)
  File "/Users/ahuang/miniconda3/envs/lumen/lib/python3.10/site-packages/param/parameterized.py", line 1497, in __set__
    self._validate(val)
  File "/Users/ahuang/miniconda3/envs/lumen/lib/python3.10/site-packages/param/parameters.py", line 830, in _validate
    self._validate_bounds(val, self.bounds, self.inclusive_bounds)
  File "/Users/ahuang/miniconda3/envs/lumen/lib/python3.10/site-packages/param/parameters.py", line 795, in _validate_bounds
    raise ValueError(
ValueError: Integer parameter 'Tabulator.page_size' must be at least 1, not 0.
```