### PR TITLE
fix dark theme scroll

### DIFF
--- a/panel/dist/css/chat_feed.css
+++ b/panel/dist/css/chat_feed.css
@@ -5,3 +5,7 @@
 ::-webkit-scrollbar {
   width: 8px;
 }
+
+::-webkit-scrollbar-thumb {
+  background-color: var(--panel-surface-color, #f1f1f1);
+}

--- a/panel/dist/css/chat_feed.css
+++ b/panel/dist/css/chat_feed.css
@@ -1,3 +1,7 @@
 .chat-feed-header {
   margin-left: 15px;
 }
+
+::-webkit-scrollbar {
+  width: 8px;
+}

--- a/panel/dist/css/chat_feed.css
+++ b/panel/dist/css/chat_feed.css
@@ -7,5 +7,5 @@
 }
 
 ::-webkit-scrollbar-thumb {
-  background-color: var(--panel-surface-color, #f1f1f1);
+  background-color: var(--panel-secondary-color, #f1f1f1);
 }


### PR DESCRIPTION
Closes https://github.com/holoviz/panel/issues/7600

Don't fully understand CSS, but adding `::-webkit-scrollbar` seems to make it properly use the theme's scrollbar colors

After:
<img width="861" alt="image" src="https://github.com/user-attachments/assets/6c062ebc-28d2-47ca-96be-87c82e313e37" />

Before:
<img width="1150" alt="image" src="https://github.com/user-attachments/assets/5e7887f6-e4d9-4e76-b90e-fa98580aef60" />

With scrollbar:

<img width="861" alt="image" src="https://github.com/user-attachments/assets/fc311e0b-016e-4f1d-bac2-49023bb07995" />

<img width="819" alt="image" src="https://github.com/user-attachments/assets/688946bb-f4f0-4496-8389-327c38ff134b" />
