### PR TITLE
Make --dev an alias for --autoreload

### DIFF
--- a/doc/explanation/develop_seamlessly.md
+++ b/doc/explanation/develop_seamlessly.md
@@ -146,10 +146,10 @@ template.servable()
 From the terminal run the following command.
 
 ```bash
-panel serve app.py --show --autoreload
+panel serve app.py --show --dev
 ```
 
-The `--show` flag will open a browser tab with the live app and the `--autoreload` flag ensures that the app reloads whenever you make a change to the Python source. `--autoreload` is key to your developer experience, you will see the app being updated live when you save your app file! In the image below the windows have been re-arranged the way web developers like, on one side the code and on the other side a live view of the app, just like the *Preview* functionality in Jupyterlab.
+The `--show` flag will open a browser tab with the live app and the `--dev` flag ensures that the app reloads whenever you make a change to the Python source. `--dev` is key to your developer experience, you will see the app being updated live when you save your app file! In the image below the windows have been re-arranged the way web developers like, on one side the code and on the other side a live view of the app, just like the *Preview* functionality in Jupyterlab.
 
 ![VSCode Preview](../_static/images/vscode_preview.png)
 

--- a/doc/getting_started/build_app.md
+++ b/doc/getting_started/build_app.md
@@ -124,7 +124,7 @@ Save the notebook with the name `app.ipynb`.
 Finally, we'll serve the app with:
 
 ```bash
-panel serve app.ipynb --autoreload
+panel serve app.ipynb --dev
 ```
 
 Now, open the app in your browser at [http://localhost:5006/app](http://localhost:5006/app).
@@ -138,7 +138,7 @@ It should look like this:
 If you prefer developing in a Python Script using an editor, you can copy the code into a file `app.py` and serve it.
 
 ```bash
-panel serve app.py --autoreload
+panel serve app.py --dev
 ```
 
 :::

--- a/doc/getting_started/core_concepts.md
+++ b/doc/getting_started/core_concepts.md
@@ -37,7 +37,7 @@ By placing a Panel component at the end of a notebook cell, it renders as part o
 To add Panel components to your app, mark them as `.servable()` and serve the app with:
 
 ```bash
-panel serve app.ipynb --autoreload
+panel serve app.ipynb --dev
 ```
 
 You've already experimented with this while [building a simple app](build_app.md).
@@ -47,10 +47,10 @@ You've already experimented with this while [building a simple app](build_app.md
 If you're working in an editor, declare the Panel components you want to display as `.servable()`, then serve the script with:
 
 ```bash
-panel serve app.py --autoreload --show
+panel serve app.py --dev --show
 ```
 
-Upon running that command, Panel launches a server that serves your app, opens a tab in your default browser (`--show`), and updates the application whenever you modify the code (`--autoreload`).
+Upon running that command, Panel launches a server that serves your app, opens a tab in your default browser (`--show`), and updates the application whenever you modify the code (`--dev`).
 
 <img src="https://assets.holoviz.org/panel/gifs/vscode_autoreload.gif" style="margin-left: auto; margin-right: auto; display: block;"></img>
 

--- a/doc/getting_started/installation.md
+++ b/doc/getting_started/installation.md
@@ -62,7 +62,7 @@ conda install panel watchfiles
 :::::
 
 :::{tip}
-We recommend also installing [`watchfiles`](https://watchfiles.helpmanual.io) while developing. This will provide a significantly better experience when using Panel's `--autoreload` feature. It's not needed for production.
+We recommend also installing [`watchfiles`](https://watchfiles.helpmanual.io) while developing. This will provide a significantly better experience when using Panel's autoreload features when activating `--dev` mode. It's not needed for production.
 :::
 
 :::{tip}

--- a/doc/how_to/server/commandline.md
+++ b/doc/how_to/server/commandline.md
@@ -12,13 +12,13 @@ or even serve a number of apps at once:
 
     panel serve apps/*.py
 
-For development it can be particularly helpful to use the ``--autoreload`` option to `panel serve` as that will automatically reload the page whenever the application code or any of its imports change.
+For development it can be particularly helpful to use the `--dev` option to `panel serve` as that will automatically reload the page whenever the application code or any of its imports change.
 
 ```{note}
-We recommend installing `watchfiles`, which will provide a significantly better user experience when using `--autoreload`.
+We recommend installing `watchfiles`, which will provide a significantly better user experience when using `--dev`.
 ```
 
-The ``panel serve`` command has the following options:
+The `panel serve` command has the following options:
 
 ```bash
 positional arguments:
@@ -142,6 +142,6 @@ options:
                         Whether to add a global loading spinner to the application(s).
 ```
 
-To turn a notebook into a deployable app simply append ``.servable()`` to one or more Panel objects, which will add the app to Bokeh's ``curdoc``, ensuring it can be discovered by Bokeh server on deployment. In this way it is trivial to build dashboards that can be used interactively in a notebook and then seamlessly deployed on Bokeh server.
+To turn a notebook into a deployable app simply append `.servable()` to one or more Panel objects, which will add the app to Bokeh's `curdoc`, ensuring it can be discovered by Bokeh server on deployment. In this way it is trivial to build dashboards that can be used interactively in a notebook and then seamlessly deployed on Bokeh server.
 
 When called on a notebook, `panel serve` first converts it to a python script using [`nbconvert.PythonExporter()`](https://nbconvert.readthedocs.io/en/stable/api/exporters.html), albeit with [IPython magics](https://ipython.readthedocs.io/en/stable/interactive/magics.html) stripped out. This means that non-code cells, such as raw cells, are entirely handled by `nbconvert` and [may modify the served app](https://nbsphinx.readthedocs.io/en/latest/raw-cells.html).

--- a/doc/how_to/streamlit_migration/get_started.md
+++ b/doc/how_to/streamlit_migration/get_started.md
@@ -54,7 +54,7 @@ pn.panel("Hello World").servable()
 You *serve* and *show* (i.e. open) the app in your browser with *autoreload* via
 
 ```bash
-panel serve app.py --autoreload --show
+panel serve app.py --dev --show
 ```
 
 ![Panel Hello World Example](../../_static/images/panel_hello_world.png)

--- a/doc/how_to/wasm/convert.md
+++ b/doc/how_to/wasm/convert.md
@@ -76,7 +76,7 @@ You can now add the `script.html` (and `script.js` file if you used the `pyodide
 
 ## Tips & Tricks for development
 
-- While developing you should run the script locally with *auto reload*: `panel serve script.py --autoreload`.
+- While developing you should run the script locally in dev mode (enabling autoreload): `panel serve script.py --dev`.
 - You can also watch your script for changes and rebuild it if you make an edit with `panel convert ... --watch`
 - If the converted app does not work as expected, you can most often find the errors in the browser
 console. [This guide](https://balsamiq.com/support/faqs/browserconsole/) describes how to open the

--- a/doc/tutorials/basic/build_animation.md
+++ b/doc/tutorials/basic/build_animation.md
@@ -146,7 +146,7 @@ VALUE = "p_cap"
 
 @pn.cache()
 def get_data():
-    return pd.read_csv("https://assets.holoviz.org/panel/tutorials/turbines.csv.gz")
+    return pd.read_csv("https://datasets.holoviz.org/windturbines/v1/windturbines.csv.gz")
 
 data = get_data()
 min_year = int(data.p_year.min())
@@ -257,7 +257,7 @@ Now serve the app with:
 :sync: script
 
 ```bash
-panel serve app.py --autoreload
+panel serve app.py --dev
 ```
 
 :::
@@ -266,7 +266,7 @@ panel serve app.py --autoreload
 :sync: notebook
 
 ```bash
-panel serve app.ipynb --autoreload
+panel serve app.ipynb --dev
 ```
 
 :::

--- a/doc/tutorials/basic/build_chatbot.md
+++ b/doc/tutorials/basic/build_chatbot.md
@@ -3,7 +3,7 @@
 In this tutorial, we will build a streaming *chat bot*. We will first use the *high-level* [`ChatInterface`](../../reference/chat/ChatInterface.md) to build a basic chat bot. Then we will add streaming.
 
 :::{note}
-When we ask to *run the code* in the sections below, we may either execute the code directly in the Panel docs via the green *run* button, in a cell in a notebook, or in a file `app.py` that is served with `panel serve app.py --autoreload`.
+When we ask to *run the code* in the sections below, we may either execute the code directly in the Panel docs via the green *run* button, in a cell in a notebook, or in a file `app.py` that is served with `panel serve app.py --dev`.
 :::
 
 ## Build a Basic Chat Bot

--- a/doc/tutorials/basic/build_crossfilter_dashboard.md
+++ b/doc/tutorials/basic/build_crossfilter_dashboard.md
@@ -234,7 +234,7 @@ pn.template.FastListTemplate(
 
 The [`FastListTemplate`](https://panel.holoviz.org/reference/templates/FastListTemplate.html) is a pre-built Panel template that provides a clean and modern layout for our dashboard. It takes our crossfiltering plot and other configurations as input, creating a cohesive and interactive web application.
 
-Now serve the app with `panel serve app.py --autoreload`. It should look like
+Now serve the app with `panel serve app.py --dev`. It should look like
 
 <video muted controls loop poster="../../_static/images/panel_crossfilter_dashboard.png" style="max-height: 400px; max-width: 100%;">
     <source src="https://assets.holoviz.org/panel/tutorials/panel_crossfilter_dashboard.mp4" type="video/mp4">

--- a/doc/tutorials/basic/build_image_classifier.md
+++ b/doc/tutorials/basic/build_image_classifier.md
@@ -10,7 +10,7 @@ In this tutorial, we will collaboratively build an *Image Classifier* that can d
 We will be using a *random* classifier, but you can later replace it with your own custom classifier if you want.
 
 :::{note}
-When we ask you to *run the code* in the sections below, you may either execute the code directly in the Panel docs via the green *run* button, in a cell in a notebook, or in a file `app.py` that is served with `panel serve app.py --autoreload`.
+When we ask you to *run the code* in the sections below, you may either execute the code directly in the Panel docs via the green *run* button, in a cell in a notebook, or in a file `app.py` that is served with `panel serve app.py --dev`.
 :::
 
 ## Install the Dependencies

--- a/doc/tutorials/basic/build_monitoring_dashboard.md
+++ b/doc/tutorials/basic/build_monitoring_dashboard.md
@@ -237,7 +237,7 @@ Now serve the app with:
 :sync: script
 
 ```bash
-panel serve app.py --autoreload
+panel serve app.py --dev
 ```
 
 :::
@@ -246,7 +246,7 @@ panel serve app.py --autoreload
 :sync: notebook
 
 ```bash
-panel serve app.ipynb --autoreload
+panel serve app.ipynb --dev
 ```
 
 :::

--- a/doc/tutorials/basic/build_streaming_dashboard.md
+++ b/doc/tutorials/basic/build_streaming_dashboard.md
@@ -5,7 +5,7 @@ In this tutorial, we come together to create a simple streaming dashboard to mon
 - We will use `pn.state.add_periodic_callback` to trigger a task to run on a schedule.
 
 :::{note}
-When we ask to *run the code* in the sections below, you may either execute the code directly in the Panel docs via the green *run* button, in a cell in a notebook, or in a file `app.py` that is served with `panel serve app.py --autoreload`.
+When we ask to *run the code* in the sections below, you may either execute the code directly in the Panel docs via the green *run* button, in a cell in a notebook, or in a file `app.py` that is served with `panel serve app.py --dev`.
 :::
 
 ## Install the Dependencies

--- a/doc/tutorials/basic/build_todo.md
+++ b/doc/tutorials/basic/build_todo.md
@@ -8,7 +8,7 @@ In this section, we will work on building a *Todo App* together so that our wind
 - Disabling or hiding buttons when necessary
 
 :::{note}
-When we ask everyone to *run the code* in the sections below, you may either execute the code directly in the Panel docs via the green *run* button, in a cell in a notebook, or in a file `app.py` that is served with `panel serve app.py --autoreload`.
+When we ask everyone to *run the code* in the sections below, you may either execute the code directly in the Panel docs via the green *run* button, in a cell in a notebook, or in a file `app.py` that is served with `panel serve app.py --dev`.
 :::
 
 <iframe src="https://panel-org-build-todo-app.hf.space" frameborder="0" style="width: 100%;height:500px"></iframe>

--- a/doc/tutorials/basic/caching.md
+++ b/doc/tutorials/basic/caching.md
@@ -7,7 +7,7 @@ Caching is a powerful technique that not only accelerates your applications but 
 With `pn.cache`, you can effortlessly cache function results, unlocking a plethora of performance benefits for your Panel apps.
 
 :::{note}
-As you proceed through the sections below, feel free to execute the code directly in the Panel docs using the handy green *run* button, in a notebook cell, or within a Python file `app.py` served with `panel serve app.py --autoreload`.
+As you proceed through the sections below, feel free to execute the code directly in the Panel docs using the handy green *run* button, in a notebook cell, or within a Python file `app.py` served with `panel serve app.py --dev`.
 :::
 
 ## Grasp Panel Application Execution
@@ -65,19 +65,19 @@ It should look like
 
 :::
 
-### Exercise: Enable `--autoreload`
+### Exercise: Enable `--dev`
 
-Try repeating the aforementioned steps with `--autoreload`.
+Try repeating the aforementioned steps with `--dev`.
 
 ```bash
-panel serve app.py --autoreload
+panel serve app.py --dev
 ```
 
 Observe the changes.
 
 :::{dropdown} Solution
 
-With `--autoreload`, both files are executed when the server starts and before the page is loaded for the first time.
+With `--dev`, both files are executed when the server starts and before the page is loaded for the first time.
 
 <img src="https://assets.holoviz.org/panel/tutorials/page_load_end_autoreload.png"></img>
 

--- a/doc/tutorials/basic/design.md
+++ b/doc/tutorials/basic/design.md
@@ -10,7 +10,7 @@ Panel empowers you to effortlessly style your apps using pre-built *designs*, re
 Additionally, Panel supports both `"default"` and `"dark"` themes to further tailor the appearance of your application.
 
 :::{note}
-In the sections below, you can run the provided code directly in the Panel documentation by utilizing the green *run* button, executing it in a notebook cell, or saving it in a file named `app.py` and serving it with `panel serve app.py --autoreload`.
+In the sections below, you can run the provided code directly in the Panel documentation by utilizing the green *run* button, executing it in a notebook cell, or saving it in a file named `app.py` and serving it with `panel serve app.py --dev`.
 :::
 
 ## Change the Design

--- a/doc/tutorials/basic/develop_editor.md
+++ b/doc/tutorials/basic/develop_editor.md
@@ -40,7 +40,7 @@ Copy this code into a file named `app.py` and save it.
 Now, open a terminal and run the following command:
 
 ```bash
-panel serve app.py --autoreload
+panel serve app.py --dev
 ```
 
 This will start the server and provide you with a URL where your app is being served. Open this URL in your browser to see your app in action.
@@ -94,7 +94,7 @@ Serving this code will print information about the `layout` object, revealing it
 Serve the app by running the below command in a terminal.
 
 ```bash
-panel serve app.py --autoreload
+panel serve app.py --dev
 ```
 
 Open [http://localhost:5006/app](http://localhost:5006/app) in a browser.
@@ -131,7 +131,7 @@ pn.Row(
 ).servable()
 ```
 
-Serve the app with `panel serve app.py --autoreload`.
+Serve the app with `panel serve app.py --dev`.
 
 Open [http://localhost:5006](http://localhost:5006) in a browser.
 

--- a/doc/tutorials/basic/indicators_activity.md
+++ b/doc/tutorials/basic/indicators_activity.md
@@ -9,7 +9,7 @@ Let's bring our Panel apps to life with dynamic indicators and notifications, mu
 - Provide notifications using `pn.state.notifications`.
 
 :::{note}
-In the sections below, you can execute the code directly in the Panel documentation using the green *run* button, in a notebook cell, or in a file named `app.py` served with `panel serve app.py --autoreload`.
+In the sections below, you can execute the code directly in the Panel documentation using the green *run* button, in a notebook cell, or in a file named `app.py` served with `panel serve app.py --dev`.
 :::
 
 ```{pyodide}

--- a/doc/tutorials/basic/indicators_performance.md
+++ b/doc/tutorials/basic/indicators_performance.md
@@ -23,7 +23,7 @@ In this tutorial, we'll explore various indicators offered by Panel to showcase 
 For a comprehensive list of indicators and their detailed reference guides, you can always refer to the [Indicators Section](https://panel.holoviz.org/reference/index.html#indicators) in the [Component Gallery](../../reference/index.md).
 
 :::{note}
-Throughout this tutorial, whenever we refer to "run the code," you can execute it directly in the Panel docs using the green *run* button, in a notebook cell, or within a file named `app.py` served with `panel serve app.py --autoreload`.
+Throughout this tutorial, whenever we refer to "run the code," you can execute it directly in the Panel docs using the green *run* button, in a notebook cell, or within a file named `app.py` served with `panel serve app.py --dev`.
 :::
 
 ## Display a Number
@@ -44,7 +44,7 @@ pn.indicators.Number(
 ```
 
 :::{note}
-Adding `.servable()` to the `Number` indicator incorporates it into the app served by `panel serve app.py --autoreload`. Note that it's not necessary for displaying the indicator in a notebook.
+Adding `.servable()` to the `Number` indicator incorporates it into the app served by `panel serve app.py --dev`. Note that it's not necessary for displaying the indicator in a notebook.
 :::
 
 Feel free to tweak the `value` from `8.6` to `11.4` and observe the color change to *red*.

--- a/doc/tutorials/basic/layouts.md
+++ b/doc/tutorials/basic/layouts.md
@@ -11,7 +11,7 @@ In this guide, we'll explore the following aspects of layouts:
 - **Reference Guides**: Explore detailed documentation for each layout in the [Layouts Section](https://panel.holoviz.org/reference/index.html#layouts) of the [Component Gallery](../../reference/index.md).
 
 :::{note}
-As you follow along with the code examples below, feel free to execute them directly in the Panel documentation, a notebook cell, or within a file named `app.py` served with `panel serve app.py --autoreload`.
+As you follow along with the code examples below, feel free to execute them directly in the Panel documentation, a notebook cell, or within a file named `app.py` served with `panel serve app.py --dev`.
 :::
 
 ## Layout in a Column

--- a/doc/tutorials/basic/panes.md
+++ b/doc/tutorials/basic/panes.md
@@ -15,7 +15,7 @@ You might notice a lot of repetition from the previous section regarding `pn.pan
 :::
 
 :::{note}
-When we ask you to *run the code* in the sections below, you may either execute the code directly in the Panel docs via the green *run* button, in a cell in a notebook, or in a file `app.py` that is served with `panel serve app.py --autoreload`.
+When we ask you to *run the code* in the sections below, you may either execute the code directly in the Panel docs via the green *run* button, in a cell in a notebook, or in a file `app.py` that is served with `panel serve app.py --dev`.
 :::
 
 ```{pyodide}
@@ -40,7 +40,7 @@ pn.pane.Str(
 ```
 
 :::{note}
-We add `.servable()` to the component to add it to the app served by `panel serve app.py --autoreload`. Adding `.servable()` is not needed to display the component in a notebook.
+We add `.servable()` to the component to add it to the app served by `panel serve app.py --dev`. Adding `.servable()` is not needed to display the component in a notebook.
 :::
 
 :::{note}

--- a/doc/tutorials/basic/pn_panel.md
+++ b/doc/tutorials/basic/pn_panel.md
@@ -5,7 +5,7 @@ In this guide, we will learn to display Python objects easily with `pn.panel`:
 - Display any Python object via `pn.panel(the_object, ...)`.
 
 :::{note}
-When we ask to *run the code* in the sections below, we may execute the code directly in the Panel docs via the green *run* button, in a cell in a notebook, or in a file `app.py` that is served with `panel serve app.py --autoreload`.
+When we ask to *run the code* in the sections below, we may execute the code directly in the Panel docs via the green *run* button, in a cell in a notebook, or in a file `app.py` that is served with `panel serve app.py --dev`.
 :::
 
 ```{pyodide}
@@ -28,7 +28,7 @@ pn.panel("Hello World").servable()
 ```
 
 :::{note}
-We add `.servable()` to the component to add it to the app served by `panel serve app.py --autoreload`. Adding `.servable()` is not needed to display the component in a notebook.
+We add `.servable()` to the component to add it to the app served by `panel serve app.py --dev`. Adding `.servable()` is not needed to display the component in a notebook.
 :::
 
 `pn.panel` uses a *heuristic* algorithm to determine how to best display the `object`. To make this very explicit, we will `print` the component in all the examples below.

--- a/doc/tutorials/basic/progressive_layouts.md
+++ b/doc/tutorials/basic/progressive_layouts.md
@@ -8,7 +8,7 @@ In this tutorial, we'll:
 - Harness the power of reactive expressions (`pn.rx`) to facilitate dynamic updates to the app.
 
 :::{note}
-When instructed to run the code, you can execute it directly in the Panel documentation using the green *run* button, in a notebook cell, or in a file named `app.py` served with `panel serve app.py --autoreload`.
+When instructed to run the code, you can execute it directly in the Panel documentation using the green *run* button, in a notebook cell, or in a file named `app.py` served with `panel serve app.py --dev`.
 :::
 
 ## Replace Content Progressively

--- a/doc/tutorials/basic/serve.md
+++ b/doc/tutorials/basic/serve.md
@@ -33,7 +33,7 @@ Here's a breakdown of the code:
 Copy the code into a file named `app.py` and save it. Then, run the Panel server in your terminal with:
 
 ```bash
-panel serve app.py --autoreload
+panel serve app.py --dev
 ```
 
 ::::
@@ -67,7 +67,7 @@ Copy the above code cells into a clean notebook named `app.ipynb`. Run the cells
 Then, run the Panel server in your terminal with:
 
 ```bash
-panel serve app.ipynb --autoreload
+panel serve app.ipynb --dev
 ```
 
 :::::
@@ -92,7 +92,7 @@ Play around with the app by modifying the `"Hello World"` text, saving the file 
 Congratulations on serving your first Panel app! Let's recap what we've learned:
 
 - How to serve a Python script or Notebook using `panel serve app.py` or `panel serve app.ipynb`, respectively.
-- How to enable *auto reload* with the `--autoreload` flag.
+- How to enable *auto reload* with the `--dev` flag.
 - How to stop the Panel server with `CTRL+C`.
 
 ## Resources

--- a/doc/tutorials/basic/size.md
+++ b/doc/tutorials/basic/size.md
@@ -12,7 +12,7 @@ Panel provides various options to control the size of components:
 - `max_width`/`max_height`: Allows setting a maximum width or height if responsive sizing is set along the corresponding dimension.
 
 :::{note}
-Throughout this tutorial, you can execute the provided code directly in the Panel documentation using the green *run* button, in a notebook cell, or within a file named `app.py` served with `panel serve app.py --autoreload`.
+Throughout this tutorial, you can execute the provided code directly in the Panel documentation using the green *run* button, in a notebook cell, or within a file named `app.py` served with `panel serve app.py --dev`.
 :::
 
 ## Inherent and Absolute Sizing

--- a/doc/tutorials/basic/style.md
+++ b/doc/tutorials/basic/style.md
@@ -5,7 +5,7 @@ Let's elevate the appearance of our Panel components using the power of [*CSS*](
 By employing *CSS*, we can finely adjust the look and feel of our wind turbine data apps, ensuring they are visually appealing and user-friendly.
 
 :::{note}
-To execute the code snippets below, feel free to run them directly in the Panel documentation via the convenient green *run* button, within a notebook cell, or within a `app.py` file served with `panel serve app.py --autoreload`.
+To execute the code snippets below, feel free to run them directly in the Panel documentation via the convenient green *run* button, within a notebook cell, or within a `app.py` file served with `panel serve app.py --dev`.
 :::
 
 ## Utilize `styles`

--- a/doc/tutorials/basic/templates.md
+++ b/doc/tutorials/basic/templates.md
@@ -26,7 +26,7 @@ pn.template.FastListTemplate(
 Serve the app with:
 
 ```bash
-panel serve app.py --autoreload
+panel serve app.py --dev
 ```
 
 It should resemble the following:
@@ -138,7 +138,7 @@ pn.template.FastListTemplate(
 Serve the app with:
 
 ```bash
-panel serve app.py --autoreload
+panel serve app.py --dev
 ```
 
 It should appear as shown below. Try toggling the theme button in the upper right corner.

--- a/doc/tutorials/basic/widgets.md
+++ b/doc/tutorials/basic/widgets.md
@@ -42,7 +42,7 @@ pn.widgets.Button(
 With features like icons, button types, and descriptions, buttons provide both functionality and visual cues to users. Hover over the button to see its description displayed as a helpful tooltip.
 
 :::{note}
-The `.servable()` method is used to include the component in the app served by `panel serve app.py --autoreload`. This is not necessary for displaying the component in a notebook.
+The `.servable()` method is used to include the component in the app served by `panel serve app.py --dev`. This is not necessary for displaying the component in a notebook.
 :::
 
 For a deeper understanding of the `Button` widget and its capabilities, refer to its detailed [reference guide](../../reference/widgets/Button.md).

--- a/doc/tutorials/expert/custom_components.md
+++ b/doc/tutorials/expert/custom_components.md
@@ -202,7 +202,7 @@ Create a file named `mario_button.css`:
 To serve the application, run the following command in your terminal:
 
 ```sh
-panel serve mario_button.py --autoreload
+panel serve mario_button.py --dev
 ```
 
 This command will start a Panel server and automatically reload changes as you edit the files.

--- a/doc/tutorials/intermediate/develop_editor.md
+++ b/doc/tutorials/intermediate/develop_editor.md
@@ -15,7 +15,7 @@ Some of the features demonstrated in this guide might require special configurat
 
 ## Resetting the Cache
 
-When developing with the `--autoreload` option and utilizing caching, you may need to reset the cache. You have the option to clear either the entire cache or just the cache for a specific function.
+When developing with the `--dev` option and utilizing caching, you may need to reset the cache. You have the option to clear either the entire cache or just the cache for a specific function.
 
 Execute the code below:
 
@@ -62,7 +62,7 @@ def handle_click(event):
 pn.widgets.Button(name="Click Me", on_click=handle_click, button_type="primary").servable()
 ```
 
-Serve the app with `panel serve app.py --autoreload`.
+Serve the app with `panel serve app.py --dev`.
 
 Open [http://localhost:5006/app](http://localhost:5006/app) in a browser.
 
@@ -75,7 +75,7 @@ Click the `Click Me` Button.
 Your terminal will look something like
 
 ```bash
-$ panel serve app.py --autoreload
+$ panel serve app.py --dev
 2024-01-20 08:12:09,512 Starting Bokeh server version 3.3.3 (running on Tornado 6.4)
 2024-01-20 08:12:09,514 User authentication hooks NOT provided (default user enabled)
 2024-01-20 08:12:09,516 Bokeh app running at: http://localhost:5006/app

--- a/doc/tutorials/intermediate/serve.md
+++ b/doc/tutorials/intermediate/serve.md
@@ -37,12 +37,12 @@ pn.panel("Hello Notebook World").servable()
 
 Run the cells and save the notebook if you have not already done it.
 
-Run `panel serve app.py app2.ipynb --autoreload`.
+Run `panel serve app.py app2.ipynb --dev`.
 
 It should look like
 
 ```bash
-$ panel serve app.py app2.ipynb --autoreload
+$ panel serve app.py app2.ipynb --dev
 2024-01-17 21:14:43,502 Starting Bokeh server version 3.3.3 (running on Tornado 6.4)
 2024-01-17 21:14:43,503 User authentication hooks NOT provided (default user enabled)
 2024-01-17 21:14:43,506 Bokeh app running at: http://localhost:5006/app

--- a/doc/tutorials/intermediate/structure_data_store.md
+++ b/doc/tutorials/intermediate/structure_data_store.md
@@ -241,7 +241,7 @@ App(
 ).servable()
 ```
 
-Once saved, run `panel serve app.py --autoreload` in your terminal to launch the app.
+Once saved, run `panel serve app.py --dev` in your terminal to launch the app.
 
 The app will look something like
 

--- a/panel/command/serve.py
+++ b/panel/command/serve.py
@@ -87,7 +87,7 @@ class AdminApplicationContext(ApplicationContext):
 
 class Serve(_BkServe):
 
-    args = _BkServe.args + (
+    args = tuple((arg, arg_obj) for arg, arg_obj in _BkServe.args if arg != '--dev') + (
         ('--static-dirs', dict(
             metavar="KEY=VALUE",
             nargs='+',
@@ -232,6 +232,10 @@ class Serve(_BkServe):
             type    = str,
             help    = "The profiler to use by default, e.g. pyinstrument, snakeviz or memray."
         )),
+        ('--dev', dict(
+            action  = 'store_true',
+            help    = "Whether to enable dev mode. Equivalent to --autoreload."
+        )),
         ('--autoreload', dict(
             action  = 'store_true',
             help    = "Whether to autoreload source when script changes."
@@ -364,17 +368,21 @@ class Serve(_BkServe):
             module.__dict__['__file__'] = fullpath(args.setup)
             state._setup_module = module
 
-        if args.warm or args.autoreload:
+        if args.warm or config.autoreload:
             argvs = {f: args.args for f in files}
             applications = build_single_handler_applications(files, argvs)
             initialize_session = not (args.num_procs and sys.version_info < (3, 12))
-            if args.autoreload:
+            if config.autoreload:
                 with record_modules(list(applications.values())):
                     self.warm_applications(
                         applications, args.reuse_sessions, error=False, initialize_session=initialize_session
                     )
             else:
                 self.warm_applications(applications, args.reuse_sessions, initialize_session=initialize_session)
+
+        # Disable Tornado's autoreload
+        if args.dev:
+            del server_kwargs['autoreload']
 
         if args.liveness:
             argvs = {f: args.args for f in files}
@@ -641,8 +649,9 @@ class Serve(_BkServe):
     def invoke(self, args: argparse.Namespace):
         # Autoreload must be enabled before the application(s) are executed
         # to avoid erroring out
-        config.autoreload = args.autoreload
+        config.autoreload = args.autoreload or bool(args.dev)
         # Empty layout are valid and the Bokeh warning is silenced as usually
         # not relevant to Panel users.
         silence(EMPTY_LAYOUT, True)
+        args.dev = None
         super().invoke(args)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,7 @@ recommended = [
     'pillow',
     'plotly',
 ]
-standard = [
+dev = [
     'watchfiles',
 ]
 tests = [


### PR DESCRIPTION
The `--dev` argument to the `panel serve` command sets up the Tornado dev tooling, e.g. to restart the server when a file changes. This does not actually work very well, while our internal `--autoreload` handling works quite well. Since `--autoreload` is kind of long and we may broaden the scope of what it does I'd like to make `--dev` an alias for `--autoreload`.