### PR TITLE
Skip streamz tests on windows due to tornado

### DIFF
--- a/panel/tests/pane/test_markup.py
+++ b/panel/tests/pane/test_markup.py
@@ -13,7 +13,7 @@ from panel import config
 from panel.pane import (
     HTML, JSON, DataFrame, Markdown, PaneBase, Str,
 )
-from panel.tests.util import streamz_available
+from panel.tests.util import not_windows, streamz_available
 
 
 def test_get_markdown_pane_type():
@@ -39,18 +39,22 @@ async def streamz_df():
         await asyncio.sleep(0.1)
     sdf.loop.asyncio_loop.close()
 
+@not_windows
 @streamz_available
 def test_get_streamz_dataframe_pane_type(streamz_df):
     assert PaneBase.get_pane_type(streamz_df) is DataFrame
 
+@not_windows
 @streamz_available
 def test_get_streamz_dataframes_pane_type(streamz_df):
     assert PaneBase.get_pane_type(streamz_df.groupby('y').sum()) is DataFrame
 
+@not_windows
 @streamz_available
 def test_get_streamz_series_pane_type(streamz_df):
     assert PaneBase.get_pane_type(streamz_df.x) is DataFrame
 
+@not_windows
 @streamz_available
 def test_get_streamz_seriess_pane_type(streamz_df):
     assert PaneBase.get_pane_type(streamz_df.groupby('y').sum().x) is DataFrame
@@ -226,6 +230,7 @@ def test_dataframe_pane_supports_escape(document, comm):
     pane._cleanup(model)
     assert pane._models == {}
 
+@not_windows
 @streamz_available
 def test_dataframe_pane_streamz(streamz_df, document, comm):
     pane = DataFrame(streamz_df)

--- a/panel/tests/util.py
+++ b/panel/tests/util.py
@@ -31,6 +31,9 @@ from panel.io.state import state
 # Will begin to fail again when the first rc is released.
 pnv = Version(pn.__version__)
 
+not_osx = pytest.mark.skipif(sys.platform == 'darwin', reason="Sometimes fails on OSX")
+not_windows = pytest.mark.skipif(sys.platform == 'win32', reason="Does not work on Windows")
+
 try:
     import holoviews as hv
     hv_version: Version | None = Version(hv.__version__)

--- a/panel/tests/widgets/test_terminal.py
+++ b/panel/tests/widgets/test_terminal.py
@@ -9,8 +9,7 @@ import pytest
 
 import panel as pn
 
-not_windows = pytest.mark.skipif(sys.platform == 'win32', reason="Does not work on Windows")
-not_osx = pytest.mark.skipif(sys.platform == 'darwin', reason="Sometimes fails on OSX")
+from panel.tests.util import not_osx, not_windows
 
 
 def test_terminal_constructor():
@@ -18,7 +17,6 @@ def test_terminal_constructor():
     terminal.write("Hello")
 
     assert repr(terminal).startswith("Terminal(")
-
 
 def test_terminal(document, comm):
     terminal = pn.widgets.Terminal("Hello")
@@ -36,7 +34,6 @@ def test_terminal(document, comm):
     model2 = terminal.get_root(document, comm)
 
     assert model2.output == ""
-
 
 @not_windows
 @not_osx
@@ -63,7 +60,6 @@ async def test_subprocess():
     assert subprocess._child_pid == 0
     assert subprocess._fd == 0
 
-
 @not_windows
 @not_osx
 @pytest.mark.subprocess
@@ -78,7 +74,6 @@ async def test_run_list_args():
         count += 1
     assert subprocess.running
     subprocess.kill()
-
 
 def test_cannot_assign_string_args_with_spaces():
     terminal = pn.widgets.Terminal()


### PR DESCRIPTION
Still having some issues with pytest-asyncio trying to shut down the event loop used by Streamz via Tornado. Tornado issues a `ResourceWarning` because the IOLoop adds a callback which never runs.