### PR TITLE
Tabulator custom filtering function returning mask instead of filtered dataframe

### DIFF
--- a/panel/tests/widgets/test_tables.py
+++ b/panel/tests/widgets/test_tables.py
@@ -2073,6 +2073,43 @@ def test_tabulator_function_filter(document, comm):
     for col, values in model.source.data.items():
         np.testing.assert_array_equal(values, expected[col])
 
+def test_tabulator_function_mask_filter(document, comm):
+    df = makeMixedDataFrame()
+    table = Tabulator(df)
+
+    model = table.get_root(document, comm)
+
+    widget = TextInput(value='foo3')
+
+    def filter_c(df, value):
+        return df.C.str.contains(value)
+
+    table.add_filter(bind(filter_c, value=widget), 'C')
+
+    expected = {
+        'index': np.array([2]),
+        'A': np.array([2]),
+        'B': np.array([0]),
+        'C': np.array(['foo3']),
+        'D': np.array(['2009-01-05T00:00:00.000000000'],
+                      dtype='datetime64[ns]').astype(np.int64) / 10e5
+    }
+    for col, values in model.source.data.items():
+        np.testing.assert_array_equal(values, expected[col])
+
+    widget.value = 'foo1'
+
+    expected = {
+        'index': np.array([0]),
+        'A': np.array([0]),
+        'B': np.array([0]),
+        'C': np.array(['foo1']),
+        'D': np.array(['2009-01-01T00:00:00.000000000'],
+                      dtype='datetime64[ns]').astype(np.int64) / 10e5
+    }
+    for col, values in model.source.data.items():
+        np.testing.assert_array_equal(values, expected[col])
+
 def test_tabulator_constant_tuple_filter(document, comm):
     df = makeMixedDataFrame()
     table = Tabulator(df)

--- a/panel/widgets/tables.py
+++ b/panel/widgets/tables.py
@@ -442,7 +442,11 @@ class BaseTable(ReactiveData, Widget):
             if col_name is not None and col_name not in df.columns:
                 continue
             if isinstance(filt, (FunctionType, MethodType, partial)):
-                df = filt(df)
+                res = filt(df)
+                if type(res) == type(df): #function returned filtered dataframe
+                    df = res
+                else: #assume boolean mask
+                    filters.append(res)
                 continue
             if isinstance(filt, param.Parameter):
                 val = getattr(filt.owner, filt.name)


### PR DESCRIPTION
Tabulator object allows to define a custom filter function that returns a new filter dataframe. Problem is that it is not possible to combine multiple filters together.
The suggested change allows the custom function to return a boolean mask that is then treated by the rest of the filtering code as any other filter mask.