### PR TITLE
Continue if session crashes

### DIFF
--- a/panel/command/serve.py
+++ b/panel/command/serve.py
@@ -289,6 +289,8 @@ class Serve(_BkServe):
             except Exception as e:
                 if error:
                     raise e
+                else:
+                    continue
             with set_curdoc(session.document):
                 if config.session_key_func:
                     reuse_sessions = False


### PR DESCRIPTION
Addresses what is seen in #7211. Not sure if we should expose the error message which is why I did not mark it as fixed.

It makes it so the user can see the error message. Making it so the original issue will show:

``` python
HTTPServerRequest(protocol='http', host='localhost:5006', method='GET', uri='/7211_Server_crash', version='HTTP/1.1', remote_ip='127.0.0.1')
Traceback (most recent call last):
  File "/home/shh/miniconda3/envs/holoviz/lib/python3.12/site-packages/tornado/web.py", line 1790, in _execute
    result = await result
             ^^^^^^^^^^^^
  File "/home/shh/projects/holoviz/repos/panel/panel/io/server.py", line 541, in get
    session = await self.get_session()
              ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/shh/projects/holoviz/repos/panel/panel/io/server.py", line 430, in get_session
    session = await super().get_session()
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/shh/miniconda3/envs/holoviz/lib/python3.12/site-packages/bokeh/server/views/session_handler.py", line 145, in get_session
    session = await self.application_context.create_session_if_needed(session_id, self.request, token)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/shh/miniconda3/envs/holoviz/lib/python3.12/site-packages/bokeh/server/contexts.py", line 240, in create_session_if_needed
    self._application.initialize_document(doc)
  File "/home/shh/projects/holoviz/repos/panel/panel/io/application.py", line 81, in initialize_document
    template.server_doc(title=template.title, location=True, doc=doc)
  File "/home/shh/projects/holoviz/repos/panel/panel/template/base.py", line 505, in server_doc
    return self._init_doc(doc, title=title, location=location)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/shh/projects/holoviz/repos/panel/panel/template/base.py", line 760, in _init_doc
    document = super()._init_doc(doc, comm, title, notebook, location)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/shh/projects/holoviz/repos/panel/panel/template/base.py", line 224, in _init_doc
    model = obj.get_root(document, comm, preprocess=False)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/shh/projects/holoviz/repos/panel/panel/layout/base.py", line 317, in get_root
    root = super().get_root(doc, comm, preprocess)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/shh/projects/holoviz/repos/panel/panel/viewable.py", line 678, in get_root
    root = self._get_model(doc, comm=comm)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/shh/projects/holoviz/repos/panel/panel/layout/base.py", line 183, in _get_model
    objects, _ = self._get_objects(model, [], doc, root, comm)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/shh/projects/holoviz/repos/panel/panel/layout/base.py", line 165, in _get_objects
    child = pane._get_model(doc, root, model, comm)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/shh/projects/holoviz/repos/panel/panel/layout/base.py", line 183, in _get_model
    objects, _ = self._get_objects(model, [], doc, root, comm)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/shh/projects/holoviz/repos/panel/panel/layout/base.py", line 165, in _get_objects
    child = pane._get_model(doc, root, model, comm)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/shh/projects/holoviz/development/dev_panel/7211_Server_crash.py", line 12, in _get_model
    model.background_fill_color = self.background
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/shh/miniconda3/envs/holoviz/lib/python3.12/site-packages/bokeh/core/has_props.py", line 336, in __setattr__
    return super().__setattr__(name, value)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/shh/miniconda3/envs/holoviz/lib/python3.12/site-packages/bokeh/core/property/descriptors.py", line 330, in __set__
    value = self.property.prepare_value(obj, self.name, value)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/shh/miniconda3/envs/holoviz/lib/python3.12/site-packages/bokeh/core/property/bases.py", line 363, in prepare_value
    raise ValueError(f"failed to validate {obj_repr}.{name}: {error}")
ValueError: failed to validate figure(id='p1105', ...).background_fill_color: expected either None or a value of type Color, got 'transparent'
```