### PR TITLE
Fix typo for FastListTemplate.ipynb

### DIFF
--- a/examples/reference/templates/FastListTemplate.ipynb
+++ b/examples/reference/templates/FastListTemplate.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The `FastGridTemplate` is a simple extension of the basic template that uses the [Fast design library](https://www.fast.design/) and applies the `panel.theme.Fast` design system by default. It is a list-like variant where the `main` area acts like a list-like container, unlike the grid-like templates such as `ReactTemplate` and `FastGridTemplate`.\n",
+    "The `FastListTemplate` is a simple extension of the basic template that uses the [Fast design library](https://www.fast.design/) and applies the `panel.theme.Fast` design system by default. It is a list-like variant where the `main` area acts like a list-like container, unlike the grid-like templates such as `ReactTemplate` and `FastGridTemplate`.\n",
     "\n",
     "## Basic Templates\n",
     "\n",


### PR DESCRIPTION
It seems that `FastGridTemplate` should be updated to reference `FastListTemplate` instead.