### PR TITLE
Fix bug in is_viewable_param

### DIFF
--- a/panel/tests/test_viewable.py
+++ b/panel/tests/test_viewable.py
@@ -7,7 +7,7 @@ from panel import config
 from panel.interact import interactive
 from panel.pane import Markdown, Str, panel
 from panel.param import ParamMethod
-from panel.viewable import Viewable, Viewer
+from panel.viewable import Viewable, Viewer, is_viewable_param
 
 from .util import jb_available
 
@@ -117,3 +117,11 @@ def test_clone_with_non_defaults():
 
     assert ([(k, v) for k, v in sorted(v.param.values().items()) if k not in ('name')] ==
             [(k, v) for k, v in sorted(clone.param.values().items()) if k not in ('name')])
+
+def test_is_viewable_parameter():
+    class Example(param.Parameterized):
+        value = param.ClassSelector(class_=(list, tuple))
+
+    example = Example()
+
+    assert not is_viewable_param(example.param.value)

--- a/panel/tests/test_viewable.py
+++ b/panel/tests/test_viewable.py
@@ -7,7 +7,9 @@ from panel import config
 from panel.interact import interactive
 from panel.pane import Markdown, Str, panel
 from panel.param import ParamMethod
-from panel.viewable import Viewable, Viewer, is_viewable_param
+from panel.viewable import (
+    Child, Children, Viewable, Viewer, is_viewable_param,
+)
 
 from .util import jb_available
 
@@ -120,8 +122,45 @@ def test_clone_with_non_defaults():
 
 def test_is_viewable_parameter():
     class Example(param.Parameterized):
-        value = param.ClassSelector(class_=(list, tuple))
+        p_dict = param.Dict()
+        p_child = Child()
+        p_children = Children()
+
+        # ClassSelector
+        c_viewable = param.ClassSelector(class_=Viewable)
+        c_viewables = param.ClassSelector(class_=(Viewable,))
+        c_none = param.ClassSelector(class_=None)
+        c_tuple = param.ClassSelector(class_=tuple)
+        c_list_tuple = param.ClassSelector(class_=(list, tuple))
+
+        # List
+        l_no_item_type = param.List()
+        l_item_type_viewable = param.List(item_type=Viewable)
+        l_item_type_not_viewable = param.List(item_type=tuple)
+
+        l_item_types_viewable = param.List(item_type=(Viewable,))
+        l_item_types_not_viewable = param.List(item_type=(tuple,))
+        l_item_types_not_viewable2 = param.List(item_type=(list, tuple,))
 
     example = Example()
 
-    assert not is_viewable_param(example.param.value)
+    assert not is_viewable_param(example.param.p_dict)
+    assert is_viewable_param(example.param.p_child)
+    assert is_viewable_param(example.param.p_children)
+
+    # ClassSelector
+    assert is_viewable_param(example.param.c_viewable)
+    assert is_viewable_param(example.param.c_viewables)
+    assert not is_viewable_param(example.param.c_none)
+    assert not is_viewable_param(example.param.c_tuple)
+    assert not is_viewable_param(example.param.c_list_tuple)
+
+    # List
+    assert not is_viewable_param(example.param.l_no_item_type)
+    assert not is_viewable_param(example.param.l_no_item_type)
+    assert is_viewable_param(example.param.l_item_type_viewable)
+    assert not is_viewable_param(example.param.l_item_type_not_viewable)
+
+    assert is_viewable_param(example.param.l_item_types_viewable)
+    assert not is_viewable_param(example.param.l_item_types_not_viewable)
+    assert not is_viewable_param(example.param.l_item_types_not_viewable2)

--- a/panel/viewable.py
+++ b/panel/viewable.py
@@ -1193,34 +1193,42 @@ class ChildDict(param.Dict):
 
 
 
+def _is_viewable_class_selector(class_selector: param.ClassSelector) -> bool:
+    if not class_selector.class_:
+        return False
+    if isinstance(class_selector.class_, tuple):
+        return all(issubclass(cls, Viewable) for cls in class_selector.class_)
+    return issubclass(class_selector.class_, Viewable)
+
+def _is_viewable_list(param_list: param.List) -> bool:
+    if not param_list.item_type:
+        return False
+    if isinstance(param_list.item_type, tuple):
+        return all(issubclass(cls, Viewable) for cls in param_list.item_type)
+    return issubclass(param_list.item_type, Viewable)
+
+
 def is_viewable_param(parameter: param.Parameter) -> bool:
     """
-    Detects whether the Parameter uniquely identifies a Viewable
-    type.
+    Determines if a parameter uniquely identifies a Viewable type.
 
     Arguments
     ---------
-    parameter: param.Parameter
+    parameter : param.Parameter
+        The parameter to evaluate.
 
     Returns
     -------
-    Whether the Parameter specieis a Parameter type
+    bool
+        True if the parameter specifies a Viewable type, False otherwise.
     """
-    p = parameter
-    if (
-        isinstance(p, (Child, Children)) or
-        (isinstance(p, param.ClassSelector) and p.class_ and (
-            (isinstance(p.class_, tuple) and
-             all(issubclass(cls, Viewable) for cls in p.class_)) or
-            issubclass(p.class_, Viewable)
-        )) or
-        (isinstance(p, param.List) and p.item_type and (
-            (isinstance(p.item_type, tuple) and
-             all(issubclass(cls, Viewable) for cls in p.item_type)) or
-            issubclass(p.item_type, Viewable)
-        ))
-    ):
+    if isinstance(parameter, (Child, Children)):
         return True
+    if isinstance(parameter, param.ClassSelector) and _is_viewable_class_selector(parameter):
+        return True
+    if isinstance(parameter, param.List) and _is_viewable_list(parameter):
+        return True
+
     return False
 
 


### PR DESCRIPTION
I was trying to use `param.ClassSelector(class_=(list,tuple)` with the `GraphicWalker` react component and I got 

```python
TypeError: issubclass() arg 1 must be a class

panel/viewable.py:1215: TypeError
```

This PR should add a test for this and fix the issue.