### PR TITLE
Add mapboxgl CSS to Plotly

### DIFF
--- a/panel/models/plotly.py
+++ b/panel/models/plotly.py
@@ -25,6 +25,13 @@ class PlotlyPlot(LayoutDOM):
     A bokeh model that wraps around a plotly plot and renders it inside
     a bokeh plot.
     """
+    __css_raw__ = [
+        "https://api.mapbox.com/mapbox-gl-js/v3.0.1/mapbox-gl.css",
+    ]
+
+    @classproperty
+    def __css__(cls):
+        return bundled_files(cls, 'css')
 
     __javascript_raw__ = [
         JS_URLS['jQuery'],

--- a/panel/tests/pane/test_holoviews.py
+++ b/panel/tests/pane/test_holoviews.py
@@ -240,7 +240,7 @@ def test_holoviews_pane_inherits_design_stylesheets(document, comm):
 
     plotly_model = row.children[0]
 
-    assert len(plotly_model.stylesheets) == 5
+    assert len(plotly_model.stylesheets) == 6
 
 @hv_available
 def test_holoviews_widgets_from_dynamicmap(document, comm):


### PR DESCRIPTION
Ensures Mapbox.gl CSS is loaded in Plotly plot, ensuring that map based plots correctly render attributions.