### PR TITLE
Fix chat message align

### DIFF
--- a/panel/dist/css/chat_message.css
+++ b/panel/dist/css/chat_message.css
@@ -85,7 +85,7 @@
   width: fit-content;
   display: flex;
   align-items: center;
-  justify-content: center;
+  justify-content: left;
   overflow-wrap: anywhere;
   word-break: break-word;
 }
@@ -146,4 +146,20 @@
   /* since 1.25em, adjust line-height */
   font-size: 1.25em;
   line-height: 0.9em;
+}
+
+pre {
+  white-space: pre-wrap;
+  word-wrap: break-word;
+  overflow-wrap: break-word;
+}
+
+p {
+  overflow-wrap: break-word;
+}
+
+code {
+  white-space: pre-wrap;
+  word-wrap: break-word;
+  overflow-wrap: break-word;
 }


### PR DESCRIPTION
Copying:
https://raw.githubusercontent.com/holoviz/hvplot/refs/heads/main/hvplot/converter.py

Before
<img width="946" alt="image" src="https://github.com/user-attachments/assets/80f8b631-e849-45ab-86bc-ff32550a108a" />

After
<img width="731" alt="image" src="https://github.com/user-attachments/assets/5279ff19-eada-4fe0-be88-bb15fec28603" />
