### PR TITLE
Fix type hint for `oauth_guest_endpoints`

### DIFF
--- a/panel/io/server.py
+++ b/panel/io/server.py
@@ -17,7 +17,7 @@ import uuid
 from functools import partial, wraps
 from html import escape
 from typing import (
-    TYPE_CHECKING, Any, Callable, Mapping, Optional, List
+    TYPE_CHECKING, Any, Callable, Mapping, Optional,
 )
 from urllib.parse import urlparse
 
@@ -825,7 +825,7 @@ def get_server(
     oauth_encryption_key: Optional[str] = None,
     oauth_jwt_user: Optional[str] = None,
     oauth_refresh_tokens: Optional[bool] = None,
-    oauth_guest_endpoints: Optional[List[str]] = None,
+    oauth_guest_endpoints: Optional[list[str]] = None,
     oauth_optional: Optional[bool] = None,
     login_endpoint: Optional[str] = None,
     logout_endpoint: Optional[str] = None,

--- a/panel/io/server.py
+++ b/panel/io/server.py
@@ -17,7 +17,7 @@ import uuid
 from functools import partial, wraps
 from html import escape
 from typing import (
-    TYPE_CHECKING, Any, Callable, Mapping, Optional,
+    TYPE_CHECKING, Any, Callable, Mapping, Optional, List
 )
 from urllib.parse import urlparse
 
@@ -825,7 +825,7 @@ def get_server(
     oauth_encryption_key: Optional[str] = None,
     oauth_jwt_user: Optional[str] = None,
     oauth_refresh_tokens: Optional[bool] = None,
-    oauth_guest_endpoints: Optional[bool] = None,
+    oauth_guest_endpoints: Optional[List[str]] = None,
     oauth_optional: Optional[bool] = None,
     login_endpoint: Optional[str] = None,
     logout_endpoint: Optional[str] = None,


### PR DESCRIPTION
`oauth_guest_endpoints` is supposed to be a list of string instead, as can be seen in the documentation here: https://github.com/holoviz/panel/blob/7dd8908108700611a55de646cac26207f0f5c0a4/panel/io/server.py#L899-L900