### PR TITLE
Ensure parameter overrides are applied to ESM components

### DIFF
--- a/panel/custom.py
+++ b/panel/custom.py
@@ -361,7 +361,14 @@ class ReactiveESM(ReactiveCustomBase, metaclass=ReactiveESMMetaclass):
         props = super()._get_properties(doc)
         cls = type(self)
         data_params = {}
-        ignored = [p for p in Reactive.param if not issubclass(cls.param[p].owner, ReactiveESM) or p in Viewable.param]
+        # Split data model properties from ESM model properties
+        # Note that inherited parameters are generally treated
+        # as ESM model properties unless their type has changed
+        ignored = [
+            p for p in Reactive.param
+            if not issubclass(cls.param[p].owner, ReactiveESM) or
+            (p in Viewable.param and p != 'name' and type(Reactive.param[p]) is type(cls.param[p]))
+        ]
         for k, v in self.param.values().items():
             p = self.param[k]
             is_viewable = is_viewable_param(p)

--- a/panel/custom.py
+++ b/panel/custom.py
@@ -361,7 +361,7 @@ class ReactiveESM(ReactiveCustomBase, metaclass=ReactiveESMMetaclass):
         props = super()._get_properties(doc)
         cls = type(self)
         data_params = {}
-        ignored = [p for p in Reactive.param if not issubclass(cls.param[p].owner, ReactiveESM)]
+        ignored = [p for p in Reactive.param if not issubclass(cls.param[p].owner, ReactiveESM) or p in Viewable.param]
         for k, v in self.param.values().items():
             p = self.param[k]
             is_viewable = is_viewable_param(p)

--- a/panel/tests/test_custom.py
+++ b/panel/tests/test_custom.py
@@ -143,3 +143,18 @@ def test_reactive_esm_children_models_cleanup_on_replace(document, comm):
     assert ref in md2._models
     md2_model, _ = md2._models[ref]
     assert model.data.children == [md2_model]
+
+class ESMOverride(ReactiveESM):
+
+    width = param.Integer(default=42)
+
+def test_esm_parameter_override(document, comm):
+    esm = ESMOverride()
+
+    model = esm.get_root(document, comm)
+
+    assert model.width == 42
+
+    esm.width = 84
+
+    assert model.width == 84


### PR DESCRIPTION
Fixes issue that caused a parameter inherited from a baseclass not to be correctly overridden.