### PR TITLE
fix: Use f-string to show filename in error message correctly

### DIFF
--- a/panel/command/convert.py
+++ b/panel/command/convert.py
@@ -114,7 +114,7 @@ class Convert(Subcommand):
         for f in args.files:
             p = pathlib.Path(f).absolute()
             if not p.is_file():
-                raise ValueError('File {f!r} not found.')
+                raise ValueError(f'File {f!r} not found.')
             elif p not in excluded:
                 included.append(p)
 


### PR DESCRIPTION
This fix makes the string an f-string. Without this change, the error message doesn't show which file is actually missing:

<img width="480" alt="image" src="https://github.com/user-attachments/assets/d2c7f8ac-c196-4d38-9800-157bea23a7ae" />