### PR TITLE
Add reference to patch_tabulator

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
         exclude: \.min\.js$
       - id: trailing-whitespace
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.6.9
+    rev: v0.7.0
     hooks:
       - id: ruff
         files: panel/
@@ -47,7 +47,7 @@ repos:
       - id: oxipng
         stages: [manual]
   - repo: https://github.com/pre-commit/mirrors-eslint
-    rev: v9.12.0
+    rev: v9.13.0
     hooks:
       - id: eslint
         args: ['-c', 'panel/.eslintrc.js', 'panel/*.ts', 'panel/models/**/*.ts', '--fix']

--- a/panel/compiler.py
+++ b/panel/compiler.py
@@ -349,13 +349,14 @@ def bundle_icons(verbose=False, external=True, download_list=None):
         shutil.copyfile(icon, dest_dir / os.path.basename(icon))
 
 def patch_tabulator():
-    # https://github.com/olifolkerd/tabulator/issues/4421
     path = BUNDLE_DIR / 'datatabulator' / 'tabulator-tables@6.3.0' / 'dist' / 'js' / 'tabulator.min.js'
     text = path.read_text()
+    # https://github.com/olifolkerd/tabulator/issues/4421
     old = '"focus"!==this.options("editTriggerEvent")&&"click"!==this.options("editTriggerEvent")'
     new = '"click"!==this.options("editTriggerEvent")'
     assert text.count(old) == 1
     text = text.replace(old, new)
+    # https://github.com/olifolkerd/tabulator/pull/4598
     old = '(i=!0,this.subscribed("table-resize")?this.dispatch("table-resize"):this.redraw())'
     new = '(i=!0,this.redrawing||(this.redrawing=!0,this.subscribed("table-resize")?this.dispatch("table-resize"):this.redraw(),this.redrawing=!1))'
     assert text.count(old) == 1


### PR DESCRIPTION
This is a small follow-up to https://github.com/holoviz/panel/pull/7419. Adding the link to the patch for easier discovery in the future.

Also, I updated the pre-commit because I could. 