### PR TITLE
Fix BokehDeprecationWarning in Tabs.ipynb

### DIFF
--- a/examples/reference/layouts/Tabs.ipynb
+++ b/examples/reference/layouts/Tabs.ipynb
@@ -2,13 +2,13 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
    "metadata": {},
-   "outputs": [],
    "source": [
     "import panel as pn\n",
     "pn.extension()"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "markdown",
@@ -45,9 +45,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
    "metadata": {},
-   "outputs": [],
    "source": [
     "from bokeh.plotting import figure\n",
     "\n",
@@ -59,7 +57,9 @@
     "\n",
     "tabs = pn.Tabs(('Scatter', p1), p2)\n",
     "tabs"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "markdown",
@@ -70,15 +70,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
    "metadata": {},
-   "outputs": [],
    "source": [
     "p3 = figure(width=300, height=300, name='Square')\n",
-    "p3.square([0, 1, 2, 3, 4, 5, 6], [0, 1, 2, 3, 2, 1, 0], size=10)\n",
+    "p3.scatter([0, 1, 2, 3, 4, 5, 6], [0, 1, 2, 3, 2, 1, 0], marker='square', size=10)\n",
     "\n",
     "tabs.append(p3)"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "markdown",
@@ -89,12 +89,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
    "metadata": {},
-   "outputs": [],
    "source": [
     "tabs"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "markdown",
@@ -112,13 +112,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
    "metadata": {},
-   "outputs": [],
    "source": [
     "print(tabs.active)\n",
     "tabs.active = 0"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "markdown",
@@ -131,14 +131,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
    "metadata": {},
-   "outputs": [],
    "source": [
     "tabs = pn.Tabs(p1, p2, p3, dynamic=True)\n",
     "\n",
     "tabs"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "markdown",
@@ -149,9 +149,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
    "metadata": {},
-   "outputs": [],
    "source": [
     "import time\n",
     "import numpy as np\n",
@@ -171,7 +169,9 @@
     "tabs = pn.Tabs(p1, p2, p3, dynamic=True)\n",
     "\n",
     "tabs"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "markdown",
@@ -184,9 +184,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
    "metadata": {},
-   "outputs": [],
    "source": [
     "tabs = pn.Tabs(\n",
     "    ('red', pn.Spacer(styles=dict(background='red'), width=100, height=100)),\n",
@@ -196,7 +194,9 @@
     ")\n",
     "\n",
     "tabs"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "markdown",
@@ -209,12 +209,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
    "metadata": {},
-   "outputs": [],
    "source": [
     "pn.Row(tabs, tabs.clone(active=1, tabs_location='right'), tabs.clone(active=2, tabs_location='below'), tabs.clone(tabs_location='left'))"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   }
  ],
  "metadata": {


### PR DESCRIPTION
Fix this warning:

```
$ time pixi run -e test-312 test-docs

...

FAILED panel/tests/test_docs.py::test_markdown_codeblocks[reference/layouts/Tabs.md] - bokeh.util.warnings.BokehDeprecationWarning: 'square() method' was deprecated in Bokeh 3.4.0 and will be removed, use "scatter(marker='square', ...) instead" instead.
```