### PR TITLE
ci: Add result test step to enable auto-merge

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -271,3 +271,13 @@ jobs:
       - name: Test Type
         run: |
           pixi run -e ${{ matrix.environment }} test-type || echo "Failed"
+
+  result_test_suite:
+    name: result:test
+    needs: [unit_test_suite, ui_test_suite, core_test_suite, type_test_suite]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: check for failures
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: echo job failed && exit 1


### PR DESCRIPTION
This is a small step in the test setup, which would make it easier to enable auto-merge.