### PR TITLE
Add ChatInterface button tooltips

### DIFF
--- a/panel/chat/interface.py
+++ b/panel/chat/interface.py
@@ -107,6 +107,9 @@ class ChatInterface(ChatFeed):
     show_button_name = param.Boolean(default=None, doc="""
         Whether to show the button name.""")
 
+    show_button_tooltips = param.Boolean(default=False, doc="""
+        Whether to show the button tooltips.""")
+
     user = param.String(default="User", doc="""
         Name of the ChatInterface user.""")
 
@@ -303,12 +306,14 @@ class ChatInterface(ChatFeed):
                     visible = self.param[f'show_{action}'] if action != "stop" else False
                 except KeyError:
                     visible = True
-                show_expr = self.param.show_button_name.rx()
+                show_name_expr = self.param.show_button_name.rx()
+                show_tooltip_expr = self.param.show_button_tooltips.rx()
                 button = Button(
-                    name=show_expr.rx.where(button_data.name.title(), ""),
+                    name=show_name_expr.rx.where(button_data.name.title(), ""),
+                    description=show_tooltip_expr.rx.where(f"Click to {button_data.name.lower()}", ""),
                     icon=button_data.icon,
                     sizing_mode="stretch_width",
-                    max_width=show_expr.rx.where(90, 45),
+                    max_width=show_name_expr.rx.where(90, 45),
                     max_height=50,
                     margin=(0, 5, 0, 0),
                     align="center",

--- a/panel/chat/interface.py
+++ b/panel/chat/interface.py
@@ -309,8 +309,8 @@ class ChatInterface(ChatFeed):
                 show_name_expr = self.param.show_button_name.rx()
                 show_tooltip_expr = self.param.show_button_tooltips.rx()
                 button = Button(
-                    name=show_name_expr.rx.where(button_data.name.title(), None),
-                    description=show_tooltip_expr.rx.where(f"Click to {button_data.name.lower()}", ""),
+                    name=show_name_expr.rx.where(button_data.name.title(), ""),
+                    description=show_tooltip_expr.rx.where(f"Click to {button_data.name.lower()}", None),
                     icon=button_data.icon,
                     sizing_mode="stretch_width",
                     max_width=show_name_expr.rx.where(90, 45),

--- a/panel/chat/interface.py
+++ b/panel/chat/interface.py
@@ -309,7 +309,7 @@ class ChatInterface(ChatFeed):
                 show_name_expr = self.param.show_button_name.rx()
                 show_tooltip_expr = self.param.show_button_tooltips.rx()
                 button = Button(
-                    name=show_name_expr.rx.where(button_data.name.title(), ""),
+                    name=show_name_expr.rx.where(button_data.name.title(), None),
                     description=show_tooltip_expr.rx.where(f"Click to {button_data.name.lower()}", ""),
                     icon=button_data.icon,
                     sizing_mode="stretch_width",

--- a/panel/tests/ui/chat/test_chat_interface_ui.py
+++ b/panel/tests/ui/chat/test_chat_interface_ui.py
@@ -60,3 +60,14 @@ def test_chat_interface_custom_js_string(page):
         msg = msg_info.value
 
     assert msg.args[0].json_value() == "Clicked"
+
+
+
+def test_chat_interface_show_button_tooltips(page):
+    chat_interface = ChatInterface(show_button_tooltips=True)
+    serve_component(page, chat_interface)
+
+    help_button = page.locator("button", has_text="send")
+    help_button.hover()
+
+    expect(page.locator(".bk-Tooltip")).to_be_visible()


### PR DESCRIPTION
Mainly useful if show_button_name is disabled.
<img width="806" alt="image" src="https://github.com/user-attachments/assets/28c4df3c-248a-4004-87e6-3fffea697374" />
