### PR TITLE
Ensure Tabulator redraw is called after full render

### DIFF
--- a/panel/models/tabulator.ts
+++ b/panel/models/tabulator.ts
@@ -550,7 +550,6 @@ export class DataTabulatorView extends HTMLBoxView {
     }
     super.render()
     this._initializing = true
-    this._building = true
     const container = div({style: {display: "contents"}})
     const el = div({style: {width: "100%", height: "100%", visibility: "hidden"}})
     this.container = el

--- a/panel/models/tabulator.ts
+++ b/panel/models/tabulator.ts
@@ -513,7 +513,7 @@ export class DataTabulatorView extends HTMLBoxView {
     const finished = this.root.has_finished()
     if (this.tabulator != null && this._initializing && !this._building && finished) {
       this._initializing = false
-      this._debounced_redraw()
+      this.redraw()
     }
   }
 
@@ -697,7 +697,7 @@ export class DataTabulatorView extends HTMLBoxView {
     this._building = false
     if (this._initializing && this.root.has_finished()) {
       this._initializing = false
-      this._debounced_redraw()
+      this.redraw()
     }
   }
 

--- a/panel/models/tabulator.ts
+++ b/panel/models/tabulator.ts
@@ -495,7 +495,6 @@ export class DataTabulatorView extends HTMLBoxView {
     if (this._building || this.tabulator == null || this._redrawing) {
       return
     }
-    console.log('redrawing')
     this._redrawing = true
     if (columns && (this.tabulator.columnManager.element != null)) {
       this.tabulator.columnManager.redraw(true)
@@ -1326,7 +1325,6 @@ export class DataTabulatorView extends HTMLBoxView {
   }
 
   rowClicked(e: any, row: any) {
-  console.log(this._initializing, this)
     if (
       this._selection_updating ||
         this._initializing ||

--- a/panel/models/tabulator.ts
+++ b/panel/models/tabulator.ts
@@ -495,6 +495,7 @@ export class DataTabulatorView extends HTMLBoxView {
     if (this._building || this.tabulator == null || this._redrawing) {
       return
     }
+    console.log('redrawing')
     this._redrawing = true
     if (columns && (this.tabulator.columnManager.element != null)) {
       this.tabulator.columnManager.redraw(true)
@@ -697,6 +698,15 @@ export class DataTabulatorView extends HTMLBoxView {
     if (this._initializing && this.root.has_finished()) {
       this._initializing = false
       this.redraw()
+    } else if (!this.root.has_finished()) {
+      const finalize = () => {
+        if (this.root.has_finished()) {
+          this._initializing = false
+        } else {
+          setTimeout(finalize, 10)
+        }
+      }
+      setTimeout(finalize, 10)
     }
   }
 
@@ -1316,6 +1326,7 @@ export class DataTabulatorView extends HTMLBoxView {
   }
 
   rowClicked(e: any, row: any) {
+  console.log(this._initializing, this)
     if (
       this._selection_updating ||
         this._initializing ||

--- a/panel/models/tabulator.ts
+++ b/panel/models/tabulator.ts
@@ -356,6 +356,7 @@ export class DataTabulatorView extends HTMLBoxView {
   _lastHorizontalScrollbarLeftPosition: number = 0
   _applied_styles: boolean = false
   _building: boolean = false
+  _redrawing: boolean = false
   _debounced_redraw: any = null
   _restore_scroll: boolean | "horizontal" | "vertical" = false
   _updating_scroll: boolean = false
@@ -491,9 +492,10 @@ export class DataTabulatorView extends HTMLBoxView {
   }
 
   redraw(columns: boolean = true, rows: boolean = true): void {
-    if (this._building || this.tabulator != null) {
+    if (this._building || this.tabulator == null || this._redrawing) {
       return
     }
+    this._redrawing = true
     if (columns && (this.tabulator.columnManager.element != null)) {
       this.tabulator.columnManager.redraw(true)
     }
@@ -502,20 +504,22 @@ export class DataTabulatorView extends HTMLBoxView {
       this.renderChildren()
       this.setStyles()
     }
+    this._redrawing = false
     this._restore_scroll = true
   }
 
   override after_layout(): void {
     super.after_layout()
-    if (this.tabulator != null && this._initializing) {
-      this.redraw()
+    const finished = this.root.has_finished()
+    if (this.tabulator != null && this._initializing && !this._building && finished) {
+      this._initializing = false
+      this._debounced_redraw()
     }
-    this._initializing = false
   }
 
   override after_resize(): void {
     super.after_resize()
-    if (!this._is_scrolling) {
+    if (!this._is_scrolling && !this._redrawing) {
       this._debounced_redraw()
     }
   }
@@ -546,6 +550,7 @@ export class DataTabulatorView extends HTMLBoxView {
     }
     super.render()
     this._initializing = true
+    this._building = true
     const container = div({style: {display: "contents"}})
     const el = div({style: {width: "100%", height: "100%", visibility: "hidden"}})
     this.container = el
@@ -643,7 +648,6 @@ export class DataTabulatorView extends HTMLBoxView {
   }
 
   tableBuilt(): void {
-    this._building = false
     this.setSelection()
     this.renderChildren()
     this.setStyles()
@@ -689,6 +693,11 @@ export class DataTabulatorView extends HTMLBoxView {
       }
       this.setMaxPage()
       this.tabulator.setPage(this.model.page)
+    }
+    this._building = false
+    if (this._initializing && this.root.has_finished()) {
+      this._initializing = false
+      this._debounced_redraw()
     }
   }
 


### PR DESCRIPTION
There were some major issues with the logic responsible for ensuring that the Tabulator was redrawn. In fact the logic was specifically skipping redraws if `this.tabulator != null`, so **we never triggered the redraw** at all since this completely incorrect PR 3 months ago: https://github.com/holoviz/panel/pull/6930

Some additional improvements we make here:

- Do not trigger a redraw, while another is in process (this could happen because a redraw can trigger a resize which triggers another redraw)
- We do not trigger a initial redraw until the `root.has_finished` (i.e. the page is fully rendered). 

