### PR TITLE
ci: Use Microsoft channel for pytest-playwright

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -161,7 +161,7 @@ channels = ["microsoft"]
 
 [feature.test-ui.dependencies]
 playwright = { version = "*", channel = "microsoft" }
-pytest-playwright = "*"
+pytest-playwright = { version = "*", channel = "microsoft" }
 pytest-asyncio = "*"
 jupyter_server = "*"
 esbuild = "*"


### PR DESCRIPTION
`pytest-playwright` was added to conda-forge a couple of days ago, but it does not support Windows; therefore, we still use the one provided by the Microsoft channel.

- https://github.com/conda-forge/staged-recipes/pull/27927
- https://anaconda.org/conda-forge/playwright