### PR TITLE
Take manual control over Plotly sizing

### DIFF
--- a/panel/models/plotly.ts
+++ b/panel/models/plotly.ts
@@ -140,6 +140,12 @@ export class PlotlyPlotView extends HTMLBoxView {
   _end_relayouting = debounce(() => {
     this._relayouting = false
   }, 2000, false)
+  _throttled_resize: any
+
+  override initialize(): void {
+    super.initialize()
+    this._throttled_resize = throttle(() => this.resize_layout(), 25)
+  }
 
   override connect_signals(): void {
     super.connect_signals()
@@ -205,28 +211,33 @@ export class PlotlyPlotView extends HTMLBoxView {
     this.container = div() as PlotlyHTMLElement
     set_size(this.container, this.model)
     this._rendered = false
-    this.shadow_el.appendChild(this.container)
     this.watch_stylesheets()
-    this.plot().then(() => {
+    this.plot(true).then(() => {
+      this.shadow_el.appendChild(this.container);
       this._rendered = true
+      this.resize_layout();
       if (this.model.relayout != null) {
-        (window as any).Plotly.relayout(this.container, this.model.relayout)
+	(window as any).Plotly.relayout(this.container, this.model.relayout)
       }
-      (window as any).Plotly.Plots.resize(this.container)
     })
   }
 
   override style_redraw(): void {
-    if (this._rendered && this.container != null) {
-      (window as any).Plotly.Plots.resize(this.container)
+    this.resize_layout()
+  }
+
+  resize_layout(): void {
+    if (!this._rendered || this.container == null) {
+      return
     }
+    const width: number = Math.min(this.model.width || this.el.clientWidth, this.model.max_width || Infinity);
+    const height: number = Math.min(this.model.height || this.el.clientHeight, this.model.max_height || Infinity);
+    (window as any).Plotly.relayout(this.container, {width, height})
   }
 
   override after_layout(): void {
     super.after_layout()
-    if (this._rendered && this.container != null) {
-      (window as any).Plotly.Plots.resize(this.container)
-    }
+    this._throttled_resize()
   }
 
   _trace_data(): any {

--- a/panel/models/plotly.ts
+++ b/panel/models/plotly.ts
@@ -213,11 +213,11 @@ export class PlotlyPlotView extends HTMLBoxView {
     this._rendered = false
     this.watch_stylesheets()
     this.plot(true).then(() => {
-      this.shadow_el.appendChild(this.container);
+      this.shadow_el.appendChild(this.container)
       this._rendered = true
-      this.resize_layout();
+      this.resize_layout()
       if (this.model.relayout != null) {
-	(window as any).Plotly.relayout(this.container, this.model.relayout)
+        (window as any).Plotly.relayout(this.container, this.model.relayout)
       }
     })
   }
@@ -230,7 +230,7 @@ export class PlotlyPlotView extends HTMLBoxView {
     if (!this._rendered || this.container == null) {
       return
     }
-    const width: number = Math.min(this.model.width || this.el.clientWidth, this.model.max_width || Infinity);
+    const width: number = Math.min(this.model.width || this.el.clientWidth, this.model.max_width || Infinity)
     const height: number = Math.min(this.model.height || this.el.clientHeight, this.model.max_height || Infinity);
     (window as any).Plotly.relayout(this.container, {width, height})
   }


### PR DESCRIPTION
The sizing behavior of the `Plotly` pane has been quite annoying since we first created it. The problem being that Plotly does not seem to correctly determine the size of its container on the initial render so what the user saw when using a responsive sizing mode was an initial render, followed by a visible resize event, i.e. noticeable flicker.

Rather than letting Plotly handle the sizing behavior itself I've decided that we are now going to simply take control of the sizing behavior ourselves by computing the sizes of the container and then applying those using a `relayout` call. This appears to work very well, particularly when throttled, since resizing is a relatively expensive operation (~25 ms for an ordinary plot).

Fixes https://github.com/holoviz/panel/issues/7445
Fixes https://github.com/holoviz/panel/issues/6173
Fixes https://github.com/holoviz/panel/issues/5970