### PR TITLE
Add pointer cursor when hovering over copybtn

### DIFF
--- a/panel/styles/models/html.less
+++ b/panel/styles/models/html.less
@@ -30,4 +30,5 @@
 
 .codehilite:hover .copybtn {
   opacity: 1;
+  cursor: pointer;
 }


### PR DESCRIPTION
When starting to use the new copy code button I felt that it was lacking the pointer cursor compared to ChatGPT.


https://github.com/user-attachments/assets/f48f74e4-fd39-4438-a450-ecad250f1447

This PR adds the pointer.

**I have not tested this as I don't know how to trigger Panel to use the updated css file.**

## Workaround

Until this PR is released you can work around the problem as below:

````python
import panel as pn
from panel.chat import ChatInterface

pn.extension("perspective")

CSS = """
.codehilite:hover .copybtn {
  cursor: pointer;
}
"""

if not CSS in pn.pane.Markdown._stylesheets:
    pn.pane.Markdown._stylesheets.append(CSS)

code = """
Some code

```python
a=1
b=a+1
print(a, b)
```
"""

pn.template.FastListTemplate(
    title="Copy Button",
    sidebar=[code],
    main=[code],
).servable()
````