### PR TITLE
Tighten up ChatMessage layout

### DIFF
--- a/panel/chat/icon.py
+++ b/panel/chat/icon.py
@@ -6,6 +6,7 @@ from typing import ClassVar
 
 import param
 
+from .._param import Margin
 from ..io.resources import CDN_DIST
 from ..layout import Column, Panel
 from ..reactive import ReactiveHTML
@@ -40,6 +41,11 @@ class ChatReactionIcons(CompositeWidget):
         If not set, the active icon name will default to its "filled" version.""")
 
     css_classes = param.List(default=["reaction-icons"], doc="The CSS classes of the widget.")
+
+    margin = Margin(default=0, doc="""
+        Allows to create additional space around the component. May
+        be specified as a two-tuple of the form (vertical, horizontal)
+        or a four-tuple (top, right, bottom, left).""")
 
     options = param.Dict(default={"favorite": "heart"}, doc="""
         A key-value pair of reaction values and their corresponding tabler icon names
@@ -148,8 +154,6 @@ class ChatCopyIcon(ReactiveHTML):
           data.fill = "none";
         """
     }
-
-    _stylesheets: ClassVar[list[str]] = [f"{CDN_DIST}css/chat_copy_icon.css"]
 
     @param.depends('_request_sync', watch=True)
     def _sync(self):

--- a/panel/dist/css/chat_copy_icon.css
+++ b/panel/dist/css/chat_copy_icon.css
@@ -1,3 +1,0 @@
-:host {
-  margin-top: 8px;
-}

--- a/panel/dist/css/chat_message.css
+++ b/panel/dist/css/chat_message.css
@@ -148,7 +148,7 @@
 }
 
 .divider {
-  margin-right: 0px;
+  margin: 0 4px;
   opacity: 0.2;
 }
 

--- a/panel/dist/css/chat_reaction_icons.css
+++ b/panel/dist/css/chat_reaction_icons.css
@@ -1,4 +1,3 @@
 :host {
-  margin-top: 4px;
   width: fit-content;
 }


### PR DESCRIPTION
Was just looking at the new `ChatMessage` and while it's an improvement the alignment of the icons and the spacing bothered me a little bit. So this PR tightens things up a bit:

## Before

<img width="1015" alt="Screenshot 2024-09-11 at 14 50 38" src="https://github.com/user-attachments/assets/9da8f453-8840-4021-b449-6cd84b928383">

## After

<img width="1229" alt="Screenshot 2024-09-11 at 14 45 28" src="https://github.com/user-attachments/assets/5e1a9b3f-8145-4194-b8a1-8fa7eaf1455f">


