### PR TITLE
Fix issue #7532: Disabled for NestedSelect

### DIFF
--- a/panel/widgets/select.py
+++ b/panel/widgets/select.py
@@ -545,7 +545,7 @@ class NestedSelect(CompositeWidget):
         value = self._lookup_value(i, options, self.value, error=False)
         widget_kwargs["options"] = options
         widget_kwargs["value"] = value
-        widget_kwargs["disabled"] = self.disabled
+        widget_kwargs["disabled"] = self.param.disabled
         if "visible" not in widget_kwargs:
             # first select widget always visible
             widget_kwargs["visible"] = i == 0 or callable(options) or len(options) > 0

--- a/panel/widgets/select.py
+++ b/panel/widgets/select.py
@@ -545,6 +545,7 @@ class NestedSelect(CompositeWidget):
         value = self._lookup_value(i, options, self.value, error=False)
         widget_kwargs["options"] = options
         widget_kwargs["value"] = value
+        widget_kwargs["disabled"] = self.disabled
         if "visible" not in widget_kwargs:
             # first select widget always visible
             widget_kwargs["visible"] = i == 0 or callable(options) or len(options) > 0


### PR DESCRIPTION
### Description

This pull request fixes issue #7532 .

### Changes Made

- Fixed the `disabled` toggle for `NestedSelect` 
- Not sure if this is it what is required.  But is working as expected
- Documentation doesn't show disabled as a parameter, however the original code did have references to it so looks like it is intended and is inline with other widgets
- Ran tests locally with pixi before opening this PR