### PR TITLE
Fix cache.clear mypy issue

### DIFF
--- a/panel/io/cache.py
+++ b/panel/io/cache.py
@@ -39,7 +39,7 @@ if TYPE_CHECKING:
     _CallableT = TypeVar("_CallableT", bound=Callable)
 
     class _CachedFunc(Protocol[_CallableT]):
-        def clear(self, func_hashes: list[str | None]) -> None:
+        def clear(self, func_hashes: list[str | None]=[None]) -> None:
             pass
 
         __call__: _CallableT


### PR DESCRIPTION
When running `mypy` on my code I see

```bash
error: Missing positional argument "func_hashes" in call to "clear" of "_CachedFunc"  [call-arg]
```

This removes the false positive.

I believe its the "correct" fix but I'm not an expert in typing.