### PR TITLE
Align JSON and CodeEditor default theme with overall theme

### DIFF
--- a/examples/reference/panes/JSON.ipynb
+++ b/examples/reference/panes/JSON.ipynb
@@ -25,7 +25,7 @@
     "* **``depth``** (int): Depth to which the JSON structure is expanded on initialization (`depth=-1` indicates full expansion)\n",
     "* **``hover_preview``** (bool): Whether to enable hover preview for collapsed nodes \n",
     "* **``object``** (str or object): JSON string or JSON serializable object\n",
-    "* **``theme``** (string): Specifies the theme, either \"light\" or \"dark\". If no value is provided, it defaults to the current theme set by `pn.config.theme`, as defined in the `JSON.THEME_CONFIGURATION` dictionary.\n",
+    "* **``theme``** (string): If no value is provided, it defaults to the current theme set by pn.config.theme, as specified in the JSON.THEME_CONFIGURATION dictionary. If not defined there, it falls back to the default parameter value ('light').\n",
     "\n",
     "___"
    ]

--- a/examples/reference/panes/JSON.ipynb
+++ b/examples/reference/panes/JSON.ipynb
@@ -25,7 +25,7 @@
     "* **``depth``** (int): Depth to which the JSON structure is expanded on initialization (`depth=-1` indicates full expansion)\n",
     "* **``hover_preview``** (bool): Whether to enable hover preview for collapsed nodes \n",
     "* **``object``** (str or object): JSON string or JSON serializable object\n",
-    "* **``theme``** (string): The color scheme, one of 'light' or 'dark'\n",
+    "* **``theme``** (string): Specifies the theme, either \"light\" or \"dark\". If no value is provided, it defaults to the current theme set by `pn.config.theme`, as defined in the `JSON.THEME_CONFIGURATION` dictionary.\n",
     "\n",
     "___"
    ]

--- a/examples/reference/widgets/CodeEditor.ipynb
+++ b/examples/reference/widgets/CodeEditor.ipynb
@@ -39,7 +39,7 @@
     "* **``language``** (str): A string declaring which language to use for code syntax highlighting (default: 'text')\n",
     "* **``on_keyup``** (bool): Whether to update the value on every key press or only upon loss of focus / hotkeys.\n",
     "* **``print_margin``** (boolean): Whether to show a print margin in the editor\n",
-    "* **``theme``** (str): theme of the editor (default: 'chrome')\n",
+    "* **``theme``** (str): If no value is provided, it defaults to the current theme set by pn.config.theme, as specified in the CodeEditor.THEME_CONFIGURATION dictionary. If not defined there, it falls back to the default parameter value ('chrome').\n",
     "* **``readonly``** (boolean): Whether the editor should be opened in read-only mode\n",
     "* **``value``** (str): State of the current code in the editor if `on_keyup`. Otherwise, only upon loss of focus, i.e. clicking outside the editor, or pressing <Ctrl+Enter> or <Cmd+Enter>.\n",
     "* **``value_input``** (str): State of the current code updated on every key press. Identical to `value` if `on_keyup`.\n",

--- a/panel/pane/markup.py
+++ b/panel/pane/markup.py
@@ -508,9 +508,10 @@ class JSON(HTMLBasePane):
         Whether to display a hover preview for collapsed nodes.""")
 
     theme = param.ObjectSelector(default="light", objects=["light", "dark"], doc="""
-        Specifies the theme, either "light" or "dark". If no value is provided,
-        it defaults to the current theme set by pn.config.theme,
-        as defined in the JSON.THEME_CONFIGURATION dictionary.""")
+        If no value is provided, it defaults to the current theme
+        set by pn.config.theme, as specified in the
+        JSON.THEME_CONFIGURATION dictionary. If not defined there, it
+        falls back to the default parameter value.""")
 
     priority: ClassVar[float | bool | None] = None
 

--- a/panel/tests/pane/test_markup.py
+++ b/panel/tests/pane/test_markup.py
@@ -5,7 +5,6 @@ from unittest.mock import patch
 
 import numpy as np
 import pandas as pd
-import pytest
 
 from panel import config
 from panel.pane import (
@@ -320,13 +319,10 @@ def test_json_pane_rerenders_on_depth_change(document, comm):
     assert model.depth is None
 
 def test_json_theme():
-    # Given
-    assert JSON.param.theme.default == JSON.THEME_CONFIGURATION["default"]
-    # When
     assert JSON({"x": 1}).theme == JSON.param.theme.default
 
-@pytest.mark.parametrize("theme", ["default", "dark"])
-def test_json_theme_with_theme_config(theme):
-    with patch('panel.config._config.theme', new_callable=lambda: theme):
-        assert config.theme == theme
+    with patch('panel.config._config.theme', new_callable=lambda: "default"):
+        assert JSON({"x": 1}).theme == JSON.param.theme.default
+
+    with patch('panel.config._config.theme', new_callable=lambda: "dark"):
         assert JSON({"x": 1}).theme == JSON.THEME_CONFIGURATION[config.theme]

--- a/panel/tests/pane/test_markup.py
+++ b/panel/tests/pane/test_markup.py
@@ -320,9 +320,13 @@ def test_json_pane_rerenders_on_depth_change(document, comm):
 
 def test_json_theme():
     assert JSON({"x": 1}).theme == JSON.param.theme.default
+    assert JSON({"x": 1}, theme="dark").theme == "dark"
 
     with patch('panel.config._config.theme', new_callable=lambda: "default"):
         assert JSON({"x": 1}).theme == JSON.param.theme.default
 
     with patch('panel.config._config.theme', new_callable=lambda: "dark"):
         assert JSON({"x": 1}).theme == JSON.THEME_CONFIGURATION[config.theme]
+
+    with patch('panel.config._config.theme', new_callable=lambda: "dark"):
+        assert JSON({"x": 1}, theme="light").theme == "light"

--- a/panel/tests/pane/test_markup.py
+++ b/panel/tests/pane/test_markup.py
@@ -1,9 +1,13 @@
 import base64
 import json
 
+from unittest.mock import patch
+
 import numpy as np
 import pandas as pd
+import pytest
 
+from panel import config
 from panel.pane import (
     HTML, JSON, DataFrame, Markdown, PaneBase, Str,
 )
@@ -314,3 +318,15 @@ def test_json_pane_rerenders_on_depth_change(document, comm):
     pane.depth = -1
 
     assert model.depth is None
+
+def test_json_theme():
+    # Given
+    assert JSON.param.theme.default == JSON.THEME_CONFIGURATION["default"]
+    # When
+    assert JSON({"x": 1}).theme == JSON.param.theme.default
+
+@pytest.mark.parametrize("theme", ["default", "dark"])
+def test_json_theme_with_theme_config(theme):
+    with patch('panel.config._config.theme', new_callable=lambda: theme):
+        assert config.theme == theme
+        assert JSON({"x": 1}).theme == JSON.THEME_CONFIGURATION[config.theme]

--- a/panel/tests/widgets/test_codeeditor.py
+++ b/panel/tests/widgets/test_codeeditor.py
@@ -1,3 +1,6 @@
+from unittest.mock import patch
+
+from panel import config
 from panel.widgets import CodeEditor
 
 
@@ -23,3 +26,12 @@ def test_ace_input(document, comm):
     editor.value = ""
     assert editor.value == ""
     assert editor.value_input == ""
+
+def test_code_editor_theme():
+    assert CodeEditor(value="My theme is appropriate").theme == CodeEditor.param.theme.default
+
+    with patch('panel.config._config.theme', new_callable=lambda: "default"):
+        assert CodeEditor(value="My theme is appropriate").theme == CodeEditor.param.theme.default
+
+    with patch('panel.config._config.theme', new_callable=lambda: "dark"):
+        assert CodeEditor(value="My theme is appropriate").theme == CodeEditor.THEME_CONFIGURATION[config.theme]

--- a/panel/tests/widgets/test_codeeditor.py
+++ b/panel/tests/widgets/test_codeeditor.py
@@ -29,9 +29,13 @@ def test_ace_input(document, comm):
 
 def test_code_editor_theme():
     assert CodeEditor(value="My theme is appropriate").theme == CodeEditor.param.theme.default
+    assert CodeEditor(value="My theme is appropriate", theme="dracula").theme == "dracula"
 
     with patch('panel.config._config.theme', new_callable=lambda: "default"):
         assert CodeEditor(value="My theme is appropriate").theme == CodeEditor.param.theme.default
 
     with patch('panel.config._config.theme', new_callable=lambda: "dark"):
         assert CodeEditor(value="My theme is appropriate").theme == CodeEditor.THEME_CONFIGURATION[config.theme]
+
+    with patch('panel.config._config.theme', new_callable=lambda: "dark"):
+        assert CodeEditor(value="My theme is appropriate", theme="chrome").theme == "chrome"

--- a/panel/widgets/codeeditor.py
+++ b/panel/widgets/codeeditor.py
@@ -67,7 +67,7 @@ class CodeEditor(Widget):
 
     _rename: ClassVar[Mapping[str, str | None]] = {"value": "code", "value_input": "code_input", "name": None}
 
-    THEME_CONFIGURATION: ClassVar[dict[str,str]] = {"dark": "clouds_midnight"}
+    THEME_CONFIGURATION: ClassVar[dict[str,str]] = {"dark": "chaos"}
 
     def __init__(self, **params):
         if 'readonly' in params:

--- a/panel/widgets/codeeditor.py
+++ b/panel/widgets/codeeditor.py
@@ -11,6 +11,7 @@ import param
 
 from pyviz_comms import JupyterComm
 
+from ..config import config
 from ..models.enums import ace_themes
 from ..util import lazy_load
 from .base import Widget
@@ -20,6 +21,8 @@ if TYPE_CHECKING:
     from bokeh.model import Model
     from pyviz_comms import Comm
 
+def _get_theme(config_theme)->str:
+    return CodeEditor.THEME_CONFIGURATION.get(config_theme, CodeEditor.param.theme.default)
 
 class CodeEditor(Widget):
     """
@@ -50,7 +53,10 @@ class CodeEditor(Widget):
         Define if editor content can be modified. Alias for disabled.""")
 
     theme = param.ObjectSelector(default="chrome", objects=list(ace_themes),
-                                 doc="Theme of the editor")
+                                 doc="""If no value is provided, it defaults to the current theme
+                                 set by pn.config.theme, as specified in the
+                                 CodeEditor.THEME_CONFIGURATION dictionary. If not defined there, it
+                                 falls back to the default parameter value.""")
 
     value = param.String(default="", doc="""
         State of the current code in the editor if `on_keyup`. Otherwise, only upon loss of focus,
@@ -61,11 +67,15 @@ class CodeEditor(Widget):
 
     _rename: ClassVar[Mapping[str, str | None]] = {"value": "code", "value_input": "code_input", "name": None}
 
+    THEME_CONFIGURATION: ClassVar[dict[str,str]] = {"dark": "clouds_midnight"}
+
     def __init__(self, **params):
         if 'readonly' in params:
             params['disabled'] = params['readonly']
         elif 'disabled' in params:
             params['readonly'] = params['disabled']
+        if "theme" not in params:
+            params["theme"]=_get_theme(config.theme)
         super().__init__(**params)
         self._internal_callbacks.append(
             self.param.watch(self._update_disabled, ['disabled', 'readonly'])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -210,7 +210,7 @@ write-changes = true
 addopts = "--pyargs --doctest-ignore-import-errors --color=yes"
 norecursedirs = "doc .git dist build _build .ipynb_checkpoints panel/examples"
 asyncio_mode = "auto"
-asyncio_default_fixture_loop_scope = "function"
+# asyncio_default_fixture_loop_scope = "function"
 xfail_strict = true
 minversion = "7"
 log_cli_level = "INFO"


### PR DESCRIPTION
Closing https://github.com/holoviz/panel/issues/7394.

Looks like below

## Default

![image](https://github.com/user-attachments/assets/62e597c3-f72a-4b96-9f1e-2591f2c77dc3)

## Dark

![image](https://github.com/user-attachments/assets/1bdfc2a8-a136-4e97-8aa5-e3559b9d67e7)

## Script

You can use the below to select the appropriate dark theme for the CodeEditor.

```python
import panel as pn

pn.extension("codeeditor", sizing_mode="stretch_width")

ace_dark_themes = [
    "ambiance",
    "chaos",
    "clouds_midnight",
    "cobalt",
    "dracula",
    "gob",
    "gruvbox",
    "idle_fingers",
    "kr_theme",
    "merbivore",
    "merbivore_soft",
    "mono_industrial",
    "monokai",
    "pastel_on_dark",
    "solarized_dark",
    "terminal",
    "tomorrow_night",
    "tomorrow_night_blue",
    "tomorrow_night_bright",
    "tomorrow_night_eighties",
    "twilight",
    "vibrant_ink"
]

code="""
import panel as pn

pn.extension("codeeditor")

code_editor = pn.widgets.CodeEditor(value="abcd")

pn.template.FastListTemplate(
    sidebar=[code_editor.param.theme],
    main=[code_editor, pn.pane.JSON({"a": 1, "b": 2})]
).servable()
"""

pn.template.FastListTemplate(
    main=[pn.widgets.CodeEditor(value=code, language="python"), pn.pane.JSON({"a": 1, "b": 2}), *[pn.Column(theme, pn.widgets.CodeEditor(value=code, language="python", theme=theme)) for theme in ace_dark_themes]],
).servable()
```