### PR TITLE
Avoid flicker when scrolling to anchor

### DIFF
--- a/panel/models/html.ts
+++ b/panel/models/html.ts
@@ -162,7 +162,7 @@ export class HTMLView extends PanelMarkupView {
           this.model.document.on_event("document_ready", () => {
             anchor.scrollIntoView()
             setTimeout(() => anchor.scrollIntoView(), 5)
-          }
+          })
         }
       }
     }

--- a/panel/models/html.ts
+++ b/panel/models/html.ts
@@ -159,7 +159,10 @@ export class HTMLView extends PanelMarkupView {
           }
         })
         if (!this.root.has_finished() && this.model.document && window.location.hash === link) {
-          this.model.document.on_event("document_ready", () => setTimeout(() => anchor.scrollIntoView(), 5))
+          this.model.document.on_event("document_ready", () => {
+            anchor.scrollIntoView()
+            setTimeout(() => anchor.scrollIntoView(), 5)
+          }
         }
       }
     }


### PR DESCRIPTION
Followup to https://github.com/holoviz/panel/pull/7258, scrolling twice to avoid user seeing initial content only to flicker and disappear.