### PR TITLE
Document Tabulator Styling with Matplotlib gradients

### DIFF
--- a/examples/reference/widgets/Tabulator.ipynb
+++ b/examples/reference/widgets/Tabulator.ipynb
@@ -538,6 +538,27 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "You can style your tables with gradients using the [`.text_gradient`](https://pandas.pydata.org/docs/reference/api/pandas.io.formats.style.Styler.text_gradient.html) or [`.background_gradient`](https://pandas.pydata.org/docs/reference/api/pandas.io.formats.style.Styler.background_gradient.html#pandas.io.formats.style.Styler.background_gradient) methods, along with [named Matplotlib color maps](https://matplotlib.org/stable/gallery/color/colormap_reference.html).\n",
+    "\n",
+    "**Note:** Styling with gradients requires Matplotlib to be installed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gradient_table = pn.widgets.Tabulator(style_df)\n",
+    "gradient_table.style.text_gradient(cmap=\"RdYlGn\", subset=[\"B\", \"C\"])\n",
+    "gradient_table.style.background_gradient(cmap=\"RdYlGn\", subset=[\"D\", \"E\"])\n",
+    "gradient_table"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Theming\n",
     "\n",
     "The Tabulator library ships with a number of themes, which are defined as CSS stylesheets. For that reason changing the theme on one table will affect all tables on the page and it will usually be preferable to see the theme once at the class level like this:\n",


### PR DESCRIPTION
One of the most used features in Excel is applying colormap gradients to your tables. You can do the same with Tabulator in Panel.

I've many times been searching for this and experienced some issues.

- How to do this is not documented.
- Often the gradients don't show. Its actually because I did not have Matplotlib installed. But its very hard to figure out because no warning or exception is displayed. I've spent countless hours trying to understand why it works locally but not when deployed. I thought Panel Tabulator Styling was a bit fragile depending on Pandas versions etc.

This PR makes it much easier for users to apply gradients to Tabulator by documenting an example and documenting Matplotlib requirement.