### PR TITLE
Tweak ChatMessage margins

### DIFF
--- a/panel/dist/css/chat_copy_icon.css
+++ b/panel/dist/css/chat_copy_icon.css
@@ -1,3 +1,4 @@
 :host {
   margin-top: 4px;
+  margin-inline: 3px;
 }

--- a/panel/dist/css/chat_message.css
+++ b/panel/dist/css/chat_message.css
@@ -39,7 +39,7 @@
 }
 
 .meta {
-  margin-bottom: -8px;
+  margin-bottom: -6px;
 }
 
 .left {
@@ -77,7 +77,6 @@
       1px;
   font-size: 1.25em;
   min-height: 50px;
-  margin-block: 2px;
   margin-left: 10px; /* Space for avatar */
   background-color: var(--panel-surface-color, #f1f1f1);
   min-width: 0;
@@ -101,7 +100,7 @@
 .timestamp {
   opacity: 0.5;
   transition: opacity 0.1s ease-in-out;
-  margin-block: 0px;
+  margin-block: 2px;
 }
 
 .timestamp:hover {
@@ -119,6 +118,8 @@
 
 .icons {
   opacity: 0.5;
+  margin-left: 8px;
+  margin-top: -2px;
   transition: opacity 0.1s ease-in-out;
 }
 
@@ -145,8 +146,4 @@
   /* since 1.25em, adjust line-height */
   font-size: 1.25em;
   line-height: 0.9em;
-}
-
-.copy-icon {
-  margin-left: 10px;
 }

--- a/panel/dist/css/chat_reaction_icons.css
+++ b/panel/dist/css/chat_reaction_icons.css
@@ -1,5 +1,5 @@
 :host {
   width: fit-content;
-  margin-top: 2px;
-  margin-left: 3px;
+  margin-top: 4px;
+  margin-inline: 3px;
 }


### PR DESCRIPTION
Without the divider, the reaction icons were too far left.
<img width="237" alt="image" src="https://github.com/user-attachments/assets/90c4d307-f4da-475f-bcc3-96aa3b452ebf">

Then I noticed that the chat copy icon and reaction icons were misaligned vertically.
<img width="86" alt="image" src="https://github.com/user-attachments/assets/e3f64d94-9557-499d-8459-ec13be71a886">

I also noticed that the chat copy icon and reaction icons inline spacing were somewhat different (more space between each reaction icon vs reaction icons + chat copy icon)
<img width="76" alt="image" src="https://github.com/user-attachments/assets/475a2d47-b72b-4fa6-9a88-dd621bf13fec">

So I tweaked it all:

Before:
<img width="1187" alt="image" src="https://github.com/user-attachments/assets/c9dd1ac5-826a-4966-83fe-42af570e4ab1">

After:
<img width="1191" alt="image" src="https://github.com/user-attachments/assets/b2500805-4605-478a-a686-ba5ddb8455cd">
