### PR TITLE
Do not load es-module-shim as module

### DIFF
--- a/panel/_templates/autoload_panel_js.js
+++ b/panel/_templates/autoload_panel_js.js
@@ -80,10 +80,10 @@ calls it with the rendered model.
       window.requirejs.config({{ config|conffilter }});
       {% for r in requirements %}
       require(["{{ r }}"], function({{ exports[r] }}) {
-	{% if r in exports %}
-	window.{{ exports[r] }} = {{ exports[r] }}
-	{% endif %}
-	on_load()
+        {% if r in exports %}
+        window.{{ exports[r] }} = {{ exports[r] }}
+        {% endif %}
+        on_load()
       })
       {% endfor %}
       root._bokeh_is_loading = css_urls.length + {{ requirements|length }};
@@ -96,15 +96,15 @@ calls it with the rendered model.
     for (let i = 0; i < links.length; i++) {
       const link = links[i]
       if (link.href != null) {
-	existing_stylesheets.push(link.href)
+        existing_stylesheets.push(link.href)
       }
     }
     for (let i = 0; i < css_urls.length; i++) {
       const url = css_urls[i];
       const escaped = encodeURI(url)
       if (existing_stylesheets.indexOf(escaped) !== -1) {
-	on_load()
-	continue;
+        on_load()
+        continue;
       }
       const element = document.createElement("link");
       element.onload = on_load;
@@ -120,7 +120,7 @@ calls it with the rendered model.
     if (((window.{{ lib }} !== undefined) && (!(window.{{ lib }} instanceof HTMLElement))) || window.requirejs) {
       var urls = {{ urls }};
       for (var i = 0; i < urls.length; i++) {
-        skip.push(escapeURI(urls[i]))
+        skip.push(encodeURI(urls[i]))
       }
     }
     {%- endfor %}
@@ -129,17 +129,17 @@ calls it with the rendered model.
     for (let i = 0; i < scripts.length; i++) {
       var script = scripts[i]
       if (script.src != null) {
-	existing_scripts.push(script.src)
+        existing_scripts.push(script.src)
       }
     }
     for (let i = 0; i < js_urls.length; i++) {
       const url = js_urls[i];
       const escaped = encodeURI(url)
       if (skip.indexOf(escaped) !== -1 || existing_scripts.indexOf(escaped) !== -1) {
-	if (!window.requirejs) {
-	  on_load();
-	}
-	continue;
+        if (!window.requirejs) {
+          on_load();
+        }
+        continue;
       }
       const element = document.createElement('script');
       element.onload = on_load;
@@ -153,10 +153,10 @@ calls it with the rendered model.
       const url = js_modules[i];
       const escaped = encodeURI(url)
       if (skip.indexOf(escaped) !== -1 || existing_scripts.indexOf(escaped) !== -1) {
-	if (!window.requirejs) {
-	  on_load();
-	}
-	continue;
+        if (!window.requirejs) {
+          on_load();
+        }
+        continue;
       }
       var element = document.createElement('script');
       element.onload = on_load;
@@ -171,10 +171,10 @@ calls it with the rendered model.
       const url = js_exports[name];
       const escaped = encodeURI(url)
       if (skip.indexOf(escaped) >= 0 || root[name] != null) {
-	if (!window.requirejs) {
-	  on_load();
-	}
-	continue;
+        if (!window.requirejs) {
+          on_load();
+        }
+        continue;
       }
       var element = document.createElement('script');
       element.onerror = on_error;
@@ -220,24 +220,24 @@ calls it with the rendered model.
   function run_inline_js() {
     if ((root.Bokeh !== undefined) || (force === true)) {
       for (let i = 0; i < inline_js.length; i++) {
-	try {
+        try {
           inline_js[i].call(root, root.Bokeh);
-	} catch(e) {
-	  if (!reloading) {
-	    throw e;
-	  }
-	}
+        } catch(e) {
+          if (!reloading) {
+            throw e;
+          }
+        }
       }
       // Cache old bokeh versions
       if (Bokeh != undefined && !reloading) {
-	var NewBokeh = root.Bokeh;
-	if (Bokeh.versions === undefined) {
-	  Bokeh.versions = new Map();
-	}
-	if (NewBokeh.version !== Bokeh.version) {
-	  Bokeh.versions.set(NewBokeh.version, NewBokeh)
-	}
-	root.Bokeh = Bokeh;
+        var NewBokeh = root.Bokeh;
+        if (Bokeh.versions === undefined) {
+          Bokeh.versions = new Map();
+        }
+        if (NewBokeh.version !== Bokeh.version) {
+          Bokeh.versions.set(NewBokeh.version, NewBokeh)
+        }
+        root.Bokeh = Bokeh;
       }
       {%- if elementid -%}
       if (force === true) {
@@ -273,12 +273,12 @@ calls it with the rendered model.
       root._bokeh_onload_callbacks = []
       const bokeh_loaded = root.Bokeh != null && (root.Bokeh.version === py_version || (root.Bokeh.versions !== undefined && root.Bokeh.versions.has(py_version)));
       if (!reloading && !bokeh_loaded) {
-	root.Bokeh = undefined;
-	console.debug("Bokeh: BokehJS not loaded, scheduling load and callback at", now());
+        root.Bokeh = undefined;
+        console.debug("Bokeh: BokehJS not loaded, scheduling load and callback at", now());
       }
       load_libs(css_urls, js_urls, js_modules, js_exports, function() {
-	console.debug("Bokeh: BokehJS plotting callback run at", now());
-	run_inline_js();
+        console.debug("Bokeh: BokehJS plotting callback run at", now());
+        run_inline_js();
       });
     }
   }

--- a/panel/io/resources.py
+++ b/panel/io/resources.py
@@ -761,8 +761,9 @@ class Resources(BkResources):
         from ..config import config
 
         # Gather JS files
-        files = super(Resources, self).js_files
-        self.extra_resources(files, '__javascript__')
+        with set_resource_mode(self.mode):
+            files = super(Resources, self).js_files
+            self.extra_resources(files, '__javascript__')
         files += [js for js in config.js_files.values()]
         if config.design:
             design_js = config.design().resolve_resources(

--- a/panel/models/esm.py
+++ b/panel/models/esm.py
@@ -52,7 +52,7 @@ class ReactiveESM(HTMLBox):
 
     @classproperty
     def __javascript__(cls):
-        return bundled_files(cls, 'javascript_modules')
+        return bundled_files(cls)
 
 
 class ReactComponent(ReactiveESM):

--- a/panel/models/esm.py
+++ b/panel/models/esm.py
@@ -46,12 +46,12 @@ class ReactiveESM(HTMLBox):
 
     importmap = bp.Dict(bp.String, bp.Dict(bp.String, bp.String))
 
-    __javascript_modules_raw__ = [
+    __javascript_raw__ = [
         f"{config.npm_cdn}/es-module-shims@^1.10.0/dist/es-module-shims.min.js"
     ]
 
     @classproperty
-    def __javascript_modules__(cls):
+    def __javascript__(cls):
         return bundled_files(cls, 'javascript_modules')
 
 

--- a/panel/models/file_dropper.py
+++ b/panel/models/file_dropper.py
@@ -49,12 +49,35 @@ class FileDropper(InputWidget):
         f"{config.npm_cdn}/filepond-plugin-file-validate-size/dist/filepond-plugin-file-validate-size.js",
         f"{config.npm_cdn}/filepond-plugin-file-validate-type/dist/filepond-plugin-file-validate-type.js",
         f"{config.npm_cdn}/filepond-plugin-pdf-preview/dist/filepond-plugin-pdf-preview.min.js",
-        f"{config.npm_cdn}/filepond@^4/dist/filepond.js"
+        f"{config.npm_cdn}/filepond@^4/dist/filepond.min.js"
     ]
 
     @classproperty
     def __javascript__(cls):
         return bundled_files(cls)
+
+    __js_require__ = {
+        'paths': {
+            "filepond":  f"{config.npm_cdn}/filepond@^4/dist/filepond",
+            "filepond-preview-image": f"{config.npm_cdn}/filepond-plugin-image-preview/dist/filepond-plugin-image-preview",
+            "filepond-validate-size": f"{config.npm_cdn}/filepond-plugin-file-validate-size/dist/filepond-plugin-file-validate-size",
+            "filepond-validate-type": f"{config.npm_cdn}/filepond-plugin-file-validate-type/dist/filepond-plugin-file-validate-type",
+            "filepond-preview-pdf": f"{config.npm_cdn}/filepond-plugin-pdf-preview/dist/filepond-plugin-pdf-preview.min",
+        },
+        'exports': {
+            'filepond': 'FilePond',
+            'filepond-preview-image': 'FilePondPluginImagePreview',
+            'filepond-preview-pdf': 'FilePondPluginPdfPreview',
+            'filepond-validate-size': 'FilePondPluginFileValidateSize',
+            'filepond-validate-type': 'FilePondPluginFileValidateType'
+        }
+    }
+
+    @classproperty
+    def __js_skip__(cls):
+        return {
+            'FilePond': cls.__javascript__[:]
+        }
 
     __css_raw__ = [
         f"{config.npm_cdn}/filepond@^4/dist/filepond.css",

--- a/panel/tests/io/test_resources.py
+++ b/panel/tests/io/test_resources.py
@@ -44,6 +44,7 @@ def test_resources_cdn():
     resources = Resources(mode='cdn', minified=True)
     assert resources.js_raw == ['Bokeh.set_log_level("info");']
     assert resources.js_files == [
+        f'https://cdn.holoviz.org/panel/{JS_VERSION}/dist/bundled/reactiveesm/es-module-shims@^1.10.0/dist/es-module-shims.min.js',
         f'https://cdn.bokeh.org/bokeh/{bk_prefix}/bokeh-{bokeh_version}.min.js',
         f'https://cdn.bokeh.org/bokeh/{bk_prefix}/bokeh-gl-{bokeh_version}.min.js',
         f'https://cdn.bokeh.org/bokeh/{bk_prefix}/bokeh-widgets-{bokeh_version}.min.js',
@@ -55,6 +56,7 @@ def test_resources_server_absolute():
     resources = Resources(mode='server', absolute=True, minified=True)
     assert resources.js_raw == ['Bokeh.set_log_level("info");']
     assert resources.js_files == [
+        'http://localhost:5006/static/extensions/panel/bundled/reactiveesm/es-module-shims@^1.10.0/dist/es-module-shims.min.js',
         'http://localhost:5006/static/js/bokeh.min.js',
         'http://localhost:5006/static/js/bokeh-gl.min.js',
         'http://localhost:5006/static/js/bokeh-widgets.min.js',
@@ -66,6 +68,7 @@ def test_resources_server():
     resources = Resources(mode='server', minified=True)
     assert resources.js_raw == ['Bokeh.set_log_level("info");']
     assert resources.js_files == [
+        'static/extensions/panel/bundled/reactiveesm/es-module-shims@^1.10.0/dist/es-module-shims.min.js',
         'static/js/bokeh.min.js',
         'static/js/bokeh-gl.min.js',
         'static/js/bokeh-widgets.min.js',
@@ -84,7 +87,7 @@ def test_resources_model_server(document):
     with set_resource_mode('server'):
         with set_curdoc(document):
             extension('tabulator')
-            assert resources.js_files[:2] == [
+            assert resources.js_files[1:3] == [
                 f'static/extensions/panel/bundled/datatabulator/tabulator-tables@{TABULATOR_VERSION}/dist/js/tabulator.min.js',
                 'static/extensions/panel/bundled/datatabulator/luxon/build/global/luxon.min.js',
             ]
@@ -97,7 +100,7 @@ def test_resources_model_cdn(document):
     with set_resource_mode('cdn'):
         with set_curdoc(document):
             extension('tabulator')
-            assert resources.js_files[:2] == [
+            assert resources.js_files[1:3] == [
                 f'{CDN_DIST}bundled/datatabulator/tabulator-tables@{TABULATOR_VERSION}/dist/js/tabulator.min.js',
                 f'{CDN_DIST}bundled/datatabulator/luxon/build/global/luxon.min.js',
             ]


### PR DESCRIPTION
It doesn't have to be loaded as a module and ends up confusing the Sphinx build and loading the shim multiple times.

Also improves some other resource loading logic, including require.js support for FileDropper and improved resource mode handling for JS files.