### PR TITLE
Tweak ChatMessage layout

### DIFF
--- a/panel/chat/icon.py
+++ b/panel/chat/icon.py
@@ -72,7 +72,12 @@ class ChatReactionIcons(CompositeWidget):
             icon._reaction = option
             icon.param.watch(self._update_value, "value")
             self._rendered_icons[option] = icon
-        self._composite[:] = [self.default_layout(*list(self._rendered_icons.values()))]
+        self._composite[:] = [
+            self.default_layout(
+                *list(self._rendered_icons.values()),
+                sizing_mode=None,
+                stylesheets=self._stylesheets + self.param.stylesheets.rx(),
+            )]
 
     @param.depends("value", watch=True)
     def _update_icons(self):

--- a/panel/chat/icon.py
+++ b/panel/chat/icon.py
@@ -75,7 +75,7 @@ class ChatReactionIcons(CompositeWidget):
         self._composite[:] = [
             self.default_layout(
                 *list(self._rendered_icons.values()),
-                sizing_mode=None,
+                sizing_mode=self.param.sizing_mode,
                 stylesheets=self._stylesheets + self.param.stylesheets.rx(),
             )]
 

--- a/panel/chat/message.py
+++ b/panel/chat/message.py
@@ -344,8 +344,8 @@ class ChatMessage(Pane):
             header_col,
             self._center_row,
             footer_col,
-            self._timestamp_html,
             self._icons_row,
+            self._timestamp_html,
             css_classes=["right"],
             sizing_mode=None,
             stylesheets=self._stylesheets + self.param.stylesheets.rx(),
@@ -556,6 +556,7 @@ class ChatMessage(Pane):
 
     def _update_reaction_icons(self, _):
         self._icons_row[-1] = self._render_reaction_icons()
+        self._icon_divider.visible = len(self.reaction_icons.options) > 0 and self.chat_copy_icon.visible
 
     def _update(self, ref, old_models):
         """

--- a/panel/chat/message.py
+++ b/panel/chat/message.py
@@ -557,7 +557,11 @@ class ChatMessage(Pane):
 
     def _update_reaction_icons(self, _):
         self._icons_row[-1] = self._render_reaction_icons()
-        self._icon_divider.visible = len(self.reaction_icons.options) > 0 and self.chat_copy_icon.visible
+        self._icon_divider.visible = (
+            len(self.reaction_icons.options) > 0 and
+            self.show_reaction_icons and
+            self.chat_copy_icon.visible
+        )
 
     def _update(self, ref, old_models):
         """
@@ -600,7 +604,10 @@ class ChatMessage(Pane):
         if isinstance(object_panel, str) and self.show_copy_icon:
             self.chat_copy_icon.value = object_panel
             self.chat_copy_icon.visible = True
-            self._icon_divider.visible = len(self.reaction_icons.options) > 0
+            self._icon_divider.visible = (
+                len(self.reaction_icons.options) > 0 and
+                self.show_reaction_icons
+            )
         else:
             self.chat_copy_icon.value = ""
             self.chat_copy_icon.visible = False

--- a/panel/chat/message.py
+++ b/panel/chat/message.py
@@ -300,8 +300,9 @@ class ChatMessage(Pane):
         self._activity_dot = HTML(
             "●",
             css_classes=["activity-dot"],
-            visible=self.param.show_activity_dot,
+            margin=(5, 0),
             sizing_mode=None,
+            visible=self.param.show_activity_dot,
         )
 
         meta_row = Row(

--- a/panel/chat/message.py
+++ b/panel/chat/message.py
@@ -599,7 +599,7 @@ class ChatMessage(Pane):
         if isinstance(object_panel, str) and self.show_copy_icon:
             self.chat_copy_icon.value = object_panel
             self.chat_copy_icon.visible = True
-            self._icon_divider.visible = True
+            self._icon_divider.visible = len(self.reaction_icons.options) > 0
         else:
             self.chat_copy_icon.value = ""
             self.chat_copy_icon.visible = False

--- a/panel/chat/message.py
+++ b/panel/chat/message.py
@@ -254,7 +254,7 @@ class ChatMessage(Pane):
 
         reaction_icons = params.get("reaction_icons", {"favorite": "heart"})
         if isinstance(reaction_icons, dict):
-            params["reaction_icons"] = ChatReactionIcons(options=reaction_icons, default_layout=Row)
+            params["reaction_icons"] = ChatReactionIcons(options=reaction_icons, default_layout=Row, sizing_mode=None)
         self._internal = True
         super().__init__(object=object, **params)
         self.chat_copy_icon = ChatCopyIcon(
@@ -294,18 +294,19 @@ class ChatMessage(Pane):
             self.param.user, height=20,
             css_classes=["name"],
             visible=self.param.show_user,
+            sizing_mode=None,
         )
 
         self._activity_dot = HTML(
             "●",
             css_classes=["activity-dot"],
             visible=self.param.show_activity_dot,
+            sizing_mode=None,
         )
 
         meta_row = Row(
             self._user_html,
             self._activity_dot,
-            sizing_mode="stretch_width",
             css_classes=["meta"],
             stylesheets=self._stylesheets + self.param.stylesheets.rx(),
         )

--- a/panel/dist/css/chat_copy_icon.css
+++ b/panel/dist/css/chat_copy_icon.css
@@ -1,3 +1,3 @@
 :host {
-  margin-top: 5px;
+  margin-top: 8px;
 }

--- a/panel/dist/css/chat_message.css
+++ b/panel/dist/css/chat_message.css
@@ -142,11 +142,9 @@
   display: inline-block;
   animation: fadeOut 2s infinite cubic-bezier(0.68, -0.55, 0.27, 1.55);
   color: #32cd32;
-  /* since 1.25em, fix margins to everything is perceived to be more aligned */
+  /* since 1.25em, adjust line-height */
   font-size: 1.25em;
-  margin-left: -2.5px;
-  margin-top: 2px;
-  margin-bottom: 5px;
+  line-height: 0.9em;
 }
 
 .divider {

--- a/panel/dist/css/chat_message.css
+++ b/panel/dist/css/chat_message.css
@@ -59,6 +59,7 @@
 
 .name {
   font-size: 1em;
+  width: fit-content;
 }
 
 .center {

--- a/panel/dist/css/chat_reaction_icons.css
+++ b/panel/dist/css/chat_reaction_icons.css
@@ -1,0 +1,4 @@
+:host {
+  margin-top: 4px;
+  width: fit-content;
+}

--- a/panel/dist/css/icon.css
+++ b/panel/dist/css/icon.css
@@ -18,5 +18,4 @@
 .bk-IconRow {
   display: flex;
   align-items: center;
-  justify-content: center;
 }

--- a/panel/tests/chat/test_message.py
+++ b/panel/tests/chat/test_message.py
@@ -86,6 +86,9 @@ class TestChatMessage:
         message.reaction_icons = ChatReactionIcons(options={})
         assert not message._icon_divider.visible
 
+        message = ChatMessage("hi", reaction_icons={})
+        assert not message._icon_divider.visible
+
     def test_reactions_link(self):
         # on init
         message = ChatMessage(reactions=["favorite"])

--- a/panel/tests/chat/test_message.py
+++ b/panel/tests/chat/test_message.py
@@ -54,7 +54,7 @@ class TestChatMessage:
         assert isinstance(object_pane, Markdown)
         assert object_pane.object == "ABC"
 
-        icons = columns[1][5][2]
+        icons = columns[1][4][2]
         assert isinstance(icons, ChatReactionIcons)
 
         footer_col = columns[1][3]
@@ -65,22 +65,26 @@ class TestChatMessage:
         assert isinstance(footer_col[1], Markdown)
         assert footer_col[1].object == "Footer 2"
 
-        timestamp_pane = columns[1][4][0]
+        timestamp_pane = columns[1][5][0]
         assert isinstance(timestamp_pane, HTML)
 
     def test_reactions_dynamic(self):
-        message = ChatMessage(reactions=["favorite"])
+        message = ChatMessage("hi", reactions=["favorite"])
         assert message.reaction_icons.value == ["favorite"]
 
         message.reactions = ["thumbs-up"]
         assert message.reaction_icons.value == ["thumbs-up"]
 
     def test_reaction_icons_dynamic(self):
-        message = ChatMessage(reaction_icons={"favorite": "heart"})
+        message = ChatMessage("hi", reaction_icons={"favorite": "heart"})
         assert message.reaction_icons.options == {"favorite": "heart"}
 
         message.reaction_icons = ChatReactionIcons(options={"like": "thumb-up"})
         assert message._icons_row[-1] == message.reaction_icons
+        assert message._icon_divider.visible
+
+        message.reaction_icons = ChatReactionIcons(options={})
+        assert not message._icon_divider.visible
 
     def test_reactions_link(self):
         # on init
@@ -171,39 +175,39 @@ class TestChatMessage:
     def test_update_timestamp(self):
         message = ChatMessage()
         columns = message._composite.objects
-        timestamp_pane = columns[1][4][0]
+        timestamp_pane = columns[1][5][0]
         assert isinstance(timestamp_pane, HTML)
         dt_str = datetime.datetime.now().strftime("%H:%M")
         assert timestamp_pane.object == dt_str
 
         message = ChatMessage(timestamp_tz="UTC")
         columns = message._composite.objects
-        timestamp_pane = columns[1][4][0]
+        timestamp_pane = columns[1][5][0]
         assert isinstance(timestamp_pane, HTML)
         dt_str = datetime.datetime.now(datetime.timezone.utc).strftime("%H:%M")
         assert timestamp_pane.object == dt_str
 
         message = ChatMessage(timestamp_tz="US/Pacific")
         columns = message._composite.objects
-        timestamp_pane = columns[1][4][0]
+        timestamp_pane = columns[1][5][0]
         assert isinstance(timestamp_pane, HTML)
         dt_str = datetime.datetime.now(tz=ZoneInfo("US/Pacific")).strftime("%H:%M")
         assert timestamp_pane.object == dt_str
 
         special_dt = datetime.datetime(2023, 6, 24, 15)
         message.timestamp = special_dt
-        timestamp_pane = columns[1][4][0]
+        timestamp_pane = columns[1][5][0]
         dt_str = special_dt.strftime("%H:%M")
         assert timestamp_pane.object == dt_str
 
         mm_dd_yyyy = "%b %d, %Y"
         message.timestamp_format = mm_dd_yyyy
-        timestamp_pane = columns[1][4][0]
+        timestamp_pane = columns[1][5][0]
         dt_str = special_dt.strftime(mm_dd_yyyy)
         assert timestamp_pane.object == dt_str
 
         message.show_timestamp = False
-        timestamp_pane = columns[1][4][0]
+        timestamp_pane = columns[1][5][0]
         assert not timestamp_pane.visible
 
     def test_does_not_turn_widget_into_str(self):
@@ -322,17 +326,20 @@ class TestChatMessage:
         message = ChatMessage(object=widget(value="testing"))
         assert message.chat_copy_icon.visible
         assert message.chat_copy_icon.value == "testing"
+        assert message._icon_divider.visible
 
     def test_chat_copy_icon_disabled(self):
         message = ChatMessage(object="testing", show_copy_icon=False)
         assert not message.chat_copy_icon.visible
         assert not message.chat_copy_icon.value
+        assert not message._icon_divider.visible
 
     @pytest.mark.parametrize("component", [Column, FileInput])
     def test_chat_copy_icon_not_string(self, component):
         message = ChatMessage(object=component())
         assert not message.chat_copy_icon.visible
         assert not message.chat_copy_icon.value
+        assert not message._icon_divider.visible
 
     def test_serialize_text_prefix_with_viewable_type(self):
         message = ChatMessage(Markdown("string"))


### PR DESCRIPTION
Ensures the icon divider is invisible if reaction_icons is empty or if copy icon is invisible.

```python
import panel as pn

pn.extension()

cm = pn.chat.ChatMessage("ABC")
cm.servable()
```
<img width="225" alt="image" src="https://github.com/user-attachments/assets/1aae881f-ee84-4e23-bafd-e82d21f50269">

`cm = pn.chat.ChatMessage("ABC", show_copy_icon=False)`

<img width="269" alt="image" src="https://github.com/user-attachments/assets/10a382c8-96a3-407a-a182-2fe2354682a2">

`cm = pn.chat.ChatMessage("ABC", reaction_icons={})`

<img width="258" alt="image" src="https://github.com/user-attachments/assets/b88520bc-7406-4238-b317-20f6b2f349c7">
