### PR TITLE
Scroll when streaming to ChatFeed and ChatStep

### DIFF
--- a/panel/chat/feed.py
+++ b/panel/chat/feed.py
@@ -704,7 +704,7 @@ class ChatFeed(ListPanel):
 
             if message_params:
                 message.param.update(**message_params)
-            self._chat_log.scroll_to_latest()
+            self._chat_log.scroll_to_latest(scroll_limit=self.auto_scroll_limit)
             return message
 
         if isinstance(value, ChatMessage):
@@ -716,7 +716,7 @@ class ChatFeed(ListPanel):
         self._replace_placeholder(message)
 
         self.param.trigger("_post_hook_trigger")
-        self._chat_log.scroll_to_latest()
+        self._chat_log.scroll_to_latest(scroll_limit=self.auto_scroll_limit)
         return message
 
     def add_step(
@@ -826,7 +826,7 @@ class ChatFeed(ListPanel):
             self.stream(steps_layout, user=user or self.callback_user, avatar=avatar)
         else:
             steps_layout.append(step)
-            self._chat_log.scroll_to_latest()
+            self._chat_log.scroll_to_latest(scroll_limit=self.auto_scroll_limit)
         return step
 
     def prompt_user(

--- a/panel/chat/feed.py
+++ b/panel/chat/feed.py
@@ -704,7 +704,7 @@ class ChatFeed(ListPanel):
 
             if message_params:
                 message.param.update(**message_params)
-            self._chat_log.scroll_to_latest(scroll_limit=200)
+            self._chat_log.scroll_to_latest()
             return message
 
         if isinstance(value, ChatMessage):
@@ -716,7 +716,7 @@ class ChatFeed(ListPanel):
         self._replace_placeholder(message)
 
         self.param.trigger("_post_hook_trigger")
-        self._chat_log.scroll_to_latest(scroll_limit=200)
+        self._chat_log.scroll_to_latest()
         return message
 
     def add_step(
@@ -826,7 +826,7 @@ class ChatFeed(ListPanel):
             self.stream(steps_layout, user=user or self.callback_user, avatar=avatar)
         else:
             steps_layout.append(step)
-            self._chat_log.scroll_to_latest(scroll_limit=200)
+            self._chat_log.scroll_to_latest()
         return step
 
     def prompt_user(

--- a/panel/chat/feed.py
+++ b/panel/chat/feed.py
@@ -704,7 +704,7 @@ class ChatFeed(ListPanel):
 
             if message_params:
                 message.param.update(**message_params)
-            self._chat_log.scroll_to_latest()
+            self._chat_log.scroll_to_latest(scroll_limit=200)
             return message
 
         if isinstance(value, ChatMessage):
@@ -716,7 +716,7 @@ class ChatFeed(ListPanel):
         self._replace_placeholder(message)
 
         self.param.trigger("_post_hook_trigger")
-        self._chat_log.scroll_to_latest()
+        self._chat_log.scroll_to_latest(scroll_limit=200)
         return message
 
     def add_step(
@@ -826,7 +826,7 @@ class ChatFeed(ListPanel):
             self.stream(steps_layout, user=user or self.callback_user, avatar=avatar)
         else:
             steps_layout.append(step)
-            self._chat_log.scroll_to_latest()
+            self._chat_log.scroll_to_latest(scroll_limit=200)
         return step
 
     def prompt_user(

--- a/panel/chat/feed.py
+++ b/panel/chat/feed.py
@@ -704,6 +704,7 @@ class ChatFeed(ListPanel):
 
             if message_params:
                 message.param.update(**message_params)
+            self._chat_log.scroll_to_latest()
             return message
 
         if isinstance(value, ChatMessage):
@@ -715,6 +716,7 @@ class ChatFeed(ListPanel):
         self._replace_placeholder(message)
 
         self.param.trigger("_post_hook_trigger")
+        self._chat_log.scroll_to_latest()
         return message
 
     def add_step(
@@ -777,6 +779,8 @@ class ChatFeed(ListPanel):
             if "context_exception" not in step_params:
                 step_params["context_exception"] = self.callback_exception
             step = ChatStep(**step_params)
+
+        step._instance = self
 
         if append:
             for i in range(1, last_messages + 1):

--- a/panel/chat/step.py
+++ b/panel/chat/step.py
@@ -265,7 +265,7 @@ class ChatStep(Card):
         else:
             stream_to(self.objects[-1], token, replace=replace)
         if self._instance is not None:
-            self._instance._chat_log.scroll_to_latest()
+            self._instance._chat_log.scroll_to_latest(scroll_limit=200)
 
     def serialize(
         self,

--- a/panel/chat/step.py
+++ b/panel/chat/step.py
@@ -238,7 +238,7 @@ class ChatStep(Card):
             original = getattr(self, f"{status}_title") or ""
             setattr(self, f"{status}_title", original + token)
 
-    def stream(self, token: str | None, replace: bool = False):
+    def stream(self, token: str | None, replace: bool = False, scroll: bool = True):
         """
         Stream a token to the last available string-like object.
 
@@ -264,6 +264,8 @@ class ChatStep(Card):
             self.append(message)
         else:
             stream_to(self.objects[-1], token, replace=replace)
+        if self._instance is not None:
+            self._instance._chat_log.scroll_to_latest()
 
     def serialize(
         self,

--- a/panel/chat/step.py
+++ b/panel/chat/step.py
@@ -238,7 +238,7 @@ class ChatStep(Card):
             original = getattr(self, f"{status}_title") or ""
             setattr(self, f"{status}_title", original + token)
 
-    def stream(self, token: str | None, replace: bool = False, scroll: bool = True):
+    def stream(self, token: str | None, replace: bool = False):
         """
         Stream a token to the last available string-like object.
 
@@ -248,8 +248,6 @@ class ChatStep(Card):
             The token to stream.
         replace : bool
             Whether to replace the existing text.
-        scroll: bool
-            Whether to scroll to the latest message when streaming.
 
         Returns
         -------
@@ -267,8 +265,8 @@ class ChatStep(Card):
         else:
             stream_to(self.objects[-1], token, replace=replace)
 
-        if self._instance is not None and scroll:
-            self._instance._chat_log.scroll_to_latest()
+        if self._instance is not None:
+            self._instance._chat_log.scroll_to_latest(self._instance.auto_scroll_limit)
 
     def serialize(
         self,

--- a/panel/chat/step.py
+++ b/panel/chat/step.py
@@ -265,7 +265,7 @@ class ChatStep(Card):
         else:
             stream_to(self.objects[-1], token, replace=replace)
         if self._instance is not None:
-            self._instance._chat_log.scroll_to_latest(scroll_limit=200)
+            self._instance._chat_log.scroll_to_latest()
 
     def serialize(
         self,

--- a/panel/chat/step.py
+++ b/panel/chat/step.py
@@ -248,6 +248,8 @@ class ChatStep(Card):
             The token to stream.
         replace : bool
             Whether to replace the existing text.
+        scroll: bool
+            Whether to scroll to the latest message when streaming.
 
         Returns
         -------
@@ -264,7 +266,8 @@ class ChatStep(Card):
             self.append(message)
         else:
             stream_to(self.objects[-1], token, replace=replace)
-        if self._instance is not None:
+
+        if self._instance is not None and scroll:
             self._instance._chat_log.scroll_to_latest()
 
     def serialize(

--- a/panel/layout/feed.py
+++ b/panel/layout/feed.py
@@ -102,7 +102,7 @@ class Feed(Column):
         if (event.type == 'triggered' or not self.view_latest or
             not event.new or event.new[-1] in event.old):
             return
-        self.scroll_to_latest()
+        self.scroll_to_latest(scroll_limit=200)
 
     @property
     def _synced_range(self):
@@ -203,11 +203,18 @@ class Feed(Column):
             # reset the buffers and loaded objects
             self.load_buffer = load_buffer
 
-    def scroll_to_latest(self):
+    def scroll_to_latest(self, scroll_limit: float = 0) -> None:
         """
         Scrolls the Feed to the latest entry.
+
+        Parameters
+        ----------
+        scroll_limit : float, optional
+            Maximum pixel distance from the latest object in the Column to
+            trigger scrolling. If the distance exceeds this limit, scrolling will not occur.
+            Setting this to 0 disables the limit.
         """
         rerender = self._last_synced and self._last_synced[-1] < len(self.objects)
         if rerender:
             self._process_event()
-        self._send_event(ScrollLatestEvent, rerender=rerender)
+        self._send_event(ScrollLatestEvent, rerender=rerender, scroll_limit=scroll_limit)

--- a/panel/layout/feed.py
+++ b/panel/layout/feed.py
@@ -102,7 +102,7 @@ class Feed(Column):
         if (event.type == 'triggered' or not self.view_latest or
             not event.new or event.new[-1] in event.old):
             return
-        self.scroll_to_latest(scroll_limit=self.auto_scroll_limit)
+        self.scroll_to_latest()
 
     @property
     def _synced_range(self):

--- a/panel/layout/feed.py
+++ b/panel/layout/feed.py
@@ -212,10 +212,9 @@ class Feed(Column):
         scroll_limit : float, optional
             Maximum pixel distance from the latest object in the Feed to
             trigger scrolling. If the distance exceeds this limit, scrolling will not occur.
-            Setting this to 0 disables scrolling. Defaults to the auto_scroll_limit param's value.
+            If this is not set, it will always scroll to the latest while setting this to 0 disables scrolling.
         """
         rerender = self._last_synced and self._last_synced[-1] < len(self.objects)
         if rerender:
             self._process_event()
-        scroll_limit = self.auto_scroll_limit if scroll_limit is None else scroll_limit
         self._send_event(ScrollLatestEvent, rerender=rerender, scroll_limit=scroll_limit)

--- a/panel/layout/feed.py
+++ b/panel/layout/feed.py
@@ -102,7 +102,7 @@ class Feed(Column):
         if (event.type == 'triggered' or not self.view_latest or
             not event.new or event.new[-1] in event.old):
             return
-        self.scroll_to_latest(scroll_limit=200)
+        self.scroll_to_latest(scroll_limit=self.auto_scroll_limit)
 
     @property
     def _synced_range(self):
@@ -203,18 +203,19 @@ class Feed(Column):
             # reset the buffers and loaded objects
             self.load_buffer = load_buffer
 
-    def scroll_to_latest(self, scroll_limit: float = 0) -> None:
+    def scroll_to_latest(self, scroll_limit: float | None = None) -> None:
         """
         Scrolls the Feed to the latest entry.
 
         Parameters
         ----------
         scroll_limit : float, optional
-            Maximum pixel distance from the latest object in the Column to
+            Maximum pixel distance from the latest object in the Feed to
             trigger scrolling. If the distance exceeds this limit, scrolling will not occur.
-            Setting this to 0 disables the limit.
+            Setting this to 0 disables scrolling. Defaults to the auto_scroll_limit param's value.
         """
         rerender = self._last_synced and self._last_synced[-1] < len(self.objects)
         if rerender:
             self._process_event()
+        scroll_limit = self.auto_scroll_limit if scroll_limit is None else scroll_limit
         self._send_event(ScrollLatestEvent, rerender=rerender, scroll_limit=scroll_limit)

--- a/panel/models/column.ts
+++ b/panel/models/column.ts
@@ -95,8 +95,8 @@ export class ColumnView extends BkColumnView {
     }
 
     requestAnimationFrame(() => {
-      this.model.scroll_position = Math.round(this.el.scrollHeight);
-    });
+      this.model.scroll_position = Math.round(this.el.scrollHeight)
+    })
   }
 
   trigger_auto_scroll(): void {

--- a/panel/models/column.ts
+++ b/panel/models/column.ts
@@ -86,11 +86,17 @@ export class ColumnView extends BkColumnView {
     })
   }
 
-  scroll_to_latest(): void {
-    // Waits for the child to be rendered before scrolling
+  scroll_to_latest(scroll_limit: number | null = null): void {
+    if (scroll_limit !== null) {
+      const within_limit = this.distance_from_latest <= scroll_limit
+      if (!within_limit) {
+        return
+      }
+    }
+
     requestAnimationFrame(() => {
-      this.model.scroll_position = Math.round(this.el.scrollHeight)
-    })
+      this.model.scroll_position = Math.round(this.el.scrollHeight);
+    });
   }
 
   trigger_auto_scroll(): void {

--- a/panel/models/feed.py
+++ b/panel/models/feed.py
@@ -10,12 +10,13 @@ class ScrollLatestEvent(ModelEvent):
 
     event_name = 'scroll_latest_event'
 
-    def __init__(self, model, rerender=False):
+    def __init__(self, model, rerender=False, scroll_limit=0):
         super().__init__(model=model)
         self.rerender = rerender
+        self.scroll_limit = scroll_limit
 
     def event_values(self) -> dict[str, Any]:
-        return dict(super().event_values(), rerender=self.rerender)
+        return dict(super().event_values(), rerender=self.rerender, scroll_limit=self.scroll_limit)
 
 
 class ScrollButtonClick(ModelEvent):

--- a/panel/models/feed.py
+++ b/panel/models/feed.py
@@ -10,7 +10,7 @@ class ScrollLatestEvent(ModelEvent):
 
     event_name = 'scroll_latest_event'
 
-    def __init__(self, model, rerender=False, scroll_limit=200):
+    def __init__(self, model, rerender=False, scroll_limit=None):
         super().__init__(model=model)
         self.rerender = rerender
         self.scroll_limit = scroll_limit

--- a/panel/models/feed.py
+++ b/panel/models/feed.py
@@ -10,7 +10,7 @@ class ScrollLatestEvent(ModelEvent):
 
     event_name = 'scroll_latest_event'
 
-    def __init__(self, model, rerender=False, scroll_limit=0):
+    def __init__(self, model, rerender=False, scroll_limit=200):
         super().__init__(model=model)
         self.rerender = rerender
         self.scroll_limit = scroll_limit

--- a/panel/models/feed.ts
+++ b/panel/models/feed.ts
@@ -72,7 +72,7 @@ export class FeedView extends ColumnView {
   override connect_signals(): void {
     super.connect_signals()
     this.model.on_event(ScrollLatestEvent, (event: ScrollLatestEvent) => {
-      if (event.scroll_limit !== 0 && event.scroll_limit && (this.el.scrollHeight - this.el.scrollTop) > event.scroll_limit) {
+      if (event.scroll_limit == 0 && event.scroll_limit && (this.el.scrollHeight - this.el.scrollTop) > event.scroll_limit) {
         return
       }
       this.scroll_to_latest()

--- a/panel/models/feed.ts
+++ b/panel/models/feed.ts
@@ -8,19 +8,20 @@ import {ColumnView as BkColumnView} from "@bokehjs/models/layouts/column"
 
 @server_event("scroll_latest_event")
 export class ScrollLatestEvent extends ModelEvent {
-  constructor(readonly model: Feed, readonly rerender: boolean) {
+  constructor(readonly model: Feed, readonly rerender: boolean, readonly scroll_limit?: number) {
     super()
     this.origin = model
     this.rerender = rerender
+    this.scroll_limit = scroll_limit
   }
 
   protected override get event_values(): Attrs {
-    return {model: this.origin, rerender: this.rerender}
+    return {model: this.origin, rerender: this.rerender, scroll_limit: this.scroll_limit}
   }
 
   static override from_values(values: object) {
-    const {model, rerender} = values as {model: Feed, rerender: boolean}
-    return new ScrollLatestEvent(model, rerender)
+    const {model, rerender, scroll_limit} = values as {model: Feed, rerender: boolean, scroll_limit?: number}
+    return new ScrollLatestEvent(model, rerender, scroll_limit)
   }
 }
 
@@ -71,6 +72,9 @@ export class FeedView extends ColumnView {
   override connect_signals(): void {
     super.connect_signals()
     this.model.on_event(ScrollLatestEvent, (event: ScrollLatestEvent) => {
+      if (event.scroll_limit !== 0 && event.scroll_limit && (this.el.scrollHeight - this.el.scrollTop) > event.scroll_limit) {
+        return
+      }
       this.scroll_to_latest()
       if (event.rerender) {
         this._rendered = false

--- a/panel/models/feed.ts
+++ b/panel/models/feed.ts
@@ -8,7 +8,7 @@ import {ColumnView as BkColumnView} from "@bokehjs/models/layouts/column"
 
 @server_event("scroll_latest_event")
 export class ScrollLatestEvent extends ModelEvent {
-  constructor(readonly model: Feed, readonly rerender: boolean, readonly scroll_limit?: number) {
+  constructor(readonly model: Feed, readonly rerender: boolean, readonly scroll_limit?: number | null) {
     super()
     this.origin = model
     this.rerender = rerender

--- a/panel/models/feed.ts
+++ b/panel/models/feed.ts
@@ -72,10 +72,7 @@ export class FeedView extends ColumnView {
   override connect_signals(): void {
     super.connect_signals()
     this.model.on_event(ScrollLatestEvent, (event: ScrollLatestEvent) => {
-      if (event.scroll_limit == 0 && event.scroll_limit && (this.el.scrollHeight - this.el.scrollTop) > event.scroll_limit) {
-        return
-      }
-      this.scroll_to_latest()
+      this.scroll_to_latest(event.scroll_limit)
       if (event.rerender) {
         this._rendered = false
       }

--- a/panel/tests/ui/layout/test_feed.py
+++ b/panel/tests/ui/layout/test_feed.py
@@ -68,6 +68,29 @@ def test_feed_view_scroll_to_latest(page):
 
     wait_until(lambda: int(page.locator('pre').last.inner_text() or 0) > 0.9 * ITEMS, page)
 
+def test_feed_scroll_limit_prevents_scrolling(page):
+    feed = Feed(*list(range(ITEMS)), height=250)
+    serve_component(page, feed)
+
+    feed_el = page.locator(".bk-panel-models-feed-Feed")
+
+    bbox = feed_el.bounding_box()
+    assert bbox["height"] == 250
+
+    expect(feed_el).to_have_class("bk-panel-models-feed-Feed scroll-vertical")
+
+    wait_until(lambda: feed_el.evaluate('(el) => el.scrollTop') == 0, page)
+
+    # Attempt to scroll to the latest item
+    feed.scroll_to_latest(scroll_limit=200)
+
+    # Because the distance to the bottom exceeds the scroll_limit of 200,
+    # the scroll position should remain unchanged.
+    # Wait briefly and then check that scrollTop is still 0
+    wait_until(lambda: feed_el.evaluate('(el) => el.scrollTop') == 0, page)
+    assert feed_el.evaluate('(el) => el.scrollTop') == 0
+
+
 def test_feed_view_scroll_button(page):
     feed = Feed(*list(range(ITEMS)), height=250, scroll_button_threshold=50)
     serve_component(page, feed)

--- a/panel/tests/ui/layout/test_feed.py
+++ b/panel/tests/ui/layout/test_feed.py
@@ -5,6 +5,7 @@ pytest.importorskip("playwright")
 from playwright.sync_api import expect
 
 from panel import Feed
+from panel.layout.spacer import Spacer
 from panel.tests.util import serve_component, wait_until
 
 pytestmark = pytest.mark.ui
@@ -50,6 +51,7 @@ def test_feed_view_latest(page):
 
     wait_until(lambda: int(page.locator('pre').last.inner_text()) > 0.9 * ITEMS, page)
 
+
 def test_feed_view_scroll_to_latest(page):
     feed = Feed(*list(range(ITEMS)), height=250)
     serve_component(page, feed)
@@ -68,27 +70,68 @@ def test_feed_view_scroll_to_latest(page):
 
     wait_until(lambda: int(page.locator('pre').last.inner_text() or 0) > 0.9 * ITEMS, page)
 
-def test_feed_scroll_limit_prevents_scrolling(page):
+
+def test_feed_scroll_to_latest_disabled_when_limit_zero(page):
+    """Test that scroll_to_latest is disabled when scroll_limit = 0"""
     feed = Feed(*list(range(ITEMS)), height=250)
     serve_component(page, feed)
 
     feed_el = page.locator(".bk-panel-models-feed-Feed")
+    initial_scroll = feed_el.evaluate('(el) => el.scrollTop')
 
-    bbox = feed_el.bounding_box()
-    assert bbox["height"] == 250
+    # Try to scroll to latest
+    feed.scroll_to_latest(scroll_limit=0)
 
-    expect(feed_el).to_have_class("bk-panel-models-feed-Feed scroll-vertical")
+    # Verify scroll position hasn't changed
+    final_scroll = feed_el.evaluate('(el) => el.scrollTop')
+    assert initial_scroll == final_scroll, "Scroll position should not change when limit is 0"
 
-    wait_until(lambda: feed_el.evaluate('(el) => el.scrollTop') == 0, page)
 
-    # Attempt to scroll to the latest item
-    feed.scroll_to_latest(scroll_limit=200)
+def test_feed_scroll_to_latest_always_when_limit_null(page):
+    """Test that scroll_to_latest always triggers when scroll_limit is null"""
+    feed = Feed(*list(range(ITEMS)), height=250)
+    serve_component(page, feed)
 
-    # Because the distance to the bottom exceeds the scroll_limit of 200,
-    # the scroll position should remain unchanged.
-    # Wait briefly and then check that scrollTop is still 0
-    wait_until(lambda: feed_el.evaluate('(el) => el.scrollTop') == 0, page)
-    assert feed_el.evaluate('(el) => el.scrollTop') == 0
+    wait_until(lambda: int(page.locator('pre').last.inner_text() or 0) < 0.9 * ITEMS, page)
+    feed.scroll_to_latest(scroll_limit=None)
+    wait_until(lambda: int(page.locator('pre').last.inner_text() or 0) > 0.9 * ITEMS, page)
+
+
+def test_feed_scroll_to_latest_within_limit(page):
+    """Test that scroll_to_latest only triggers within the specified limit"""
+    feed = Feed(
+        Spacer(styles=dict(background='red'), width=200, height=200),
+        Spacer(styles=dict(background='green'), width=200, height=200),
+        Spacer(styles=dict(background='blue'), width=200, height=200),
+        auto_scroll_limit=0, height=420
+    )
+    serve_component(page, feed)
+
+    feed_el = page.locator(".bk-panel-models-feed-Feed")
+
+    expect(feed_el).to_have_js_property('scrollTop', 0)
+
+    feed.scroll_to_latest(scroll_limit=100)
+
+    # assert scroll location is still at top
+    feed.append(Spacer(styles=dict(background='yellow'), width=200, height=200))
+
+    page.wait_for_timeout(500)
+
+    expect(feed_el.locator('div')).to_have_count(5)
+    expect(feed_el).to_have_js_property('scrollTop', 0)
+
+    # scroll to close to bottom
+    feed_el.evaluate('(el) => el.scrollTo({top: el.scrollHeight})')
+
+    # assert auto scroll works; i.e. distance from bottom is 0
+    feed.append(Spacer(styles=dict(background='yellow'), width=200, height=200))
+
+    feed.scroll_to_latest(scroll_limit=100)
+
+    wait_until(lambda: feed_el.evaluate(
+        '(el) => el.scrollHeight - el.scrollTop - el.clientHeight'
+    ) == 0, page)
 
 
 def test_feed_view_scroll_button(page):


### PR DESCRIPTION
It's a nicer experience to follow along while it's streaming though we should see if there's a mechanism to disable this behavior.