### PR TITLE
pin bokeh_fastapi to existing version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,7 @@ recommended = [
     'plotly',
 ]
 fastapi = [
-    'bokeh-fastapi >= 0.1.2',
+    'bokeh-fastapi >= 0.1.1',
     'fastapi[standard]',
 ]
 dev = [


### PR DESCRIPTION
In 7f850dc3c57a516d4c02656675e884a5b1ddd930 (Cc @philippjfr) the dependency was upped to `bokeh_fastapi>=0.1.2`. However, as of right now, the [latest release is `0.1.1`](https://pypi.org/project/bokeh-fastapi/#history):

![image](https://github.com/user-attachments/assets/82c51bcd-899b-4a6b-8e41-72e44ef91a8e)

Meaning, `pip install panel[fastapi]` currently fails as `pip` cannot find a version that satisfies the constraints.

This PR drops the pin back down to `bokeh_fastapi>=0.1.1`, which is likely what was intended in the first place.