### PR TITLE
fix: Log authorization callback errors

### DIFF
--- a/panel/io/server.py
+++ b/panel/io/server.py
@@ -426,6 +426,7 @@ class DocHandler(LoginUrlMixin, BkDocHandler):
                 auth_error = None
         except Exception:
             auth_error = f'Authorization callback errored. Could not validate user {state.user}.'
+            logger.warning(auth_error)
         return authorized, auth_error
 
     def _render_auth_error(self, auth_error):

--- a/panel/io/server.py
+++ b/panel/io/server.py
@@ -456,6 +456,7 @@ class DocHandler(LoginUrlMixin, BkDocHandler):
             if authorized is None:
                 return
             elif not authorized:
+                self.set_status(403)
                 page = self._render_auth_error(auth_error)
                 self.set_header("Content-Type", 'text/html')
                 self.write(page)

--- a/panel/tests/command/test_serve.py
+++ b/panel/tests/command/test_serve.py
@@ -3,12 +3,14 @@ import re
 import tempfile
 import time
 
+from textwrap import dedent
+
 import pytest
 import requests
 
 from panel.tests.util import (
-    linux_only, run_panel_serve, unix_only, wait_for_port, wait_for_regex,
-    write_file,
+    NBSR, linux_only, run_panel_serve, unix_only, wait_for_port,
+    wait_for_regex, write_file,
 )
 
 
@@ -175,3 +177,24 @@ def test_serve_setup(tmp_path):
     with run_panel_serve(["--port", "0", py, "--setup", setup_py], cwd=tmp_path) as p:
         _, output = wait_for_regex(p.stdout, regex=regex, return_output=True)
         assert output[0].strip() == "Setup running before"
+
+
+def test_serve_authorize_callback_exception(tmp_path):
+    app = "import panel as pn; pn.panel('Hello').servable()"
+    py = tmp_path / "app.py"
+    py.write_text(app)
+
+    setup_app = """\
+        import panel as pn
+        def auth(userinfo):
+            raise ValueError("This is an error")
+        pn.config.authorize_callback = auth"""
+    setup_py = tmp_path / "setup.py"
+    setup_py.write_text(dedent(setup_app))
+
+    regex = re.compile('(Authorization callback errored)')
+    with run_panel_serve(["--port", "0", py, "--setup", setup_py], cwd=tmp_path) as p:
+        nsbr = NBSR(p.stdout)
+        port = wait_for_port(nsbr)
+        requests.get(f"http://localhost:{port}/")
+        wait_for_regex(nsbr, regex=regex)

--- a/panel/tests/command/test_serve.py
+++ b/panel/tests/command/test_serve.py
@@ -196,5 +196,6 @@ def test_serve_authorize_callback_exception(tmp_path):
     with run_panel_serve(["--port", "0", py, "--setup", setup_py], cwd=tmp_path) as p:
         nsbr = NBSR(p.stdout)
         port = wait_for_port(nsbr)
-        requests.get(f"http://localhost:{port}/")
+        resp = requests.get(f"http://localhost:{port}/")
         wait_for_regex(nsbr, regex=regex)
+        assert resp.status_code == 403

--- a/panel/tests/util.py
+++ b/panel/tests/util.py
@@ -395,7 +395,10 @@ class NBSR:
             return None
 
 def wait_for_regex(stdout, regex, count=1, return_output=False):
-    nbsr = NBSR(stdout)
+    if isinstance(stdout, NBSR):
+        nbsr = stdout
+    else:
+        nbsr = NBSR(stdout)
     m = None
     output, found = [], []
     for _ in range(20):


### PR DESCRIPTION
So a warning is emitted if something goes wrong in the authentication callback.

Also, set the status code if no auth fails to 403.