### PR TITLE
Various changes to improve Tabulator robustness

### DIFF
--- a/panel/models/button.ts
+++ b/panel/models/button.ts
@@ -55,7 +55,7 @@ export class ButtonView extends BkButtonView {
         visible,
       })
     }
-    let timer: number
+    let timer: ReturnType<typeof setTimeout> | undefined
     this.el.addEventListener("mouseenter", () => {
       timer = setTimeout(() => toggle(true), this.model.tooltip_delay)
     })

--- a/panel/models/checkbox_button_group.ts
+++ b/panel/models/checkbox_button_group.ts
@@ -58,7 +58,7 @@ export class CheckboxButtonGroupView extends bkCheckboxButtonGroupView {
         visible,
       })
     }
-    let timer: number
+    let timer: ReturnType<typeof setTimeout> | undefined
     this.el.addEventListener("mouseenter", () => {
       timer = setTimeout(() => toggle(true), this.model.tooltip_delay)
     })

--- a/panel/models/html.ts
+++ b/panel/models/html.ts
@@ -73,7 +73,7 @@ export function run_scripts(node: Element): void {
 }
 
 function throttle(func: Function, limit: number): any {
-  let lastFunc: number
+  let lastFunc: ReturnType<typeof setTimeout> | undefined
   let lastRan: number
 
   return function(...args: any) {
@@ -85,7 +85,6 @@ function throttle(func: Function, limit: number): any {
       lastRan = Date.now()
     } else {
       clearTimeout(lastFunc)
-
       lastFunc = setTimeout(function() {
         if ((Date.now() - lastRan) >= limit) {
           func.apply(context, args)

--- a/panel/models/icon.ts
+++ b/panel/models/icon.ts
@@ -90,7 +90,7 @@ export class ClickableIconView extends ControlView {
         visible,
       })
     }
-    let timer: number
+    let timer: ReturnType<typeof setTimeout> | undefined
     this.el.addEventListener("mouseenter", () => {
       timer = setTimeout(() => toggle_tooltip(true), this.model.tooltip_delay)
     })

--- a/panel/models/radio_button_group.ts
+++ b/panel/models/radio_button_group.ts
@@ -58,7 +58,7 @@ export class RadioButtonGroupView extends bkRadioButtonGroupView {
         visible,
       })
     }
-    let timer: number
+    let timer: ReturnType<typeof setTimeout> | undefined
     this.el.addEventListener("mouseenter", () => {
       timer = setTimeout(() => toggle(true), this.model.tooltip_delay)
     })

--- a/panel/models/tabulator.ts
+++ b/panel/models/tabulator.ts
@@ -652,7 +652,7 @@ export class DataTabulatorView extends HTMLBoxView {
     const holder = this.shadow_el.querySelector(".tabulator-tableholder")
     let scroll_timeout: ReturnType<typeof setTimeout> | undefined
     if (holder) {
-      holder.addEventListener('scroll', () => {
+      holder.addEventListener("scroll", () => {
         this.record_scroll()
         this._is_scrolling = true
         clearTimeout(scroll_timeout)

--- a/panel/models/tabulator.ts
+++ b/panel/models/tabulator.ts
@@ -595,7 +595,9 @@ export class DataTabulatorView extends HTMLBoxView {
       return `${cell.getColumn().getField()}: ${cell.getValue()}`
     })
     this.tabulator.on("scrollVertical", debounce(() => {
-      clearTimeout(this._scroll_timeout)
+      if (isNumber(this._scroll_timeout)) {
+        clearTimeout(this._scroll_timeout)
+      }
       this.record_scroll()
       this.setStyles()
       this._scroll_timeout = setTimeout(() => {


### PR DESCRIPTION
Two fixes to improve Tabulator robustness:

1. Guard `this.model.children` look-ups since, when empty it sometimes appears to be an object rather than a Map.
2. Track scrolling state more robustly and do not run resize handler while scrolling (this was triggering tons of re-renders)