### PR TITLE
enh: Set Bokeh log level to info when importing dask.distributed

### DIFF
--- a/panel/command/serve.py
+++ b/panel/command/serve.py
@@ -672,6 +672,7 @@ class Serve(_BkServe):
         silence(EMPTY_LAYOUT, True)
         # dask.distributed changes the logging level of Bokeh, we will overwrite it
         # if the environment variable is not set to the default Bokeh level
+        # See https://github.com/holoviz/panel/issues/2302
         if "DASK_DISTRIBUTED__LOGGING__BOKEH" not in os.environ:
             os.environ["DASK_DISTRIBUTED__LOGGING__BOKEH"] = "info"
         args.dev = None

--- a/panel/command/serve.py
+++ b/panel/command/serve.py
@@ -670,5 +670,9 @@ class Serve(_BkServe):
         # Empty layout are valid and the Bokeh warning is silenced as usually
         # not relevant to Panel users.
         silence(EMPTY_LAYOUT, True)
+        # dask.distributed changes the logging level of Bokeh, we will overwrite it
+        # if the environment variable is not set to the default Bokeh level
+        if "DASK_DISTRIBUTED__LOGGING__BOKEH" not in os.environ:
+            os.environ["DASK_DISTRIBUTED__LOGGING__BOKEH"] = "info"
         args.dev = None
         super().invoke(args)


### PR DESCRIPTION
Fixes https://github.com/holoviz/panel/issues/2302

This should be non-intrusive (IMO). 

It is pretty annoying not getting any logging when working with holoviews + datashader. 