### PR TITLE
Combine throttle implementations

### DIFF
--- a/panel/models/html.ts
+++ b/panel/models/html.ts
@@ -6,6 +6,7 @@ import {entries} from "@bokehjs/core/util/object"
 import {Markup} from "@bokehjs/models/widgets/markup"
 import {PanelMarkupView} from "./layout"
 import {serializeEvent} from "./event-to-object"
+import {throttle} from "./util"
 
 import html_css from "styles/models/html.css"
 
@@ -75,29 +76,6 @@ export function run_scripts(node: Element): void {
     const parent_node = old_script.parentNode
     if (parent_node != null) {
       parent_node.replaceChild(new_script, old_script)
-    }
-  }
-}
-
-function throttle(func: Function, limit: number): any {
-  let lastFunc: ReturnType<typeof setTimeout> | undefined
-  let lastRan: number
-
-  return function(...args: any) {
-    // @ts-ignore
-    const context = this
-
-    if (!lastRan) {
-      func.apply(context, args)
-      lastRan = Date.now()
-    } else {
-      clearTimeout(lastFunc)
-      lastFunc = setTimeout(function() {
-        if ((Date.now() - lastRan) >= limit) {
-          func.apply(context, args)
-          lastRan = Date.now()
-        }
-      }, limit - (Date.now() - lastRan))
     }
   }
 }

--- a/panel/models/util.ts
+++ b/panel/models/util.ts
@@ -11,13 +11,27 @@ export const get = (obj: any, path: string, defaultValue: any = undefined) => {
   return result === undefined || result === obj ? defaultValue : result
 }
 
-export function throttle(func: any, timeFrame: number) {
-  let lastTime: number = 0
-  return function() {
-    const now: number = Number(new Date())
-    if (now - lastTime >= timeFrame) {
-      func()
-      lastTime = now
+function throttle(func: Function, limit: number): any {
+  let lastRan: number = 0
+  let trailingCall: ReturnType<typeof setTimeout> | null = null
+
+  return function(...args: any) {
+    // @ts-ignore
+    const context = this
+    const now = Date.now()
+    if (trailingCall) {
+      clearTimeout(trailingCall)
+    }
+
+    if ((now - lastRan) >= limit) {
+      func.apply(context, args)
+      lastRan = Date.now()
+    } else {
+      trailingCall = setTimeout(function() {
+	func.apply(context, args)
+	lastRan = Date.now()
+	trailingCall = null
+      }, limit - (now - lastRan))
     }
   }
 }

--- a/panel/models/util.ts
+++ b/panel/models/util.ts
@@ -11,7 +11,7 @@ export const get = (obj: any, path: string, defaultValue: any = undefined) => {
   return result === undefined || result === obj ? defaultValue : result
 }
 
-function throttle(func: Function, limit: number): any {
+export function throttle(func: Function, limit: number): any {
   let lastRan: number = 0
   let trailingCall: ReturnType<typeof setTimeout> | null = null
 

--- a/panel/models/util.ts
+++ b/panel/models/util.ts
@@ -28,9 +28,9 @@ function throttle(func: Function, limit: number): any {
       lastRan = Date.now()
     } else {
       trailingCall = setTimeout(function() {
-	func.apply(context, args)
-	lastRan = Date.now()
-	trailingCall = null
+        func.apply(context, args)
+        lastRan = Date.now()
+        trailingCall = null
       }, limit - (now - lastRan))
     }
   }


### PR DESCRIPTION
We had two `throttle` JS implementations, both were flawed.

1. The one used for throttling streaming HTML output was actually debouncing, causing updates to be stalled until the streaming stopped.
2. The implementation used elsewhere was mostly okay but did not implement trailing execution which meant that if the final update was never executed if the previous update occurred within the timeout period. 