### PR TITLE
compat: Hathling 1.26

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,6 +111,7 @@ raw-options = { version_scheme = "no-guess-dev" }
 
 [tool.hatch.build.targets.wheel]
 include = ["panel"]
+exclude = ["panel/node_modules"]
 
 [tool.hatch.build.targets.wheel.force-include]
 "panel/dist" = "panel/dist"
@@ -121,7 +122,7 @@ include = ["panel"]
 
 [tool.hatch.build.targets.sdist]
 include = ["panel", "scripts", "examples"]
-exclude = ["scripts/jupyterlite"]
+exclude = ["scripts/jupyterlite", "panel/node_modules"]
 
 [tool.hatch.build.targets.sdist.force-include]
 "panel/dist" = "panel/dist"


### PR DESCRIPTION
Changes made in Hathling 1.26.0 no longer ignore `node_modules`. I think it is related to https://github.com/pypa/hatch/pull/1643.

I will add a test to detect size increases.