### PR TITLE
docs: Ignore warnings in documentation

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -201,6 +201,7 @@ test-type = 'mypy panel'
 MOZ_HEADLESS = "1"
 PANEL_IPYWIDGET = "1"
 OBJC_DISABLE_INITIALIZE_FORK_SAFETY = "YES"
+PYTHONWARNINGS="ignore"
 
 [feature.doc.dependencies]
 lxml = "*"


### PR DESCRIPTION
I'm not sure if we ignore warnings with the current setup. If we don't currently ignore warnings, we could add this environment variable so warnings are not shown in documentation. If we do ignore them, this PR can be closed. 

xref: https://github.com/holoviz-dev/nbsite/issues/312