### PR TITLE
Correctly detect max depth of NestedSelect if level is empty

### DIFF
--- a/panel/tests/widgets/test_select.py
+++ b/panel/tests/widgets/test_select.py
@@ -300,6 +300,15 @@ def test_nested_select_init_empty(document, comm):
     assert select.options is None
     assert select.levels == []
 
+def test_nested_select_max_depth_empty_first_sublevel(document, comm):
+    select = NestedSelect(options={'foo': ['a', 'b'], 'bar': []})
+
+    assert select._max_depth == 2
+
+def test_nested_select_max_depth_empty_second_sublevel(document, comm):
+    select = NestedSelect(options={'foo': {'0': ['a', 'b'], '1': []}, 'bar': {'0': []}})
+
+    assert select._max_depth == 3
 
 def test_nested_select_init_levels(document, comm):
     options = {
@@ -500,7 +509,7 @@ def test_nested_select_partial_options_set(document, comm):
     select.options = {"Ben": []}
     assert select._widgets[0].value == 'Ben'
     assert select._widgets[0].visible
-    assert select.value == {0: 'Ben'}
+    assert select.value == {0: 'Ben', 1: None}
 
 
 def test_nested_select_partial_value_init(document, comm):

--- a/panel/widgets/select.py
+++ b/panel/widgets/select.py
@@ -422,19 +422,11 @@ class NestedSelect(CompositeWidget):
         return False
 
     def _find_max_depth(self, d, depth=1):
-        if d is None or len(d) == 0:
-            return 0
-        elif not isinstance(d, dict):
-            return depth
-
+        if isinstance(d, list) or d is None:
+            return depth-1
         max_depth = depth
         for value in d.values():
-            if isinstance(value, dict):
-                max_depth = max(max_depth, self._find_max_depth(value, depth + 1))
-            # dict means it's a level, so it's not the last level
-            # list means it's a leaf, so it's the last level
-            if isinstance(value, list) and len(value) == 0 and max_depth > 0:
-                max_depth -= 1
+            max_depth = max(max_depth, self._find_max_depth(value, depth + 1))
         return max_depth
 
     def _resolve_callable_options(self, i, options) -> dict | list:


### PR DESCRIPTION
Empty levels were not treated correctly, resulting in errors when a leaf was empty and incorrectly treating a two-level `NestedSelect` as a single level