### PR TITLE
Reference notebook - Tabulator theme: notes on font-size

### DIFF
--- a/examples/reference/widgets/Tabulator.ipynb
+++ b/examples/reference/widgets/Tabulator.ipynb
@@ -601,6 +601,24 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### Change font-size\n",
+    "\n",
+    "Font-size may vary from theme to theme. E.g with 'bootstrap' it is 13px while with 'bootstrap5' it is 16px. Below is one way to overwrite the font-size value for theme 'bootstrap5' to 10px."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pn.widgets.Tabulator(df, theme='bootstrap5', stylesheets=[\"\"\":host .tabulator {font-size: 10px;}\"\"\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Selection/Click\n",
     "\n",
     "The `selection` parameter controls which rows in the table are selected and can be set from Python and updated by selecting rows on the frontend:"
@@ -1398,9 +1416,22 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
    "name": "python",
-   "pygments_lexer": "ipython3"
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.9"
   }
  },
  "nbformat": 4,

--- a/examples/reference/widgets/Tabulator.ipynb
+++ b/examples/reference/widgets/Tabulator.ipynb
@@ -612,7 +612,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "pn.widgets.Tabulator(df, theme='bootstrap5', stylesheets=[\"\"\":host .tabulator {font-size: 10px;}\"\"\"])"
+    "pn.widgets.Tabulator(df, theme='bootstrap5', stylesheets=[\":host .tabulator {font-size: 10px;}\"])"
    ]
   },
   {

--- a/examples/reference/widgets/Tabulator.ipynb
+++ b/examples/reference/widgets/Tabulator.ipynb
@@ -601,7 +601,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Change font-size\n",
+    "### Changing font-size\n",
     "\n",
     "Font-size may vary from theme to theme. E.g with 'bootstrap' it is 13px while with 'bootstrap5' it is 16px. Below is one way to overwrite the font-size value for theme 'bootstrap5' to 10px."
    ]
@@ -1416,22 +1416,8 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.11.9"
+   "name": "python"
   }
  },
  "nbformat": 4,

--- a/examples/reference/widgets/Tabulator.ipynb
+++ b/examples/reference/widgets/Tabulator.ipynb
@@ -1417,7 +1417,8 @@
  ],
  "metadata": {
   "language_info": {
-   "name": "python"
+   "name": "python",
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Add notes to the Tabulator user guide notebook about font-sizes of different themes. Linked issue: https://github.com/holoviz/panel/issues/7100