### PR TITLE
Prevent pipeline network plot from linking with other plots

### DIFF
--- a/panel/pipeline.py
+++ b/panel/pipeline.py
@@ -523,9 +523,10 @@ class Pipeline(Viewer):
             yoffset=-.30, default_tools=[], axiswise=True, backend='bokeh'
         )
         plot = (graph * labels * nodes) if self._linear else (graph * nodes)
+        xlim = (-0.25, depth + 0.25)
         plot.opts(
             xaxis=None, yaxis=None, min_width=400, responsive=True,
-            show_frame=False, height=height, xlim=(-0.25, depth+0.25),
+            show_frame=False, height=height, xlim=xlim, shared_axes=False,
             ylim=(0, 1), default_tools=['hover'], toolbar=None, backend='bokeh'
         )
         return plot


### PR DESCRIPTION
Fixes #7367 

I just realised that this had been taken care of a long time ago #1438 but the issue resurfaced for some reason.