### PR TITLE
Ensure that autoreload records modules to watch before startup

### DIFF
--- a/panel/command/serve.py
+++ b/panel/command/serve.py
@@ -388,7 +388,7 @@ class Serve(_BkServe):
         if args.warm or config.autoreload:
             argvs = {f: args.args for f in files}
             applications = build_single_handler_applications(files, argvs)
-            initialize_session = not (args.num_procs and sys.version_info < (3, 12))
+            initialize_session = not args.num_procs or sys.version_info < (3, 12)
             if config.autoreload:
                 with record_modules(list(applications.values())):
                     self.warm_applications(

--- a/panel/command/serve.py
+++ b/panel/command/serve.py
@@ -388,7 +388,8 @@ class Serve(_BkServe):
         if args.warm or config.autoreload:
             argvs = {f: args.args for f in files}
             applications = build_single_handler_applications(files, argvs)
-            initialize_session = not args.num_procs or sys.version_info < (3, 12)
+            nprocs = args.num_procs
+            initialize_session = not ((nprocs == 0 or nprocs > 1) and sys.version_info < (3, 12))
             if config.autoreload:
                 with record_modules(list(applications.values())):
                     self.warm_applications(

--- a/panel/command/serve.py
+++ b/panel/command/serve.py
@@ -388,8 +388,7 @@ class Serve(_BkServe):
         if args.warm or config.autoreload:
             argvs = {f: args.args for f in files}
             applications = build_single_handler_applications(files, argvs)
-            nprocs = args.num_procs
-            initialize_session = not ((nprocs == 0 or nprocs > 1) and sys.version_info < (3, 12))
+            initialize_session = not (args.num_procs != 1 and sys.version_info < (3, 12))
             if config.autoreload:
                 with record_modules(list(applications.values())):
                     self.warm_applications(

--- a/panel/tests/command/test_serve.py
+++ b/panel/tests/command/test_serve.py
@@ -31,6 +31,29 @@ def test_autoreload_app(py_file):
         assert r2.status_code == 200
         assert "<title>B</title>" in r2.content.decode('utf-8')
 
+
+@linux_only
+def test_autoreload_app_local_module(py_files):
+    py_file1, py_file2 = py_files
+    app_name = os.path.basename(py_file1.name)[:-3]
+    mod_name = os.path.basename(py_file2.name)[:-3]
+    app = f"import panel as pn; from {mod_name} import title; pn.Row('# Example').servable(title=title)"
+    write_file(app, py_file1.file)
+    write_file("title = 'A'", py_file2.file)
+
+    with run_panel_serve(["--port", "0", '--autoreload', py_file1.name]) as p:
+        port = wait_for_port(p.stdout)
+        r = requests.get(f"http://localhost:{port}/{app_name}")
+        assert r.status_code == 200
+        assert "<title>A</title>" in r.content.decode('utf-8')
+
+        write_file("title = 'B'", py_file2.file)
+
+        r2 = requests.get(f"http://localhost:{port}/{app_name}")
+        assert r2.status_code == 200
+        assert "<title>B</title>" in r2.content.decode('utf-8')
+
+
 @linux_only
 def test_serve_admin(py_file):
     app = "import panel as pn; pn.Row('# Example').servable(title='A')"

--- a/panel/tests/command/test_serve.py
+++ b/panel/tests/command/test_serve.py
@@ -1,6 +1,7 @@
 import os
 import re
 import tempfile
+import time
 
 import pytest
 import requests
@@ -48,6 +49,8 @@ def test_autoreload_app_local_module(py_files):
         assert "<title>A</title>" in r.content.decode('utf-8')
 
         write_file("title = 'B'", py_file2.file)
+        py_file2.file.close()
+        time.sleep(1)
 
         r2 = requests.get(f"http://localhost:{port}/{app_name}")
         assert r2.status_code == 200


### PR DESCRIPTION
Fixes a regression that meant that the `--autoreload`/`--dev` options did not correctly record the modules that would have to be reloaded.

Fixes https://github.com/holoviz/panel/issues/7398, Fixes https://github.com/holoviz/panel/issues/7396