### PR TITLE
Improve and document hold utility

### DIFF
--- a/doc/how_to/performance/hold.md
+++ b/doc/how_to/performance/hold.md
@@ -1,0 +1,53 @@
+# Batching updates with `hold`
+
+When working with interactive dashboards and applications in Panel, you might encounter situations where updating multiple components simultaneously causes unnecessary re-renders. This is because Panel generally dispatches any change to a parameter immediately. This can lead to performance issues and a less responsive user experience because each individual update may trigger re-renders on the frontend. The `hold` utility in Panel allows you to batch updates to the frontend, reducing the number of re-renders and improving performance.
+
+In this guide, we'll explore how to use hold both as a context manager and as a decorator to optimize your Panel applications.
+
+## What is hold?
+
+The `hold` function is a context manager and decorator that temporarily holds events on a Bokeh Document. When you update multiple components within a hold block, the events are collected and dispatched all at once when the block exits. This means that the frontend will only re-render once, regardless of how many updates were made, leading to a smoother and more efficient user experience.
+
+## Using `hold`
+
+If you have a function that updates components and you want to ensure that all updates are held, you can use hold as a decorator, e.g. here we update 100 components at once. If you do not hold then each of these events is sent and applied in series, potentially resulting in visible updates.
+
+```{pyodide}
+import panel as pn
+from panel.io import hold
+
+@hold()
+def increment(e):
+    for obj in column:
+        obj.object = str(e.new)
+
+column = pn.FlexBox(*['0']*100)
+button = pn.widgets.Button(name='Increment', on_click=increment)
+
+pn.Column(column, button).servable()
+```
+
+Applying the hold decorator means all the updates are sent in a single Websocket message and applied on the frontend simultaneously.
+
+Alternatively the `hold` function can be used as a context manager, potentially giving you finer grained control over which events are batched and which are not:
+
+```{pyodide}
+import time
+
+import panel as pn
+from panel.io import hold
+
+def increment(e):
+    with button.param.update(name='Incrementing...', disabled=True):
+        time.sleep(0.5)
+        with hold():
+            for obj in column:
+                obj.object = str(e.new)
+
+column = pn.FlexBox(*['0']*100)
+button = pn.widgets.Button(name='Increment', on_click=increment)
+
+pn.Column(column, button).servable()
+```
+
+Here the updates to the `Button` are dispatched immediately while the updates to the counters are batched.

--- a/doc/how_to/performance/index.md
+++ b/doc/how_to/performance/index.md
@@ -19,6 +19,13 @@ Discover how to reuse sessions to improve the start render time.
 Discover how to enable throttling to reduce the number of events being processed.
 :::
 
+:::{grid-item-card} {octicon}`tab;2.5em;sd-mr-1 sd-animate-grow50` Batching Updates with `hold`
+:link: hold
+:link-type: doc
+
+Discover how to improve performance by using the `hold` context manager and decorator to batch updates to multiple components.
+:::
+
 ::::
 
 ```{toctree}
@@ -28,4 +35,5 @@ Discover how to enable throttling to reduce the number of events being processed
 
 reuse_sessions
 throttling
+hold
 ```

--- a/panel/io/model.py
+++ b/panel/io/model.py
@@ -22,6 +22,7 @@ from bokeh.model import DataModel
 from bokeh.models import ColumnDataSource, FlexBox, Model
 from bokeh.protocol.messages.patch_doc import patch_doc
 
+from ..util.warnings import deprecated
 from .state import state
 
 if TYPE_CHECKING:
@@ -174,7 +175,7 @@ def bokeh_repr(obj: Model, depth: int = 0, ignored: Optional[Iterable[str]] = No
     return r
 
 @contextmanager
-def hold(doc: Document, policy: HoldPolicyType = 'combine', comm: Comm | None = None):
+def hold(doc: Document | None = None, policy: HoldPolicyType = 'combine', comm: Comm | None = None):
     """
     Context manager that holds events on a particular Document
     allowing them all to be collected and dispatched when the context
@@ -192,22 +193,6 @@ def hold(doc: Document, policy: HoldPolicyType = 'combine', comm: Comm | None = 
     comm: Comm
         The Comm to dispatch events on when the context manager exits.
     """
-    doc = doc or state.curdoc
-    if doc is None:
-        yield
-        return
-    held = doc.callbacks.hold_value
-    try:
-        if policy is None:
-            doc.unhold()
-        else:
-            doc.hold(policy)
-        yield
-    finally:
-        if held:
-            doc.callbacks._hold = held
-        else:
-            if comm is not None:
-                from .notebook import push
-                push(doc, comm)
-            doc.unhold()
+    deprecated('1.7.0', 'panel.io.model.hold', 'panel.io.document.hold')
+    from .document import hold
+    hold(doc, policy, comm)

--- a/panel/io/model.py
+++ b/panel/io/model.py
@@ -193,6 +193,9 @@ def hold(doc: Document | None = None, policy: HoldPolicyType = 'combine', comm: 
     comm: Comm
         The Comm to dispatch events on when the context manager exits.
     """
-    deprecated('1.7.0', 'panel.io.model.hold', 'panel.io.document.hold')
+    deprecated(
+        '1.7.0', 'panel.io.model.hold', 'panel.io.document.hold',
+        warn_version='1.6.0'
+    )
     from .document import hold
-    hold(doc, policy, comm)
+    yield hold(doc, policy, comm)

--- a/panel/layout/base.py
+++ b/panel/layout/base.py
@@ -15,8 +15,7 @@ import param
 from bokeh.models import Row as BkRow
 from param.parameterized import iscoroutinefunction, resolve_ref
 
-from ..io.document import freeze_doc
-from ..io.model import hold
+from ..io.document import freeze_doc, hold
 from ..io.resources import CDN_DIST
 from ..models import Column as PnColumn
 from ..reactive import Reactive

--- a/panel/layout/grid.py
+++ b/panel/layout/grid.py
@@ -16,8 +16,7 @@ import param
 
 from bokeh.models import FlexBox as BkFlexBox, GridBox as BkGridBox
 
-from ..io.document import freeze_doc
-from ..io.model import hold
+from ..io.document import freeze_doc, hold
 from ..io.resources import CDN_DIST
 from ..viewable import ChildDict
 from .base import (

--- a/panel/reactive.py
+++ b/panel/reactive.py
@@ -35,8 +35,7 @@ from param.parameterized import (
     resolve_ref, resolve_value,
 )
 
-from .io.document import unlocked
-from .io.model import hold
+from .io.document import hold, unlocked
 from .io.notebook import push
 from .io.resources import (
     CDN_DIST, loading_css, patch_stylesheet, process_raw_css,

--- a/panel/util/warnings.py
+++ b/panel/util/warnings.py
@@ -59,6 +59,7 @@ def deprecated(
     remove_version: Version | str,
     old: str,
     new: str | None = None,
+    *
     extra: str | None = None,
     warn_version: Version | str | None = None
 ) -> None:

--- a/panel/util/warnings.py
+++ b/panel/util/warnings.py
@@ -60,12 +60,19 @@ def deprecated(
     old: str,
     new: str | None = None,
     extra: str | None = None,
+    warn_version: Version | str | None = None
 ) -> None:
 
-    import panel as pn
+    from .. import __version__
 
-    current_version = Version(pn.__version__)
+    current_version = Version(__version__)
     base_version = Version(current_version.base_version)
+
+    if warn_version:
+        if isinstance(warn_version, str):
+            warn_version = Version(warn_version)
+        if base_version < warn_version:
+            return
 
     if isinstance(remove_version, str):
         remove_version = Version(remove_version)

--- a/panel/util/warnings.py
+++ b/panel/util/warnings.py
@@ -59,11 +59,10 @@ def deprecated(
     remove_version: Version | str,
     old: str,
     new: str | None = None,
-    *
+    *,
     extra: str | None = None,
     warn_version: Version | str | None = None
 ) -> None:
-
     from .. import __version__
 
     current_version = Version(__version__)


### PR DESCRIPTION
The `hold` utility is likely criminally underused by users simply because we haven't made it very visible. In this PR I did a few things:

- Improve the way events are batched and dispatched by `hold`
- Add how-to guide on using `hold`
- Move it from `panel.io.model` to `panel.io.document`