### PR TITLE
Ensure Tabulator selection consistency when pagination='local'

### DIFF
--- a/panel/models/tabulator.ts
+++ b/panel/models/tabulator.ts
@@ -918,7 +918,6 @@ export class DataTabulatorView extends HTMLBoxView {
     if (this.model.configuration.dataTree) {
       data = group_data(data, this.model.columns, this.model.indexes, this.model.aggregators)
     }
-    console.trace(data)
     return data
   }
 

--- a/panel/models/tabulator.ts
+++ b/panel/models/tabulator.ts
@@ -603,7 +603,9 @@ export class DataTabulatorView extends HTMLBoxView {
     }, 50, false))
 
     // Sync state with model
-    this.tabulator.on("rowSelectionChanged", (data: any, rows: any, selected: any, deselected: any) => this.rowSelectionChanged(data, rows, selected, deselected))
+    this.tabulator.on("rowSelectionChanged", (data: any, rows: any, selected: any, deselected: any) => {
+      this.rowSelectionChanged(data, rows, selected, deselected)
+    })
     this.tabulator.on("rowClick", (e: any, row: any) => this.rowClicked(e, row))
     this.tabulator.on("cellEdited", (cell: any) => this.cellEdited(cell))
     this.tabulator.on("dataFiltering", (filters: any) => {
@@ -778,16 +780,7 @@ export class DataTabulatorView extends HTMLBoxView {
       configuration.ajaxURL = "http://panel.pyviz.org"
       configuration.sortMode = "remote"
     }
-    const cds: any = this.model.source
-    let data: any[]
-    if (cds === null || (cds.columns().length === 0)) {
-      data = []
-    } else {
-      data = transform_cds_to_records(cds, true)
-    }
-    if (configuration.dataTree) {
-      data = group_data(data, this.model.columns, this.model.indexes, this.model.aggregators)
-    }
+    const data = this.getData()
     return {
       ...configuration,
       data,
@@ -915,10 +908,17 @@ export class DataTabulatorView extends HTMLBoxView {
   }
 
   getData(): any[] {
-    let data = transform_cds_to_records(this.model.source, true)
+    const cds = this.model.source
+    let data: any[]
+    if (cds === null || (cds.columns().length === 0)) {
+      data = []
+    } else {
+      data = transform_cds_to_records(cds, true)
+    }
     if (this.model.configuration.dataTree) {
       data = group_data(data, this.model.columns, this.model.indexes, this.model.aggregators)
     }
+    console.trace(data)
     return data
   }
 

--- a/panel/models/tabulator.ts
+++ b/panel/models/tabulator.ts
@@ -550,6 +550,7 @@ export class DataTabulatorView extends HTMLBoxView {
     }
     super.render()
     this._initializing = true
+    this._building = true
     const container = div({style: {display: "contents"}})
     const el = div({style: {width: "100%", height: "100%", visibility: "hidden"}})
     this.container = el

--- a/panel/models/tabulator.ts
+++ b/panel/models/tabulator.ts
@@ -859,7 +859,6 @@ export class DataTabulatorView extends HTMLBoxView {
     let viewEl
     if (prev_child != null && prev_child.className == "row-content") {
       viewEl = prev_child
-      console.log(prev_child)
       if (viewEl.children.length && viewEl.children[0] === view.el) {
         return
       }

--- a/panel/models/util.ts
+++ b/panel/models/util.ts
@@ -148,7 +148,6 @@ export function find_attributes(text: string, obj: string, ignored: string[]) {
   return uniq(matches)
 }
 
-
 export function schedule_when(func: () => void, predicate: () => boolean, timeout: number = 10): void {
   const scheduled = () => {
     if (predicate()) {

--- a/panel/models/util.ts
+++ b/panel/models/util.ts
@@ -147,3 +147,15 @@ export function find_attributes(text: string, obj: string, ignored: string[]) {
 
   return uniq(matches)
 }
+
+
+export function schedule_when(func: () => void, predicate: () => boolean, timeout: number = 10): void {
+  const scheduled = () => {
+    if (predicate()) {
+      func()
+    } else {
+      setTimeout(scheduled, timeout)
+    }
+  }
+  scheduled()
+}

--- a/panel/tests/conftest.py
+++ b/panel/tests/conftest.py
@@ -144,7 +144,8 @@ def pytest_addoption(parser):
     for marker, info in optional_markers.items():
         parser.addoption(f"--{marker}", action="store_true",
                          default=False, help=info['help'])
-
+    parser.addoption('--repeat', action='store',
+        help='Number of times to repeat each test')
 
 def pytest_configure(config):
     for marker, info in optional_markers.items():
@@ -155,6 +156,19 @@ def pytest_configure(config):
 
     config.addinivalue_line("markers", "internet: mark test as requiring an internet connection")
 
+def pytest_generate_tests(metafunc):
+    if metafunc.config.option.repeat is not None:
+        count = int(metafunc.config.option.repeat)
+
+        # We're going to duplicate these tests by parametrizing them,
+        # which requires that each test has a fixture to accept the parameter.
+        # We can add a new fixture like so:
+        metafunc.fixturenames.append('tmp_ct')
+
+        # Now we parametrize. This is what happens when we do e.g.,
+        # @pytest.mark.parametrize('tmp_ct', range(count))
+        # def test_foo(): pass
+        metafunc.parametrize('tmp_ct', range(count))
 
 def pytest_collection_modifyitems(config, items):
     skipped, selected = [], []

--- a/panel/widgets/tables.py
+++ b/panel/widgets/tables.py
@@ -1343,10 +1343,10 @@ class Tabulator(BaseTable):
         self._validate_iloc(idx, iloc)
         event.row = iloc
         if event_col not in self.buttons:
-            if event_col not in self.value.columns:
-                event.value = self.value.index[event.row]
-            else:
+            if event_col in self.value.columns:
                 event.value = self.value[event_col].iloc[event.row]
+            else:
+                event.value = self.value.index[event.row]
 
         # Set the old attribute on a table edit event
         if event.event_name == 'table-edit':
@@ -1403,7 +1403,7 @@ class Tabulator(BaseTable):
 
         import pandas as pd
         df = pd.DataFrame(data)
-        filters = self._get_header_filters(df)
+        filters = self._get_header_filters(df) if self.pagination == 'remote' else []
         if filters:
             mask = filters[0]
             for f in filters:

--- a/panel/widgets/tables.py
+++ b/panel/widgets/tables.py
@@ -1440,6 +1440,7 @@ class Tabulator(BaseTable):
             indexes = [df.index.name or default_index]
         if len(indexes) > 1:
             page_df = page_df.reset_index()
+            df = df.reset_index()
         data = ColumnDataSource.from_df(page_df).items()
         return df, {k if isinstance(k, str) else str(k): v for k, v in data}
 

--- a/panel/widgets/tables.py
+++ b/panel/widgets/tables.py
@@ -423,7 +423,7 @@ class BaseTable(ReactiveData, Widget):
         df_sorted.drop(columns=['_index_'], inplace=True)
         return df_sorted
 
-    def _filter_dataframe(self, df: pd.DataFrame) -> pd.DataFrame:
+    def _filter_dataframe(self, df: pd.DataFrame, header_filters: bool = True, internal_filters: bool = True) -> pd.DataFrame:
         """
         Filter the DataFrame.
 
@@ -438,7 +438,7 @@ class BaseTable(ReactiveData, Widget):
             The filtered DataFrame
         """
         filters = []
-        for col_name, filt in self._filters:
+        for col_name, filt in (self._filters if internal_filters else []):
             if col_name is not None and col_name not in df.columns:
                 continue
             if isinstance(filt, (FunctionType, MethodType, partial)):
@@ -477,7 +477,8 @@ class BaseTable(ReactiveData, Widget):
                                  "tuple or list.")
             filters.append(mask)
 
-        filters.extend(self._get_header_filters(df))
+        if header_filters:
+            filters.extend(self._get_header_filters(df))
 
         if filters:
             mask = filters[0]
@@ -624,8 +625,13 @@ class BaseTable(ReactiveData, Widget):
         return self._process_df_and_convert_to_cds(self.value)
 
     def _process_df_and_convert_to_cds(self, df: pd.DataFrame) -> tuple[pd.DataFrame, DataDict]:
+        # By default we potentially have two distinct views of the data
+        # locally we hold the fully filtered data, i.e. with header filters
+        # applied but since header filters are applied on the frontend
+        # we send the unfiltered data
+
         import pandas as pd
-        df = self._filter_dataframe(df)
+        df = self._filter_dataframe(df, header_filters=False)
         if df is None:
             return [], {}
         if isinstance(self.value.index, pd.MultiIndex):
@@ -1414,6 +1420,9 @@ class Tabulator(BaseTable):
     def _get_data(self):
         if self.pagination != 'remote' or self.value is None:
             return super()._get_data()
+
+        # If data is paginated the current view on the frontend
+        # and locally are identical and both paginated
         import pandas as pd
         df = self._filter_dataframe(self.value)
         df = self._sort_df(df)
@@ -2139,4 +2148,5 @@ class Tabulator(BaseTable):
         df = self._processed
         if self.pagination == 'remote':
             return df
+        df = self._filter_dataframe(df, header_filters=True, internal_filters=False)
         return self._sort_df(df)


### PR DESCRIPTION
When pagination was set to 'local', selections were not being computed correctly when `header_filters` were being applied. Specifically the problem was that the `header_filters` were still being applied on the server, which would cause the `selection` going out of sync with the data that was visible to the frontend. We fix this by not applying `header_filters` on the server in this scenario, and only when the user accesses the `current_view` do we apply the additional filters so that the view the user sees still matches what is visible on the frontend.