### PR TITLE
Fix dark theme for FileDropper

### DIFF
--- a/panel/styles/models/filedropper.less
+++ b/panel/styles/models/filedropper.less
@@ -1,4 +1,9 @@
 .bk-input.filepond--root {
-  background-color: unset;
+  background-color: var(--panel-surface-color, #f1f1f1);
   border: unset;
+}
+
+.bk-input.filepond--root .filepond--drop-label {
+  color: var(--panel-on-surface-color, #000);
+  background-color: var(--panel-surface-color, #f1f1f1);
 }


### PR DESCRIPTION
Closes https://github.com/holoviz/panel/issues/7599

Could not find where to adjust the little strip on the bottom, but it looks okay.

<img width="868" alt="image" src="https://github.com/user-attachments/assets/622b98ff-6bfa-44eb-9cd3-ba7fba3e0dc4" />
