### PR TITLE
Add FastAPI based serve functions

### DIFF
--- a/doc/how_to/integrations/FastAPI.md
+++ b/doc/how_to/integrations/FastAPI.md
@@ -152,8 +152,8 @@ def create_panel_app():
 
 add_applications({
     "/panel_app1": create_panel_app,
-	"/panel_app2": pn.Column('I am a Panel object!'),
-	"/panel_app3": "my_panel_app.py"
+    "/panel_app2": pn.Column('I am a Panel object!'),
+    "/panel_app3": "my_panel_app.py"
 }, app=app)
 ```
 

--- a/doc/how_to/integrations/FastAPI.md
+++ b/doc/how_to/integrations/FastAPI.md
@@ -1,272 +1,161 @@
-# Integrating Panel with FastAPI
+# Running Panel apps in FastAPI
 
-Panel generally runs on the Bokeh server which itself runs on Tornado. However, it is also often useful to embed a Panel app in large web application, such as a FastAPI web server. [FastAPI](https://fastapi.tiangolo.com/) is especially useful compared to others like Flask and Django because of it's lightning fast, lightweight framework. Using Panel with FastAPI requires a bit more work than for notebooks and Bokeh servers.
+Panel generally runs on the Bokeh server, which itself runs on [Tornado](https://tornadoweb.org/en/stable/). However, it is also often useful to embed a Panel app in an existing web application, such as a [FastAPI](https://fastapi.tiangolo.com/) web server.
 
-Following FastAPI's [Tutorial - User Guide](https://fastapi.tiangolo.com/tutorial/) make sure you first have FastAPI installed using: `conda install -c conda-forge fastapi`. Also make sure Panel is installed `conda install -c conda-forge panel`.
+Since Panel 1.5.0 it is possible to run Panel application(s) natively on a FastAPI and uvicorn based server. Therefore this how-to guide will explain how to add Panel application(s) directly to an existing FastAPI application. This functionality is new and experimental so we also provide a [how-to guide to embed a Tornado based Panel server application inside a FastAPI application](./FastAPI_Tornado).
 
-## Configuration
+By the end of this guide, you'll be able to run a FastAPI application that serves a simple interactive Panel app. The Panel app will consist of a slider widget that dynamically updates a string of stars (⭐) based on the slider's value.
 
-Before we start adding a bokeh app to our FastAPI server we have to set up some of the basic plumbing. In the `examples/apps/fastApi` folder we will add some basic configurations.
+## Setup
 
-You'll need to create a file called `examples/apps/fastApi/main.py`.
+Following FastAPI's [Tutorial - User Guide](https://fastapi.tiangolo.com/tutorial/) make sure you first have FastAPI installed using:
 
-In `main.py` you'll need to import the following( which should all be already available from the above conda installs):
+::::{tab-set}
 
-```python
-import panel as pn
-from bokeh.embed import server_document
-from fastapi import FastAPI, Request
-from fastapi.templating import Jinja2Templates
+:::{tab-item} `conda`
+```bash
+conda install fastapi
 ```
+:::
 
+:::{tab-item} `pip`
+```pip
+conda install fastapi
+```
+:::
 
-Each of these will be explained as we add them in.
+## Create a FastAPI application
 
-Next we are going to need to create an instance of FastAPI below your imports in `main.py` and set up the path to your templates like so:
-
+Start by creating a FastAPI application. In this application, we will define a root endpoint that returns a simple JSON response. Open your text editor or IDE and create a file named main.py:
 
 ```python
+from fastapi import FastAPI
+
+# Initialize FastAPI application
 app = FastAPI()
-templates = Jinja2Templates(directory="examples/apps/fastApi/templates")
-```
 
-We will now need to create our first route via an async function and point it to the path of our server:
-
-```python
 @app.get("/")
-async def bkapp_page(request: Request):
-    script = server_document('http://127.0.0.1:5000/app')
-    return templates.TemplateResponse("base.html", {"request": request, "script": script})
+async def read_root():
+    return {"Hello": "World"}
 ```
 
-As you can see in this code we will also need to create an html  [Jinja2](https://fastapi.tiangolo.com/advanced/templates/#using-jinja2templates) template. Create a new directory named `examples/apps/fastApi/templates` and create the file `examples/apps/fastApi/templates/base.html` in that directory.
+## Create a Panel Application
 
-Now add the following to `base.html`. This is a minimal version but feel free to add whatever else you need to it.
-
-```html
-<!DOCTYPE html>
-<html>
-    <head>
-        <title>Panel in FastAPI: sliders</title>
-    </head>
-    <body>
-        {{ script|safe }}
-    </body>
-</html>
-```
-
-Return back to your `examples/apps/fastApi/main.py` file. We will use pn.serve() to start the bokeh server (Which Panel is built on). Configure it to whatever port and address you want, for our example we will use port 5000 and address 127.0.0.1. show=False will make it so the bokeh server is spun up but not shown yet. The allow_websocket_origin will list of hosts that can connect to the websocket, for us this is FastAPI so we will use (127.0.0.1:8000). The `createApp` function call in this example is how we call our panel app. This is not set up yet but will be in the next section.
-
-```python
-pn.serve({'/app': createApp},
-        port=5000, allow_websocket_origin=["127.0.0.1:8000"],
-        address="127.0.0.1", show=False)
-```
-
-You could optionally add BOKEH_ALLOW_WS_ORIGIN=127.0.0.1:8000 as an environment variable instead of setting it here. In conda it is done like this.
-
-`conda env config vars set BOKEH_ALLOW_WS_ORIGIN=127.0.0.1:8000`
-
-## Sliders app
-
-Based on a standard FastAPI app template, this app shows how to integrate Panel and FastAPI.
-
-The sliders app is in `examples/apps/fastApi/sliders`. We will cover the following additions/modifications to the Django2 app template:
-
-  * `sliders/sinewave.py`: a parameterized object (representing your pre-existing code)
-
-  * `sliders/pn_app.py`: creates an app function from the SineWave class
-
-  To start with, in `sliders/sinewave.py` we create a parameterized object to serve as a placeholder for your own, existing code:
-
-```python
-import numpy as np
-import param
-from bokeh.models import ColumnDataSource
-from bokeh.plotting import figure
-
-
-class SineWave(param.Parameterized):
-    offset = param.Number(default=0.0, bounds=(-5.0, 5.0))
-    amplitude = param.Number(default=1.0, bounds=(-5.0, 5.0))
-    phase = param.Number(default=0.0, bounds=(0.0, 2 * np.pi))
-    frequency = param.Number(default=1.0, bounds=(0.1, 5.1))
-    N = param.Integer(default=200, bounds=(0, None))
-    x_range = param.Range(default=(0, 4 * np.pi), bounds=(0, 4 * np.pi))
-    y_range = param.Range(default=(-2.5, 2.5), bounds=(-10, 10))
-
-    def __init__(self, **params):
-        super(SineWave, self).__init__(**params)
-        x, y = self.sine()
-        self.cds = ColumnDataSource(data=dict(x=x, y=y))
-        self.plot = figure(plot_height=400, plot_width=400,
-                           tools="crosshair, pan, reset, save, wheel_zoom",
-                           x_range=self.x_range, y_range=self.y_range)
-        self.plot.line('x', 'y', source=self.cds, line_width=3, line_alpha=0.6)
-
-    @param.depends('N', 'frequency', 'amplitude', 'offset', 'phase', 'x_range', 'y_range', watch=True)
-    def update_plot(self):
-        x, y = self.sine()
-        self.cds.data = dict(x=x, y=y)
-        self.plot.x_range.start, self.plot.x_range.end = self.x_range
-        self.plot.y_range.start, self.plot.y_range.end = self.y_range
-
-    def sine(self):
-        x = np.linspace(0, 4 * np.pi, self.N)
-        y = self.amplitude * np.sin(self.frequency * x + self.phase) + self.offset
-        return x, y
-```
-
-However the app itself is defined we need to configure an entry point, which is a function that adds the application to it. In case of the slider app it looks like this in `sliders/pn_app.py`:
+Next we will define a simple Panel application that allows you to control the number of displayed stars with an integer slider and decorate it with the `add_panel_app` decorator:
 
 ```python
 import panel as pn
 
-from .sinewave import SineWave
+from panel.io.fastapi import add_panel_app
 
-def createApp():
-    sw = SineWave()
-    return pn.Row(sw.param, sw.plot).servable()
+@add_panel_app('/panel', app=app, title='My Panel App')
+def create_panel_app():
+    slider = pn.widgets.IntSlider(name='Slider', start=0, end=10, value=3)
+    return slider.rx() * '⭐'
 ```
 
-We now need to return to our `main.py` and import the createApp function. Add the following import near the other imports:
+That's it! This decorator will map a specific URL path to the Panel app, allowing it to be served as part of the FastAPI application.
 
-```python
-from sliders.pn_app import createApp
-```
-
-Your file structure should now be like the following:
-
-```
-fastApi
-│   main.py
-│
-└───sliders
-│   │   sinewave.py
-│   │   pn_app.py
-│
-└───templates
-    │   base.html
-```
-
-And your finished `main.py` should look like this:
+The complete file should now look something like this:
 
 ```python
 import panel as pn
-from bokeh.embed import server_document
-from fastapi import FastAPI, Request
-from fastapi.templating import Jinja2Templates
 
-from sliders.pn_app import createApp
+from fastapi import FastAPI
+from panel.io.fastapi import add_application
 
 app = FastAPI()
-templates = Jinja2Templates(directory="templates")
 
 @app.get("/")
-async def bkapp_page(request: Request):
-    script = server_document('http://127.0.0.1:5000/app')
-    return templates.TemplateResponse("base.html", {"request": request, "script": script})
+async def read_root():
+    return {"Hello": "World"}
 
-
-pn.serve({'/app': createApp},
-        port=5000, allow_websocket_origin=["127.0.0.1:8000"],
-         address="127.0.0.1", show=False)
+@add_application('/panel', app=app, title='My Panel App')
+def create_panel_app():
+    slider = pn.widgets.IntSlider(name='Slider', start=0, end=10, value=3)
+    return slider.rx() * '⭐'
 ```
 
-```
-uvicorn main:app --reload
-```
+Now run it with:
 
-The output should give you a link to go to to view your app:
-
-```
-Uvicorn running on http://127.0.0.1:8000 (Press CTRL+C to quit)
+```bash
+fastapi dev main.py
 ```
 
-Go to that address and your app should be there running!
+You should see the following output:
 
-## Multiple apps
-
-
-This is the most basic configuration for a bokeh server. It is of course possible to add multiple apps in the same way and then registering them with FastAPI in the way described in the [configuration](#configuration) section above. To see a multi-app FastAPI server have a look at ``examples/apps/fastApi_multi_apps`` and launch it with `uvicorn main:app --reload` as before.
-
-To run multiple apps you will need to do the following:
-1. Create a new directory in your and a new file with your panel app (ex. `sinewave.py`).
-2. Create another pn_app file in your new directory (ex. `pn_app.py`) That might look something like this:
 ```
+INFO     Using path main.py
+INFO     Resolved absolute path /home/user/code/awesomeapp/main.py
+INFO     Searching for package file structure from directories with __init__.py files
+INFO     Importing from /home/user/code/awesomeapp/fast_api
+
+ ╭─ Python module file ─╮
+ │                      │
+ │  🐍 main.py          │
+ │                      │
+ ╰──────────────────────╯
+
+INFO     Importing module main
+/panel
+INFO     Found importable FastAPI app
+
+ ╭─ Importable FastAPI app ─╮
+ │                          │
+ │  from main import app    │
+ │                          │
+ ╰──────────────────────────╯
+
+INFO     Using import string main:app
+
+ ╭────────── FastAPI CLI - Development mode ───────────╮
+ │                                                     │
+ │  Serving at: http://127.0.0.1:8000                  │
+ │                                                     │
+ │  API docs: http://127.0.0.1:8000/docs               │
+ │                                                     │
+ │  Running in development mode, for production use:   │
+ │                                                     │
+ │  fastapi run                                        │
+ │                                                     │
+ ╰─────────────────────────────────────────────────────╯
+
+INFO:     Will watch for changes in these directories: ['/home/user/code/awesomeapp/']
+INFO:     Uvicorn running on http://127.0.0.1:8000 (Press CTRL+C to quit)
+INFO:     Started reloader process [39089] using WatchFiles
+INFO:     Started server process [39128]
+INFO:     Waiting for application startup.
+INFO:     Application startup complete.
+```
+
+If you visit `http://127.0.0.1:8000` you will see the Panel application.
+
+## Adding multiple applications
+
+The `add_application` decorator is useful when server an application defined in a function, if you want to serve multiple applications, whether they are existing Panel objects, functions, or paths to Panel application scripts you can use the `add_applications` function instead, e.g.:
+
+```python
 import panel as pn
 
-from .sinewave import SineWave
+from fastapi import FastAPI
+from panel.io.fastapi import add_application
 
-def createApp2():
-    sw = SineWave()
-    return pn.Row(sw.param, sw.plot).servable()
-```
+app = FastAPI()
 
-With this as your new file structure:
-
-```
-fastApi
-│   main.py
-│
-└───sliders
-│   │   sinewave.py
-│   │   pn_app.py
-│   │
-└───sliders2
-│   │   sinewave.py
-│   │   pn_app.py
-│
-└───templates
-    │   base.html
-```
-
-3. Create a new html template (ex. app2.html) with the same contents as base.html in `examples/apps/fastApi/templates`
-4. Import your new app in main.py `from sliders2.pn_app import createApp2`
-5. Add your new app to the dictionary in pn.serve()
-
-```python
-{'/app': createApp, '/app2': createApp2}
-```
-
-7. Add a new async function to rout your new app (The bottom of `main.py` should look something like this now):
-
-```python
 @app.get("/")
-async def bkapp_page(request: Request):
-    script = server_document('http://127.0.0.1:5000/app')
-    return templates.TemplateResponse("base.html", {"request": request, "script": script})
+async def read_root():
+    return {"Hello": "World"}
 
-@app.get("/app2")
-async def bkapp_page2(request: Request):
-    script = server_document('http://127.0.0.1:5000/app2')
-    return templates.TemplateResponse("app2.html", {"request": request, "script": script})
+def create_panel_app():
+    slider = pn.widgets.IntSlider(name='Slider', start=0, end=10, value=3)
+    return slider.rx() * '⭐'
 
-pn.serve({'/app': createApp, '/app2': createApp2},
-        port=5000, allow_websocket_origin=["127.0.0.1:8000"],
-         address="127.0.0.1", show=False)
+add_applications({
+    "/panel_app1": create_panel_app,
+	"/panel_app2": pn.Column('I am a Panel object!'),
+	"/panel_app3": "my_panel_app.py"
+}, app=app)
 ```
-
-With this as your file structure
-
-```
-fastApi
-│   main.py
-│
-└───sliders
-│   │   sinewave.py
-│   │   pn_app.py
-│   │
-└───sliders2
-│   │   sinewave.py
-│   │   pn_app.py
-│
-└───templates
-    │   base.html
-    │   app2.html
-```
-
-Sliders 2 will be available at `http://127.0.0.1:8000/app2`
 
 ## Conclusion
 

--- a/doc/how_to/integrations/FastAPI_Tornado.md
+++ b/doc/how_to/integrations/FastAPI_Tornado.md
@@ -1,0 +1,274 @@
+# Embedding a Panel Server in FastAPI
+
+Panel generally runs on the Bokeh server which itself runs on Tornado. However, it is also often useful to embed a Panel app in large web application, such as a FastAPI web server. [FastAPI](https://fastapi.tiangolo.com/) is especially useful compared to others like Flask and Django because of it's lightning fast, lightweight framework.
+
+Following FastAPI's [Tutorial - User Guide](https://fastapi.tiangolo.com/tutorial/) make sure you first have FastAPI installed using: `conda install -c conda-forge fastapi`. Also make sure Panel is installed `conda install -c conda-forge panel`.
+
+
+## Configuration
+
+Before we start adding a bokeh app to our FastAPI server we have to set up some of the basic plumbing. In the `examples/apps/fastApi` folder we will add some basic configurations.
+
+You'll need to create a file called `examples/apps/fastApi/main.py`.
+
+In `main.py` you'll need to import the following( which should all be already available from the above conda installs):
+
+```python
+import panel as pn
+from bokeh.embed import server_document
+from fastapi import FastAPI, Request
+from fastapi.templating import Jinja2Templates
+```
+
+
+Each of these will be explained as we add them in.
+
+Next we are going to need to create an instance of FastAPI below your imports in `main.py` and set up the path to your templates like so:
+
+
+```python
+app = FastAPI()
+templates = Jinja2Templates(directory="examples/apps/fastApi/templates")
+```
+
+We will now need to create our first route via an async function and point it to the path of our server:
+
+```python
+@app.get("/")
+async def bkapp_page(request: Request):
+    script = server_document('http://127.0.0.1:5000/app')
+    return templates.TemplateResponse("base.html", {"request": request, "script": script})
+```
+
+As you can see in this code we will also need to create an html  [Jinja2](https://fastapi.tiangolo.com/advanced/templates/#using-jinja2templates) template. Create a new directory named `examples/apps/fastApi/templates` and create the file `examples/apps/fastApi/templates/base.html` in that directory.
+
+Now add the following to `base.html`. This is a minimal version but feel free to add whatever else you need to it.
+
+```html
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Panel in FastAPI: sliders</title>
+    </head>
+    <body>
+        {{ script|safe }}
+    </body>
+</html>
+```
+
+Return back to your `examples/apps/fastApi/main.py` file. We will use pn.serve() to start the bokeh server (Which Panel is built on). Configure it to whatever port and address you want, for our example we will use port 5000 and address 127.0.0.1. show=False will make it so the bokeh server is spun up but not shown yet. The allow_websocket_origin will list of hosts that can connect to the websocket, for us this is FastAPI so we will use (127.0.0.1:8000). The `createApp` function call in this example is how we call our panel app. This is not set up yet but will be in the next section.
+
+```python
+pn.serve({'/app': createApp},
+        port=5000, allow_websocket_origin=["127.0.0.1:8000"],
+        address="127.0.0.1", show=False)
+```
+
+You could optionally add BOKEH_ALLOW_WS_ORIGIN=127.0.0.1:8000 as an environment variable instead of setting it here. In conda it is done like this.
+
+`conda env config vars set BOKEH_ALLOW_WS_ORIGIN=127.0.0.1:8000`
+
+## Sliders app
+
+Based on a standard FastAPI app template, this app shows how to integrate Panel and FastAPI.
+
+The sliders app is in `examples/apps/fastApi/sliders`. We will cover the following additions/modifications to the Django2 app template:
+
+  * `sliders/sinewave.py`: a parameterized object (representing your pre-existing code)
+
+  * `sliders/pn_app.py`: creates an app function from the SineWave class
+
+  To start with, in `sliders/sinewave.py` we create a parameterized object to serve as a placeholder for your own, existing code:
+
+```python
+import numpy as np
+import param
+from bokeh.models import ColumnDataSource
+from bokeh.plotting import figure
+
+
+class SineWave(param.Parameterized):
+    offset = param.Number(default=0.0, bounds=(-5.0, 5.0))
+    amplitude = param.Number(default=1.0, bounds=(-5.0, 5.0))
+    phase = param.Number(default=0.0, bounds=(0.0, 2 * np.pi))
+    frequency = param.Number(default=1.0, bounds=(0.1, 5.1))
+    N = param.Integer(default=200, bounds=(0, None))
+    x_range = param.Range(default=(0, 4 * np.pi), bounds=(0, 4 * np.pi))
+    y_range = param.Range(default=(-2.5, 2.5), bounds=(-10, 10))
+
+    def __init__(self, **params):
+        super(SineWave, self).__init__(**params)
+        x, y = self.sine()
+        self.cds = ColumnDataSource(data=dict(x=x, y=y))
+        self.plot = figure(plot_height=400, plot_width=400,
+                           tools="crosshair, pan, reset, save, wheel_zoom",
+                           x_range=self.x_range, y_range=self.y_range)
+        self.plot.line('x', 'y', source=self.cds, line_width=3, line_alpha=0.6)
+
+    @param.depends('N', 'frequency', 'amplitude', 'offset', 'phase', 'x_range', 'y_range', watch=True)
+    def update_plot(self):
+        x, y = self.sine()
+        self.cds.data = dict(x=x, y=y)
+        self.plot.x_range.start, self.plot.x_range.end = self.x_range
+        self.plot.y_range.start, self.plot.y_range.end = self.y_range
+
+    def sine(self):
+        x = np.linspace(0, 4 * np.pi, self.N)
+        y = self.amplitude * np.sin(self.frequency * x + self.phase) + self.offset
+        return x, y
+```
+
+However the app itself is defined we need to configure an entry point, which is a function that adds the application to it. In case of the slider app it looks like this in `sliders/pn_app.py`:
+
+```python
+import panel as pn
+
+from .sinewave import SineWave
+
+def createApp():
+    sw = SineWave()
+    return pn.Row(sw.param, sw.plot).servable()
+```
+
+We now need to return to our `main.py` and import the createApp function. Add the following import near the other imports:
+
+```python
+from sliders.pn_app import createApp
+```
+
+Your file structure should now be like the following:
+
+```
+fastApi
+│   main.py
+│
+└───sliders
+│   │   sinewave.py
+│   │   pn_app.py
+│
+└───templates
+    │   base.html
+```
+
+And your finished `main.py` should look like this:
+
+```python
+import panel as pn
+from bokeh.embed import server_document
+from fastapi import FastAPI, Request
+from fastapi.templating import Jinja2Templates
+
+from sliders.pn_app import createApp
+
+app = FastAPI()
+templates = Jinja2Templates(directory="templates")
+
+@app.get("/")
+async def bkapp_page(request: Request):
+    script = server_document('http://127.0.0.1:5000/app')
+    return templates.TemplateResponse("base.html", {"request": request, "script": script})
+
+
+pn.serve({'/app': createApp},
+        port=5000, allow_websocket_origin=["127.0.0.1:8000"],
+         address="127.0.0.1", show=False)
+```
+
+```
+uvicorn main:app --reload
+```
+
+The output should give you a link to go to to view your app:
+
+```
+Uvicorn running on http://127.0.0.1:8000 (Press CTRL+C to quit)
+```
+
+Go to that address and your app should be there running!
+
+## Multiple apps
+
+
+This is the most basic configuration for a bokeh server. It is of course possible to add multiple apps in the same way and then registering them with FastAPI in the way described in the [configuration](#configuration) section above. To see a multi-app FastAPI server have a look at ``examples/apps/fastApi_multi_apps`` and launch it with `uvicorn main:app --reload` as before.
+
+To run multiple apps you will need to do the following:
+1. Create a new directory in your and a new file with your panel app (ex. `sinewave.py`).
+2. Create another pn_app file in your new directory (ex. `pn_app.py`) That might look something like this:
+```
+import panel as pn
+
+from .sinewave import SineWave
+
+def createApp2():
+    sw = SineWave()
+    return pn.Row(sw.param, sw.plot).servable()
+```
+
+With this as your new file structure:
+
+```
+fastApi
+│   main.py
+│
+└───sliders
+│   │   sinewave.py
+│   │   pn_app.py
+│   │
+└───sliders2
+│   │   sinewave.py
+│   │   pn_app.py
+│
+└───templates
+    │   base.html
+```
+
+3. Create a new html template (ex. app2.html) with the same contents as base.html in `examples/apps/fastApi/templates`
+4. Import your new app in main.py `from sliders2.pn_app import createApp2`
+5. Add your new app to the dictionary in pn.serve()
+
+```python
+{'/app': createApp, '/app2': createApp2}
+```
+
+7. Add a new async function to rout your new app (The bottom of `main.py` should look something like this now):
+
+```python
+@app.get("/")
+async def bkapp_page(request: Request):
+    script = server_document('http://127.0.0.1:5000/app')
+    return templates.TemplateResponse("base.html", {"request": request, "script": script})
+
+@app.get("/app2")
+async def bkapp_page2(request: Request):
+    script = server_document('http://127.0.0.1:5000/app2')
+    return templates.TemplateResponse("app2.html", {"request": request, "script": script})
+
+pn.serve({'/app': createApp, '/app2': createApp2},
+        port=5000, allow_websocket_origin=["127.0.0.1:8000"],
+         address="127.0.0.1", show=False)
+```
+
+With this as your file structure
+
+```
+fastApi
+│   main.py
+│
+└───sliders
+│   │   sinewave.py
+│   │   pn_app.py
+│   │
+└───sliders2
+│   │   sinewave.py
+│   │   pn_app.py
+│
+└───templates
+    │   base.html
+    │   app2.html
+```
+
+Sliders 2 will be available at `http://127.0.0.1:8000/app2`
+
+## Conclusion
+
+That's it! You now have embedded panel in FastAPI! You can now build off of this to create your own web app tailored to your needs.

--- a/doc/how_to/integrations/index.md
+++ b/doc/how_to/integrations/index.md
@@ -5,6 +5,33 @@ These guides will cover how to integrate Panel applications with various externa
 ::::{grid} 1 3 3 3
 :gutter: 1 1 1 2
 
+:::{grid-item-card} FastAPI
+:link: FastAPI
+:link-type: doc
+
+Discover to run Panel applications natively on a FastAPI server.
+
+![FastAPI Logo](../../_static/logos/fastapi.png)
+:::
+
+:::{grid-item-card} FastAPI (Embedded)
+:link: FastAPI_Tornado
+:link-type: doc
+
+Discover to embed a Panel Tornado server application in a FastAPI server.
+
+![FastAPI Logo](../../_static/logos/fastapi.png)
+:::
+
+:::{grid-item-card} Django
+:link: Django
+:link-type: doc
+
+Discover to run Panel applications natively on a Django server.
+
+![Django Logo](../../_static/logos/django.png)
+:::
+
 :::{grid-item-card} Flask
 :link: flask
 :link-type: doc
@@ -14,23 +41,6 @@ Discover to run Panel applications alongside an existing Flask server.
 ![Flask Logo](../../_static/logos/flask.png)
 :::
 
-:::{grid-item-card} FastAPI
-:link: FastAPI
-:link-type: doc
-
-Discover to run Panel applications alongside an existing FastAPI server.
-
-![FastAPI Logo](../../_static/logos/fastapi.png)
-:::
-
-:::{grid-item-card} Django
-:link: Django
-:link-type: doc
-
-Discover to run Panel applications on a Django server (replacing the standard Tornado based server).
-
-![Django Logo](../../_static/logos/django.png)
-:::
 
 ::::
 
@@ -39,7 +49,8 @@ Discover to run Panel applications on a Django server (replacing the standard To
 :hidden:
 :maxdepth: 2
 
-flask
 FastAPI
+FastAPI_Tornado
+flask
 Django
 ```

--- a/panel/io/application.py
+++ b/panel/io/application.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 import json
 import logging
 import os
-import pathlib
 
 from functools import partial
 from types import FunctionType, MethodType

--- a/panel/io/application.py
+++ b/panel/io/application.py
@@ -198,11 +198,11 @@ bokeh.command.util.build_single_handler_application = build_single_handler_appli
 
 def build_applications(
     panel: TViewableFuncOrPath | Mapping[str, TViewableFuncOrPath],
-    title: str | dict[str, str] = None,
+    title: str | dict[str, str] | None = None,
     location: bool | Location = True,
     admin: bool = False,
     server_id: str | None = None,
-    custom_handlers: list = None
+    custom_handlers: list | None = None
 ) -> dict[str, Application]:
     """
     Converts a variety of objects into a dictionary of Applications.
@@ -228,7 +228,7 @@ def build_applications(
 
     apps = {}
     for slug, app in panel.items():
-        if slug.endswith('/') and not slug == '/':
+        if slug.endswith('/') and slug != '/':
             raise ValueError(f"Invalid URL: trailing slash '/' used for {slug!r} not supported.")
         if isinstance(title, dict):
             try:
@@ -254,7 +254,7 @@ def build_applications(
             if app is True:
                 continue
 
-        if isinstance(app, pathlib.Path):
+        if isinstance(app, os.PathLike):
             app = str(app) # enables serving apps from Paths
         if (isinstance(app, str) and app.endswith(('.py', '.ipynb', '.md'))
             and os.path.isfile(app)):

--- a/panel/io/application.py
+++ b/panel/io/application.py
@@ -243,7 +243,7 @@ def build_applications(
         slug = slug if slug.startswith('/') else '/'+slug
 
         # Handle other types of apps using a custom handler
-        for handler in custom_handlers:
+        for handler in (custom_handlers or ()):
             new_app = handler(slug, app)
             if app is not None:
                 break

--- a/panel/io/fastapi.py
+++ b/panel/io/fastapi.py
@@ -64,7 +64,7 @@ def add_applications(
     apps = build_applications(panel)
     application = BokehFastAPI(apps, server=server, **kwargs)
 
-    @application.server.get(
+    @application.app.get(
         f"/{COMPONENT_PATH.rstrip('/')}" + "/{path:path}", include_in_schema=False
     )
     def get_component_resource(path: str):
@@ -128,7 +128,7 @@ def get_server(
     application = add_applications(
         panel, title=title, location=location, admin=admin, **kwargs
     )
-    config = uvicorn.Config(application.server, port=port, loop=loop)
+    config = uvicorn.Config(application.app, port=port, loop=loop)
     server = uvicorn.Server(config)
 
     state._servers[server_id] = (server, panel, [])

--- a/panel/io/fastapi.py
+++ b/panel/io/fastapi.py
@@ -35,7 +35,7 @@ extra_socket_handlers[WSHandler] = dispatch_fastapi
 def add_applications(
     panel: TViewableFuncOrPath | Mapping[str, TViewableFuncOrPath],
     server: FastAPI | None = None,
-    title: str | dict[str, str] = None,
+    title: str | dict[str, str] | None = None,
     location: bool | Location = True,
     admin: bool = False,
     **kwargs
@@ -82,7 +82,7 @@ def get_server(
     panel: TViewableFuncOrPath | Mapping[str, TViewableFuncOrPath],
     port: int | None = 0,
     start: bool = False,
-    title: str | dict[str, str] = None,
+    title: str | dict[str, str] | None = None,
     location: bool | Location = True,
     admin: bool = False,
     **kwargs

--- a/panel/io/fastapi.py
+++ b/panel/io/fastapi.py
@@ -6,19 +6,23 @@ import uuid
 from functools import wraps
 from typing import TYPE_CHECKING, Mapping, cast
 
-from bokeh_fastapi import BokehFastAPI
-from bokeh_fastapi.handler import WSHandler
-from fastapi import (
-    FastAPI, HTTPException, Query, Request,
-)
-from fastapi.responses import FileResponse
-
 from .application import build_applications
 from .document import _cleanup_doc, extra_socket_handlers
 from .resources import COMPONENT_PATH
 from .server import ComponentResourceHandler
 from .state import state
 from .threads import StoppableThread
+
+try:
+    from bokeh_fastapi import BokehFastAPI
+    from bokeh_fastapi.handler import WSHandler
+    from fastapi import (
+        FastAPI, HTTPException, Query, Request,
+    )
+    from fastapi.responses import FileResponse
+except ImportError:
+    msg = "bokeh_fastapi must be installed to use the panel.io.fastapi module."
+    raise ImportError(msg) from None
 
 if TYPE_CHECKING:
     from uvicorn import Server

--- a/panel/io/fastapi.py
+++ b/panel/io/fastapi.py
@@ -48,8 +48,8 @@ def add_applications(
     panel: Viewable, function or {str: Viewable}
         A Panel object, a function returning a Panel object or a
         dictionary mapping from the URL slug to either.
-    server: FastAPI
-        FastAPI server to add Panel application(s) to
+    app: FastAPI
+        FastAPI app to add Panel application(s) to
     title : str or {str: str} (optional, default=None)
         An HTML title for the application or a dictionary mapping
         from the URL slug to a customized title.

--- a/panel/io/fastapi.py
+++ b/panel/io/fastapi.py
@@ -1,0 +1,229 @@
+from __future__ import annotations
+
+import asyncio
+import uuid
+
+from typing import TYPE_CHECKING, Mapping, cast
+
+from bokeh_fastapi import BokehFastAPI
+from bokeh_fastapi.handler import WSHandler
+from fastapi import FastAPI
+from fastapi.responses import FileResponse
+
+from .application import build_applications
+from .document import extra_socket_handlers
+from .resources import COMPONENT_PATH
+from .server import ComponentResourceHandler
+from .state import state
+from .threads import StoppableThread
+
+if TYPE_CHECKING:
+    from uvicorn import Server
+
+    from .application import TViewableFuncOrPath
+    from .location import Location
+
+
+def dispatch_fastapi(conn, events=None, msg=None):
+    if msg is None:
+        msg = conn.protocol.create("PATCH-DOC", events)
+    return [conn._socket.send_message(msg)]
+
+extra_socket_handlers[WSHandler] = dispatch_fastapi
+
+
+def add_applications(
+    panel: TViewableFuncOrPath | Mapping[str, TViewableFuncOrPath],
+    server: FastAPI | None = None,
+    title: str | dict[str, str] = None,
+    location: bool | Location = True,
+    admin: bool = False,
+    **kwargs
+):
+    """
+    Adds application(s) to an existing uvicorn based FastAPI server.
+
+    Arguments
+    ---------
+    panel: Viewable, function or {str: Viewable}
+        A Panel object, a function returning a Panel object or a
+        dictionary mapping from the URL slug to either.
+    server: FastAPI
+        FastAPI server to add Panel application(s) to
+    title : str or {str: str} (optional, default=None)
+        An HTML title for the application or a dictionary mapping
+        from the URL slug to a customized title.
+    location : boolean or panel.io.location.Location
+        Whether to create a Location component to observe and
+        set the URL location.
+    admin: boolean (default=False)
+        Whether to enable the admin panel
+    **kwargs:
+        Additional keyword arguments to pass to the BokehFastAPI application
+    """
+    apps = build_applications(panel)
+    application = BokehFastAPI(apps, server=server, **kwargs)
+
+    @application.server.get(
+        f"/{COMPONENT_PATH.rstrip('/')}" + "/{path:path}", include_in_schema=False
+    )
+    def get_component_resource(path: str):
+        # ComponentResourceHandler.parse_url_path only ever accesses
+        # self._resource_attrs, which fortunately is a class attribute. Thus, we can
+        # get away with using the method without actually instantiating the class
+        self_ = cast(ComponentResourceHandler, ComponentResourceHandler)
+        resolved_path = ComponentResourceHandler.parse_url_path(self_, path)
+        return FileResponse(resolved_path)
+
+    return application
+
+
+def get_server(
+    panel: TViewableFuncOrPath | Mapping[str, TViewableFuncOrPath],
+    port: int | None = 0,
+    start: bool = False,
+    title: str | dict[str, str] = None,
+    location: bool | Location = True,
+    admin: bool = False,
+    **kwargs
+):
+    """
+    Creates a FastAPI server running the provided Panel application(s).
+
+    Arguments
+    ---------
+    panel: Viewable, function or {str: Viewable}
+        A Panel object, a function returning a Panel object or a
+        dictionary mapping from the URL slug to either.
+    port: int (optional, default=0)
+      Allows specifying a specific port.
+    start : boolean(optional, default=False)
+      Whether to start the Server.
+    title : str or {str: str} (optional, default=None)
+        An HTML title for the application or a dictionary mapping
+        from the URL slug to a customized title.
+    location : boolean or panel.io.location.Location
+        Whether to create a Location component to observe and
+        set the URL location.
+    admin: boolean (default=False)
+        Whether to enable the admin panel
+    start : boolean(optional, default=False)
+      Whether to start the Server.
+    **kwargs:
+        Additional keyword arguments to pass to the BokehFastAPI application
+    """
+    try:
+        import uvicorn
+    except Exception as e:
+        raise ImportError(
+            "Running a FastAPI server requires uvicorn to be available. "
+            "If you want to use a different server implementation use the "
+            "panel.io.fastapi.add_applications API."
+        ) from e
+
+    loop = kwargs.pop('loop')
+    if loop:
+        asyncio.set_event_loop(loop)
+    server_id = kwargs.pop('server_id', uuid.uuid4().hex)
+    application = add_applications(
+        panel, title=title, location=location, admin=admin, **kwargs
+    )
+    config = uvicorn.Config(application.server, port=port, loop=loop)
+    server = uvicorn.Server(config)
+
+    state._servers[server_id] = (server, panel, [])
+    if start:
+        if loop:
+            try:
+                loop.run_until_complete(server.serve())
+            except asyncio.CancelledError:
+                pass
+        else:
+            server.run()
+    return server
+
+
+def serve(
+    panels: TViewableFuncOrPath | Mapping[str, TViewableFuncOrPath],
+    port: int = 0,
+    address: str | None = None,
+    websocket_origin: str | list[str] | None = None,
+    loop: asyncio.AbstractEventLoop | None = None,
+    show: bool = True,
+    start: bool = True,
+    title: str | None = None,
+    verbose: bool = True,
+    location: bool = True,
+    threaded: bool = False,
+    admin: bool = False,
+    **kwargs
+) -> StoppableThread | Server:
+    """
+    Allows serving one or more panel objects on a single server.
+    The panels argument should be either a Panel object or a function
+    returning a Panel object or a dictionary of these two. If a
+    dictionary is supplied the keys represent the slugs at which
+    each app is served, e.g. `serve({'app': panel1, 'app2': panel2})`
+    will serve apps at /app and /app2 on the server.
+
+    Reference: https://panel.holoviz.org/user_guide/Server_Configuration.html#serving-multiple-apps
+
+    Arguments
+    ---------
+    panel: Viewable, function or {str: Viewable or function}
+      A Panel object, a function returning a Panel object or a
+      dictionary mapping from the URL slug to either.
+    port: int (optional, default=0)
+      Allows specifying a specific port
+    address : str
+      The address the server should listen on for HTTP requests.
+    websocket_origin: str or list(str) (optional)
+      A list of hosts that can connect to the websocket.
+
+      This is typically required when embedding a server app in
+      an external web site.
+
+      If None, "localhost" is used.
+    loop : tornado.ioloop.IOLoop (optional, default=IOLoop.current())
+      The tornado IOLoop to run the Server on
+    show : boolean (optional, default=True)
+      Whether to open the server in a new browser tab on start
+    start : boolean(optional, default=True)
+      Whether to start the Server
+    title: str or {str: str} (optional, default=None)
+      An HTML title for the application or a dictionary mapping
+      from the URL slug to a customized title
+    verbose: boolean (optional, default=True)
+      Whether to print the address and port
+    location : boolean or panel.io.location.Location
+      Whether to create a Location component to observe and
+      set the URL location.
+    threaded: boolean (default=False)
+      Whether to start the server on a new Thread
+    admin: boolean (default=False)
+      Whether to enable the admin panel
+    kwargs: dict
+      Additional keyword arguments to pass to Server instance
+    """
+    # Empty layout are valid and the Bokeh warning is silenced as usually
+    # not relevant to Panel users.
+    kwargs = dict(kwargs, **dict(
+        port=port, address=address, websocket_origin=websocket_origin,
+        loop=loop, show=show, start=start, title=title, verbose=verbose,
+        location=location, admin=admin
+    ))
+    if threaded:
+        # To ensure that we have correspondence between state._threads and state._servers
+        # we must provide a server_id here
+        kwargs['loop'] = loop = asyncio.new_event_loop() if loop is None else loop
+        if 'server_id' not in kwargs:
+            kwargs['server_id'] = uuid.uuid4().hex
+        server = StoppableThread(
+            target=get_server, io_loop=loop, args=(panels,), kwargs=kwargs
+        )
+        server_id = kwargs['server_id']
+        state._threads[server_id] = server
+        server.start()
+    else:
+        return get_server(panels, **kwargs)
+    return server

--- a/panel/io/fastapi.py
+++ b/panel/io/fastapi.py
@@ -62,7 +62,7 @@ def add_applications(
         Additional keyword arguments to pass to the BokehFastAPI application
     """
     apps = build_applications(panel)
-    application = BokehFastAPI(apps, server=server, **kwargs)
+    application = BokehFastAPI(apps, app=app, **kwargs)
 
     @application.app.get(
         f"/{COMPONENT_PATH.rstrip('/')}" + "/{path:path}", include_in_schema=False

--- a/panel/io/server.py
+++ b/panel/io/server.py
@@ -845,7 +845,7 @@ def get_server(
     loop: Optional[IOLoop] = None,
     show: bool = False,
     start: bool = False,
-    title: str | dict[str, str] = None,
+    title: str | dict[str, str] | None = None,
     verbose: bool = False,
     location: bool | Location = True,
     admin: bool = False,

--- a/panel/io/server.py
+++ b/panel/io/server.py
@@ -774,8 +774,6 @@ def serve(
     kwargs: dict
       Additional keyword arguments to pass to Server instance
     """
-    # Empty layout are valid and the Bokeh warning is silenced as usually
-    # not relevant to Panel users.
     kwargs = dict(kwargs, **dict(
         port=port, address=address, websocket_origin=websocket_origin,
         loop=loop, show=show, start=start, title=title, verbose=verbose,

--- a/panel/io/server.py
+++ b/panel/io/server.py
@@ -1103,7 +1103,7 @@ def get_server(
         server.io_loop.add_callback(show_callback)
 
     def sig_exit(*args, **kwargs):
-        server.io_loop.add_callback_from_signal(do_stop)
+        server.io_loop.asyncio_loop.call_soon_threadsafe(do_stop)
 
     def do_stop(*args, **kwargs):
         server.io_loop.stop()

--- a/panel/io/server.py
+++ b/panel/io/server.py
@@ -19,9 +19,8 @@ import uuid
 from contextlib import contextmanager
 from functools import partial, wraps
 from html import escape
-from types import FunctionType, MethodType
 from typing import (
-    TYPE_CHECKING, Any, Callable, Mapping, Optional, Union,
+    TYPE_CHECKING, Any, Callable, Mapping, Optional,
 )
 from urllib.parse import urljoin, urlparse
 
@@ -30,7 +29,6 @@ import param
 import tornado
 
 # Bokeh imports
-from bokeh.application import Application as BkApplication
 from bokeh.application.handlers.function import FunctionHandler
 from bokeh.core.json_encoder import serialize_json
 from bokeh.core.templates import AUTOLOAD_JS, FILE, MACROS
@@ -40,7 +38,6 @@ from bokeh.embed.bundle import Script
 from bokeh.embed.elements import script_for_render_items
 from bokeh.embed.util import RenderItem
 from bokeh.embed.wrappers import wrap_in_script_tag
-from bokeh.models import CustomJS
 from bokeh.server.server import Server as BokehServer
 from bokeh.server.urls import per_app_patterns, toplevel_patterns
 from bokeh.server.views.autoload_js_handler import (
@@ -64,15 +61,13 @@ from tornado.wsgi import WSGIContainer
 from ..config import config
 from ..util import edit_readonly, fullpath
 from ..util.warnings import warn
-from .application import Application, build_single_handler_application
+from .application import Application, build_applications
 from .document import (  # noqa
     _cleanup_doc, init_doc, unlocked, with_lock,
 )
 from .liveness import LivenessHandler
 from .loading import LOADING_INDICATOR_CSS_CLASS
-from .logging import (
-    LOG_SESSION_CREATED, LOG_SESSION_DESTROYED, LOG_SESSION_LAUNCHING,
-)
+from .logging import LOG_SESSION_CREATED
 from .reload import record_modules
 from .resources import (
     BASE_TEMPLATE, CDN_DIST, COMPONENT_PATH, ERROR_TEMPLATE, LOCAL_DIST,
@@ -86,17 +81,14 @@ logger = logging.getLogger(__name__)
 if TYPE_CHECKING:
     from bokeh.bundle import Bundle
     from bokeh.core.types import ID
-    from bokeh.document.document import DocJson, Document
+    from bokeh.document.document import DocJson
     from bokeh.server.contexts import BokehSessionContext
     from bokeh.server.session import ServerSession
     from jinja2 import Template
 
-    from ..template.base import BaseTemplate
-    from ..viewable import Viewable, Viewer
+    from .application import TViewableFuncOrPath
     from .location import Location
 
-    TViewable = Union[Viewable, Viewer, BaseTemplate]
-    TViewableFuncOrPath = Union[TViewable, Callable[[], TViewable], os.PathLike, str]
 
 #---------------------------------------------------------------------
 # Private API
@@ -115,38 +107,6 @@ def _server_url(url: str, port: int) -> str:
         return '%s:%d%s' % (url.rsplit(':', 1)[0], port, "/")
     else:
         return 'http://%s:%d%s' % (url.split(':')[0], port, "/")
-
-def _eval_panel(
-    panel: TViewableFuncOrPath, server_id: str, title: str,
-    location: bool | Location, admin: bool, doc: Document
-):
-    from ..pane import panel as as_panel
-    from ..template import BaseTemplate
-
-    if config.global_loading_spinner:
-        doc.js_on_event(
-            'document_ready', CustomJS(code=f"""
-            const body = document.getElementsByTagName('body')[0]
-            body.classList.remove({LOADING_INDICATOR_CSS_CLASS!r}, {config.loading_spinner!r})
-            """)
-        )
-
-    doc.on_event('document_ready', partial(state._schedule_on_load, doc))
-
-    # Set up instrumentation for logging sessions
-    logger.info(LOG_SESSION_LAUNCHING, id(doc))
-    def _log_session_destroyed(session_context):
-        logger.info(LOG_SESSION_DESTROYED, id(doc))
-    doc.on_session_destroyed(_log_session_destroyed)
-
-    with set_curdoc(doc):
-        if isinstance(panel, (FunctionType, MethodType)):
-            panel = panel()
-        if isinstance(panel, BaseTemplate):
-            doc = panel._modify_doc(server_id, title, doc, location)
-        else:
-            doc = as_panel(panel)._modify_doc(server_id, title, doc, location)
-        return doc
 
 def async_execute(func: Callable[..., None]) -> None:
     """
@@ -888,7 +848,7 @@ def get_server(
     loop: Optional[IOLoop] = None,
     show: bool = False,
     start: bool = False,
-    title: bool = None,
+    title: str | dict[str, str] = None,
     verbose: bool = False,
     location: bool | Location = True,
     admin: bool = False,
@@ -1016,56 +976,27 @@ def get_server(
     from .rest import REST_PROVIDERS
 
     server_id = kwargs.pop('server_id', uuid.uuid4().hex)
-    kwargs['extra_patterns'] = extra_patterns = kwargs.get('extra_patterns', [])
-    if isinstance(panel, dict):
-        apps = {}
-        for slug, app in panel.items():
-            if slug.endswith('/') and not slug == '/':
-                raise ValueError(f"Invalid URL: trailing slash '/' used for {slug!r} not supported.")
-            if isinstance(title, dict):
-                try:
-                    title_ = title[slug]
-                except KeyError:
-                    raise KeyError(
-                        "Keys of the title dictionary and of the apps "
-                        f"dictionary must match. No {slug} key found in the "
-                        "title dictionary.") from None
-            else:
-                title_ = title
-            slug = slug if slug.startswith('/') else '/'+slug
-            if 'flask' in sys.modules:
-                from flask import Flask
-                if isinstance(app, Flask):
-                    wsgi = WSGIContainer(app)
-                    if slug == '/':
-                        raise ValueError('Flask apps must be served on a subpath.')
-                    if not slug.endswith('/'):
-                        slug += '/'
-                    extra_patterns.append(('^'+slug+'.*', ProxyFallbackHandler,
-                                           dict(fallback=wsgi, proxy=slug)))
-                    continue
-            if isinstance(app, pathlib.Path):
-                app = str(app) # enables serving apps from Paths
-            if (isinstance(app, str) and app.endswith(('.py', '.ipynb', '.md'))
-                and os.path.isfile(app)):
-                apps[slug] = app = build_single_handler_application(app)
-                app._admin = admin
-            elif isinstance(app, BkApplication):
-                apps[slug] = app
-            else:
-                handler = FunctionHandler(partial(_eval_panel, app, server_id, title_, location, admin))
-                apps[slug] = Application(handler, admin=admin)
-    else:
-        if isinstance(panel, pathlib.Path):
-            panel = str(panel) # enables serving apps from Paths
-        if isinstance(panel, BkApplication):
-            panel = {'/': app}
-        elif (isinstance(panel, str) and panel.endswith(('.py', '.ipynb', '.md'))
-            and os.path.isfile(panel)):
-            apps = {'/': build_single_handler_application(panel)}
-        else:
-            handler = FunctionHandler(partial(_eval_panel, panel, server_id, title, location, admin))
-            apps = {'/': Application(handler, admin=admin)}
+    kwargs['extra_patterns'] = extra_patterns = list(kwargs.get('extra_patterns', []))
+
+    def flask_handler(slug, app):
+        if 'flask' not in sys.modules:
+            return
+        from flask import Flask
+        if not isinstance(app, Flask):
+            return
+        wsgi = WSGIContainer(app)
+        if slug == '/':
+            raise ValueError('Flask apps must be served on a subpath.')
+        if not slug.endswith('/'):
+            slug += '/'
+        extra_patterns.append((
+            f'^{slug}.*', ProxyFallbackHandler, dict(fallback=wsgi, proxy=slug)
+        ))
+        return True
+
+    apps = build_applications(
+        panel, title=title, location=location, admin=admin, custom_handlers=(flask_handler,)
+    )
 
     if warm or config.autoreload:
         for app in apps.values():

--- a/panel/io/threads.py
+++ b/panel/io/threads.py
@@ -48,7 +48,8 @@ class StoppableThread(threading.Thread):
         self._shutdown_task = asyncio.run_coroutine_threadsafe(self._shutdown(), self.asyncio_loop)
 
     async def _shutdown(self):
-        tasks = [t for t in asyncio.all_tasks() if t is not asyncio.current_task()]
+        cur_task = asyncio.current_task()
+        tasks = [t for t in asyncio.all_tasks() if t is not cur_task]
         for task in tasks:
             task.cancel()
         await asyncio.gather(*tasks, return_exceptions=True)

--- a/panel/io/threads.py
+++ b/panel/io/threads.py
@@ -1,0 +1,56 @@
+import asyncio
+import threading
+
+
+class StoppableThread(threading.Thread):
+    """Thread class with a stop() method."""
+
+    def __init__(self, io_loop, **kwargs):
+        super().__init__(**kwargs)
+        # Backward compatibility to handle Tornado IOLoop
+        if hasattr(io_loop, 'asyncio_loop'):
+            io_loop = io_loop.asyncio_loop
+        self.asyncio_loop = io_loop
+        self._shutdown_task = None
+
+    def run(self) -> None:
+        if hasattr(self, '_target'):
+            target, args, kwargs = self._target, self._args, self._kwargs # type: ignore
+        else:
+            target, args, kwargs = self._Thread__target, self._Thread__args, self._Thread__kwargs # type: ignore
+        if not target:
+            return
+        bokeh_server = None
+        try:
+            bokeh_server = target(*args, **kwargs)
+        finally:
+            if hasattr(bokeh_server, 'stop'):
+                # Handle tornado server
+                try:
+                    bokeh_server.stop()
+                except Exception:
+                    pass
+            elif hasattr(bokeh_server, 'shutdown'):
+                # Handle uvicorn server
+                try:
+                    self.asyncio_loop.run_until_complete(bokeh_server.shutdown())
+                except Exception:
+                    pass
+            if hasattr(self, '_target'):
+                del self._target, self._args, self._kwargs # type: ignore
+            else:
+                del self._Thread__target, self._Thread__args, self._Thread__kwargs # type: ignore
+
+    def stop(self) -> None:
+        """Signal to stop the event loop gracefully."""
+        if self._shutdown_task:
+            raise RuntimeError("Thread already stopping")
+        self._shutdown_task = asyncio.run_coroutine_threadsafe(self._shutdown(), self.asyncio_loop)
+
+    async def _shutdown(self):
+        tasks = [t for t in asyncio.all_tasks() if t is not asyncio.current_task()]
+        for task in tasks:
+            task.cancel()
+        await asyncio.gather(*tasks, return_exceptions=True)
+        self.asyncio_loop.stop()
+        self._shutdown_task = None

--- a/panel/tests/conftest.py
+++ b/panel/tests/conftest.py
@@ -33,6 +33,7 @@ from panel.io.reload import (
 )
 from panel.io.state import set_curdoc, state
 from panel.pane import HTML, Markdown
+from panel.tests.util import get_open_ports
 from panel.theme import Design
 
 CUSTOM_MARKS = ('ui', 'jupyter', 'subprocess', 'docs')
@@ -246,11 +247,7 @@ async def watch_files():
 
 @pytest.fixture
 def port():
-    worker_id = os.environ.get("PYTEST_XDIST_WORKER", "0")
-    worker_count = int(os.environ.get("PYTEST_XDIST_WORKER_COUNT", "1"))
-    new_port = PORT[0] + int(re.sub(r"\D", "", worker_id))
-    PORT[0] += worker_count
-    return new_port
+    return get_open_ports()[0]
 
 
 @pytest.fixture

--- a/panel/tests/conftest.py
+++ b/panel/tests/conftest.py
@@ -26,6 +26,8 @@ from bokeh.document import Document
 from bokeh.io.doc import curdoc, set_curdoc as set_bkdoc
 from pyviz_comms import Comm
 
+import panel.tests.util
+
 from panel import config, serve
 from panel.config import panel_extension
 from panel.io.reload import (
@@ -563,3 +565,20 @@ def df_strings():
     code = [f'{i:02d}' for i in range(len(descr))]
 
     return pd.DataFrame(dict(code=code, descr=descr))
+
+@pytest.fixture
+def tornado():
+    return 'tornado'
+
+@pytest.fixture
+def fastapi():
+    return 'fastapi'
+
+@pytest.fixture
+def server_implementation(request):
+    old = panel.tests.util.server_implementation
+    panel.tests.util.server_implementation = request.param
+    try:
+        yield
+    finally:
+        panel.tests.util.server_implementation = old

--- a/panel/tests/conftest.py
+++ b/panel/tests/conftest.py
@@ -4,6 +4,7 @@ A module containing testing utilities and fixtures.
 import asyncio
 import atexit
 import datetime as dt
+import importlib
 import os
 import pathlib
 import re
@@ -567,15 +568,11 @@ def df_strings():
     return pd.DataFrame(dict(code=code, descr=descr))
 
 @pytest.fixture
-def tornado():
-    return 'tornado'
-
-@pytest.fixture
-def fastapi():
-    return 'fastapi'
-
-@pytest.fixture
 def server_implementation(request):
+    try:
+        importlib.import_module(request.param)
+    except Exception:
+        pytest.skip(f'Could not import {request.param}')
     old = panel.tests.util.server_implementation
     panel.tests.util.server_implementation = request.param
     try:

--- a/panel/tests/conftest.py
+++ b/panel/tests/conftest.py
@@ -4,7 +4,6 @@ A module containing testing utilities and fixtures.
 import asyncio
 import atexit
 import datetime as dt
-import importlib
 import os
 import pathlib
 import re
@@ -26,8 +25,6 @@ from bokeh.client import pull_session
 from bokeh.document import Document
 from bokeh.io.doc import curdoc, set_curdoc as set_bkdoc
 from pyviz_comms import Comm
-
-import panel.tests.util
 
 from panel import config, serve
 from panel.config import panel_extension
@@ -566,16 +563,3 @@ def df_strings():
     code = [f'{i:02d}' for i in range(len(descr))]
 
     return pd.DataFrame(dict(code=code, descr=descr))
-
-@pytest.fixture
-def server_implementation(request):
-    try:
-        importlib.import_module(request.param)
-    except Exception:
-        pytest.skip(f'Could not import {request.param}')
-    old = panel.tests.util.server_implementation
-    panel.tests.util.server_implementation = request.param
-    try:
-        yield
-    finally:
-        panel.tests.util.server_implementation = old

--- a/panel/tests/test_server.py
+++ b/panel/tests/test_server.py
@@ -80,7 +80,8 @@ def test_server_root_handler():
     assert 'href="./app"' in r.content.decode('utf-8')
 
 
-def test_server_template_static_resources():
+@pytest.mark.parametrize('server_implementation', ["tornado", "fastapi"], indirect=True)
+def test_server_template_static_resources(server_implementation):
     template = BootstrapTemplate()
 
     r = serve_and_request({'template': template}, suffix="/static/extensions/panel/bundled/bootstraptemplate/bootstrap.css")
@@ -89,7 +90,8 @@ def test_server_template_static_resources():
         assert f.read() == r.content.decode('utf-8').replace('\r\n', '\n')
 
 
-def test_server_template_static_resources_with_prefix():
+#@pytest.mark.parametrize('server_implementation', ["tornado", "fastapi"], indirect=True)
+def test_server_template_static_resources_with_prefix(server_implementation):
     template = BootstrapTemplate()
 
     r = serve_and_request({'template': template}, prefix="/prefix", suffix="/prefix/static/extensions/panel/bundled/bootstraptemplate/bootstrap.css")
@@ -98,7 +100,8 @@ def test_server_template_static_resources_with_prefix():
         assert f.read() == r.content.decode('utf-8').replace('\r\n', '\n')
 
 
-def test_server_template_static_resources_with_prefix_relative_url():
+#@pytest.mark.parametrize('server_implementation', ["tornado", "fastapi"], indirect=True)
+def test_server_template_static_resources_with_prefix_relative_url(server_implementation):
     template = BootstrapTemplate()
 
     r = serve_and_request({'template': template}, prefix='/prefix', suffix="/prefix/template")
@@ -114,7 +117,8 @@ def test_server_template_static_resources_with_subpath_and_prefix_relative_url()
     assert f'href="../static/extensions/panel/bundled/bootstraptemplate/bootstrap.css?v={JS_VERSION}"' in r.content.decode('utf-8')
 
 
-def test_server_extensions_on_root():
+@pytest.mark.parametrize('server_implementation', ["tornado", "fastapi"], indirect=True)
+def test_server_extensions_on_root(server_implementation):
     md = Markdown('# Title')
     assert serve_and_request(md).ok
 
@@ -129,7 +133,8 @@ def test_autoload_js(port):
     assert f"http://localhost:{port}/static/extensions/panel/panel.min.js" in r.content.decode('utf-8')
 
 
-def test_server_async_callbacks():
+@pytest.mark.parametrize('server_implementation', ["tornado", "fastapi"], indirect=True)
+def test_server_async_callbacks(server_implementation):
     button = Button(name='Click')
 
     counts = []
@@ -153,7 +158,8 @@ def test_server_async_callbacks():
     wait_until(lambda: len(counts) > 0 and max(counts) > 1)
 
 
-def test_server_async_local_state(bokeh_curdoc):
+@pytest.mark.parametrize('server_implementation', ["tornado", "fastapi"], indirect=True)
+def test_server_async_local_state(server_implementation, bokeh_curdoc):
     docs = {}
 
     async def task():
@@ -174,7 +180,8 @@ def test_server_async_local_state(bokeh_curdoc):
     wait_until(lambda: all([len(set(docs)) == 1 and docs[0] is doc for doc, docs in docs.items()]))
 
 
-def test_server_async_local_state_nested_tasks(bokeh_curdoc):
+@pytest.mark.parametrize('server_implementation', ["tornado", "fastapi"], indirect=True)
+def test_server_async_local_state_nested_tasks(server_implementation, bokeh_curdoc):
     docs = {}
     _tasks = set()
 
@@ -200,7 +207,8 @@ def test_server_async_local_state_nested_tasks(bokeh_curdoc):
     wait_until(lambda: all(len(set(docs)) == 1 and docs[0] is doc for doc, docs in docs.items()))
 
 
-def test_serve_config_per_session_state():
+@pytest.mark.parametrize('server_implementation', ["tornado", "fastapi"], indirect=True)
+def test_serve_config_per_session_state(server_implementation):
     CSS1 = 'body { background-color: red }'
     CSS2 = 'body { background-color: green }'
     def app1():
@@ -223,7 +231,8 @@ def test_serve_config_per_session_state():
     assert CSS2 in r2
 
 
-def test_server_on_session_created():
+@pytest.mark.parametrize('server_implementation', ["tornado", "fastapi"], indirect=True)
+def test_server_on_session_created(server_implementation):
     session_contexts = []
     def append_session(session_context):
         session_contexts.append(session_context)
@@ -236,7 +245,8 @@ def test_server_on_session_created():
     assert len(session_contexts) == 3
 
 
-def test_server_on_session_destroyed():
+#@pytest.mark.parametrize('server_implementation', ["tornado", "fastapi"], indirect=True)
+def test_server_on_session_destroyed(server_implementation):
     session_contexts = []
     def append_session(session_context):
         session_contexts.append(session_context)
@@ -281,7 +291,8 @@ def test_server_session_info():
     assert state.session_info['live'] == 0
 
 
-def test_server_periodic_async_callback(threads):
+@pytest.mark.parametrize('server_implementation', ["tornado", "fastapi"], indirect=True)
+def test_server_periodic_async_callback(server_implementation, threads):
     counts = []
 
     async def cb(count=[0]):
@@ -301,7 +312,8 @@ def test_server_periodic_async_callback(threads):
     wait_until(lambda: len(counts) >= 5 and counts == list(range(len(counts))))
 
 
-def test_server_schedule_repeat():
+@pytest.mark.parametrize('server_implementation', ["tornado", "fastapi"], indirect=True)
+def test_server_schedule_repeat(server_implementation):
     state.cache['count'] = 0
     def periodic_cb():
         state.cache['count'] += 1
@@ -314,7 +326,9 @@ def test_server_schedule_repeat():
 
     wait_until(lambda: state.cache['count'] > 0)
 
-def test_server_schedule_threaded(threads):
+
+@pytest.mark.parametrize('server_implementation', ["tornado", "fastapi"], indirect=True)
+def test_server_schedule_threaded(server_implementation, threads):
     counts = []
     def periodic_cb(count=[0]):
         count[0] += 1
@@ -333,7 +347,8 @@ def test_server_schedule_threaded(threads):
     wait_until(lambda: len(counts) > 0 and max(counts) > 1)
 
 
-def test_server_schedule_at():
+@pytest.mark.parametrize('server_implementation', ["tornado", "fastapi"], indirect=True)
+def test_server_schedule_at(server_implementation):
     def periodic_cb():
         state.cache['at'] = dt.datetime.now()
 
@@ -351,7 +366,8 @@ def test_server_schedule_at():
     assert len(state._scheduled) == 0
 
 
-def test_server_schedule_at_iterator():
+@pytest.mark.parametrize('server_implementation', ["tornado", "fastapi"], indirect=True)
+def test_server_schedule_at_iterator(server_implementation):
     state.cache['at'] = []
     def periodic_cb():
         state.cache['at'].append(dt.datetime.now())
@@ -376,7 +392,8 @@ def test_server_schedule_at_iterator():
     assert len(state._scheduled) == 0
 
 
-def test_server_schedule_at_callable():
+@pytest.mark.parametrize('server_implementation', ["tornado", "fastapi"], indirect=True)
+def test_server_schedule_at_callable(server_implementation):
     state.cache['at'] = []
     def periodic_cb():
         state.cache['at'].append(dt.datetime.now())
@@ -487,20 +504,23 @@ def test_multiple_titles(multiple_apps_server_sessions):
             slugs=('app1', 'app2'), titles={'badkey': 'APP1', 'app2': 'APP2'})
 
 
-def test_serve_can_serve_panel_app_from_file():
+@pytest.mark.parametrize('server_implementation', ["tornado", "fastapi"], indirect=True)
+def test_serve_can_serve_panel_app_from_file(server_implementation):
     path = pathlib.Path(__file__).parent / "io"/"panel_app.py"
     server = get_server({"panel-app": path})
     assert "/panel-app" in server._tornado.applications
 
 
-def test_serve_can_serve_bokeh_app_from_file():
+@pytest.mark.parametrize('server_implementation', ["tornado", "fastapi"], indirect=True)
+def test_serve_can_serve_bokeh_app_from_file(server_implementation):
     path = pathlib.Path(__file__).parent / "io"/"bk_app.py"
     server = get_server({"bk-app": path})
     assert "/bk-app" in server._tornado.applications
 
 
 
-def test_server_on_load_after_init_with_threads(threads):
+@pytest.mark.parametrize('server_implementation', ["tornado", "fastapi"], indirect=True)
+def test_server_on_load_after_init_with_threads(server_implementation, threads):
     loaded = []
 
     def cb():
@@ -526,7 +546,8 @@ def test_server_on_load_after_init_with_threads(threads):
     assert loaded == [(doc, False), (doc, True)]
 
 
-def test_server_on_load_after_init():
+@pytest.mark.parametrize('server_implementation', ["tornado", "fastapi"], indirect=True)
+def test_server_on_load_after_init(server_implementation):
     loaded = []
 
     def cb():
@@ -552,7 +573,8 @@ def test_server_on_load_after_init():
     assert loaded == [(doc, False), (doc, True)]
 
 
-def test_server_on_load_during_load(threads):
+@pytest.mark.parametrize('server_implementation', ["tornado", "fastapi"], indirect=True)
+def test_server_on_load_during_load(server_implementation, threads):
     loaded = []
 
     def cb():
@@ -576,7 +598,8 @@ def test_server_on_load_during_load(threads):
     wait_until(lambda: loaded == [False, False])
 
 
-def test_server_thread_pool_on_load(threads):
+@pytest.mark.parametrize('server_implementation', ["tornado", "fastapi"], indirect=True)
+def test_server_thread_pool_on_load(server_implementation, threads):
     counts = []
 
     def cb(count=[0]):
@@ -602,7 +625,8 @@ def test_server_thread_pool_on_load(threads):
     wait_until(lambda: len(counts) > 0 and max(counts) > 1)
 
 
-def test_server_thread_pool_execute(threads):
+@pytest.mark.parametrize('server_implementation', ["tornado", "fastapi"], indirect=True)
+def test_server_thread_pool_execute(server_implementation, threads):
     counts = []
 
     def cb(count=[0]):
@@ -622,7 +646,8 @@ def test_server_thread_pool_execute(threads):
     wait_until(lambda: len(counts) > 0 and max(counts) > 1)
 
 
-def test_server_thread_pool_defer_load(threads):
+@pytest.mark.parametrize('server_implementation', ["tornado", "fastapi"], indirect=True)
+def test_server_thread_pool_defer_load(server_implementation, threads):
     counts = []
 
     def cb(count=[0]):
@@ -650,7 +675,8 @@ def test_server_thread_pool_defer_load(threads):
     wait_until(lambda: len(counts) > 0 and max(counts) > 1)
 
 
-def test_server_thread_pool_change_event(threads):
+@pytest.mark.parametrize('server_implementation', ["tornado", "fastapi"], indirect=True)
+def test_server_thread_pool_change_event(server_implementation, threads):
     button = Button(name='Click')
     button2 = Button(name='Click')
 
@@ -678,7 +704,8 @@ def test_server_thread_pool_change_event(threads):
     wait_until(lambda: len(counts) > 0 and max(counts) > 1)
 
 
-def test_server_thread_pool_bokeh_event(threads):
+@pytest.mark.parametrize('server_implementation', ["tornado", "fastapi"], indirect=True)
+def test_server_thread_pool_bokeh_event(server_implementation, threads):
     import pandas as pd
 
     df = pd.DataFrame([[1, 1], [2, 2]], columns=['A', 'B'])
@@ -706,7 +733,8 @@ def test_server_thread_pool_bokeh_event(threads):
     wait_until(lambda: len(counts) > 0 and max(counts) > 1)
 
 
-def test_server_thread_pool_periodic(threads):
+@pytest.mark.parametrize('server_implementation', ["tornado", "fastapi"], indirect=True)
+def test_server_thread_pool_periodic(server_implementation, threads):
     counts = []
 
     def cb(count=[0]):
@@ -755,7 +783,8 @@ def test_server_thread_pool_onload(threads):
     wait_until(lambda: len(counts) > 0 and max(counts) > 1)
 
 
-def test_server_thread_pool_busy(threads):
+@pytest.mark.parametrize('server_implementation', ["tornado", "fastapi"], indirect=True)
+def test_server_thread_pool_busy(server_implementation, threads):
     button = Button(name='Click')
     clicks = []
 

--- a/panel/tests/test_server.py
+++ b/panel/tests/test_server.py
@@ -24,7 +24,9 @@ from panel.pane import Markdown
 from panel.param import ParamFunction
 from panel.reactive import ReactiveHTML
 from panel.template import BootstrapTemplate
-from panel.tests.util import serve_and_request, serve_and_wait, wait_until
+from panel.tests.util import (
+    get_open_ports, serve_and_request, serve_and_wait, wait_until,
+)
 from panel.widgets import (
     Button, Tabulator, Terminal, TextInput,
 )
@@ -225,7 +227,7 @@ def test_serve_config_per_session_state(server_implementation):
     def app2():
         config.raw_css = [CSS2]
 
-    port1, port2 = 7001, 7002
+    port1, port2 = get_open_ports(n=2)
     serve_and_wait(app1, port=port1)
     serve_and_wait(app2, port=port2)
 

--- a/panel/tests/test_server.py
+++ b/panel/tests/test_server.py
@@ -91,7 +91,7 @@ def test_server_template_static_resources(server_implementation):
 
 
 #@pytest.mark.parametrize('server_implementation', ["tornado", "fastapi"], indirect=True)
-def test_server_template_static_resources_with_prefix(server_implementation):
+def test_server_template_static_resources_with_prefix():
     template = BootstrapTemplate()
 
     r = serve_and_request({'template': template}, prefix="/prefix", suffix="/prefix/static/extensions/panel/bundled/bootstraptemplate/bootstrap.css")
@@ -101,7 +101,7 @@ def test_server_template_static_resources_with_prefix(server_implementation):
 
 
 #@pytest.mark.parametrize('server_implementation', ["tornado", "fastapi"], indirect=True)
-def test_server_template_static_resources_with_prefix_relative_url(server_implementation):
+def test_server_template_static_resources_with_prefix_relative_url():
     template = BootstrapTemplate()
 
     r = serve_and_request({'template': template}, prefix='/prefix', suffix="/prefix/template")
@@ -246,7 +246,7 @@ def test_server_on_session_created(server_implementation):
 
 
 #@pytest.mark.parametrize('server_implementation', ["tornado", "fastapi"], indirect=True)
-def test_server_on_session_destroyed(server_implementation):
+def test_server_on_session_destroyed():
     session_contexts = []
     def append_session(session_context):
         session_contexts.append(session_context)

--- a/panel/tests/test_server.py
+++ b/panel/tests/test_server.py
@@ -41,7 +41,7 @@ def server_implementation(request):
     old = serve_and_wait.server_implementation
     serve_and_wait.server_implementation = request.param
     try:
-        yield
+        yield request.param
     finally:
         serve_and_wait.server_implementation = old
 

--- a/panel/tests/util.py
+++ b/panel/tests/util.py
@@ -273,19 +273,23 @@ def get_ctrl_modifier():
         raise ValueError(f'No control modifier defined for platform {sys.platform}')
 
 
-def get_open_port():
-    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    s.bind(('127.0.0.1', 0))
-    addr, port = s.getsockname()
-    s.close()
-    return port
+def get_open_ports(n=1):
+    sockets,ports = [], []
+    for _ in range(n):
+        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        s.bind(('127.0.0.1', 0))
+        ports.append(s.getsockname()[1])
+        sockets.append(s)
+    for s in sockets:
+        s.close()
+    return tuple(ports)
 
 
 def serve_and_wait(app, page=None, prefix=None, port=None, **kwargs):
     server_id = kwargs.pop('server_id', uuid.uuid4().hex)
     if serve_and_wait.server_implementation == 'fastapi':
         from panel.io.fastapi import serve as serve_app
-        port = port or get_open_port()
+        port = port or get_open_ports()[0]
     else:
         serve_app = serve
     serve_app(app, port=port or 0, threaded=True, show=False, liveness=True, server_id=server_id, prefix=prefix or "", **kwargs)

--- a/panel/tests/util.py
+++ b/panel/tests/util.py
@@ -59,7 +59,6 @@ jb_available = pytest.mark.skipif(jupyter_bokeh is None, reason="requires jupyte
 APP_PATTERN = re.compile(r'Bokeh app running at: http://localhost:(\d+)/')
 ON_POSIX = 'posix' in sys.builtin_module_names
 
-server_implementation = 'tornado'
 linux_only = pytest.mark.skipif(platform.system() != 'Linux', reason="Only supported on Linux")
 unix_only = pytest.mark.skipif(platform.system() == 'Windows', reason="Only supported on unix-like systems")
 
@@ -284,7 +283,7 @@ def get_open_port():
 
 def serve_and_wait(app, page=None, prefix=None, port=None, **kwargs):
     server_id = kwargs.pop('server_id', uuid.uuid4().hex)
-    if server_implementation == 'fastapi':
+    if serve_and_wait.server_implementation == 'fastapi':
         from panel.io.fastapi import serve as serve_app
         port = port or get_open_port()
     else:
@@ -292,13 +291,14 @@ def serve_and_wait(app, page=None, prefix=None, port=None, **kwargs):
     serve_app(app, port=port or 0, threaded=True, show=False, liveness=True, server_id=server_id, prefix=prefix or "", **kwargs)
     wait_until(lambda: server_id in state._servers, page)
     server = state._servers[server_id][0]
-    if server_implementation == 'fastapi':
+    if serve_and_wait.server_implementation == 'fastapi':
         port = port
     else:
         port = server.port
     wait_for_server(port, prefix=prefix)
     return port
 
+serve_and_wait.server_implementation = 'tornado'
 
 def serve_component(page, app, suffix='', wait=True, **kwargs):
     msgs = []

--- a/pixi.toml
+++ b/pixi.toml
@@ -123,7 +123,7 @@ scipy = "*"
 textual = "*"
 
 [feature.test.pypi-dependencies]
-bokeh-fastapi = "0.1.0a0"
+bokeh-fastapi = "~=0.1.0a0"
 
 [feature.test-unit-task.tasks] # So it is not showing up in the test-ui environment
 test-unit = 'pytest panel/tests -n logical --dist loadgroup'

--- a/pixi.toml
+++ b/pixi.toml
@@ -112,6 +112,7 @@ pytest-xdist = "*"
 altair = "*"
 anywidget = "*"
 diskcache = "*"
+fastapi = "*"
 folium = "*"
 ipympl = "*"
 ipyvuetify = "*"
@@ -120,6 +121,9 @@ numba = "*"
 reacton = "*"
 scipy = "*"
 textual = "*"
+
+[feature.test.pypi-dependencies]
+bokeh-fastapi = "0.1.0a0"
 
 [feature.test-unit-task.tasks] # So it is not showing up in the test-ui environment
 test-unit = 'pytest panel/tests -n logical --dist loadgroup'


### PR DESCRIPTION
Builds on top of [bokeh-fastapi](https://github.com/bokeh/bokeh-fastapi/) and adds two main user facing APIs:

- `panel.io.fastapi.serve`: Mirrors the `panel.serve` API but launches a FastAPI backed uvicorn server (optionally on a separate thread).
- `panel.io.fastapi.add_applications`: Adds Panel applications to an existing FastAPI application.
- `panel.io.fastapi.add_application`: Decorator to add a function returning Panel objects to the FastAPI server.

@pmeier, thoughts and review appreciated. I'd like to get an initial cut of this in pretty soon but then we'll have about 1 - 1.5 weeks to add docs and more tests.