### PR TITLE
Tweak repr of ChatMessage

### DIFF
--- a/panel/chat/message.py
+++ b/panel/chat/message.py
@@ -698,3 +698,6 @@ class ChatMessage(Pane):
             prefix_with_viewable_label=prefix_with_viewable_label,
             prefix_with_container_label=prefix_with_container_label,
         )
+
+    def __repr__(self, depth: int = 0) -> str:
+        return f"ChatMessage(object={self.object!r}, user={self.user!r}, reactions={self.reactions!r})"

--- a/panel/chat/utils.py
+++ b/panel/chat/utils.py
@@ -127,7 +127,7 @@ def get_obj_label(obj):
     Get the label for the object; defaults to specified object name;
     if unspecified, defaults to the type name.
     """
-    label = obj.name
+    label = obj.name if hasattr(obj, "name") else ""
     type_name = type(obj).__name__
     # If the name is just type + ID, simply use type
     # e.g. Column10241 -> Column

--- a/panel/tests/chat/test_feed.py
+++ b/panel/tests/chat/test_feed.py
@@ -608,6 +608,15 @@ class TestChatFeed:
         assert chat_feed._chat_log.scroll_button_threshold == 10
         assert chat_feed._chat_log.auto_scroll_limit == 10
 
+    def test_repr(self, chat_feed):
+        chat_feed.send("A")
+        chat_feed.send("B")
+        assert repr(chat_feed) == (
+            "ChatFeed(_placeholder=ChatMessage, sizing_mode='stretch_width')\n"
+            "    [0] ChatMessage(object='A', user='User', reactions=[])\n"
+            "    [1] ChatMessage(object='B', user='User', reactions=[])"
+        )
+
 
 @pytest.mark.xdist_group("chat")
 class TestChatFeedPromptUser:

--- a/panel/tests/chat/test_message.py
+++ b/panel/tests/chat/test_message.py
@@ -390,3 +390,11 @@ class TestChatMessage:
     def test_serialize_dataframe(self):
         message = ChatMessage(DataFrame(pd.DataFrame({'a': [1, 2, 3]})))
         assert message.serialize() == "DataFrame=   a\n0  1\n1  2\n2  3"
+
+    def test_repr(self):
+        message = ChatMessage(object="Hello", user="User", avatar="A", reactions=["favorite"])
+        assert repr(message) == "ChatMessage(object='Hello', user='User', reactions=['favorite'])"
+
+    def test_repr_dataframe(self):
+        message = ChatMessage(pd.DataFrame({'a': [1, 2, 3]}), avatar="D")
+        assert repr(message) == "ChatMessage(object=   a\n0  1\n1  2\n2  3, user='User', reactions=[])"


### PR DESCRIPTION
While debugging, the ChatMessage repr, and also the ChatFeed, can be excessively bloated and spammy. This reduces it to show only object, user, and reactions.

After (top) and Before (bottom):
<img width="2131" alt="image" src="https://github.com/user-attachments/assets/11ba2c32-fa65-49bf-8650-10547580be17">


