### PR TITLE
filter out empty plotly_selected events

### DIFF
--- a/panel/models/plotly.ts
+++ b/panel/models/plotly.ts
@@ -299,6 +299,10 @@ export class PlotlyPlotView extends HTMLBoxView {
 
     //  - plotly_selected
     this.container.on("plotly_selected", (eventData: any) => {
+      if (eventData === undefined || eventData === null) {
+        // filter out the empty events that come from single-click
+        return
+      }
       const data = filterEventData(this.container, eventData, "selected")
       this.model.trigger_event(new PlotlyEvent({type: "selected", data}))
     })


### PR DESCRIPTION
plotly.js emits `plotly_selected` events with [empty data on single click](https://github.com/plotly/plotly.js/blob/f6253deb1f6a4abba43afd2ab159760a4b2d62dd/src/components/selections/select.js#L450-L456) - odd behavior but it has been kept for backward compatibility. In Dash these are [filtered out](https://github.com/plotly/dash/blob/ef003236f5258d9f2b6e00e4bc7aa7791241ee09/components/dash-core-components/src/fragments/Graph.react.js#L430) (that's the `if (!isNil(selected)`). I'm just replicating that behavior here, so that an empty `selected_data` param truly means there's no selection.