### PR TITLE
Fix import map typing

### DIFF
--- a/panel/custom.py
+++ b/panel/custom.py
@@ -223,7 +223,7 @@ class ReactiveESM(ReactiveCustomBase, metaclass=ReactiveESMMetaclass):
     # 3. Named export (`{ <export>, ... }`): ("<export>", ...)
     _exports__: ClassVar[ExportSpec] = {}
 
-    _importmap: ClassVar[dict[Literal['imports', 'scopes'], str]] = {}
+    _importmap: ClassVar[dict[Literal['imports', 'scopes'], dict[str,str]]] = {}
 
     __abstract = True
 


### PR DESCRIPTION
Fix `_importmap` typing as they are on the form

```python
_importmap = {
        "imports": {
            "mermaid": f"https://cdn.jsdelivr.net/npm/mermaid@{VERSION}/dist/mermaid.esm.min.mjs"
        }
    }
```
