### PR TITLE
Increase max limit of ChatAreaInput

### DIFF
--- a/examples/reference/chat/ChatAreaInput.ipynb
+++ b/examples/reference/chat/ChatAreaInput.ipynb
@@ -46,7 +46,7 @@
     "* **`auto_grow`** (boolean, default=True): Whether the TextArea should automatically grow in height to fit the content.\n",
     "* **`cols`** (int, default=2): The number of columns in the text input field.\n",
     "* **`disabled`** (boolean, default=False): Whether the widget is editable\n",
-    "* **`max_length`** (int, default=5000): Max character length of the input field. Defaults to 5000\n",
+    "* **`max_length`** (int, default=50000): Max character length of the input field. Defaults to 50000\n",
     "* **`max_rows`** (int, default=10): The maximum number of rows in the text input field when `auto_grow=True`.\n",
     "* **`name`** (str): The title of the widget\n",
     "* **`placeholder`** (str): A placeholder string displayed when no value is entered\n",

--- a/panel/chat/input.py
+++ b/panel/chat/input.py
@@ -71,6 +71,9 @@ class ChatAreaInput(_PnTextAreaInput):
         Can only be set during initialization.""",
     )
 
+    max_length = param.Integer(default=50000, doc="""
+        Max count of characters in the input field.""")
+
     _widget_type: ClassVar[type[Model]] = _bkChatAreaInput
 
     _rename: ClassVar[Mapping[str, str | None]] = {


### PR DESCRIPTION
I think the original default, inherited from _TextInputBase is too limiting.

This increases it by 10x, so about 12k tokens?

Based on 
<img width="850" alt="image" src="https://github.com/user-attachments/assets/307d4e8a-1112-4d22-880c-c2a386834381" />
