### PR TITLE
More improvements for loading notebook extension

### DIFF
--- a/panel/config.py
+++ b/panel/config.py
@@ -840,8 +840,7 @@ class panel_extension(_pyviz_extension):
             else:
                 with param.logging_level('ERROR'):
                     hv.plotting.Renderer.load_nb(config.inline)
-                    if hasattr(hv.plotting.Renderer, '_render_with_panel'):
-                        nb_loaded = True
+                    nb_loaded = True
 
         # Disable simple ids, old state and multiple tabs in notebooks can cause IDs to clash
         bk_settings.simple_ids.set_value(False)

--- a/panel/io/notebook.py
+++ b/panel/io/notebook.py
@@ -126,7 +126,7 @@ def _autoload_js(
             config[key].update(c)
     return AUTOLOAD_NB_JS.render(
         bundle    = bundle,
-        force     = True,
+        force     = not reloading,
         reloading = reloading,
         timeout   = load_timeout,
         config    = config,


### PR DESCRIPTION
Turns out there were more problems with the notebook load script. Specifically if you got into a failed loading state, there was no way to recover because `root._bokeh_is_loading` would still be non-zero, indicating that initialization was still in process and should therefore be skipped. We also now do not override the existing timeout, fix the error handling when a resource is unavailable, reset the timeout when we re-attempt loading Bokeh. Lastly we avoid loading Bokeh and Panel twice if HoloViews is imported.