### PR TITLE
Remove Param _param_watchers compatibility code

### DIFF
--- a/panel/config.py
+++ b/panel/config.py
@@ -24,7 +24,6 @@ from pyviz_comms import (
 from .__version import __version__
 from .io.logging import panel_log_handler
 from .io.state import state
-from .util import param_watchers
 
 _LOCAL_DEV_VERSION = (
     any(v in __version__ for v in ('post', 'dirty'))
@@ -407,7 +406,7 @@ class _config(_base_config):
             if state.curdoc not in self._session_config:
                 self._session_config[state.curdoc] = {}
             self._session_config[state.curdoc][attr] = value
-            watchers = param_watchers(self).get(attr, {}).get('value', [])
+            watchers = self.param.watchers.get(attr, {}).get('value', [])
             for w in watchers:
                 w.fn()
         elif f'_{attr}' in _config._parameter_set and hasattr(self, f'_{attr}_'):

--- a/panel/io/document.py
+++ b/panel/io/document.py
@@ -29,7 +29,6 @@ from bokeh.model.util import visit_immediate_value_references
 from bokeh.models import CustomJS
 
 from ..config import config
-from ..util import param_watchers
 from .loading import LOADING_INDICATOR_CSS_CLASS
 from .model import monkeypatch_events  # noqa: F401 API import
 from .state import curdoc_locked, state
@@ -120,10 +119,10 @@ def _cleanup_doc(doc, destroy=True):
                 pane._hooks = []
                 for p in pane.select():
                     p._hooks = []
-                    param_watchers(p, {})
+                    p.param.watchers = {}
                     p._documents = {}
                     p._internal_callbacks = {}
-            param_watchers(pane, {})
+            pane.param.watchers = {}
             pane._documents = {}
             pane._internal_callbacks = {}
         else:

--- a/panel/io/embed.py
+++ b/panel/io/embed.py
@@ -16,7 +16,6 @@ from bokeh.core.property.bases import Property
 from bokeh.models import CustomJS
 from param.parameterized import Watcher
 
-from ..util import param_watchers
 from .model import add_to_doc, diff
 from .state import state
 
@@ -82,7 +81,7 @@ def save_dict(state, key=(), depth=0, max_depth=None, save_path='', load_path=No
 
 
 def get_watchers(reactive):
-    return [w for pwatchers in param_watchers(reactive).values()
+    return [w for pwatchers in reactive.param.watchers.values()
             for awatchers in pwatchers.values() for w in awatchers]
 
 
@@ -158,7 +157,7 @@ def links_to_jslinks(model, widget):
 
         mappings = []
         for pname, tgt_spec in link.links.items():
-            if Watcher(*link[:-4]) in param_watchers(widget)[pname]['value']:
+            if Watcher(*link[:-4]) in widget.param.watchers[pname]['value']:
                 mappings.append((pname, tgt_spec))
 
         if mappings:

--- a/panel/layout/base.py
+++ b/panel/layout/base.py
@@ -19,7 +19,7 @@ from ..io.document import freeze_doc, hold
 from ..io.resources import CDN_DIST
 from ..models import Column as PnColumn
 from ..reactive import Reactive
-from ..util import param_name, param_reprs, param_watchers
+from ..util import param_name, param_reprs
 from ..viewable import Children
 
 if TYPE_CHECKING:
@@ -570,7 +570,7 @@ class NamedListLike(param.Parameterized):
         self.param.watch(self._update_names, 'objects')
         # ALERT: Ensure that name update happens first, should be
         #        replaced by watch precedence support in param
-        param_watchers(self)['objects']['value'].reverse()
+        self.param.watchers['objects']['value'].reverse()
 
     def _to_object_and_name(self, item):
         from ..pane import panel

--- a/panel/pane/base.py
+++ b/panel/pane/base.py
@@ -28,7 +28,7 @@ from ..layout.base import (
 from ..links import Link
 from ..models import ReactiveHTML as _BkReactiveHTML
 from ..reactive import Reactive
-from ..util import param_reprs, param_watchers
+from ..util import param_reprs
 from ..util.checks import is_dataframe, is_series
 from ..util.parameters import get_params_to_inherit
 from ..viewable import (
@@ -702,7 +702,7 @@ class ReplacementPane(Pane):
         custom_watchers = []
         if isinstance(object, Reactive):
             watchers = [
-                w for pwatchers in param_watchers(object).values()
+                w for pwatchers in object.param.watchers.values()
                 for awatchers in pwatchers.values() for w in awatchers
             ]
             custom_watchers = [

--- a/panel/tests/pane/test_base.py
+++ b/panel/tests/pane/test_base.py
@@ -17,7 +17,6 @@ from panel.param import (
     Param, ParamFunction, ParamMethod, ParamRef, ReactiveExpr,
 )
 from panel.tests.util import check_layoutable_properties
-from panel.util import param_watchers
 
 SKIP_PANES = (
     Bokeh, ChatMessage, HoloViews, Interactive, IPyWidget, Param,
@@ -90,7 +89,7 @@ def test_pane_untracked_watchers(pane, document, comm):
     except ImportError:
         pytest.skip("Dependent library could not be imported.")
     watchers = [
-        w for pwatchers in param_watchers(p).values()
+        w for pwatchers in p.param.watchers.values()
         for awatchers in pwatchers.values() for w in awatchers
     ]
     assert len([wfn for wfn in watchers if wfn not in p._internal_callbacks and not hasattr(wfn.fn, '_watcher_name')]) == 0

--- a/panel/tests/widgets/test_base.py
+++ b/panel/tests/widgets/test_base.py
@@ -5,7 +5,6 @@ from panel.io import block_comm
 from panel.layout import Row
 from panel.links import CallbackGenerator
 from panel.tests.util import check_layoutable_properties
-from panel.util import param_watchers
 from panel.widgets import (
     CompositeWidget, Dial, FileDownload, FloatSlider, LinearGauge,
     LoadingSpinner, Terminal, TextInput, ToggleGroup, Tqdm, Widget,
@@ -38,7 +37,7 @@ def test_widget_untracked_watchers(widget, document, comm):
     except ImportError:
         pytest.skip("Dependent library could not be imported.")
     watchers = [
-        w for pwatchers in param_watchers(widg).values()
+        w for pwatchers in widg.param.watchers.values()
         for awatchers in pwatchers.values() for w in awatchers
     ]
     assert len([wfn for wfn in watchers if wfn not in widg._internal_callbacks and not hasattr(wfn.fn, '_watcher_name')]) == 0

--- a/panel/util/__init__.py
+++ b/panel/util/__init__.py
@@ -37,7 +37,7 @@ from .checks import (  # noqa
     is_series, isdatetime, isfile, isIn, isurl,
 )
 from .parameters import (  # noqa
-    edit_readonly, extract_dependencies, get_method_owner, param_watchers,
+    edit_readonly, extract_dependencies, get_method_owner,
     recursive_parameterized,
 )
 

--- a/panel/util/parameters.py
+++ b/panel/util/parameters.py
@@ -7,10 +7,6 @@ from typing import Any, Iterator
 
 import param
 
-from packaging.version import Version
-
-_unset = object()
-
 
 def should_inherit(parameterized: param.Parameterized, p: str, v: Any) -> Any:
     pobj = parameterized.param[p]
@@ -83,19 +79,6 @@ def extract_dependencies(function):
         elif p not in params:
             params.append(p)
     return params
-
-
-def param_watchers(parameterized: param.Parameterized, value=_unset):
-    if Version(param.__version__) <= Version('2.0.0a2'):
-        if value is not _unset:
-            parameterized._param_watchers = value
-        else:
-            return parameterized._param_watchers
-    else:
-        if value is not _unset:
-            parameterized.param.watchers = value
-        else:
-            return parameterized.param.watchers
 
 
 def recursive_parameterized(parameterized: param.Parameterized, objects=None) -> list[param.Parameterized]:


### PR DESCRIPTION
Basically undoing what was done in https://github.com/holoviz/panel/pull/5350 a while back before the release of Param 2. Panel now depends on `param>=2.1` so `<ParamObj>.param.watchers` is available.