### PR TITLE
type: Return `Self` for `.servable`

### DIFF
--- a/panel/template/base.py
+++ b/panel/template/base.py
@@ -56,6 +56,7 @@ if TYPE_CHECKING:
     from bokeh.server.contexts import BokehSessionContext
     from jinja2 import Template as _Template
     from pyviz_comms import Comm
+    from typing_extensions import Self
 
     from ..io.location import Location
     from ..io.resources import ResourcesType
@@ -506,7 +507,7 @@ class BaseTemplate(param.Parameterized, MimeRenderMixin, ServableMixin, Resource
     def servable(
         self, title: str | None = None, location: bool | Location = True,
         area: str = 'main', target: str | None = None
-    ) -> ServableMixin:
+    ) -> Self:
         """
         Serves the template and returns self to allow it to display
         itself in a notebook context.

--- a/panel/viewable.py
+++ b/panel/viewable.py
@@ -23,7 +23,7 @@ import uuid
 
 from collections.abc import Callable, Mapping
 from typing import (
-    IO, TYPE_CHECKING, Any, ClassVar, Self,
+    IO, TYPE_CHECKING, Any, ClassVar,
 )
 
 import param  # type: ignore
@@ -56,6 +56,7 @@ if TYPE_CHECKING:
     from bokeh.model import Model
     from bokeh.server.contexts import BokehSessionContext
     from bokeh.server.server import Server
+    from typing_extensions import Self
 
     from .io.location import Location
     from .io.notebook import Mimebundle

--- a/panel/viewable.py
+++ b/panel/viewable.py
@@ -23,7 +23,7 @@ import uuid
 
 from collections.abc import Callable, Mapping
 from typing import (
-    IO, TYPE_CHECKING, Any, ClassVar,
+    IO, TYPE_CHECKING, Any, ClassVar, Self,
 )
 
 import param  # type: ignore
@@ -359,7 +359,7 @@ class ServableMixin:
     def servable(
         self, title: str | None = None, location: bool | Location = True,
         area: str = 'main', target: str | None = None
-    ) -> ServableMixin:
+    ) -> Self:
         """
         Serves the object or adds it to the configured
         pn.state.template if in a `panel serve` context, writes to the


### PR DESCRIPTION
I noticed this code will confuse the LSP.

``` python
import panel as pn

button = pn.widgets.Button().servable()
button.on_click()
```
Before:
![ Screenshot 2024-12-03 15 42 30](https://github.com/user-attachments/assets/d88596d4-c8d6-45ca-bb5c-1257990df495)

After:
![ Screenshot 2024-12-03 15 42 14](https://github.com/user-attachments/assets/0ca17fed-f44a-4d74-90e6-d802dccfa9db)


