### PR TITLE
Add panel compile command to bundle ESM components

### DIFF
--- a/doc/how_to/custom_components/esm/build.md
+++ b/doc/how_to/custom_components/esm/build.md
@@ -1,4 +1,4 @@
-# Include and Bundle external resources
+# Compile and Bundle ESM Components
 
 The ESM components make it possible to load external libraries from a CDN, NPM or GitHub using one of two approaches:
 

--- a/doc/how_to/custom_components/index.md
+++ b/doc/how_to/custom_components/index.md
@@ -59,11 +59,11 @@ Build custom components in Javascript using so called ESM components, which allo
 :gutter: 1 1 1 2
 
 
-:::{grid-item-card} {octicon}`tools;2.5em;sd-mr-1 sd-animate-grow50` Building and Bundling ESM components
+:::{grid-item-card} {octicon}`tools;2.5em;sd-mr-1 sd-animate-grow50` Compile and Bundle ESM Components
 :link: esm/build
 :link-type: doc
 
-How to specify and bundle external dependencies for ESM components.
+How to specify external dependencies for ESM components and compile them into JS bundles.
 :::
 
 :::{grid-item-card} {octicon}`pencil;2.5em;sd-mr-1 sd-animate-grow50` Add callbacks to ESM components

--- a/panel/command/__init__.py
+++ b/panel/command/__init__.py
@@ -12,6 +12,7 @@ from bokeh.util.strings import nice_join
 
 from .. import __version__
 from .bundle import Bundle
+from .compile import Compile
 from .convert import Convert
 from .oauth_secret import OAuthSecret
 from .serve import Serve
@@ -51,7 +52,7 @@ def transform_cmds(argv):
 def main(args=None):
     """Mirrors bokeh CLI and adds additional Panel specific commands """
     from bokeh.command.subcommands import all as bokeh_commands
-    bokeh_commands = bokeh_commands + [OAuthSecret, Convert, Bundle]
+    bokeh_commands = bokeh_commands + [OAuthSecret, Compile, Convert, Bundle]
 
     parser = argparse.ArgumentParser(
         prog="panel", epilog="See '<command> --help' to read about a specific subcommand."
@@ -65,6 +66,10 @@ def main(args=None):
         if cls is BkServe:
             subparser = subs.add_parser(Serve.name, help=Serve.help)
             subcommand = Serve(parser=subparser)
+            subparser.set_defaults(invoke=subcommand.invoke)
+        elif cls is Compile:
+            subparser = subs.add_parser(Compile.name, help=Compile.help)
+            subcommand = Compile(parser=subparser)
             subparser.set_defaults(invoke=subcommand.invoke)
         elif cls is Convert:
             subparser = subs.add_parser(Convert.name, help=Convert.help)
@@ -102,6 +107,9 @@ def main(args=None):
         elif sys.argv[1] == 'bundle':
             args = parser.parse_args(sys.argv[1:])
             ret = Bundle(parser).invoke(args)
+        elif sys.argv[1] == 'compile':
+            args = parser.parse_args(sys.argv[1:])
+            ret = Compile(parser).invoke(args)
         else:
             ret = bokeh_entry_point()
     else:

--- a/panel/command/compile.py
+++ b/panel/command/compile.py
@@ -20,6 +20,11 @@ class Compile(Subcommand):
             help    = "The Python modules to compile. May optionally define a single class.",
             default = None,
         )),
+        ('--build-dir', dict(
+            action = 'store',
+            type    = str,
+            help    = "Where to write the build directory."
+        )),
         ('--outfile', dict(
             action = 'store',
             type    = str,
@@ -31,7 +36,7 @@ class Compile(Subcommand):
         )),
         ('--verbose', dict(
             action  = 'store_true',
-            help    = "Whether to print progress"
+            help    = "Whether to show verbose output. Note when setting --outfile only the result will be printed to stdout."
         )),
     )
 
@@ -60,7 +65,11 @@ class Compile(Subcommand):
                 )
                 return 1
         out = compile_components(
-            components, minify=not args.unminify, verbose=args.verbose and args.outfile, outfile=args.outfile
+            components,
+            build_dir=args.build_dir,
+            minify=not args.unminify,
+            outfile=args.outfile,
+            verbose=args.verbose and args.outfile,
         )
         if args.outfile:
             if not out == 0:

--- a/panel/command/compile.py
+++ b/panel/command/compile.py
@@ -1,6 +1,6 @@
 from bokeh.command.subcommand import Argument, Subcommand
 
-from ..io.compile import RED, compile_component, find_components
+from ..io.compile import RED, compile_components, find_components
 
 
 class Compile(Subcommand):
@@ -14,11 +14,16 @@ class Compile(Subcommand):
     help = "Compiles an ESM component using node and esbuild"
 
     args = (
-        ('module', Argument(
+        ('modules', Argument(
             metavar = 'DIRECTORY-OR-SCRIPT',
-            nargs   = 1,
-            help    = "The Python module to compile. May optionally define a single class.",
+            nargs   = "*",
+            help    = "The Python modules to compile. May optionally define a single class.",
             default = None,
+        )),
+        ('--outfile', dict(
+            action = 'store',
+            type    = str,
+            help    = "File to write the bundle to."
         )),
         ('--unminify', dict(
             action  = 'store_true',
@@ -31,31 +36,37 @@ class Compile(Subcommand):
     )
 
     def invoke(self, args):
-        module_spec = args.module[0]
-        if '.py:' in module_spec:
-            *parts, cls = module_spec.split(':')
-            module = ':'.join(parts)
-        elif not module_spec.endswith('.py'):
-            print(  # noqa
-                f'{RED} Can only compile ESM components defined in a Python '
-                'module, ensure you provide a file with a .py extension.'
-            )
+        components = []
+        for module_spec in args.modules:
+            if '.py:' in module_spec:
+                *parts, cls = module_spec.split(':')
+                module = ':'.join(parts)
+            elif not module_spec.endswith('.py'):
+                print(  # noqa
+                    f'{RED} Can only compile ESM components defined in a Python '
+                    'module, ensure you provide a file with a .py extension.'
+                )
+                return 1
+            else:
+                module = module_spec
+                cls = None
+            try:
+                components += find_components(module, cls)
+            except ValueError:
+                cls_error = f' and that class {cls!r} is defined therein' if cls else ''
+                print(  # noqa
+                    f'{RED} Could not find any ESM components to compile, ensure '
+                    f'you provided the right module{cls_error}.'
+                )
+                return 1
+        out = compile_components(
+            components, minify=not args.unminify, verbose=args.verbose and args.outfile, outfile=args.outfile
+        )
+        if args.outfile:
+            if not out == 0:
+                return 1
+        elif out is None:
             return 1
         else:
-            module = module_spec
-            cls = None
-        components = find_components(module)
-        compiled, errors = 0, 0
-        for component in components:
-            if cls is not None and component.__name__ != cls:
-                continue
-            errors += compile_component(component, minify=not args.unminify, verbose=args.verbose)
-            compiled += 1
-        if not compiled:
-            cls_error = f' and that class {cls!r} is defined therein' if cls else ''
-            print(  # noqa
-                f'{RED} Could not find any ESM components to compile, ensure '
-                f'you provided the right module{cls_error}.'
-            )
-            return 1
-        return 1 if errors else 0
+            print(out)  # noqa
+        return 0

--- a/panel/command/compile.py
+++ b/panel/command/compile.py
@@ -30,7 +30,7 @@ class Compile(Subcommand):
             type    = str,
             help    = "File to write the bundle to."
         )),
-        ('--unminify', dict(
+        ('--unminified', dict(
             action  = 'store_true',
             help    = "Whether to generate unminified output."
         )),
@@ -46,6 +46,7 @@ class Compile(Subcommand):
             if '.py:' in module_spec:
                 *parts, cls = module_spec.split(':')
                 module = ':'.join(parts)
+                classes = cls.split(',')
             elif not module_spec.endswith('.py'):
                 print(  # noqa
                     f'{RED} Can only compile ESM components defined in a Python '
@@ -56,7 +57,7 @@ class Compile(Subcommand):
                 module = module_spec
                 cls = None
             try:
-                components += find_components(module, cls)
+                components += find_components(module, classes)
             except ValueError:
                 cls_error = f' and that class {cls!r} is defined therein' if cls else ''
                 print(  # noqa
@@ -67,9 +68,9 @@ class Compile(Subcommand):
         out = compile_components(
             components,
             build_dir=args.build_dir,
-            minify=not args.unminify,
+            minify=not args.unminified,
             outfile=args.outfile,
-            verbose=args.verbose and args.outfile,
+            verbose=args.verbose,
         )
         if args.outfile:
             if not out == 0:

--- a/panel/command/compile.py
+++ b/panel/command/compile.py
@@ -1,0 +1,27 @@
+from bokeh.command.subcommand import Argument, Subcommand
+
+from ..io.compile import compile_module
+
+
+class Compile(Subcommand):
+    ''' Subcommand to generate a new encryption key.
+
+    '''
+
+    #: name for this subcommand
+    name = "compile"
+
+    help = "Compiles an ESM component using node and esbuild"
+
+    args = (
+        ('files', Argument(
+            metavar = 'DIRECTORY-OR-SCRIPT',
+            nargs   = '*',
+            help    = "The app directories or scripts to serve (serve empty document if not specified)",
+            default = None,
+        )),
+    )
+
+    def invoke(self, args):
+        for module in args.files:
+            compile_module(module)

--- a/panel/command/compile.py
+++ b/panel/command/compile.py
@@ -1,3 +1,9 @@
+import os
+import pathlib
+import sys
+
+from collections import defaultdict
+
 from bokeh.command.subcommand import Argument, Subcommand
 
 from ..io.compile import RED, compile_components, find_components
@@ -25,11 +31,6 @@ class Compile(Subcommand):
             type    = str,
             help    = "Where to write the build directory."
         )),
-        ('--outfile', dict(
-            action = 'store',
-            type    = str,
-            help    = "File to write the bundle to."
-        )),
         ('--unminified', dict(
             action  = 'store_true',
             help    = "Whether to generate unminified output."
@@ -41,42 +42,59 @@ class Compile(Subcommand):
     )
 
     def invoke(self, args):
-        components = []
+        bundles = defaultdict(list)
         for module_spec in args.modules:
-            if '.py:' in module_spec:
+            if ':' in module_spec:
                 *parts, cls = module_spec.split(':')
                 module = ':'.join(parts)
-                classes = cls.split(',')
-            elif not module_spec.endswith('.py'):
-                print(  # noqa
-                    f'{RED} Can only compile ESM components defined in a Python '
-                    'module, ensure you provide a file with a .py extension.'
-                )
-                return 1
             else:
                 module = module_spec
-                cls = None
+                cls = ''
+            classes = cls.split(',') if cls else None
+            module_name, ext = os.path.splitext(os.path.basename(module))
+            if ext not in ('', '.py'):
+                print(  # noqa
+                    f'{RED} Can only compile ESM components defined in Python '
+                    'file or importable module.'
+                )
+                return 1
             try:
-                components += find_components(module, classes)
+                components = find_components(module, classes)
             except ValueError:
-                cls_error = f' and that class {cls!r} is defined therein' if cls else ''
+                cls_error = f' and that class(es) {cls!r} are defined therein' if cls else ''
                 print(  # noqa
                     f'{RED} Could not find any ESM components to compile, ensure '
                     f'you provided the right module{cls_error}.'
                 )
                 return 1
-        out = compile_components(
-            components,
-            build_dir=args.build_dir,
-            minify=not args.unminified,
-            outfile=args.outfile,
-            verbose=args.verbose,
-        )
-        if args.outfile:
-            if not out == 0:
-                return 1
-        elif out is None:
-            return 1
-        else:
-            print(out)  # noqa
-        return 0
+            if module in sys.modules:
+                module_path = sys.modules[module].__file__
+            else:
+                module_path = module
+            module_path = pathlib.Path(module_path).parent
+            for component in components:
+                if component._bundle:
+                    bundle_path = component._bundle
+                    if isinstance(bundle_path, str):
+                        path = (module_path / bundle_path).absolute()
+                    else:
+                        path = bundle_path.absolute()
+                    bundles[str(path)].append(component)
+                elif len(components) > 1 and not classes:
+                    component_module = module_name if ext else component.__module__
+                    bundles[module_path / f'{component_module}.bundle.js'].append(component)
+                else:
+                    bundles[module_path / f'{component.__name__}.bundle.js'].append(component)
+
+        errors = 0
+        for bundle, components in bundles.items():
+            out = compile_components(
+                components,
+                build_dir=args.build_dir,
+                minify=not args.unminified,
+                outfile=bundle,
+                verbose=args.verbose,
+            )
+            if not out:
+                errors += 1
+        return int(errors>0)

--- a/panel/command/compile.py
+++ b/panel/command/compile.py
@@ -1,6 +1,6 @@
 from bokeh.command.subcommand import Argument, Subcommand
 
-from ..io.compile import compile_module
+from ..io.compile import RED, compile_component, find_components
 
 
 class Compile(Subcommand):
@@ -14,14 +14,48 @@ class Compile(Subcommand):
     help = "Compiles an ESM component using node and esbuild"
 
     args = (
-        ('files', Argument(
+        ('module', Argument(
             metavar = 'DIRECTORY-OR-SCRIPT',
-            nargs   = '*',
-            help    = "The app directories or scripts to serve (serve empty document if not specified)",
+            nargs   = 1,
+            help    = "The Python module to compile. May optionally define a single class.",
             default = None,
+        )),
+        ('--unminify', dict(
+            action  = 'store_true',
+            help    = "Whether to generate unminified output."
+        )),
+        ('--verbose', dict(
+            action  = 'store_true',
+            help    = "Whether to print progress"
         )),
     )
 
     def invoke(self, args):
-        for module in args.files:
-            compile_module(module)
+        module_spec = args.module[0]
+        if '.py:' in module_spec:
+            *parts, cls = module_spec.split(':')
+            module = ':'.join(parts)
+        elif not module_spec.endswith('.py'):
+            print(  # noqa
+                f'{RED} Can only compile ESM components defined in a Python '
+                'module, ensure you provide a file with a .py extension.'
+            )
+            return 1
+        else:
+            module = module_spec
+            cls = None
+        components = find_components(module)
+        compiled, errors = 0, 0
+        for component in components:
+            if cls is not None and component.__name__ != cls:
+                continue
+            errors += compile_component(component, minify=not args.unminify, verbose=args.verbose)
+            compiled += 1
+        if not compiled:
+            cls_error = f' and that class {cls!r} is defined therein' if cls else ''
+            print(  # noqa
+                f'{RED} Could not find any ESM components to compile, ensure '
+                f'you provided the right module{cls_error}.'
+            )
+            return 1
+        return 1 if errors else 0

--- a/panel/custom.py
+++ b/panel/custom.py
@@ -99,6 +99,8 @@ class ReactiveESM(ReactiveCustomBase, metaclass=ReactiveESMMetaclass):
 
     _esm: ClassVar[str | os.PathLike] = ""
 
+    _exports: ClassVar[str] = ""
+
     _importmap: ClassVar[dict[Literal['imports', 'scopes'], str]] = {}
 
     __abstract = True
@@ -148,6 +150,7 @@ class ReactiveESM(ReactiveCustomBase, metaclass=ReactiveESMMetaclass):
         else:
             esm = cls._esm
         esm = textwrap.dedent(esm)
+        esm += textwrap.dedent(cls._exports)
         return esm
 
     def _cleanup(self, root: Model | None) -> None:
@@ -394,6 +397,11 @@ class ReactComponent(ReactiveESM):
     _bokeh_model = _BkReactComponent
 
     _react_version = '18.3.1'
+
+    _exports = """
+    import * as React from "react"
+    import { createRoot } from "react-dom/client"
+    export default {render, React, createRoot}"""
 
     @classmethod
     def _process_importmap(cls):

--- a/panel/custom.py
+++ b/panel/custom.py
@@ -111,7 +111,7 @@ class ReactiveESM(ReactiveCustomBase, metaclass=ReactiveESMMetaclass):
     @classproperty
     def _compiled_path(cls) -> os.PathLike | None:
         if config.autoreload:
-            return False
+            return None
         mod_path = pathlib.Path(inspect.getfile(cls)).parent
         cls_name = camel_to_kebab(cls.__name__)
         path = mod_path / f'{cls_name}.compiled.js'

--- a/panel/custom.py
+++ b/panel/custom.py
@@ -253,7 +253,7 @@ class ReactiveESM(ReactiveCustomBase, metaclass=ReactiveESMMetaclass):
         if not ((config.autoreload or getattr(self, '_debug', False)) and import_available('watchfiles')):
             return
         super()._setup_autoreload()
-        if (self._esm_path(compile=False) and not self._watching_esm):
+        if (self._esm_path(compiled=False) and not self._watching_esm):
             self._watching_esm = asyncio.Event()
             state.execute(self._watch_esm)
 

--- a/panel/custom.py
+++ b/panel/custom.py
@@ -205,10 +205,7 @@ class ReactiveESM(ReactiveCustomBase, metaclass=ReactiveESMMetaclass):
             data_params[k] = v
         data_props = self._process_param_change(data_params)
         precompiled = self._compiled_path is not None
-        if precompiled:
-            importmap = {}
-        else:
-            importmap = self._process_importmap()
+        importmap = {} if precompiled else self._process_importmap()
         params.update({
             'class_name': camel_to_kebab(cls.__name__),
             'data': self._data_model(**{p: v for p, v in data_props.items() if p not in ignored}),
@@ -248,7 +245,7 @@ class ReactiveESM(ReactiveCustomBase, metaclass=ReactiveESMMetaclass):
         if not ((config.autoreload or getattr(self, '_debug', False)) and import_available('watchfiles')):
             return
         super()._setup_autoreload()
-        if (self._esm_path(False) and not self._watching_esm):
+        if (self._esm_path(compile=False) and not self._watching_esm):
             self._watching_esm = asyncio.Event()
             state.execute(self._watch_esm)
 

--- a/panel/custom.py
+++ b/panel/custom.py
@@ -144,13 +144,14 @@ class ReactiveESM(ReactiveCustomBase, metaclass=ReactiveESMMetaclass):
         return None
 
     @classmethod
-    def _render_esm(cls, compiled: bool = True):
-        if (esm_path:= cls._esm_path(compiled=compiled)):
+    def _render_esm(cls, compiled: bool | Literal['compiling'] = True):
+        if (esm_path:= cls._esm_path(compiled=compiled is True)):
             esm = esm_path.read_text(encoding='utf-8')
         else:
             esm = cls._esm
         esm = textwrap.dedent(esm)
-        esm += textwrap.dedent(cls._exports)
+        if compiled == 'compiling':
+            esm += textwrap.dedent(cls._exports)
         return esm
 
     def _cleanup(self, root: Model | None) -> None:

--- a/panel/io/compile.py
+++ b/panel/io/compile.py
@@ -145,6 +145,13 @@ def compile_component(component: type[ReactiveESM], minify: bool = True):
     Compiles and bundles the ESM code of a ReactiveESM component and
     writes the compiled JS file to a file adjacent to the module
     the component was defined in.
+
+    Arguments
+    ---------
+    component: type[ReactiveESM]
+        The component to compile.
+    minify: bool
+        Whether to minify the output.
     """
     name = camel_to_kebab(component.__name__)
     ext = 'jsx' if issubclass(component, ReactComponent) else 'js'
@@ -190,5 +197,16 @@ def compile_component(component: type[ReactiveESM], minify: bool = True):
 
 
 def compile_module(module: str | os.PathLike, minify: bool = True):
+    """
+    Compiles and bundles all ESM components in a module and writes the
+    resulting JS file(s) to disk alongside the input module.
+
+    Arguments
+    ---------
+    module: str | os.PathLike
+        Input module where one or more ESM components can be defined.
+    minify: boolean
+        Whether to minify the output.
+    """
     for component in find_components(module):
         compile_component(component, minify=minify)

--- a/panel/io/compile.py
+++ b/panel/io/compile.py
@@ -133,7 +133,7 @@ def compile_component(component: type[ReactiveESM], minify: bool = True):
         out_path = component.__path__
     else:
         out_path = pathlib.Path(inspect.getfile(component)).parent
-    out = (pathlib.Path(out_path) / f'{name}.compiled.js').absolute()
+    out = (out_path / f'{name}.compiled.js').absolute()
 
     code, package_json = extract_dependencies(component)
 

--- a/panel/io/compile.py
+++ b/panel/io/compile.py
@@ -129,8 +129,6 @@ def extract_dependencies(component: type[ReactiveESM]) -> tuple[str, dict[str, a
 
     dependencies = packages_from_importmap(importmap.get('imports', {}))
     esm = component._render_esm(compiled=False)
-    if issubclass(component, ReactComponent):
-        esm += '\nimport * as React from "react"\nimport { createRoot } from "react-dom/client"\nexport default {render, React, createRoot}'
     js_code, packages = packages_from_code(esm)
     dependencies.update(packages)
 

--- a/panel/io/compile.py
+++ b/panel/io/compile.py
@@ -136,12 +136,6 @@ def extract_dependencies(component: type[ReactiveESM]) -> tuple[str, dict[str, a
         A dictionary of package dependencies and their versions.
     """
     importmap = component._process_importmap()
-    if not importmap:
-        raise ValueError(
-            f'{component.__name__} did not declare an importmap '
-            'and cannot be compiled.'
-        )
-
     dependencies = packages_from_importmap(importmap.get('imports', {}))
     esm = component._render_esm(compiled=False)
     js_code, packages = packages_from_code(esm)

--- a/panel/io/compile.py
+++ b/panel/io/compile.py
@@ -1,0 +1,177 @@
+import inspect
+import json
+import os
+import pathlib
+import re
+import subprocess
+import tempfile
+
+from bokeh.application.handlers.code_runner import CodeRunner
+
+from ..custom import ReactComponent, ReactiveESM
+from ..util import camel_to_kebab
+
+
+def find_components(path: str | os.PathLike) -> list[type[ReactiveESM]]:
+    """
+    Creates a temporary module given a path-like object and finds all
+    the ReactiveESM components defined therein.
+
+    Arguments
+    ---------
+    path : str | os.PathLike
+        The path to the Python module.
+
+    Returns
+    -------
+    List of ReactiveESM components defined in the module.
+    """
+    path_obj = pathlib.Path(path)
+    source = path_obj.read_text(encoding='utf-8')
+    runner = CodeRunner(source, path, [])
+    module = runner.new_module()
+    runner.run(module)
+    components = []
+    for v in module.__dict__.values():
+        if isinstance(v, type) and issubclass(v, ReactiveESM) and not v.abstract:
+            v.__path__ = path_obj.parent.absolute()
+            components.append(v)
+    return components
+
+
+def extract_packages(esm_code: str) -> dict[str, str]:
+    """
+    Extracts package version definitions from ESM code.
+
+    Arguments
+    ---------
+    esm_code : str
+        The ESM code to search for package imports.
+
+    Returns
+    -------
+    Dictionary of packages and their versions.
+    """
+    # Regex pattern to match import statements with URLs starting with https
+    pattern = r"import\s+.*?\s+from\s+['\"](https:\/\/[^\/]+\/([^@\/]+)(?:@([\d\.\w-]+))?)['\"]"
+
+    # Find all matching import statements
+    matches = re.findall(pattern, esm_code)
+
+    packages = {}
+
+    for match in matches:
+        replace, package_name, version = match
+        # Add to dictionary
+        packages[package_name] = version
+        esm_code = esm_code.replace(replace, package_name)
+
+    return esm_code, packages
+
+
+def extract_dependencies(component: type[ReactiveESM]) -> tuple[str, dict[str, any]]:
+    """
+    Extracts dependencies from a ReactiveESM component by parsing its
+    importmap and the associated code and replaces URL import
+    specifiers with package imports.
+
+    Arguments
+    ---------
+    component: type[ReactiveESM]
+        The ReactiveESM component to extract a dependency definition from.
+
+    Returns
+    -------
+    code: str
+        Code where the URL imports have been replaced by package imports.
+    dependencies: dict[str, str]
+        A dictionary of package dependencies and their versions.
+    """
+    importmap = component._process_importmap()
+    if not importmap:
+        raise ValueError(
+            f'{component.__name__} did not declare an importmap '
+            'and cannot be compiled.'
+        )
+
+    # Extract dependencies and versions
+    dependencies = {}
+    for key, url in importmap["imports"].items():
+        match = re.search(r'@(\d+\.\d+\.\d+)', url)
+        if key.endswith('/'):
+            key = key[:-1]
+
+        if match:
+            dependencies[key] = f"^{match.group(1)}"
+        else:
+            dependencies[key] = "latest"
+
+    esm = component._render_esm(compiled=False)
+    if issubclass(component, ReactComponent):
+        esm += '\nimport * as React from "react"\nimport { createRoot } from "react-dom/client"\nexport default {render, React, createRoot}'
+
+    js_code, packages = extract_packages(esm)
+    dependencies.update(packages)
+
+    # Create package.json structure
+    package_json = {
+        "name": camel_to_kebab(component.__name__),
+        "dependencies": dependencies
+    }
+    return js_code, package_json
+
+
+def compile_component(component: type[ReactiveESM], minify: bool = True):
+    """
+    Compiles and bundles the ESM code of a ReactiveESM component and
+    writes the compiled JS file to a file adjacent to the module
+    the component was defined in.
+    """
+    name = camel_to_kebab(component.__name__)
+    ext = 'jsx' if issubclass(component, ReactComponent) else 'js'
+    if hasattr(component, '__path__'):
+        out_path = component.__path__
+    else:
+        out_path = pathlib.Path(inspect.getfile(component)).parent
+    out = (pathlib.Path(out_path) / f'{name}.compiled.js').absolute()
+
+    code, package_json = extract_dependencies(component)
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        package_json_path = os.path.join(temp_dir, 'package.json')
+        with open(package_json_path, 'w') as package_json_file:
+            json.dump(package_json, package_json_file, indent=2)
+
+        index_js_path = os.path.join(temp_dir, f'index.{ext}')
+        with open(index_js_path, 'w') as index_js_file:
+            index_js_file.write(code)
+
+        os.chdir(temp_dir)
+
+        install_cmd = ['npm', 'install']
+        try:
+            print(f"Running command: {' '.join(install_cmd)}")  # noqa
+            result = subprocess.run(install_cmd, check=True, capture_output=True, text=True)
+            print("esbuild output:", result.stdout)  # noqa
+            if result.stderr:
+                print("esbuild errors:", result.stderr)  # noqa
+        except subprocess.CalledProcessError as e:
+            print("An error occurred while running esbuild:")  # noqa
+            print(e.stderr)  # noqa
+
+        minify_arg = ['--minify'] if minify else []
+        build_cmd = ['esbuild', index_js_path, '--bundle', '--format=esm', f'--outfile={out}'] + minify_arg
+        try:
+            print(f"Running command: {' '.join(build_cmd)}")  # noqa
+            result = subprocess.run(build_cmd, check=True, capture_output=True, text=True)
+            print("esbuild output:", result.stdout)  # noqa
+            if result.stderr:
+                print("esbuild errors:", result.stderr)  # noqa
+        except subprocess.CalledProcessError as e:
+            print("An error occurred while running esbuild:")  # noqa
+            print(e.stderr)  # noqa
+
+
+def compile_module(module: str | os.PathLike, minify: bool = True):
+    for component in find_components(module):
+        compile_component(component, minify=minify)

--- a/panel/models/anywidget_component.ts
+++ b/panel/models/anywidget_component.ts
@@ -1,7 +1,6 @@
 import type * as p from "@bokehjs/core/properties"
 
-import {ReactiveESM} from "./reactive_esm"
-import {ReactComponent, ReactComponentView} from "./react_component"
+import {ReactiveESM, ReactiveESMView} from "./reactive_esm"
 
 class AnyWidgetModelAdapter {
   declare model: AnyWidgetComponent
@@ -91,7 +90,7 @@ class AnyWidgetAdapter extends AnyWidgetModelAdapter {
 
 }
 
-export class AnyWidgetComponentView extends ReactComponentView {
+export class AnyWidgetComponentView extends ReactiveESMView {
   declare model: AnyWidgetComponent
   adapter: AnyWidgetAdapter
   destroyer: Promise<((props: any) => void) | null>
@@ -132,12 +131,12 @@ export default {render}`
 export namespace AnyWidgetComponent {
   export type Attrs = p.AttrsOf<Props>
 
-  export type Props = ReactComponent.Props
+  export type Props = ReactiveESM.Props
 }
 
 export interface AnyWidgetComponent extends AnyWidgetComponent.Attrs {}
 
-export class AnyWidgetComponent extends ReactComponent {
+export class AnyWidgetComponent extends ReactiveESM {
   declare properties: AnyWidgetComponent.Props
 
   constructor(attrs?: Partial<AnyWidgetComponent.Attrs>) {
@@ -147,10 +146,6 @@ export class AnyWidgetComponent extends ReactComponent {
   protected override _run_initializer(initialize: (props: any) => void): void {
     const props = {model: new AnyWidgetModelAdapter(this)}
     initialize(props)
-  }
-
-  override compile(): string | null {
-    return ReactiveESM.prototype.compile.call(this)
   }
 
   static override __module__ = "panel.models.esm"

--- a/panel/models/esm.py
+++ b/panel/models/esm.py
@@ -39,6 +39,8 @@ class ReactiveESM(HTMLBox):
 
     importmap = bp.Dict(bp.String, bp.Dict(bp.String, bp.String))
 
+    precompiled = bp.Bool(False)
+
     __javascript_modules_raw__ = [
         f"{config.npm_cdn}/es-module-shims@^1.10.0/dist/es-module-shims.min.js"
     ]
@@ -52,8 +54,6 @@ class ReactComponent(ReactiveESM):
     """
     Renders jsx/tsx based ESM bundles using React.
     """
-
-    react_version = bp.String('18.3.1')
 
 
 class AnyWidgetComponent(ReactComponent):

--- a/panel/models/esm.py
+++ b/panel/models/esm.py
@@ -27,6 +27,8 @@ class ESMEvent(ModelEvent):
 
 class ReactiveESM(HTMLBox):
 
+    bundle = bp.Nullable(bp.String)
+
     class_name = bp.String()
 
     children = bp.List(bp.String)
@@ -38,8 +40,6 @@ class ReactiveESM(HTMLBox):
     esm = bp.String()
 
     importmap = bp.Dict(bp.String, bp.Dict(bp.String, bp.String))
-
-    precompiled = bp.Bool(False)
 
     __javascript_modules_raw__ = [
         f"{config.npm_cdn}/es-module-shims@^1.10.0/dist/es-module-shims.min.js"

--- a/panel/models/react_component.ts
+++ b/panel/models/react_component.ts
@@ -44,21 +44,26 @@ if (rendered && view.model.usesReact) {
   }
 }`
     let import_code
-    if (this.model.precompiled) {
+    if (this.model.bundle) {
       import_code = `
-const ns = view._module_cache.get(view.model.name)
-const React = ns.default.React
-const createRoot = ns.default.createRoot`
+const ns = await view._module_cache.get(view.model.bundle)
+const {React, createRoot} = ns.default`
     } else {
       import_code = `
 import * as React from "react"
 import { createRoot } from "react-dom/client"`
     }
     if (this.model.usesMui) {
-      import_code = `
+      if (this.model.bundle) {
+        import_code = `
+const ns = await view._module_cache.get(view.model.bundle)
+const {CacheProvider, React, createCache, createRoot} = ns.default`
+      } else {
+	import_code = `
 ${import_code}
 import createCache from "@emotion/cache"
 import { CacheProvider } from "@emotion/react"`
+      }
       render_code = `
   if (rendered) {
     const cache = createCache({
@@ -249,7 +254,7 @@ export class ReactComponent extends ReactiveESM {
 
   override compile(): string | null {
     const compiled = super.compile()
-    if (this.precompiled) {
+    if (this.bundle) {
       return compiled
     } else if (compiled === null || !compiled.includes("React")) {
       return compiled

--- a/panel/models/react_component.ts
+++ b/panel/models/react_component.ts
@@ -46,8 +46,9 @@ if (rendered && view.model.usesReact) {
     let import_code
     if (this.model.precompiled) {
       import_code = `
-const React = view.compiled_module.default.React
-const createRoot = view.compiled_module.default.createRoot`
+const ns = view._module_cache.get(view.model.name)
+const React = ns.default.React
+const createRoot = ns.default.createRoot`
     } else {
       import_code = `
 import * as React from "react"

--- a/panel/models/react_component.ts
+++ b/panel/models/react_component.ts
@@ -59,7 +59,7 @@ import { createRoot } from "react-dom/client"`
 const ns = await view._module_cache.get(view.model.bundle)
 const {CacheProvider, React, createCache, createRoot} = ns.default`
       } else {
-	import_code = `
+        import_code = `
 ${import_code}
 import createCache from "@emotion/cache"
 import { CacheProvider } from "@emotion/react"`

--- a/panel/models/reactive_esm.ts
+++ b/panel/models/reactive_esm.ts
@@ -628,12 +628,12 @@ export class ReactiveESM extends HTMLBox {
     }
     this.compiled_module = (esm_module as Promise<any>).then((mod: any) => {
       if (!this.dev) {
-	MODULE_CACHE.set(this.name, mod)
+        MODULE_CACHE.set(this.name, mod)
       }
       try {
         let initialize
-	const parts = (this.name as string).split('.')
-	const name = parts[parts.length-1]
+        const parts = (this.name as string).split('.')
+        const name = parts[parts.length-1]
         if (this.precompiled && (mod.default || {}).hasOwnProperty(name)) {
           mod = mod.default[name]
         }

--- a/panel/models/reactive_esm.ts
+++ b/panel/models/reactive_esm.ts
@@ -637,13 +637,13 @@ export class ReactiveESM extends HTMLBox {
   static {
     this.prototype.default_view = ReactiveESMView
     this.define<ReactiveESM.Props>(({Any, Array, Bool, String}) => ({
-      children:   [ Array(String),       [] ],
-      class_name: [ String,              "" ],
-      data:       [ Any                     ],
-      dev:        [ Bool,             false ],
-      esm:        [ String,              "" ],
-      importmap:  [ Any,                 {} ],
-      precompiled:[ Bool,             false ],
+      children:    [ Array(String),       [] ],
+      class_name:  [ String,              "" ],
+      data:        [ Any                     ],
+      dev:         [ Bool,             false ],
+      esm:         [ String,              "" ],
+      importmap:   [ Any,                 {} ],
+      precompiled: [ Bool,             false ],
     }))
   }
 }

--- a/panel/models/reactive_esm.ts
+++ b/panel/models/reactive_esm.ts
@@ -168,6 +168,7 @@ export class ReactiveESMView extends HTMLBoxView {
     ["resize", []],
     ["remove", []],
   ])
+  _module_cache: Map<string, any> = MODULE_CACHE
   _rendered: boolean = false
   _stale_children: boolean = false
 
@@ -627,12 +628,14 @@ export class ReactiveESM extends HTMLBox {
     }
     this.compiled_module = (esm_module as Promise<any>).then((mod: any) => {
       if (!this.dev) {
-        MODULE_CACHE.set(this.name, mod)
+	MODULE_CACHE.set(this.name, mod)
       }
       try {
         let initialize
-        if (this.precompiled && (mod.default || {}).hasOwnProperty(this.name)) {
-          mod = mod.default[this.name as string]
+	const parts = (this.name as string).split('.')
+	const name = parts[parts.length-1]
+        if (this.precompiled && (mod.default || {}).hasOwnProperty(name)) {
+          mod = mod.default[name]
         }
         if (mod.initialize) {
           initialize = mod.initialize

--- a/panel/models/reactive_esm.ts
+++ b/panel/models/reactive_esm.ts
@@ -459,6 +459,7 @@ export namespace ReactiveESM {
     dev: p.Property<boolean>
     esm: p.Property<string>
     importmap: p.Property<any>
+    precompiled: p.Property<boolean>
   }
 }
 
@@ -570,6 +571,9 @@ export class ReactiveESM extends HTMLBox {
   }
 
   compile(): string | null {
+    if (this.precompiled) {
+      return this.esm
+    }
     let compiled
     try {
       compiled = transform(
@@ -639,6 +643,7 @@ export class ReactiveESM extends HTMLBox {
       dev:        [ Bool,             false ],
       esm:        [ String,              "" ],
       importmap:  [ Any,                 {} ],
+      precompiled:[ Bool,             false ],
     }))
   }
 }

--- a/panel/models/reactive_esm.ts
+++ b/panel/models/reactive_esm.ts
@@ -632,7 +632,7 @@ export class ReactiveESM extends HTMLBox {
       }
       try {
         let initialize
-        const parts = (this.name as string).split('.')
+        const parts = (this.name as string).split(".")
         const name = parts[parts.length-1]
         if (this.precompiled && (mod.default || {}).hasOwnProperty(name)) {
           mod = mod.default[name]

--- a/panel/tests/io/test_compile.py
+++ b/panel/tests/io/test_compile.py
@@ -1,6 +1,8 @@
 import pytest
 
-from panel.io.compile import packages_from_code
+from panel.io.compile import (
+    packages_from_code, packages_from_importmap, replace_imports,
+)
 
 
 def test_packages_from_code_simple():
@@ -21,5 +23,44 @@ def test_packages_from_code_dev(dev):
 ])
 def test_packages_from_code_path(import_code):
     code, pkgs = packages_from_code(import_code)
+    assert code == 'import * from "chart.js/auto"'
+    assert pkgs == {'chart.js': '^1.0.0'}
+
+def test_replace_imports_single_quote():
+    assert replace_imports("import {foo} from 'bar'", {'bar': 'pkg-bar'}) == "import {foo} from 'pkg-bar'"
+
+def test_replace_imports_double_quote():
+    assert replace_imports('import {foo} from "bar"', {'bar': 'pkg-bar'}) == 'import {foo} from "pkg-bar"'
+
+def test_replace_imports_trailing_slash():
+    assert replace_imports('import {foo} from "bar/baz"', {'bar': 'pkg-bar'}) == 'import {foo} from "pkg-bar/baz"'
+
+def test_replace_imports_only_from():
+    assert replace_imports('import {bar} from "bar"', {'bar': 'pkg-bar'}) == 'import {bar} from "pkg-bar"'
+
+def test_packages_from_importmap_simple():
+    code, packages = packages_from_importmap(
+        'import * from "confetti"',
+        {'confetti': 'https://esm.sh/confetti-canvas@1.0.0'}
+    )
+    assert code == 'import * from "confetti-canvas"'
+    assert packages == {'confetti-canvas': '^1.0.0'}
+
+@pytest.mark.parametrize('dev', ['rc', 'a', 'b'])
+def test_packages_from_importmap_dev(dev):
+    code, pkgs = packages_from_importmap(
+        'import * from "confetti"',
+        {'confetti': f'https://esm.sh/confetti-canvas@1.0.0-{dev}.1'}
+    )
+    assert code == 'import * from "confetti-canvas"'
+    assert pkgs == {'confetti-canvas': f'^1.0.0-{dev}.1'}
+
+@pytest.mark.parametrize('url', [
+    "https://esm.sh/chart.js@1.0.0/",
+    "https://esm.sh/chart.js@1.0.0/?deps=react",
+    "https://esm.sh/chart.js@1.0.0&external=react/",
+])
+def test_packages_from_importmap_path(url):
+    code, pkgs = packages_from_importmap('import * from "chart-js/auto"', {'chart-js/': url})
     assert code == 'import * from "chart.js/auto"'
     assert pkgs == {'chart.js': '^1.0.0'}

--- a/panel/tests/io/test_compile.py
+++ b/panel/tests/io/test_compile.py
@@ -5,10 +5,20 @@ from panel.io.compile import (
 )
 
 
-def test_packages_from_code_simple():
+def test_packages_from_code_esm_sh():
     code, pkgs = packages_from_code('import * from "https://esm.sh/confetti-canvas@1.0.0"')
     assert code == 'import * from "confetti-canvas"'
     assert pkgs == {'confetti-canvas': '^1.0.0'}
+
+def test_packages_from_code_unpkg():
+    code, pkgs = packages_from_code('import * from "https://unpkg.com/esm@3.2.25/esm/loader.js"')
+    assert code == 'import * from "esm"'
+    assert pkgs == {'esm': '^3.2.25'}
+
+def test_packages_from_code_jsdelivr():
+    code, pkgs = packages_from_code('import * as vg from "https://cdn.jsdelivr.net/npm/@uwdata/vgplot@0.8.0/+esm"')
+    assert code == 'import * as vg from "@uwdata/vgplot"'
+    assert pkgs == {'@uwdata/vgplot': '^0.8.0'}
 
 @pytest.mark.parametrize('dev', ['rc', 'a', 'b'])
 def test_packages_from_code_dev(dev):
@@ -38,13 +48,29 @@ def test_replace_imports_trailing_slash():
 def test_replace_imports_only_from():
     assert replace_imports('import {bar} from "bar"', {'bar': 'pkg-bar'}) == 'import {bar} from "pkg-bar"'
 
-def test_packages_from_importmap_simple():
+def test_packages_from_importmap_esm_sh():
     code, packages = packages_from_importmap(
         'import * from "confetti"',
         {'confetti': 'https://esm.sh/confetti-canvas@1.0.0'}
     )
     assert code == 'import * from "confetti-canvas"'
     assert packages == {'confetti-canvas': '^1.0.0'}
+
+def test_packages_from_importmap_unpkg():
+    code, pkgs = packages_from_importmap(
+        'import * from "esm"',
+        {'esm': 'https://unpkg.com/esm@3.2.25/esm/loader.js'}
+    )
+    assert code == 'import * from "esm"'
+    assert pkgs == {'esm': '^3.2.25'}
+
+def test_packages_from_importmap_jsdelivr():
+    code, pkgs = packages_from_importmap(
+        'import * as vg from "@uwdata/vgplot"',
+        {"@uwdata/vgplot": "https://cdn.jsdelivr.net/npm/@uwdata/vgplot@0.8.0/+esm"}
+    )
+    assert code == 'import * as vg from "@uwdata/vgplot"'
+    assert pkgs == {'@uwdata/vgplot': '^0.8.0'}
 
 @pytest.mark.parametrize('dev', ['rc', 'a', 'b'])
 def test_packages_from_importmap_dev(dev):

--- a/panel/tests/io/test_compile.py
+++ b/panel/tests/io/test_compile.py
@@ -1,0 +1,25 @@
+import pytest
+
+from panel.io.compile import packages_from_code
+
+
+def test_packages_from_code_simple():
+    code, pkgs = packages_from_code('import * from "https://esm.sh/confetti-canvas@1.0.0"')
+    assert code == 'import * from "confetti-canvas"'
+    assert pkgs == {'confetti-canvas': '^1.0.0'}
+
+@pytest.mark.parametrize('dev', ['rc', 'a', 'b'])
+def test_packages_from_code_dev(dev):
+    code, pkgs = packages_from_code(f'import * from "https://esm.sh/confetti-canvas@1.0.0-{dev}.1"')
+    assert code == 'import * from "confetti-canvas"'
+    assert pkgs == {'confetti-canvas': f'^1.0.0-{dev}.1'}
+
+@pytest.mark.parametrize('import_code', [
+    'import * from "https://esm.sh/chart.js@1.0.0/auto"',
+    'import * from "https://esm.sh/chart.js@1.0.0/auto?deps=react"',
+    'import * from "https://esm.sh/chart.js@1.0.0&external=react/auto"',
+])
+def test_packages_from_code_path(import_code):
+    code, pkgs = packages_from_code(import_code)
+    assert code == 'import * from "chart.js/auto"'
+    assert pkgs == {'chart.js': '^1.0.0'}

--- a/panel/tests/ui/test_custom.py
+++ b/panel/tests/ui/test_custom.py
@@ -133,6 +133,76 @@ def test_initialize(page, component):
     expect(page.locator('h1')).to_have_text('1')
 
 
+class AnyWidgetModuleCached(AnyWidgetComponent):
+
+    count = param.Integer(default=0)
+
+    _esm = """
+    let count = 0
+
+    export function initialize({ model }) {
+      count += 1
+      model.set('count', count)
+      model.save_changes()
+    }
+
+    export function render({ model, el }) {
+      const h1 = document.createElement('h1')
+      h1.textContent = `${model.get('count')}`
+      el.append(h1)
+    }
+    """
+
+class JSModuleCached(JSComponent):
+
+    count = param.Integer(default=0)
+
+    _esm = """
+    let count = 0
+
+    export function initialize({ model }) {
+      count += 1
+      model.count = count
+    }
+
+    export function render({ model }) {
+      const h1 = document.createElement('h1')
+      h1.textContent = `${model.count}`
+      return h1
+    }
+    """
+
+class ReactModuleCached(ReactComponent):
+
+    count = param.Integer(default=0)
+
+    _esm = """
+    let count = 0
+
+    export function initialize({ model }) {
+      count += 1
+      model.count = count
+    }
+
+    export function render({ model }) {
+      const [count] = model.useState('count')
+      return <h1>{count}</h1>
+    }
+    """
+
+@pytest.mark.parametrize('component', [AnyWidgetModuleCached, JSModuleCached, ReactModuleCached])
+def test_module_cached(page, component):
+    example = Row(component())
+
+    serve_component(page, example)
+
+    expect(page.locator('h1')).to_have_text('1')
+
+    example[0] = component()
+
+    expect(page.locator('h1')).to_have_text('2')
+
+
 class JSUnwatch(JSComponent):
 
     text = param.String()

--- a/panel/tests/ui/test_custom.py
+++ b/panel/tests/ui/test_custom.py
@@ -7,6 +7,7 @@ pytest.importorskip("playwright")
 
 from playwright.sync_api import expect
 
+from panel.config import config
 from panel.custom import (
     AnyWidgetComponent, Child, Children, JSComponent, ReactComponent,
 )
@@ -540,16 +541,18 @@ def test_reload(page, js_file, component, before, after):
         _esm = pathlib.Path(js_file.name)
 
     example = CustomReload()
-    serve_component(page, example)
 
-    expect(page.locator('h1')).to_have_text('foo')
+    with config.set(autoreload=True):
+        serve_component(page, example)
 
-    js_file.file.write(after)
-    js_file.file.flush()
-    js_file.file.seek(0)
-    example._update_esm()
+        expect(page.locator('h1')).to_have_text('foo')
 
-    expect(page.locator('h1')).to_have_text('bar')
+        js_file.file.write(after)
+        js_file.file.flush()
+        js_file.file.seek(0)
+        example._update_esm()
+
+        expect(page.locator('h1')).to_have_text('bar')
 
 
 def test_anywidget_custom_event(page):

--- a/panel/viewable.py
+++ b/panel/viewable.py
@@ -313,7 +313,7 @@ class ServableMixin:
         """
         Callback to handle FunctionHandler document creation.
         """
-        if server_id:
+        if server_id and server_id in state._servers:
             state._servers[server_id][2].append(doc)
         return self.server_doc(doc, title, location) # type: ignore
 

--- a/pixi.toml
+++ b/pixi.toml
@@ -140,6 +140,7 @@ playwright = { version = "*", channel = "microsoft" }
 pytest-playwright = "*"
 pytest-asyncio = "*"
 jupyter_server = "*"
+esbuild = "*"
 packaging = "*"
 
 [feature.test-ui.tasks]


### PR DESCRIPTION
This PR makes it possible to compile and bundle dependencies of an ESM component using a simple command. Specifically the user can run:

```
panel compile my_module_containing_esm_components.py
```

which will perform the following steps:

1. Create a temporary module for the provided file(s)
2. Find all `ReactiveESM` components in those file(s)
3. For each `ReactiveESM` component extract the required dependencies from the `importmap` and the code itself
4. Write the JS code and the generated nodeJS `package.json` containing the dependencies to a temporary directory
5. Invoke `npm install` to fetch the dependencies
6. Invoke `esbuild index.js --bundled --format=esm --minify`
7. Write the generated file to the directory where the original file is located

The compiled JS bundle will then be used the next time the component is used, as long as `--autoreload` is disabled.