### PR TITLE
Corrected styles in doc

### DIFF
--- a/examples/reference/panes/GIF.ipynb
+++ b/examples/reference/panes/GIF.ipynb
@@ -26,7 +26,7 @@
     "* **``fixed_aspect``** (boolean, default=True): Whether the aspect ratio of the image should be forced to be equal.\n",
     "* **``link_url``** (str, default=None): A link URL to make the image clickable and link to some other website.\n",
     "* **``object``** (str or object): The string to display. If a non-string type is supplied the repr is displayed. \n",
-    "* **``style``** (dict): Dictionary specifying CSS styles\n",
+    "* **``styles``** (dict): Dictionary specifying CSS styles\n",
     "\n",
     "___"
    ]

--- a/examples/reference/panes/Image.ipynb
+++ b/examples/reference/panes/Image.ipynb
@@ -37,7 +37,7 @@
     "* **``fixed_aspect``** (boolean, default=True): Whether the aspect ratio of the image should be forced to be equal.\n",
     "* **``link_url``** (str, default=None): A link URL to make the image clickable and link to some other website.\n",
     "* **``object``** (str or object): The Image file to display. Can be a string pointing to a local or remote file, or an object with a ``_repr_extension_`` method, where extension is an image file extension.\n",
-    "* **``style``** (dict): Dictionary specifying CSS styles\n",
+    "* **``styles``** (dict): Dictionary specifying CSS styles\n",
     "\n",
     "___"
    ]

--- a/examples/reference/panes/JPG.ipynb
+++ b/examples/reference/panes/JPG.ipynb
@@ -26,7 +26,7 @@
     "* **``fixed_aspect``** (boolean, default=True): Whether the aspect ratio of the image should be forced to be equal.\n",
     "* **``link_url``** (str, default=None): A link URL to make the image clickable and link to some other website.\n",
     "* **``object``** (str or object): The JPEG file to display.  Can be a string pointing to a local or remote file, or an object with a ``_repr_jpeg_`` method.\n",
-    "* **``style``** (dict): Dictionary specifying CSS styles\n",
+    "* **``styles``** (dict): Dictionary specifying CSS styles\n",
     "\n",
     "___"
    ]

--- a/examples/reference/panes/PDF.ipynb
+++ b/examples/reference/panes/PDF.ipynb
@@ -24,7 +24,7 @@
     "* **``embed``** (boolean, default=False): If given a URL to a file this determines whether the image will be embedded as base64 or merely linked to.\n",
     "* **``object``** (str or object): The PDF file to display. Can be a string pointing to a local or remote file, or an object with a ``_repr_pdf_`` method.\n",
     "* **``start_page``** (int): Start page of the `.pdf` file when loading the page. \n",
-    "* **``style``** (dict): Dictionary specifying CSS styles.\n",
+    "* **``styles``** (dict): Dictionary specifying CSS styles.\n",
     "\n",
     "___"
    ]

--- a/examples/reference/panes/PNG.ipynb
+++ b/examples/reference/panes/PNG.ipynb
@@ -26,7 +26,7 @@
     "* **``fixed_aspect``** (boolean, default=True): Whether the aspect ratio of the image should be forced to be equal.\n",
     "* **``link_url``** (str, default=None): A link URL to make the image clickable and link to some other website.\n",
     "* **``object``** (str or object): The PNG file to display. Can be a string pointing to a local or remote file, or an object with a ``_repr_png_`` method.\n",
-    "* **``style``** (dict): Dictionary specifying CSS styles\n",
+    "* **``styles``** (dict): Dictionary specifying CSS styles\n",
     "\n",
     "___"
    ]

--- a/examples/reference/panes/SVG.ipynb
+++ b/examples/reference/panes/SVG.ipynb
@@ -27,7 +27,7 @@
     "* **``link_url``** (str, default=None): A link URL to make the image clickable and link to some other website.\n",
     "* **``encode``** (bool, default=True): Whether to base64 encode the SVG, when enabled SVG links may not work while disabling encoding will prevent image scaling from working.\n",
     "* **``object``** (str or object): The svg file to display. Can be a string pointing to a local or remote file, or an object with a ``_repr_svg_`` method.\n",
-    "* **``style``** (dict): Dictionary specifying CSS styles\n",
+    "* **``styles``** (dict): Dictionary specifying CSS styles\n",
     "\n",
     "___"
    ]

--- a/examples/reference/panes/Str.ipynb
+++ b/examples/reference/panes/Str.ipynb
@@ -26,7 +26,7 @@
     "For details on other options for customizing the component see the [layout](../../how_to/layout/index.md) and [styling](../../how_to/styling/index.md) how-to guides.\n",
     "\n",
     "* **``object``** (str or object): The string to display. If a non-string type is supplied, the `repr` of that object is displayed. \n",
-    "* **``style``** (dict): Dictionary specifying CSS styles\n",
+    "* **``styles``** (dict): Dictionary specifying CSS styles\n",
     "\n",
     "___"
    ]

--- a/examples/reference/panes/WebP.ipynb
+++ b/examples/reference/panes/WebP.ipynb
@@ -26,7 +26,7 @@
     "* **``fixed_aspect``** (boolean, default=True): Whether the aspect ratio of the image should be forced to be equal.\n",
     "* **``link_url``** (str, default=None): A link URL to make the image clickable and link to some other website.\n",
     "* **``object``** (str or object): The PNG file to display. Can be a string pointing to a local or remote file, or an object with a ``_repr_png_`` method.\n",
-    "* **``style``** (dict): Dictionary specifying CSS styles\n",
+    "* **``styles``** (dict): Dictionary specifying CSS styles\n",
     "\n",
     "___"
    ]


### PR DESCRIPTION
- [x] closes #7337. fixed the typo error in document files, changed _style_ to styles, they are:
- [x] examples/reference/panes/GIF.ipynb
- [x] examples/reference/panes/Image.ipynb  
- [x] examples/reference/panes/JPG.ipynb
- [x] examples/reference/panes/PDF.ipynb
- [x] examples/reference/panes/PNG.ipynb
- [x] examples/reference/panes/SVG.ipynb
- [x] examples/reference/panes/WebP.ipynb

