### PR TITLE
compat: websockets 14

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -224,6 +224,9 @@ filterwarnings = [
     "ignore:distutils Version classes are deprecated:DeprecationWarning:ipywidgets_bokeh.kernel", # OK
     "ignore:unclosed file <_io.TextIOWrapper name='(/dev/null|nul)' mode='w':ResourceWarning", # OK
     "ignore:Deprecated in traitlets 4.1, use the instance .metadata dictionary directly", # OK (ipywidgets internal)
+    # 2024-11
+    "ignore:websockets.legacy is deprecated:DeprecationWarning", # https://github.com/encode/uvicorn/issues/1908
+    "ignore:websockets.server.WebSocketServerProtocol is deprecated:DeprecationWarning", # https://github.com/encode/uvicorn/issues/1908
 ]
 
 [tool.mypy]


### PR DESCRIPTION
To fix the following warnings. By the look of it not much we can do on our end. 

``` python-traceback
  File "/Users/runner/work/panel/panel/.pixi/envs/test-310/lib/python3.10/site-packages/uvicorn/protocols/websockets/auto.py", line 19, in <module>
    from uvicorn.protocols.websockets.websockets_impl import WebSocketProtocol
  File "/Users/runner/work/panel/panel/.pixi/envs/test-310/lib/python3.10/site-packages/uvicorn/protocols/websockets/websockets_impl.py", line 10, in <module>
    import websockets.legacy.handshake
  File "/Users/runner/work/panel/panel/.pixi/envs/test-310/lib/python3.10/site-packages/websockets/legacy/__init__.py", line 6, in <module>
    warnings.warn(  # deprecated in 14.0 - 2024-11-09
DeprecationWarning: websockets.legacy is deprecated; see https://websockets.readthedocs.io/en/stable/howto/upgrade.html for upgrade instructions
```

``` python-traceback
  File "/Users/runner/work/panel/panel/.pixi/envs/test-310/lib/python3.10/site-packages/uvicorn/protocols/websockets/auto.py", line 19, in <module>
    from uvicorn.protocols.websockets.websockets_impl import WebSocketProtocol
  File "/Users/runner/work/panel/panel/.pixi/envs/test-310/lib/python3.10/site-packages/uvicorn/protocols/websockets/websockets_impl.py", line 16, in <module>
    from websockets.server import WebSocketServerProtocol
  File "/Users/runner/work/panel/panel/.pixi/envs/test-310/lib/python3.10/site-packages/websockets/imports.py", line 86, in __getattr__
    warnings.warn(
DeprecationWarning: websockets.server.WebSocketServerProtocol is deprecated
```