### PR TITLE
Move session prefixes from handlers to Application

### DIFF
--- a/panel/io/application.py
+++ b/panel/io/application.py
@@ -123,7 +123,7 @@ class Application(BkApplication):
         super().add(handler)
 
     def _set_session_prefix(self, doc):
-        if not doc.session_context:
+        if not doc.session_context and doc.session_context.server_context:
             return
         request = doc.session_context.request
         app_context = doc.session_context.server_context.application_context

--- a/panel/io/application.py
+++ b/panel/io/application.py
@@ -123,10 +123,11 @@ class Application(BkApplication):
         super().add(handler)
 
     def _set_session_prefix(self, doc):
-        if not doc.session_context and doc.session_context.server_context:
+        session_context = doc.session_context
+        if not (session_context and session_context.server_context):
             return
-        request = doc.session_context.request
-        app_context = doc.session_context.server_context.application_context
+        request = session_context.request
+        app_context = session_context.server_context.application_context
         prefix = request.uri.replace(app_context._url, '')
         if not prefix.endswith('/'):
             prefix += '/'

--- a/panel/io/application.py
+++ b/panel/io/application.py
@@ -135,9 +135,9 @@ class Application(BkApplication):
 
         with set_curdoc(doc):
             # Handle autoload.js absolute paths
-            abs_url = None#self.get_argument('bokeh-absolute-url', default=None)
-            if abs_url is not None:
-                rel_path = abs_url.replace(app_context._url, '')
+            abs_url = request.arguments.get('bokeh-absolute-url')
+            if abs_url:
+                rel_path = abs_url[0].decode('utf-8').replace(app_context._url, '')
 
             state.base_url = base_url
             state.rel_path = rel_path

--- a/panel/io/application.py
+++ b/panel/io/application.py
@@ -134,12 +134,12 @@ class Application(BkApplication):
         base_url = urljoin('/', prefix)
         rel_path = '/'.join(['..'] * app_context._url.strip('/').count('/'))
 
-        with set_curdoc(doc):
-            # Handle autoload.js absolute paths
-            abs_url = request.arguments.get('bokeh-absolute-url')
-            if abs_url:
-                rel_path = abs_url[0].decode('utf-8').replace(app_context._url, '')
+        # Handle autoload.js absolute paths
+        abs_url = request.arguments.get('bokeh-absolute-url')
+        if abs_url:
+            rel_path = abs_url[0].decode('utf-8').replace(app_context._url, '')
 
+        with set_curdoc(doc):
             state.base_url = base_url
             state.rel_path = rel_path
 


### PR DESCRIPTION
Moving the handling of relative paths and the base urls from the tornado handlers to the `Application` ensures that all server implementations inherit this handling rather than merely being supported by the Tornado server implementation.

Fixes https://github.com/bokeh/bokeh-fastapi/issues/24