### PR TITLE
Tabulator: ensure markup panes wrap text in row_content

### DIFF
--- a/panel/models/tabulator.ts
+++ b/panel/models/tabulator.ts
@@ -2,6 +2,7 @@ import {display, undisplay} from "@bokehjs/core/dom"
 import {sum} from "@bokehjs/core/util/arrayable"
 import {isArray, isBoolean, isString, isNumber} from "@bokehjs/core/util/types"
 import {ModelEvent} from "@bokehjs/core/bokeh_events"
+import type {StyleSheetLike} from "@bokehjs/core/dom"
 import {div} from "@bokehjs/core/dom"
 import {Enum} from "@bokehjs/core/kinds"
 import type * as p from "@bokehjs/core/properties"
@@ -16,6 +17,8 @@ import {comm_settings} from "./comm_manager"
 import {transform_cds_to_records} from "./data"
 import {HTMLBox, HTMLBoxView} from "./layout"
 import {schedule_when} from "./util"
+
+import tabulator_css from "styles/models/tabulator.css"
 
 export class TableEditEvent extends ModelEvent {
   constructor(readonly column: string, readonly row: number, readonly pre: boolean) {
@@ -545,6 +548,10 @@ export class DataTabulatorView extends HTMLBoxView {
     }
     this.redraw(true, true)
     this.restore_scroll()
+  }
+
+  override stylesheets(): StyleSheetLike[] {
+    return [...super.stylesheets(), tabulator_css]
   }
 
   setCSSClasses(el: HTMLDivElement): void {

--- a/panel/styles/models/tabulator.less
+++ b/panel/styles/models/tabulator.less
@@ -1,0 +1,3 @@
+.tabulator-table {
+  max-width: 100%
+}

--- a/panel/styles/models/tabulator.less
+++ b/panel/styles/models/tabulator.less
@@ -1,3 +1,7 @@
 .tabulator-table {
-  max-width: 100%
+  max-width: 100%;
+
+  .tabulator-row .row-content .bk-panel-models-markup-HTML {
+    white-space: normal;
+  }
 }

--- a/panel/tests/ui/widgets/test_tabulator.py
+++ b/panel/tests/ui/widgets/test_tabulator.py
@@ -23,6 +23,7 @@ from panel.depends import bind
 from panel.io.state import state
 from panel.layout.base import Column
 from panel.models.tabulator import _TABULATOR_THEMES_MAPPING
+from panel.pane import Markdown
 from panel.tests.util import get_ctrl_modifier, serve_component, wait_until
 from panel.util import BOKEH_GE_3_6
 from panel.widgets import Select, Tabulator, TextInput
@@ -4079,3 +4080,17 @@ def test_tabulator_header_tooltips(page):
     page.wait_for_timeout(200)
 
     expect(page.locator('.tabulator-tooltip')).to_have_text("Test")
+
+
+def test_tabulator_row_content_markup_wrap(page):
+    # https://github.com/holoviz/panel/issues/7388
+
+    df = pd.DataFrame({"col": ["foo"]})
+    long_markdown = Markdown("xxxx " * 50)
+    widget = Tabulator(df, row_content=lambda row: long_markdown, expanded=[0], width=200)
+
+    serve_component(page, widget)
+
+    md = page.locator('.row-content .bk-panel-models-markup-HTML')
+
+    assert md.bounding_box()['height'] >= 130


### PR DESCRIPTION
Fixes https://github.com/holoviz/panel/issues/7388

Depends on https://github.com/holoviz/panel/pull/7425 as it's touching the newly created `tabulator.less` file in this PR.