### PR TITLE
docs: `auto` field of FileDownload widget

### DIFF
--- a/examples/reference/widgets/FileDownload.ipynb
+++ b/examples/reference/widgets/FileDownload.ipynb
@@ -26,7 +26,7 @@
     "\n",
     "##### Core\n",
     "\n",
-    "* **`auto`** (boolean):  Whether to download the file the initial click (if `True`) or when clicking a second time (or via the right-click Save file menu).\n",
+    "* **`auto`** (boolean):  Whether to download the file with the first click (if `True`) or only after clicking a second time (if `False`, enables right-click -> Save as).\n",
     "* **`callback`** (callable): A callable that returns a file or file-like object (takes precedence over `file` if set). \n",
     "* **`embed`** (boolean):  Whether to embed the data on initialization.\n",
     "* **`file`** (str, Path or file-like object):  A path to a file or a file-like object.\n",


### PR DESCRIPTION
Was missing a word + clarify advantage of user-defined filename.