### PR TITLE
add fastapi extra dependencies

### DIFF
--- a/doc/how_to/integrations/FastAPI.md
+++ b/doc/how_to/integrations/FastAPI.md
@@ -19,8 +19,14 @@ conda install fastapi
 :::
 
 :::{tab-item} `pip`
-```pip
-conda install fastapi
+```bash
+pip install fastapi
+```
+:::
+
+:::{tab-item} `panel`
+```bash
+pip install panel[fastapi]
 ```
 :::
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,10 @@ recommended = [
     'pillow',
     'plotly',
 ]
+fastapi = [
+    'bokeh-fastapi == 0.1.0',
+    'uvicorn',
+]
 dev = [
     'watchfiles',
 ]


### PR DESCRIPTION
With the new functionality added to serve panel through FastAPI, this adds an extra dependency so you can `pip install panel[fastapi]` and get everything you need.