### PR TITLE
Fix detection of old Bokeh in notebook load script

### DIFF
--- a/panel/_templates/autoload_panel_js.js
+++ b/panel/_templates/autoload_panel_js.js
@@ -61,9 +61,6 @@ calls it with the rendered model.
       run_callbacks();
       return null;
     }
-    if (!reloading) {
-      console.debug("Bokeh: BokehJS not loaded, scheduling load and callback at", now());
-    }
 
     function on_load() {
       root._bokeh_is_loading--;
@@ -270,9 +267,10 @@ calls it with the rendered model.
     } else {
       root._bokeh_is_initializing = true
       root._bokeh_onload_callbacks = []
-      var bokeh_loaded = Bokeh != null && (Bokeh.version === py_version || (Bokeh.versions !== undefined && Bokeh.versions.has(py_version)));
+      const bokeh_loaded = root.Bokeh != null && (root.Bokeh.version === py_version || (root.Bokeh.versions !== undefined && root.Bokeh.versions.has(py_version)));
       if (!reloading && !bokeh_loaded) {
 	root.Bokeh = undefined;
+	console.debug("Bokeh: BokehJS not loaded, scheduling load and callback at", now());
       }
       load_libs(css_urls, js_urls, js_modules, js_exports, function() {
 	console.debug("Bokeh: BokehJS plotting callback run at", now());

--- a/panel/_templates/autoload_panel_js.js
+++ b/panel/_templates/autoload_panel_js.js
@@ -23,10 +23,10 @@ calls it with the rendered model.
     return new Date();
   }
 
-  var force = {{ force|default(False)|json }};
-  var py_version = '{{ version }}'.replace('rc', '-rc.').replace('.dev', '-dev.');
-  var reloading = {{ reloading|default(False)|json }};
-  var Bokeh = root.Bokeh;
+  const force = {{ force|default(False)|json }};
+  const py_version = '{{ version }}'.replace('rc', '-rc.').replace('.dev', '-dev.');
+  const reloading = {{ reloading|default(False)|json }};
+  const Bokeh = root.Bokeh;
 
   if (typeof (root._bokeh_timeout) === "undefined" || force) {
     root._bokeh_timeout = Date.now() + {{ timeout|default(0)|json }};
@@ -75,7 +75,7 @@ calls it with the rendered model.
       console.error("failed to load " + url);
     }
 
-    var skip = [];
+    const skip = [];
     if (window.requirejs) {
       window.requirejs.config({{ config|conffilter }});
       {% for r in requirements %}
@@ -91,17 +91,18 @@ calls it with the rendered model.
       root._bokeh_is_loading = css_urls.length + js_urls.length + js_modules.length + Object.keys(js_exports).length;
     }
 
-    var existing_stylesheets = []
-    var links = document.getElementsByTagName('link')
-    for (var i = 0; i < links.length; i++) {
-      var link = links[i]
+    const existing_stylesheets = []
+    const links = document.getElementsByTagName('link')
+    for (let i = 0; i < links.length; i++) {
+      const link = links[i]
       if (link.href != null) {
 	existing_stylesheets.push(link.href)
       }
     }
-    for (var i = 0; i < css_urls.length; i++) {
-      var url = css_urls[i];
-      if (existing_stylesheets.indexOf(url) !== -1) {
+    for (let i = 0; i < css_urls.length; i++) {
+      const url = css_urls[i];
+      const escaped = encodeURI(url)
+      if (existing_stylesheets.indexOf(escaped) !== -1) {
 	on_load()
 	continue;
       }
@@ -119,27 +120,28 @@ calls it with the rendered model.
     if (((window.{{ lib }} !== undefined) && (!(window.{{ lib }} instanceof HTMLElement))) || window.requirejs) {
       var urls = {{ urls }};
       for (var i = 0; i < urls.length; i++) {
-        skip.push(urls[i])
+        skip.push(escapeURI(urls[i]))
       }
     }
     {%- endfor %}
     var existing_scripts = []
-    var scripts = document.getElementsByTagName('script')
-    for (var i = 0; i < scripts.length; i++) {
+    const scripts = document.getElementsByTagName('script')
+    for (let i = 0; i < scripts.length; i++) {
       var script = scripts[i]
       if (script.src != null) {
 	existing_scripts.push(script.src)
       }
     }
-    for (var i = 0; i < js_urls.length; i++) {
-      var url = js_urls[i];
-      if (skip.indexOf(url) !== -1 || existing_scripts.indexOf(url) !== -1) {
+    for (let i = 0; i < js_urls.length; i++) {
+      const url = js_urls[i];
+      const escaped = encodeURI(url)
+      if (skip.indexOf(escaped) !== -1 || existing_scripts.indexOf(escaped) !== -1) {
 	if (!window.requirejs) {
 	  on_load();
 	}
 	continue;
       }
-      var element = document.createElement('script');
+      const element = document.createElement('script');
       element.onload = on_load;
       element.onerror = on_error;
       element.async = false;
@@ -147,9 +149,10 @@ calls it with the rendered model.
       console.debug("Bokeh: injecting script tag for BokehJS library: ", url);
       document.head.appendChild(element);
     }
-    for (var i = 0; i < js_modules.length; i++) {
-      var url = js_modules[i];
-      if (skip.indexOf(url) !== -1 || existing_scripts.indexOf(url) !== -1) {
+    for (let i = 0; i < js_modules.length; i++) {
+      const url = js_modules[i];
+      const escaped = encodeURI(url)
+      if (skip.indexOf(escaped) !== -1 || existing_scripts.indexOf(escaped) !== -1) {
 	if (!window.requirejs) {
 	  on_load();
 	}
@@ -165,8 +168,9 @@ calls it with the rendered model.
       document.head.appendChild(element);
     }
     for (const name in js_exports) {
-      var url = js_exports[name];
-      if (skip.indexOf(url) >= 0 || root[name] != null) {
+      const url = js_exports[name];
+      const escaped = encodeURI(url)
+      if (skip.indexOf(escaped) >= 0 || root[name] != null) {
 	if (!window.requirejs) {
 	  on_load();
 	}
@@ -195,11 +199,11 @@ calls it with the rendered model.
     document.body.appendChild(element);
   }
 
-  var js_urls = {{ bundle.js_urls|json }};
-  var js_modules = {{ bundle.js_modules|json }};
-  var js_exports = {{ bundle.js_module_exports|json }};
-  var css_urls = {{ bundle.css_urls|json }};
-  var inline_js = [
+  const js_urls = {{ bundle.js_urls|json }};
+  const js_modules = {{ bundle.js_modules|json }};
+  const js_exports = {{ bundle.js_module_exports|json }};
+  const css_urls = {{ bundle.css_urls|json }};
+  const inline_js = [
     {%- for css in bundle.css_raw %}
     function(Bokeh) {
       inject_raw_css({{ css|json }});
@@ -215,7 +219,7 @@ calls it with the rendered model.
 
   function run_inline_js() {
     if ((root.Bokeh !== undefined) || (force === true)) {
-      for (var i = 0; i < inline_js.length; i++) {
+      for (let i = 0; i < inline_js.length; i++) {
 	try {
           inline_js[i].call(root, root.Bokeh);
 	} catch(e) {


### PR DESCRIPTION
The notebook load script was designed to detect old versions of Bokeh (and Panel) and potentially run multiple copies of the libraries side-by-side. It did this by comparing the global `Bokeh` object version, if already defined, to the new version being loaded. However it seems like scoping rules meant that in some cases it was comparing a local `Bokeh` variable rather than the global `window.Bokeh` object, which meant that it would incorrectly detect that Bokeh should be replaced, but then later correctly detect that it doesn't actually have to reload Bokeh. This meant that it would unload Bokeh and then not **re**load it.

Additionally I've found that due to escaping rules meant that special characters (such as `^`) in URLs would be escaped so that some of the checks that tried to ensure libraries weren't loaded twice were not detecting this correctly because they compared escaped with non-escaped URIs. We now escape them using the `escapeURI` function before comparing.

Fixes https://github.com/holoviz/panel/issues/7264