### PR TITLE
Align ChatStep's header title to left and properly wrap

### DIFF
--- a/panel/dist/css/chat_step.css
+++ b/panel/dist/css/chat_step.css
@@ -16,11 +16,14 @@
 }
 
 :host(.step-header) {
-  width: max-content;
+  width: fit-content;
 }
 
 .step-title {
+  width: calc(100% - 50px);
   font-size: 1.25em;
+  text-align: left;
+  overflow-wrap: break-word;
 }
 
 .step-message {


### PR DESCRIPTION
```python
step = pn.chat.ChatStep(title="Abcdefghijklmnopqrstuvwxyz abcd efgh ijkl mnop qrst uvwx yz ashadshadsjasdjasdjashashsaashsa", name="Step 1", width=1000)
```

<img width="805" alt="image" src="https://github.com/user-attachments/assets/e969306e-2b50-4e7c-8afa-5250d1bcb544">

<img width="273" alt="image" src="https://github.com/user-attachments/assets/d6a58cf0-b32f-48a7-8c6d-16edaf857b43">
<img width="342" alt="image" src="https://github.com/user-attachments/assets/cbe30580-f80c-4bc1-aeb2-47804a17950e">
