### PR TITLE
Add Audio Input Widget

### DIFF
--- a/panel/widgets/microphone.py
+++ b/panel/widgets/microphone.py
@@ -1,0 +1,92 @@
+"""The Microphone widget controls the Media Stream Recording API of the browser.
+
+It wraps the [Media Stream Recording API](https://developer.mozilla.org/en-US/docs/Web/API/MediaStream_Recording_API/Using_the_MediaStream_Recording_API).
+"""
+
+import tempfile
+
+from os import PathLike
+from pathlib import Path
+
+import numpy as np
+import param
+
+from ..custom import JSComponent
+from .button import BUTTON_TYPES
+
+
+class Microphone(JSComponent):
+    # Alternatively AudioRecorder. Or MediaRecorder if should support both video and audio.
+    """The Microphone widget can be used to record audio and create speech to "other media" applications.
+
+    recorder = Microphone(format="mp3")
+    pn.Column("Click the button below to start recording", recorder)
+    """
+
+    value = param.Bytes(doc="""The value recorded in the format given by the format parameter""")
+    # Maybe I will have to transfer as data url instead of bytes.
+
+    format = param.Selector(default="webm", objects=["wav", "webm", "mp3"], doc="""The format of the value""")
+    # webm by default because that is the default in the Mediau Stream Recording API
+
+    # Alternatively: state = param.Selector(default="not-recoding", objects=["not-recording", "recording"])
+
+    # The below parameters are aligned with SpeechToText
+    state = param.Selector(default="started", objects=["paused", "started", "stopped"])
+
+    continuous = param.Boolean(default=False, doc="""If True incremental values are streamed during the recording.
+        If False a single value is transferred when the recording ends.""")
+    # Alternatively: streaming = param.Boolean(default=False)
+
+    button_hide = param.Boolean(default=False, label="Hide the Button", doc="""
+        If True no button is shown. If False a toggle Start/ Stop button is shown.""")
+
+    button_type = param.ObjectSelector(default="light", objects=BUTTON_TYPES+['light', 'dark'], doc="""
+        The button styling.""")
+
+    button_not_started = param.String(label="Button Text when not started", doc="""
+        The text to show on the button when the Media
+        service is NOT started.  If '' a *muted microphone* icon is
+        shown.""")
+
+    button_started = param.String(label="Button Text when started", doc="""
+        The text to show on the button when the Media
+        service is started. If '' a *microphone* icon is
+        shown.""")
+
+    options = param.Dict(doc="""Wavesurfer Options""")
+    # We should figure out if we want to use Wavesurfer: https://wavesurfer.xyz/docs/
+
+    @staticmethod
+    def _to_data_url(self, value: bytes)->str:
+        raise NotImplementedError()
+
+    @param.depends("value")
+    def value_as_data_url(self):
+        return self._to_data_url(self.value)
+
+    @staticmethod
+    def _to_numpy(self, value: bytes)->tuple[int, np.ndarray]:
+        """Returns the sample rate and numpy array"""
+        raise NotImplementedError()
+
+    # I want to make it easy for users to bind to the numpy array but not spend resources on
+    # calculating it if not needed.
+    @param.depends("value")
+    def value_as_numpy(self)->tuple[int, np.ndarray]:
+        """Returns the value as a tuple of sample rate and numpy array"""
+        return self._to_numpy(self.value)
+
+    @param.depends("value")
+    def value_as_file(self)->Path:
+        # This is currently the best way to bind to the Audio player!
+        if not self.value:
+            return None
+        else:
+            with tempfile.NamedTemporaryFile(delete=False, suffix=f".{self.format}") as temp_file:
+                temp_file.write(self.value)
+                temp_file_name = temp_file.name
+            return temp_file_name
+
+    def save(self, path: PathLike):
+        raise NotImplementedError()


### PR DESCRIPTION
Closing https://github.com/holoviz/panel/issues/4048.

For now this is exploration in order to be able to design the widget.

## Related issues

- https://github.com/holoviz/panel/issues/7035
- https://github.com/holoviz/panel/issues/7090
- https://github.com/holoviz/panel/issues/7021 (We should show how to integrate audio input with chat)
- https://github.com/holoviz/panel/issues/4861
- 

## Design

###  Inspiration
- Gradio Real time speech recognition: https://www.gradio.app/guides/real-time-speech-recognition
  - https://github.com/gradio-app/gradio/blob/main/gradio/components/audio.py
  - https://github.com/gradio-app/gradio/blob/main/js/audio/recorder/AudioRecorder.svelte
- Conversion in the browser: https://stackoverflow.com/questions/57365486/converting-blob-webm-to-audio-file-wav-or-mp3
- Wave Surfer: https://wavesurfer.xyz/docs/ and recording example https://wavesurfer.xyz/examples/?record.js
- Streamlit Experimental Audio Recorder https://docs.streamlit.io/develop/api-reference/widgets/st.audio_input and https://github.com/streamlit/streamlit/tree/develop/frontend/lib/src/components/widgets/AudioInput.
- Streamlit Audio Recorder, https://github.com/stefanrmmr/streamlit-audio-recorder, Audio React Recorder: https://doppelgunner.github.io/audio-react-recorder/, https://github.com/doppelgunner/audio-react-recorder?tab=readme-ov-file
- Audio Recorder Streamlit: https://github.com/Joooohan/audio-recorder-streamlit
- Streamlit-audiorecorder: https://github.com/theevann/streamlit-audiorecorder and https://github.com/samhirtarif/react-audio-recorder
- https://github.com/whitphx/streamlit-webrtc
- OpenAI Realtime API https://platform.openai.com/docs/guides/realtime/overview

## Questions

Design Decisions to be taken

- Do we want to focus on Audio input or combine Audio and Video? The Media Stream Api Supports both?
  - [x] Audio.
  - [ ] Video
- What should the name be
  - [ ] `Microphone`
  - [x] `AudioInput`
  - [ ] `AudioRecorder`
- Do we want to enable incremental streaming? Or just sending value when recording is finished?
  - [x] Final Value
  - [ ] Streaming value
- Do we want to support more value formats than default webm? mp3, ogg, wav etc. Converting on client side might require cross origin isolation. Converting on server side might require ffmpeg installation.
  - [x] mp3, ogg, wav 
  - [x] Conversion on client side
- Do we want bare minimum UI (Start, Stop, Pause)? Or extra features:
  - [x] submit button
  - [x] playback button?
  - [x] wave graph?
  - [ ] editing possibilities?
- Do we want compact UI like Streamlit or large UI like Gradio?
  - [x] Compact UI
  - [ ] Large UI
- Do we want to build on raw Media Stream Recording API or library?
  - [x] Wavesurfer https://wavesurfer.xyz/docs/  (What Gradio and Streamlit are using)
  - [ ] React Audio Recorder https://github.com/samhirtarif/react-audio-recorder (looks really simple to implement. But uses React).
- Do we want to make it easy for users to
  - [x] Play the value in the Audio pane?
  - [x] work with the value as a Numpy Array?
  - [x] work with the value as a data url?
  - [x] Save the value to a file?
- How do we most efficiently transfer the media from client to server
  - [x] Bytes (I don't yet know how to do this)
  - [ ] data url (This is easily doable)

Items marked with [x] are the choices we should select to implement.