### PR TITLE
Fix typo in JPG component docs

### DIFF
--- a/examples/reference/panes/JPG.ipynb
+++ b/examples/reference/panes/JPG.ipynb
@@ -25,7 +25,7 @@
     "* **``embed``** (boolean, default=False): If given a URL to an image this determines whether the image will be embedded as base64 or merely linked to.\n",
     "* **``fixed_aspect``** (boolean, default=True): Whether the aspect ratio of the image should be forced to be equal.\n",
     "* **``link_url``** (str, default=None): A link URL to make the image clickable and link to some other website.\n",
-    "* **``object``** (str or object): The JPEG file to display.  Can be a string pointing to a local or remote file, or an object with a ``_repr_jpg_`` method.\n",
+    "* **``object``** (str or object): The JPEG file to display.  Can be a string pointing to a local or remote file, or an object with a ``_repr_jpeg_`` method.\n",
     "* **``style``** (dict): Dictionary specifying CSS styles\n",
     "\n",
     "___"


### PR DESCRIPTION
I noticed this typo in the [docs for the JPG component](https://panel.holoviz.org/reference/panes/JPG.html). I had tried to follow this by creating an object with a `_repr_jpg_` method but that didn't work, and I found that `_repr_jpeg_` was what Panel was actually looking for (and what is mentioned in the [docs for the Image component](https://panel.holoviz.org/reference/panes/Image.html)).