### PR TITLE
Prevent tabulator from overlapping when max_height is set

### DIFF
--- a/panel/models/tabulator.ts
+++ b/panel/models/tabulator.ts
@@ -562,7 +562,7 @@ export class DataTabulatorView extends HTMLBoxView {
     this._initializing = true
     this._building = true
     const container = div({style: {display: "contents"}})
-    const el = div({style: {width: "100%", height: "100%", maxHeight: this.model.max_height ? `${this.model.max_height}px` : "100%", visibility: "hidden"}})
+    const el = div({style: {width: "100%", height: "100%", visibility: "hidden"}})
     this.container = el
     this.setCSSClasses(el)
     container.appendChild(el)
@@ -780,6 +780,9 @@ export class DataTabulatorView extends HTMLBoxView {
         return (this.model.frozen_rows.length > 0) ? this.model.frozen_rows.includes(row._row.data._index) : false
       },
       rowFormatter: (row: any) => this._render_row(row, false),
+    }
+    if (this.model.max_height != null) {
+      configuration.maxHeight = this.model.max_height
     }
     if (this.model.pagination === "remote") {
       configuration.ajaxURL = "http://panel.pyviz.org"

--- a/panel/models/tabulator.ts
+++ b/panel/models/tabulator.ts
@@ -562,7 +562,7 @@ export class DataTabulatorView extends HTMLBoxView {
     this._initializing = true
     this._building = true
     const container = div({style: {display: "contents"}})
-    const el = div({style: {width: "100%", height: "100%", visibility: "hidden"}})
+    const el = div({style: {width: "100%", height: "100%", maxHeight: this.model.max_height ? `${this.model.max_height}px` : "100%", visibility: "hidden"}})
     this.container = el
     this.setCSSClasses(el)
     container.appendChild(el)

--- a/panel/tests/ui/widgets/test_tabulator.py
+++ b/panel/tests/ui/widgets/test_tabulator.py
@@ -1159,6 +1159,17 @@ def test_tabulator_patch_no_height_resize(page):
     wait_until(lambda: page.locator('.pnx-tabulator').evaluate(at_bottom_script), page)
 
 
+def test_tabulator_max_height_not_overlap(page):
+    df = pd.DataFrame({'col': np.random.random(100)})
+    widget = Tabulator(df, max_height=200)
+
+    serve_component(page, widget)
+
+    table = page.locator('.pnx-tabulator')
+    expect(table).to_have_css('max-height', '200px')
+    assert table.bounding_box()['height'] <= 200
+
+
 @pytest.mark.parametrize(
     'pagination', ('local', 'remote', None)
 )

--- a/panel/tests/ui/widgets/test_tabulator.py
+++ b/panel/tests/ui/widgets/test_tabulator.py
@@ -1181,7 +1181,7 @@ def test_tabulator_max_height_unset(page):
     serve_component(page, widget)
 
     table = page.locator('.pnx-tabulator')
-    expect(table).not_to_have_css('max-height', '200px')
+    expect(table).to_have_css('max-height', 'none')
     assert table.bounding_box()['height'] >= 200
 
 

--- a/panel/tests/ui/widgets/test_tabulator.py
+++ b/panel/tests/ui/widgets/test_tabulator.py
@@ -1159,7 +1159,7 @@ def test_tabulator_patch_no_height_resize(page):
     wait_until(lambda: page.locator('.pnx-tabulator').evaluate(at_bottom_script), page)
 
 
-def test_tabulator_max_height_not_overlap(page):
+def test_tabulator_max_height_set(page):
     df = pd.DataFrame({'col': np.random.random(100)})
     widget = Tabulator(df, max_height=200)
 
@@ -1168,6 +1168,21 @@ def test_tabulator_max_height_not_overlap(page):
     table = page.locator('.pnx-tabulator')
     expect(table).to_have_css('max-height', '200px')
     assert table.bounding_box()['height'] <= 200
+
+
+def test_tabulator_max_height_unset(page):
+    """
+    If max_height is not set, Tabulator should not set it to null;
+    else there's some recursion issues in the console and lag
+    """
+    df = pd.DataFrame({'col': np.random.random(100)})
+    widget = Tabulator(df)
+
+    serve_component(page, widget)
+
+    table = page.locator('.pnx-tabulator')
+    expect(table).not_to_have_css('max-height', '200px')
+    assert table.bounding_box()['height'] >= 200
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Closes https://github.com/holoviz/panel/issues/7401

Before:
![image](https://github.com/user-attachments/assets/6b4098e2-d598-4d38-bb2d-cd1f25176727)

After, properly truncates

```python
import panel as pn
import pandas as pd
import numpy as np

pn.extension("tabulator")


df = pd.DataFrame(
    np.random.randn(100, 5),
)
pn.Column(pn.widgets.Tabulator(df, max_height=300), "Hello!").servable()
```
<img width="385" alt="image" src="https://github.com/user-attachments/assets/921ec03e-4958-495e-b2be-a4228bbf2c48">



```python
import panel as pn
import pandas as pd
import numpy as np

pn.extension("tabulator")


df = pd.DataFrame(
    np.random.randn(1, 5),
)
pn.Column(pn.widgets.Tabulator(df, max_height=1000), "Hello!").servable()
```

Does not use up all the space as max_height
<img width="368" alt="image" src="https://github.com/user-attachments/assets/4439fab9-6fe8-44f8-a261-35583e91d241">
