### PR TITLE
Tabulator aggregators: allow nested dict, fix data aggregation

### DIFF
--- a/examples/reference/widgets/Tabulator.ipynb
+++ b/examples/reference/widgets/Tabulator.ipynb
@@ -882,7 +882,7 @@
     "\n",
     "The `Tabulator` widget can also render a hierarchical multi-index and aggregate over specific categories. If a DataFrame with a hierarchical multi-index is supplied and the `hierarchical` is enabled the widget will group data by the categories in the order they are defined in. Additionally for each group in the multi-index an aggregator may be provided which will aggregate over the values in that category.\n",
     "\n",
-    "For example we may load population data for locations around the world broken down by sex and age-group. If we specify aggregators over the 'AgeGrp' and 'Sex' indexes we can see the aggregated values for each of those groups (note that we do not have to specify an aggregator for the outer index since we specify the aggregators over the subgroups in this case the 'Sex'):"
+    "For example we may load population data for locations around the world for years 2000 and 2020, broken down by sex and age-group. If we specify aggregators over the 'AgeGrp' and 'Sex' indexes we can see the aggregated values for each of those groups (note that if no aggregators specified to an index level, it will be aggregated by the default method of `sum`):"
    ]
   },
   {
@@ -893,9 +893,29 @@
    "source": [
     "from bokeh.sampledata.population import data as population_data \n",
     "\n",
-    "pop_df = population_data[population_data.Year == 2020].set_index(['Location', 'AgeGrp', 'Sex'])[['Value']]\n",
+    "pop_df = population_data[population_data.Year.isin([2000, 2020])]\n",
     "\n",
-    "pn.widgets.Tabulator(value=pop_df, hierarchical=True, aggregators={'Sex': 'sum', 'AgeGrp': 'sum'}, height=200)"
+    "pop_df = pop_df.pivot_table(index=[\"Location\", \"AgeGrp\", \"Sex\"], columns=\"Year\", values=\"Value\")[[2000, 2020]].dropna()\n",
+    "\n",
+    "pn.widgets.Tabulator(value=pop_df, hierarchical=True, aggregators={'AgeGrp': 'mean'}, height=200)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Separate aggregators for different columns are also supported. You can specify the `aggregators` as a nested dictionary as `{index_name: {column_name: aggregator}}`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nested_aggs = {'AgeGrp': {2000: \"max\", 2020: \"min\"}, \"Sex\": \"mean\", \"Location\": \"mean\"}\n",
+    "\n",
+    "pn.widgets.Tabulator(value=pop_df, hierarchical=True, aggregators=nested_aggs, height=200)"
    ]
   },
   {

--- a/examples/reference/widgets/Tabulator.ipynb
+++ b/examples/reference/widgets/Tabulator.ipynb
@@ -882,7 +882,7 @@
     "\n",
     "The `Tabulator` widget can also render a hierarchical multi-index and aggregate over specific categories. If a DataFrame with a hierarchical multi-index is supplied and the `hierarchical` is enabled the widget will group data by the categories in the order they are defined in. Additionally for each group in the multi-index an aggregator may be provided which will aggregate over the values in that category.\n",
     "\n",
-    "For example we may load the Automobile Mileage dataset for various car models from the 1970s and 1980s around the world, broken down by regions, model years and manufacturers. The dataset includes details on car characteristics and performance metrics, making it ideal for exploring trends in automobile efficiency and performance during this period. If we specify aggregators over the 'origin' (Region) and 'yr' (Model Year) index, we can see the aggregated values for each of those groups (note that if no aggregators specified to an outer index level, it will be aggregated by the default method of `sum`):"
+    "We will use the Automobile Mileage dataset for various car models from the 1970s and 1980s around the world, broken down by regions, model years and manufacturers. The dataset includes details on car characteristics and performance metrics."
    ]
   },
   {
@@ -894,7 +894,22 @@
     "from bokeh.sampledata.autompg import autompg_clean as autompg_df\n",
     "\n",
     "autompg_df = autompg_df.set_index([\"origin\", \"yr\", \"mfr\"])\n",
-    "\n",
+    "autompg_df.head(3)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If we specify aggregators over the 'origin' (region) and 'yr' (model year) indexes, we can see the aggregated values for each of those groups. Note that if no aggregators are specified to an outer index level, it will be aggregated with the default method of `sum`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "pn.widgets.Tabulator(value=autompg_df, hierarchical=True, aggregators={\"origin\": \"mean\", \"yr\": \"mean\"}, height=200)"
    ]
   },
@@ -904,9 +919,7 @@
    "source": [
     "Separate aggregators for different columns are also supported. You can specify the `aggregators` as a nested dictionary as `{index_name: {column_name: aggregator}}`\n",
     "\n",
-    "Applied to the Automobile Mileage dataset we just loaded, we can do different aggregations for different columns:\n",
-    "- mpg: Average fuel economy, a meaningful metric to evaluate fuel efficiency within groups.\n",
-    "- hp: Maximum horsepower to find the most powerful cars within each subgroup."
+    "Applied to the same dataset, we can aggregate the data in the `mpg` (miles per galon) and `hp` columns differently, with `mean` and `max`, respectively."
    ]
   },
   {
@@ -916,7 +929,6 @@
    "outputs": [],
    "source": [
     "nested_aggs = {\"origin\": {\"mpg\": \"mean\", \"hp\": \"max\"}, \"yr\": {\"mpg\": \"mean\", \"hp\": \"max\"}}\n",
-    "\n",
     "pn.widgets.Tabulator(value=autompg_df[[\"mpg\", \"hp\"]], hierarchical=True, aggregators=nested_aggs, height=200)"
    ]
   },

--- a/examples/reference/widgets/Tabulator.ipynb
+++ b/examples/reference/widgets/Tabulator.ipynb
@@ -882,7 +882,7 @@
     "\n",
     "The `Tabulator` widget can also render a hierarchical multi-index and aggregate over specific categories. If a DataFrame with a hierarchical multi-index is supplied and the `hierarchical` is enabled the widget will group data by the categories in the order they are defined in. Additionally for each group in the multi-index an aggregator may be provided which will aggregate over the values in that category.\n",
     "\n",
-    "For example we may load population data for locations around the world for years 2000 and 2020, broken down by sex and age-group. If we specify aggregators over the 'AgeGrp' and 'Sex' indexes we can see the aggregated values for each of those groups (note that if no aggregators specified to an index level, it will be aggregated by the default method of `sum`):"
+    "For example we may load the Automobile Mileage dataset for various car models from the 1970s and 1980s around the world, broken down by regions, model years and manufacturers. The dataset includes details on car characteristics and performance metrics, making it ideal for exploring trends in automobile efficiency and performance during this period. If we specify aggregators over the 'origin' (Region) and 'yr' (Model Year) index, we can see the aggregated values for each of those groups (note that if no aggregators specified to an outer index level, it will be aggregated by the default method of `sum`):"
    ]
   },
   {
@@ -891,20 +891,22 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from bokeh.sampledata.population import data as population_data \n",
+    "from bokeh.sampledata.autompg import autompg_clean as autompg_df\n",
     "\n",
-    "pop_df = population_data[population_data.Year.isin([2000, 2020])]\n",
+    "df = autompg_df.set_index([\"origin\", \"yr\", \"mfr\"])\n",
     "\n",
-    "pop_df = pop_df.pivot_table(index=[\"Location\", \"AgeGrp\", \"Sex\"], columns=\"Year\", values=\"Value\")[[2000, 2020]].dropna()\n",
-    "\n",
-    "pn.widgets.Tabulator(value=pop_df, hierarchical=True, aggregators={'AgeGrp': 'mean'}, height=200)"
+    "pn.widgets.Tabulator(value=df, hierarchical=True, aggregators={\"origin\": \"mean\", \"yr\": \"mean\"}, height=200)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Separate aggregators for different columns are also supported. You can specify the `aggregators` as a nested dictionary as `{index_name: {column_name: aggregator}}`"
+    "Separate aggregators for different columns are also supported. You can specify the `aggregators` as a nested dictionary as `{index_name: {column_name: aggregator}}`\n",
+    "\n",
+    "Applied to the Automobile Mileage dataset we just loaded, we can do different aggregations for different columns:\n",
+    "- mpg: Average fuel economy, a meaningful metric to evaluate fuel efficiency within groups.\n",
+    "- hp: Maximum horsepower to find the most powerful cars within each subgroup."
    ]
   },
   {
@@ -913,9 +915,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "nested_aggs = {'AgeGrp': {2000: \"max\", 2020: \"min\"}, \"Sex\": \"mean\", \"Location\": \"mean\"}\n",
+    "nested_aggs = {\"origin\": {\"mpg\": \"mean\", \"hp\": \"max\"}, \"yr\": {\"mpg\": \"mean\", \"hp\": \"max\"}}\n",
     "\n",
-    "pn.widgets.Tabulator(value=pop_df, hierarchical=True, aggregators=nested_aggs, height=200)"
+    "pn.widgets.Tabulator(value=df[[\"mpg\", \"hp\"]], hierarchical=True, aggregators=nested_aggs, height=200)"
    ]
   },
   {

--- a/examples/reference/widgets/Tabulator.ipynb
+++ b/examples/reference/widgets/Tabulator.ipynb
@@ -893,9 +893,9 @@
    "source": [
     "from bokeh.sampledata.autompg import autompg_clean as autompg_df\n",
     "\n",
-    "df = autompg_df.set_index([\"origin\", \"yr\", \"mfr\"])\n",
+    "autompg_df = autompg_df.set_index([\"origin\", \"yr\", \"mfr\"])\n",
     "\n",
-    "pn.widgets.Tabulator(value=df, hierarchical=True, aggregators={\"origin\": \"mean\", \"yr\": \"mean\"}, height=200)"
+    "pn.widgets.Tabulator(value=autompg_df, hierarchical=True, aggregators={\"origin\": \"mean\", \"yr\": \"mean\"}, height=200)"
    ]
   },
   {
@@ -917,7 +917,7 @@
    "source": [
     "nested_aggs = {\"origin\": {\"mpg\": \"mean\", \"hp\": \"max\"}, \"yr\": {\"mpg\": \"mean\", \"hp\": \"max\"}}\n",
     "\n",
-    "pn.widgets.Tabulator(value=df[[\"mpg\", \"hp\"]], hierarchical=True, aggregators=nested_aggs, height=200)"
+    "pn.widgets.Tabulator(value=autompg_df[[\"mpg\", \"hp\"]], hierarchical=True, aggregators=nested_aggs, height=200)"
    ]
   },
   {

--- a/panel/models/tabulator.py
+++ b/panel/models/tabulator.py
@@ -4,8 +4,8 @@ Implementation of the Tabulator model.
 See http://tabulator.info/
 """
 from bokeh.core.properties import (
-    Any, Bool, Dict, Either, Enum, Float, Instance, Int, List, Nullable,
-    String, Tuple,
+    Any, Bool, Dict, Either, Enum, Instance, Int, List, Nullable, String,
+    Tuple,
 )
 from bokeh.events import ModelEvent
 from bokeh.models import ColumnDataSource, LayoutDOM
@@ -113,7 +113,7 @@ class DataTabulator(HTMLBox):
     See http://tabulator.info/
     """
 
-    aggregators = Dict(Either(String, Int, Float), Either(String, Dict(Either(String, Int, Float), String)))
+    aggregators = Dict(Either(String, Int), Either(String, Dict(Either(String, Int), String)))
 
     buttons = Dict(String, String)
 

--- a/panel/models/tabulator.py
+++ b/panel/models/tabulator.py
@@ -113,7 +113,7 @@ class DataTabulator(HTMLBox):
     See http://tabulator.info/
     """
 
-    aggregators = Dict(String, String)
+    aggregators = Dict(String, Any)
 
     buttons = Dict(String, String)
 

--- a/panel/models/tabulator.py
+++ b/panel/models/tabulator.py
@@ -113,7 +113,7 @@ class DataTabulator(HTMLBox):
     See http://tabulator.info/
     """
 
-    aggregators = Dict(String, Any)
+    aggregators = Dict(String, Either(String, Dict(String, String)))
 
     buttons = Dict(String, String)
 

--- a/panel/models/tabulator.py
+++ b/panel/models/tabulator.py
@@ -4,8 +4,8 @@ Implementation of the Tabulator model.
 See http://tabulator.info/
 """
 from bokeh.core.properties import (
-    Any, Bool, Dict, Either, Enum, Instance, Int, List, Nullable, String,
-    Tuple,
+    Any, Bool, Dict, Either, Enum, Float, Instance, Int, List, Nullable,
+    String, Tuple,
 )
 from bokeh.events import ModelEvent
 from bokeh.models import ColumnDataSource, LayoutDOM
@@ -113,7 +113,7 @@ class DataTabulator(HTMLBox):
     See http://tabulator.info/
     """
 
-    aggregators = Dict(String, Either(String, Dict(String, String)))
+    aggregators = Dict(Either(String, Int, Float), Either(String, Dict(Either(String, Int, Float), String)))
 
     buttons = Dict(String, String)
 

--- a/panel/models/tabulator.ts
+++ b/panel/models/tabulator.ts
@@ -84,25 +84,43 @@ function summarize(grouped: any[], columns: any[], aggregators: string[]): any {
       if (isArray(subsummary[col])) {
         group[col] = sum(subsummary[col] as number[]) / subsummary[col].length
       } else {
-        group[col] = subsummary[col]
+        if (col in aggregators) {
+          group[col] = subsummary[col]
+        }
+        else {
+          group[col] = NaN
+        }
       }
     }
     for (const column of columns.slice(1)) {
       const val = group[column.field]
       const agg = aggregators[column.field]
+
       if (column.field in summary) {
-        const old_val = summary[column.field]
+        const old_val = summary[column.field];
+        // Apply aggregation based on type
         if (agg === "min") {
-          summary[column.field] = Math.min(val, old_val)
-        } else if (agg === "max") {
-          summary[column.field] = Math.max(val, old_val)
-        } else if (agg === "sum") {
-          summary[column.field] = val + old_val
-        } else if (agg === "mean") {
-          if (isArray(summary[column.field])) {
-            summary[column.field].push(val)
+          if (val instanceof Date && old_val instanceof Date) {
+            summary[column.field] = new Date(Math.min(val.getTime(), old_val.getTime()));
           } else {
-            summary[column.field] = [old_val, val]
+            summary[column.field] = val < old_val ? val : old_val;
+          }
+        } else if (agg === "max") {
+          if (val instanceof Date && old_val instanceof Date) {
+            summary[column.field] = new Date(Math.max(val.getTime(), old_val.getTime()));
+          } else {
+            summary[column.field] = val > old_val ? val : old_val;
+          }
+        } else if (agg === "sum") {
+          if (typeof val === "boolean" && typeof old_val === "boolean") {
+            summary[column.field] = (val ? 1 : 0) + (old_val ? 1 : 0);
+          } else if (typeof val === "number" && typeof old_val === "number") {
+            summary[column.field] = val + old_val;
+        } else if (agg === "mean") {
+          if (Array.isArray(summary[column.field])) {
+            summary[column.field].push(val);
+          } else {
+            summary[column.field] = [old_val, val];
           }
         }
       } else {

--- a/panel/models/tabulator.ts
+++ b/panel/models/tabulator.ts
@@ -84,12 +84,7 @@ function summarize(grouped: any[], columns: any[], aggregators: string[]): any {
       if (isArray(subsummary[col])) {
         group[col] = sum(subsummary[col] as number[]) / subsummary[col].length
       } else {
-        if (col in aggregators) {
-          group[col] = subsummary[col]
-        }
-        else {
-          group[col] = NaN
-        }
+        group[col] = subsummary[col]
       }
     }
     for (const column of columns.slice(1)) {
@@ -98,23 +93,11 @@ function summarize(grouped: any[], columns: any[], aggregators: string[]): any {
 
       if (column.field in summary) {
         const old_val = summary[column.field];
-        // Apply aggregation based on type
         if (agg === "min") {
-          if (val instanceof Date && old_val instanceof Date) {
-            summary[column.field] = new Date(Math.min(val.getTime(), old_val.getTime()));
-          } else {
-            summary[column.field] = val < old_val ? val : old_val;
-          }
+            summary[column.field] = (val < old_val) ? val : old_val;
         } else if (agg === "max") {
-          if (val instanceof Date && old_val instanceof Date) {
-            summary[column.field] = new Date(Math.max(val.getTime(), old_val.getTime()));
-          } else {
-            summary[column.field] = val > old_val ? val : old_val;
-          }
+            summary[column.field] = (val > old_val) ? val : old_val;
         } else if (agg === "sum") {
-          if (typeof val === "boolean" && typeof old_val === "boolean") {
-            summary[column.field] = (val ? 1 : 0) + (old_val ? 1 : 0);
-          } else if (typeof val === "number" && typeof old_val === "number") {
             summary[column.field] = val + old_val;
         } else if (agg === "mean") {
           if (Array.isArray(summary[column.field])) {

--- a/panel/models/tabulator.ts
+++ b/panel/models/tabulator.ts
@@ -101,7 +101,7 @@ function summarize(grouped: any[], columns: any[], aggregators: any[], depth: nu
       if (typeof aggs === "string") {
         agg = aggs
       } else if (column.field in aggs) {
-          agg = aggs[column.field]
+        agg = aggs[column.field]
       }
       const val = group[column.field]
       if (column.field in summary) {

--- a/panel/models/tabulator.ts
+++ b/panel/models/tabulator.ts
@@ -78,7 +78,7 @@ function summarize(grouped: any[], columns: any[], aggregators: any[], depth: nu
   if (grouped.length == 0) {
     return summary
   }
-  // depth level 0 is leaves, do not aggregate data over this level
+  // depth level 0 is the root, finish here
   let aggs = ""
   if (depth > 0) {
     aggs = aggregators[depth-1]
@@ -159,6 +159,7 @@ function group_data(records: any[], columns: any[], indexes: string[], aggregato
   for (const index of indexes) {
     if (index in aggregators) {
       if (aggregators[index] instanceof Map) {
+        // when some column names are numeric, need to convert that from a Map to an Object
         aggs.push(Object.fromEntries(aggregators[index]))
       } else {
         aggs.push(aggregators[index])

--- a/panel/models/tabulator.ts
+++ b/panel/models/tabulator.ts
@@ -100,10 +100,8 @@ function summarize(grouped: any[], columns: any[], aggregators: any[], depth: nu
       let agg: string = ""
       if (typeof aggs === "string") {
         agg = aggs
-      } else {
-        if (column.field in aggs) {
+      } else if (column.field in aggs) {
           agg = aggs[column.field]
-        }
       }
       const val = group[column.field]
       if (column.field in summary) {

--- a/panel/models/tabulator.ts
+++ b/panel/models/tabulator.ts
@@ -73,13 +73,13 @@ function find_group(key: any, value: string, records: any[]): any {
   return null
 }
 
-function summarize(grouped: any[], columns: any[], aggregators: string[], depth: number = 0): any {
+function summarize(grouped: any[], columns: any[], aggregators: string[]): any {
   const summary: any = {}
   if (grouped.length == 0) {
     return summary
   }
   for (const group of grouped) {
-    const subsummary = summarize(group._children, columns, aggregators, depth+1)
+    const subsummary = summarize(group._children, columns, aggregators)
     for (const col in subsummary) {
       if (isArray(subsummary[col])) {
         group[col] = sum(subsummary[col] as number[]) / subsummary[col].length

--- a/panel/models/tabulator.ts
+++ b/panel/models/tabulator.ts
@@ -159,7 +159,15 @@ function group_data(records: any[], columns: any[], indexes: string[], aggregato
   }
   const aggs = []
   for (const index of indexes) {
-    aggs.push((index in aggregators) ? aggregators[index] : "sum")
+    if (index in aggregators) {
+      if (aggregators[index] instanceof Map) {
+        aggs.push(Object.fromEntries(aggregators[index]))
+      } else {
+        aggs.push(aggregators[index])
+      }
+    } else {
+      aggs.push("sum")
+    }
   }
   summarize(grouped, columns, aggs)
   return grouped

--- a/panel/models/tabulator.ts
+++ b/panel/models/tabulator.ts
@@ -92,18 +92,18 @@ function summarize(grouped: any[], columns: any[], aggregators: string[]): any {
       const agg = aggregators[column.field]
 
       if (column.field in summary) {
-        const old_val = summary[column.field];
+        const old_val = summary[column.field]
         if (agg === "min") {
-            summary[column.field] = (val < old_val) ? val : old_val;
+          summary[column.field] = (val < old_val) ? val : old_val
         } else if (agg === "max") {
-            summary[column.field] = (val > old_val) ? val : old_val;
+          summary[column.field] = (val > old_val) ? val : old_val
         } else if (agg === "sum") {
-            summary[column.field] = val + old_val;
+          summary[column.field] = val + old_val
         } else if (agg === "mean") {
           if (Array.isArray(summary[column.field])) {
-            summary[column.field].push(val);
+            summary[column.field].push(val)
           } else {
-            summary[column.field] = [old_val, val];
+            summary[column.field] = [old_val, val]
           }
         }
       } else {

--- a/panel/models/tabulator.ts
+++ b/panel/models/tabulator.ts
@@ -73,7 +73,7 @@ function find_group(key: any, value: string, records: any[]): any {
   return null
 }
 
-function summarize(grouped: any[], columns: any[], aggregators: any, depth: number = 0): any {
+function summarize(grouped: any[], columns: any[], aggregators: any[], depth: number = 0): any {
   const summary: any = {}
   if (grouped.length == 0) {
     return summary
@@ -115,7 +115,7 @@ function summarize(grouped: any[], columns: any[], aggregators: any, depth: numb
         } else if (agg === "sum") {
           summary[column.field] = val + old_val
         } else if (agg === "mean") {
-          if (Array.isArray(summary[column.field])) {
+          if (isArray(summary[column.field])) {
             summary[column.field].push(val)
           } else {
             summary[column.field] = [old_val, val]
@@ -158,7 +158,7 @@ function group_data(records: any[], columns: any[], indexes: string[], aggregato
     }
   }
   const aggs = []
-  for (const index of indexes.slice()) {
+  for (const index of indexes) {
     aggs.push((index in aggregators) ? aggregators[index] : "sum")
   }
   summarize(grouped, columns, aggs)

--- a/panel/tests/ui/widgets/test_tabulator.py
+++ b/panel/tests/ui/widgets/test_tabulator.py
@@ -4099,54 +4099,26 @@ def test_tabulator_row_content_markup_wrap(page):
 @pytest.fixture(scope='session')
 def df_agg():
     data = {
-        "employee_id": range(101, 111),
-        "name": [
-            "Alice", "Bob", "Charlie", "David", "Eve",
-            "Frank", "Grace", "Heidi", "Ivan", "Judy"
-        ],
-        "gender": [
-            "Female", "Male", "Male", "Male", "Female",
-            "Male", "Female", "Female", "Male", "Female"
-        ],
-        "salary": [
-            75000.0, 82000.5, np.nan, 64000.0, 91000.0,
-            54000.0, 67000.5, 71000.0, 95000.0, 78000.5
-        ],
+        "employee_id": range(1, 6),
+        "name": ["Charlie", "Bob", "Alice", "David", "Eve"],
+        "gender": ["Male", "Male", "Female", "Male", "Female"],
+        "salary": [75000.0, 82000.5, np.nan, 64000.0, 91000.0],
+        "region": ["East", "North", "North", "North", "North"],
+        "active": [True, False, True, np.nan, True],
+        "department": ["HR", "IT", "HR", "Finance", "HR"],
         "days_off_used": [
-            [2, 1, 3, 0],  # Alice's days off in the last 4 months
+            [3, 2, 1, 1],  # Charlie's days off in the last 4 months
             [1, 0, 2, 2],  # Bob's days off
-            [3, 2, 1, 1],  # Charlie's days off
+            [2, 1, 3, 0],  # Alice's days off
             [0, 1, 0, 0],  # Diana's days off
-            [1, 1, 2, 1],  # Evan's days off
-            [4, 3, 3, 4],  # Fay's days off
-            [2, 1, 1, 1],  # George's days off
-            [0, 0, 1, 2],  # Hana's days off
-            [3, 2, 2, 2],  # Ivy's days off
             [1, 1, 0, 1]  # Jack's days off
         ],
-        "active": [
-            True, False, True, np.nan, True,
-            True, False, True, True, False
-        ],
-        "department": [
-            "HR", "IT", "HR", "Finance", "HR",
-            "Finance", "IT", "HR", "Finance", "IT"
-        ],
         "date_joined": [
-            dt.datetime(2020, 1, 10),  # Alice
-            dt.datetime(2019, 3, 15),  # Bob
             np.nan,  # Charlie
+            dt.datetime(2019, 3, 15),  # Bob
+            dt.datetime(2020, 1, 10),  # Alice
             dt.datetime(2021, 5, 20),  # David
             dt.datetime(2022, 7, 30),  # Eve
-            dt.datetime(2020, 8, 25),  # Frank
-            dt.datetime(2021, 2, 10),  # Grace
-            dt.datetime(2023, 11, 5),  # Heidi
-            dt.datetime(2020, 12, 1),  # Ivan
-            dt.datetime(2021, 4, 22),  # Judy
-        ],
-        "region": [
-            "East", "West", "North", "West", "North",
-            "North", "West", "North", "North", "South"
         ],
     }
     # Create DataFrame
@@ -4157,40 +4129,41 @@ def df_agg():
         'active': 'bool',
         'department': 'string',
         'date_joined': 'datetime64[ns]',
-    }).set_index(["region", "employee_id"])
+    })
     return df
 
 
-@pytest.fixture(scope='session')
-def nested_aggregators():
-    return {
-        'region': {
-            'name': 'min',
-            'gender': 'min',
-            'salary': 'sum',
-            'department': 'max',
-            'date_joined': 'max',
-        }
-    }
-
-
-@pytest.fixture(scope='session')
-def flat_aggregators():
-    return {
-        'name': 'min',
-        'gender': 'min',
-        'salary': 'sum',
-        'department': 'max',
-        'date_joined': 'max',
-    }
-
-
-def test_tabulator_flat_aggregators(page, df_agg, flat_aggregators):
-    widget = Tabulator(df_agg, hierarchical=True, aggregators=flat_aggregators)
+@pytest.mark.parametrize("aggs", [{'salary': 'mean'}, {'region': {'salary': 'mean'}}])
+def test_tabulator_aggregators(page, df_agg, aggs):
+    widget = Tabulator(df_agg.set_index(["region", "employee_id"]), hierarchical=True, aggregators=aggs)
     serve_component(page, widget)
 
 
-def test_tabulator_flat_aggregators_group_data(page, df_agg, flat_aggregators):
-    widget = Tabulator(df_agg, hierarchical=True, aggregators=flat_aggregators)
+@pytest.mark.parametrize("aggs", [{'salary': 'mean'}, {'region': {'salary': 'mean'}}])
+def test_tabulator_aggregators_data_grouping(page, df_agg, aggs):
+    widget = Tabulator(df_agg.set_index(["region", "employee_id"]), hierarchical=True, aggregators=aggs)
     serve_component(page, widget)
-    expect(page.locator('.tabulator-data-tree-control-expand')).to_have_count(4)
+
+    expanded_groups = page.locator('.tabulator-tree-level-0 .tabulator-data-tree-control-collapse')
+    collapsed_groups = page.locator('.tabulator-tree-level-0 .tabulator-data-tree-control-expand')
+    expect(collapsed_groups).to_have_count(2)
+    expect(expanded_groups).to_have_count(0)
+    group_east = collapsed_groups.nth(0)
+    group_north = collapsed_groups.nth(1)
+
+    # expand first group and see the data there
+    group_east.click()
+    expect(collapsed_groups).to_have_count(1)
+    expect(expanded_groups).to_have_count(1)
+    expanded_group_members = page.locator(".tabulator-tree-level-1")
+    expect(expanded_group_members).to_have_count(1)
+    expect(expanded_group_members).to_contain_text("Charlie")
+
+    # collapse 1st group and expand 2nd group and see the data there
+    expanded_groups.click()
+    group_north.click()
+    expect(expanded_group_members).to_have_count(4)
+    expect(expanded_group_members.nth(0)).to_contain_text("Bob")
+    expect(expanded_group_members.nth(1)).to_contain_text("Alice")
+    expect(expanded_group_members.nth(2)).to_contain_text("David")
+    expect(expanded_group_members.nth(3)).to_contain_text("Eve")

--- a/panel/tests/ui/widgets/test_tabulator.py
+++ b/panel/tests/ui/widgets/test_tabulator.py
@@ -4167,3 +4167,20 @@ def test_tabulator_aggregators_data_grouping(page, df_agg, aggs):
     expect(expanded_group_members.nth(1)).to_contain_text("Alice")
     expect(expanded_group_members.nth(2)).to_contain_text("David")
     expect(expanded_group_members.nth(3)).to_contain_text("Eve")
+
+
+def test_tabulator_aggregators_numeric_data_aggregation(page, df_agg):
+    # TODO: parametrize agg_method and column
+    agg_method, column = "sum", "salary"
+    aggs = {column: agg_method}
+    widget = Tabulator(df_agg.set_index(["region", "employee_id"]), hierarchical=True, aggregators=aggs)
+    serve_component(page, widget)
+
+    column_titles = page.locator('.tabulator-col-title')
+    column_index = 3  # salary column is the 4th column displayed in the table (1st is not displayed)
+    expect(column_titles.nth(column_index + 1)).to_have_text("salary")
+    rows = page.locator('.tabulator-row')
+    expect(rows).to_have_count(2)
+    assert rows.nth(0).inner_text().split("\n")[column_index] == "75,000.0"
+    # sum with a NaN value
+    assert rows.nth(1).inner_text().split("\n")[column_index] == "-"

--- a/panel/tests/ui/widgets/test_tabulator.py
+++ b/panel/tests/ui/widgets/test_tabulator.py
@@ -4245,13 +4245,26 @@ def test_tabulator_aggregators_flat_data_aggregation(page, df_agg):
         "region2": rows.nth(1).inner_text().split("\n"),
     }
     region_agged = {
-        "region1": {
-            "salary": agged["region1"][col_mapping["salary"] - 1],
-            "date_joined": agged["region1"][col_mapping["date_joined"] - 1],
-        },
-        "region2": {
-            "salary": agged["region2"][col_mapping["salary"] - 1],
-            "date_joined": agged["region2"][col_mapping["date_joined"] - 1],
-        },
+        region: {col: agged[region][col_mapping[col] - 1] for col in col_mapping} for region in agged
     }
     assert region_agged == expected_results["region"]
+
+    regions = page.locator('.tabulator-tree-level-0 .tabulator-data-tree-control-expand')
+    # expand all region groups and see the data there
+    regions.nth(0).click()
+    regions.nth(0).click()
+    rows = page.locator(".tabulator-row.tabulator-tree-level-1")
+    expect(rows).to_have_count(3)
+    # gender level
+    agged = {
+        "region1": {"Male": rows.nth(0).inner_text().split("\n")},
+        "region2": {
+            "Male": rows.nth(1).inner_text().split("\n"),
+            "Female": rows.nth(2).inner_text().split("\n"),
+        },
+    }
+    gender_agged = {
+        region: {
+            gender: {col: agged[region][gender][col_mapping[col] - 1] for col in col_mapping} for gender in agged[region]} for region in agged
+    }
+    assert gender_agged == expected_results["gender"]

--- a/panel/tests/ui/widgets/test_tabulator.py
+++ b/panel/tests/ui/widgets/test_tabulator.py
@@ -4121,38 +4121,7 @@ def df_agg_int_column_names(df_agg):
 
 
 @pytest.mark.parametrize("df", ["df_agg", "df_agg_int_column_names"])
-def test_tabulator_2level_hierarchical_data_grouping(page, df, request):
-    df_agg = request.getfixturevalue(df)
-    widget = Tabulator(df_agg.set_index(["region", "employee_id"]), hierarchical=True)
-    serve_component(page, widget)
-
-    expanded_groups = page.locator('.tabulator-tree-level-0 .tabulator-data-tree-control-collapse')
-    collapsed_groups = page.locator('.tabulator-tree-level-0 .tabulator-data-tree-control-expand')
-    expect(collapsed_groups).to_have_count(2)
-    expect(expanded_groups).to_have_count(0)
-    group_east = collapsed_groups.nth(0)
-    group_north = collapsed_groups.nth(1)
-
-    # expand first group and see the data there
-    group_east.click()
-    expect(collapsed_groups).to_have_count(1)
-    expect(expanded_groups).to_have_count(1)
-    expanded_group_members = page.locator(".tabulator-tree-level-1")
-    expect(expanded_group_members).to_have_count(1)
-    expect(expanded_group_members).to_contain_text("Charlie")
-
-    # collapse 1st group and expand 2nd group and see the data there
-    expanded_groups.click()
-    group_north.click()
-    expect(expanded_group_members).to_have_count(4)
-    expect(expanded_group_members.nth(0)).to_contain_text("Bob")
-    expect(expanded_group_members.nth(1)).to_contain_text("Alice")
-    expect(expanded_group_members.nth(2)).to_contain_text("David")
-    expect(expanded_group_members.nth(3)).to_contain_text("Eve")
-
-
-@pytest.mark.parametrize("df", ["df_agg", "df_agg_int_column_names"])
-def test_tabulator_3level_hierarchical_data_grouping(page, df, request):
+def test_tabulator_hierarchical_data_grouping(page, df, request):
     df_agg = request.getfixturevalue(df)
     widget = Tabulator(df_agg.set_index(["region", "gender", "employee_id"]), hierarchical=True)
     serve_component(page, widget)

--- a/panel/tests/ui/widgets/test_tabulator.py
+++ b/panel/tests/ui/widgets/test_tabulator.py
@@ -4111,19 +4111,8 @@ def df_agg():
             dt.datetime(2021, 5, 20),  # David
             dt.datetime(2022, 7, 30),  # Eve
         ],
-        # "active": [True, False, True, np.nan, True],
-        # "department": ["HR", "IT", "HR", "Finance", "HR"],
-        # "days_off_used": [
-        #     [3, 2, 1, 1],  # Charlie's days off in the last 4 months
-        #     [1, 0, 2, 2],  # Bob's days off
-        #     [2, 1, 3, 0],  # Alice's days off
-        #     [0, 1, 0, 0],  # David's days off
-        #     [1, 1, 0, 1]  # Eve's days off
-        # ],
     }
-    # Create DataFrame
-    df = pd.DataFrame(data)
-    return df
+    return pd.DataFrame(data)
 
 
 @pytest.fixture(scope='session')
@@ -4210,12 +4199,6 @@ def test_tabulator_3level_hierarchical_data_grouping(page, df, request):
     expect(employees).to_have_count(2)
     expect(employees.nth(0)).to_contain_text("Alice")
     expect(employees.nth(1)).to_contain_text("Eve")
-
-
-@pytest.mark.parametrize("aggs", [{}, {"gender": "sum"}, {"region": "mean", "gender": {"salary": "min"}}])
-def test_tabulator_aggregators(page, df_agg, aggs):
-    widget = Tabulator(df_agg.set_index(["region", "gender", "employee_id"]), hierarchical=True, aggregators=aggs)
-    serve_component(page, widget)
 
 
 @pytest.mark.parametrize("aggs", [

--- a/panel/tests/ui/widgets/test_tabulator.py
+++ b/panel/tests/ui/widgets/test_tabulator.py
@@ -4209,9 +4209,14 @@ def test_tabulator_aggregators(page, df_agg, aggs):
     serve_component(page, widget)
 
 
-def test_tabulator_aggregators_flat_data_aggregation(page, df_agg):
+@pytest.mark.parametrize("aggs", [
+    {"region": "min", "gender": "max"},
+    {"region": "min", "gender": {"salary": "max", "date_joined": "max"}},
+    {"region": {"salary": "min", "date_joined": "min"}, "gender": {"salary": "max", "date_joined": "max"}},
+    {"region": {"salary": "min", "date_joined": "min"}, "gender": "max"},
+])
+def test_tabulator_aggregators_data_aggregation(page, df_agg, aggs):
     # TODO: parametrize agg_method, index level and column
-    aggs = {"region": "min", "gender": "max"}
     widget = Tabulator(df_agg.set_index(["region", "gender", "employee_id"]), hierarchical=True, aggregators=aggs)
     serve_component(page, widget)
 

--- a/panel/widgets/tables.py
+++ b/panel/widgets/tables.py
@@ -1272,69 +1272,6 @@ class Tabulator(BaseTable):
             self.style._todo = style._todo
         self.param.selection.callable = self._get_selectable
 
-    @param.depends('aggregators', 'value', watch=True, on_init=True)
-    def _validate_aggregators(self):
-
-        def _validate_aggs(
-            df: pd.DataFrame,
-            aggregators: dict,
-        ) -> list[str]:
-            import pandas as pd
-
-            aggs_by_types = {
-                'number': ['sum', 'mean', 'min', 'max'],
-                'datetime': ['min', 'max'],
-                'string': ['min', 'max'],
-                'boolean': ['sum', 'mean']  # sum and mean will treat True as 1 and False as 0
-            }
-
-            for key, value in aggregators.items():
-                # Check if value is a dictionary (nested)
-                if isinstance(value, dict):
-                    # check if key is an index of the df
-                    if key not in df.index.names:
-                        raise ValueError(
-                            f'Error validating `aggregators`, {key} is not an index of the dataframe.'
-                        )
-                    # Recursively validate nested dictionary
-                    _validate_aggs(df, value)
-                else:
-                    # Handle non-nested case (leaf node)
-                    if key not in df.columns:
-                        raise ValueError(
-                            f'Error validating `aggregators`, column {key} not found.'
-                        )
-
-                    # Determine the data type of the column
-                    dtype = df[key].dtype
-                    if pd.api.types.is_numeric_dtype(dtype):
-                        dtype_category = 'number'
-                    elif pd.api.types.is_datetime64_any_dtype(dtype):
-                        dtype_category = 'datetime'
-                    elif pd.api.types.is_bool_dtype(dtype):
-                        dtype_category = 'boolean'
-                    elif pd.api.types.is_string_dtype(dtype):
-                        dtype_category = 'string'
-                    else:
-                        dtype_category = None
-
-                    # Validate aggregator method based on data type
-                    if dtype_category:
-                        valid_aggregators = aggs_by_types[dtype_category]
-                        if value not in valid_aggregators:
-                            raise ValueError(
-                                f"Invalid aggregator '{value}' for column '{key}' "
-                                f"of type '{dtype_category}'. Valid options are: {valid_aggregators}."
-                            )
-                    else:
-                        raise ValueError(f"Unsupported aggregating on column '{key}' of type {dtype}.")
-
-        if self.value is None or self.value.empty:
-            pass
-        if not self.aggregators:
-            pass
-        _validate_aggs(self.value, self.aggregators)
-
     @param.depends('value', watch=True, on_init=True)
     def _apply_max_size(self):
         """

--- a/panel/widgets/tables.py
+++ b/panel/widgets/tables.py
@@ -1291,6 +1291,11 @@ class Tabulator(BaseTable):
             for key, value in aggregators.items():
                 # Check if value is a dictionary (nested)
                 if isinstance(value, dict):
+                    # check if key is an index of the df
+                    if key not in df.index.names:
+                        raise ValueError(
+                            f'Error validating `aggregators`, {key} is not an index of the dataframe.'
+                        )
                     # Recursively validate nested dictionary
                     _validate_aggs(df, value)
                 else:


### PR DESCRIPTION
Fixes https://github.com/holoviz/panel/issues/7281 and partially https://github.com/holoviz/panel/issues/7449

TODO:
- [x] add tests
- [x] add docs for nested aggs

TODO LATER in other PRs:
- validate input aggs?
- for columns with no agg method, set NaNs to them? Needs a bit more experiment to see what we should do
- display the indexes properly
- scope out the data types to support. Handle String, Datetime, and Boolean data types?
