### PR TITLE
Update conf.py to retrieve version numbers for various libraries, so they can be referred to dynamucally in various docs

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -273,6 +273,37 @@ def update_versions(app, docname, source):
         "{{VIZZU_VERSION}}" : VIZZU_VERSION,
     }
 
+def update_versions(app, docname, source):
+    from panel.models.deckgl import DECKGL_VERSION
+    from panel.models.echarts import ECHARTS_VERSION
+    from panel.models.katex import KATEX_VERSION
+    from panel.models.mathjax import MATHJAX_VERSION
+    from panel.models.plotly import PLOTLY_VERSION
+    from panel.models.pydeck import PYDECK_VERSION
+    from panel.models.pyecharts import PYECHARTS_VERSION
+    from panel.models.tabulator import TABULATOR_VERSION
+    from panel.models.vega import VEGA_VERSION
+    from panel.models.vizzu import VIZZU_VERSION
+
+    # Inspired by: https://stackoverflow.com/questions/8821511
+    version_replace = {
+        "{{PANEL_VERSION}}": PY_VERSION,
+        "{{BOKEH_VERSION}}": BOKEH_VERSION,
+        "{{PYSCRIPT_VERSION}}": PYSCRIPT_VERSION,
+        "{{PYODIDE_VERSION}}": _get_pyodide_version(),
+        "{{ALTAIR_VERSION}}": ALTAIR_VERSION,
+        "{{DECKGL_VERSION}}": DECKGL_VERSION,
+        "{{ECHARTS_VERSION}}": ECHARTS_VERSION,
+        "{{KATEX_VERSION}}": KATEX_VERSION,
+        "{{MATHJAX_VERSION}}": MATHJAX_VERSION,
+        "{{PLOTLY_VERSION}}": PLOTLY_VERSION,
+        "{{PYDECK_VERSION}}": PYDECK_VERSION,
+        "{{PYECHARTS_VERSION}}": PYECHARTS_VERSION,
+        "{{TABULATOR_VERSION}}": TABULATOR_VERSION,
+        "{{VEGA_VERSION}}": VEGA_VERSION,
+        "{{VIZZU_VERSION}}": VIZZU_VERSION,
+    }
+
     for old, new in version_replace.items():
         source[0] = source[0].replace(old, new)
 


### PR DESCRIPTION

See below PR where this was implemented for Tabulator doc.

https://github.com/holoviz/panel/pull/7053

References need to be added / updated in the   various docs for the respective libraries to dynamically show the library version numbers.