### PR TITLE
Various improvements for writing ESM components

### DIFF
--- a/doc/how_to/custom_components/esm/build.md
+++ b/doc/how_to/custom_components/esm/build.md
@@ -184,7 +184,7 @@ panel compile confetti
 ```
 
 :::{hint}
-`panel compile` accepts file paths, e.g. `my_components/custom.py`, and dotted module name, e.g. `my_package.custom`. If you provide a module name it must be importable.
+`panel compile` accepts file paths, e.g. `my_components/custom.py`, or dotted module names, e.g. `my_package.custom`. If you provide a module name it must be importable.
 :::
 
 This will automatically discover the `ConfettiButton` but you can also explicitly request a single component by adding the class name:
@@ -216,7 +216,11 @@ esbuild output:
 ⚡ Done in 9ms
 ```
 
-The compiled JavaScript file will be automatically loaded if it remains alongside the component. If you rename the component or modify its code or `_importmap`, you must recompile the component. For ongoing development, consider using the `--dev` option to ignore the compiled file and automatically reload the development version when it changes.
+If the supplied module or package contains multiple components they will all be bundled together by default. If instead you want to generate bundles for each file explicitly you must list them with the `:` syntax, e.g. `panel compile package.module:Component1,Component2`. You may also provide a glob pattern to request multiple components to be built individually without listing them all out, e.g. `panel compile "package.module:Component*"`.
+
+During runtime the compiled bundles will be resolved automatically, where bundles compiled for a specific component (i.e. `<component-name>.bundle.js`) take highest precedence and we then search for module bundles up to the root package, e.g. for a component that lives in `package.module` we first search for `package.module.bundle.js` in the same directory as the component and then recursively search in parent directories until we reach the root of the package.
+
+If you rename the component or modify its code or `_importmap`, you must recompile the component. For ongoing development, consider using the `--dev` option to ignore the compiled file and automatically reload the development version when it changes.
 
 #### Compilation Steps
 

--- a/panel/command/compile.py
+++ b/panel/command/compile.py
@@ -81,12 +81,12 @@ class Compile(Subcommand):
                     component_module = module_name or component.__module__
                     bundles[module_path / f'{component_module}.bundle.js'].append(component)
                 else:
-                    bundles[module_path / f'{component.__name__}.bundle.js'].append(component)
+                    bundles[component._module_path / f'{component.__name__}.bundle.js'].append(component)
 
         errors = 0
         for bundle, components in bundles.items():
             component_names = '\n- '.join(c.name for c in components)
-            print(f"Building {bundle} containing the following components:\n\n- {component_names}")  # noqa
+            print(f"Building {bundle} containing the following components:\n\n- {component_names}\n")  # noqa
             out = compile_components(
                 components,
                 build_dir=args.build_dir,

--- a/panel/custom.py
+++ b/panel/custom.py
@@ -239,6 +239,8 @@ class ReactiveESM(ReactiveCustomBase, metaclass=ReactiveESMMetaclass):
 
     @classproperty
     def _module_path(cls):
+        if hasattr(cls, '__path__'):
+            return pathlib.Path(cls.__path__).parent
         try:
             return pathlib.Path(inspect.getfile(cls)).parent
         except (OSError, TypeError, ValueError):

--- a/panel/custom.py
+++ b/panel/custom.py
@@ -267,7 +267,7 @@ class ReactiveESM(ReactiveCustomBase, metaclass=ReactiveESMMetaclass):
                 if bundle_path.is_file():
                     return bundle_path
             raise ValueError(
-                'Could not resolve {cls.__name__}._bundle: {cls._bundle}. Ensure '
+                f'Could not resolve {cls.__name__}._bundle: {cls._bundle}. Ensure '
                 'you provide either a string with a relative or absolute '
                 'path or a Path object to a .js file extension.'
             )

--- a/panel/custom.py
+++ b/panel/custom.py
@@ -438,7 +438,7 @@ class ReactiveESM(ReactiveCustomBase, metaclass=ReactiveESMMetaclass):
             p = self.param[k]
             if not is_viewable_param(p):
                 continue
-            children[k] = self._get_child_model(k, v)
+            children[k] = self._get_child_model(v, doc, root, parent, comm)
         return children
 
     def _setup_autoreload(self):

--- a/panel/custom.py
+++ b/panel/custom.py
@@ -240,7 +240,7 @@ class ReactiveESM(ReactiveCustomBase, metaclass=ReactiveESMMetaclass):
     @classproperty
     def _module_path(cls):
         if hasattr(cls, '__path__'):
-            return pathlib.Path(cls.__path__).parent
+            return pathlib.Path(cls.__path__)
         try:
             return pathlib.Path(inspect.getfile(cls)).parent
         except (OSError, TypeError, ValueError):

--- a/panel/custom.py
+++ b/panel/custom.py
@@ -168,7 +168,7 @@ class ReactiveESMMetaclass(ReactiveMetaBase):
         model_name = f'{name}{ReactiveMetaBase._name_counter[name]}'
         ignored = [p for p in Reactive.param if not issubclass(type(mcs.param[p].owner), ReactiveESMMetaclass)]
         mcs._data_model = construct_data_model(
-            mcs, name=model_name, ignore=ignored
+            mcs, name=model_name, ignore=ignored, extras={'esm_constants': param.Dict}
         )
 
 
@@ -215,6 +215,8 @@ class ReactiveESM(ReactiveCustomBase, metaclass=ReactiveESMMetaclass):
     _bokeh_model = _BkReactiveESM
 
     _bundle: ClassVar[str | os.PathLike | None] = None
+
+    _constants: ClassVar[dict[str, Any]] = {}
 
     _esm: ClassVar[str | os.PathLike] = ""
 
@@ -401,6 +403,7 @@ class ReactiveESM(ReactiveCustomBase, metaclass=ReactiveESMMetaclass):
         else:
             bundle_hash = None
         data_props = self._process_param_change(data_params)
+        data_props['esm_constants'] = self._constants
         props.update({
             'bundle': bundle_hash,
             'class_name': camel_to_kebab(cls.__name__),

--- a/panel/custom.py
+++ b/panel/custom.py
@@ -688,6 +688,7 @@ class ReactComponent(ReactiveESM):
                 "react-is": f"https://esm.sh/react-is@{v_react}&external=react",
                 "@emotion/cache": f"https://esm.sh/@emotion/cache?deps=react@{v_react},react-dom@{v_react}",
                 "@emotion/react": f"https://esm.sh/@emotion/react?deps=react@{v_react},react-dom@{v_react}&external=react,react-is",
+                "@emotion/styled": f"https://esm.sh/@emotion/styled?deps=react@{v_react},react-dom@{v_react}&external=react,react-is",
             })
         for k, v in imports.items():
             if '?' not in v and 'esm.sh' in v:

--- a/panel/io/compile.py
+++ b/panel/io/compile.py
@@ -86,7 +86,10 @@ def find_module_bundles(module_spec: str) -> dict[pathlib.PurePath, list[Reactiv
     -------
     Dictionary containing the bundle paths and list of components to bundle.
     """
-    if ':' in module_spec:
+    if re.match(r'^[A-Za-z]:\\', module_spec):
+        # Handle windows paths
+        module, cls = module_spec.rsplit(':', 1)
+    elif ':' in module_spec:
         *parts, cls = module_spec.split(':')
         module = ':'.join(parts)
     else:

--- a/panel/io/compile.py
+++ b/panel/io/compile.py
@@ -87,7 +87,7 @@ def find_module_bundles(module_spec: str) -> dict[pathlib.PurePath, list[Reactiv
     Dictionary containing the bundle paths and list of components to bundle.
     """
     # Split module spec, while respecting Windows drive letters
-    if ':' in module_spec and (not re.match(r'^[A-Za-z]:\\', module_spec) or module_spec.count(':') > 1):
+    if ':' in module_spec and (module_spec[1:3] != ':\\' or module_spec.count(':') > 1):
         module, cls = module_spec.rsplit(':', 1)
     else:
         module = module_spec

--- a/panel/io/compile.py
+++ b/panel/io/compile.py
@@ -86,12 +86,9 @@ def find_module_bundles(module_spec: str) -> dict[pathlib.PurePath, list[Reactiv
     -------
     Dictionary containing the bundle paths and list of components to bundle.
     """
-    if re.match(r'^[A-Za-z]:\\', module_spec):
-        # Handle windows paths
+    # Split module spec, while respecting Windows drive letters
+    if ':' in module_spec and (not re.match(r'^[A-Za-z]:\\', module_spec) or module_spec.count(':') > 1):
         module, cls = module_spec.rsplit(':', 1)
-    elif ':' in module_spec:
-        *parts, cls = module_spec.split(':')
-        module = ':'.join(parts)
     else:
         module = module_spec
         cls = ''

--- a/panel/io/datamodel.py
+++ b/panel/io/datamodel.py
@@ -115,7 +115,7 @@ PARAM_MAPPING = {
 }
 
 
-def construct_data_model(parameterized, name=None, ignore=[], types={}):
+def construct_data_model(parameterized, name=None, ignore=[], types={}, extras={}):
     """
     Dynamically creates a Bokeh DataModel class from a Parameterized
     object.
@@ -132,6 +132,8 @@ def construct_data_model(parameterized, name=None, ignore=[], types={}):
     types: dict
         A dictionary mapping from parameter name to a Parameter type,
         making it possible to override the default parameter types.
+    extras: dict
+        Additional properties to define on the DataModel.
 
     Returns
     -------
@@ -163,6 +165,10 @@ def construct_data_model(parameterized, name=None, ignore=[], types={}):
         for bkp, convert in accepts:
             bk_prop = bk_prop.accepts(bkp, convert)
         properties[pname] = bk_prop
+    for pname, ptype in extras.items():
+        if issubclass(ptype, pm.Parameter):
+            ptype = PARAM_MAPPING.get(ptype)(None, {})
+        properties[pname] = ptype
     name = name or parameterized.name
     return type(name, (DataModel,), properties)
 

--- a/panel/layout/base.py
+++ b/panel/layout/base.py
@@ -564,8 +564,9 @@ class NamedListLike(param.Parameterized):
                     'as positional arguments or as a keyword, not both.'
                 )
             items = params.pop('objects')
-        params['objects'], self._names = self._to_objects_and_names(items)
+        params['objects'], names = self._to_objects_and_names(items)
         super().__init__(**params)
+        self._names = names
         self._panels = defaultdict(dict)
         self.param.watch(self._update_names, 'objects')
         # ALERT: Ensure that name update happens first, should be

--- a/panel/reactive.py
+++ b/panel/reactive.py
@@ -215,7 +215,7 @@ class Syncable(Renderable):
             stylesheets += properties['stylesheets']
             wrapped = []
             for stylesheet in stylesheets:
-                if isinstance(stylesheet, str) and stylesheet.split('?')[0].endswith('.css'):
+                if isinstance(stylesheet, str) and (stylesheet.split('?')[0].endswith('.css') or stylesheet.startswith('http')):
                     cache = (state._stylesheets if state.curdoc else {}).get(state.curdoc, {})
                     if stylesheet in cache:
                         stylesheet = cache[stylesheet]

--- a/panel/tests/io/test_compile.py
+++ b/panel/tests/io/test_compile.py
@@ -1,9 +1,27 @@
+import pathlib
+
 import pytest
 
+from panel.custom import ReactiveESM
 from panel.io.compile import (
-    packages_from_code, packages_from_importmap, replace_imports,
+    find_module_bundles, packages_from_code, packages_from_importmap,
+    replace_imports,
 )
 
+
+class ESM1(ReactiveESM):
+    pass
+
+
+def test_find_module_bundles_as_dotted_module():
+    assert find_module_bundles('panel.tests.io.test_compile') == {pathlib.Path(__file__).parent / 'ESM1.bundle.js': [ESM1]}
+
+def test_find_module_bundles_as_path():
+    path = pathlib.Path(__file__).parent / 'ESM1.bundle.js'
+    bundles = find_module_bundles(__file__)
+    assert path in bundles
+    assert len(bundles[path]) == 1
+    assert bundles[path][0].name == 'ESM1'
 
 def test_packages_from_code_esm_sh():
     code, pkgs = packages_from_code('import * from "https://esm.sh/confetti-canvas@1.0.0"')


### PR DESCRIPTION
This PR provides a number of fixes and improvements for ESM components that I encountered as I was building a library with many components. This includes:

- **Ensure bundle path is correctly resolved on superclasses**: This allows compiling a single bundle for an entire package of different ESM components
- **Refactor ESM child resolution**: Makes it easier to modify the creation of child models (e.g. to allow lazily creating the models)
- **Allow defining constants on ESM model**: Allows providing a `_constants` dict on a component to modify the behavior of a component without having to define (public) parameters
- **Allow providing URL to _stylesheets**: Useful for loading external CSS resources
- **Load @emotion/styled for Material UI components**: Required for rendering certain Material UI components
- **Allow initializing NamedListPanel title dict as parameter**: Required for implementing ESM components implementing the `NamedListPanel` interfaces.



