### PR TITLE
Do not set max-width: 100% on Tabulator table node

### DIFF
--- a/panel/styles/models/tabulator.less
+++ b/panel/styles/models/tabulator.less
@@ -1,5 +1,5 @@
 .tabulator-table {
-  max-width: 100%;
+  max-width: max-content;
 
   .tabulator-row .row-content .bk-panel-models-markup-HTML {
     white-space: normal;


### PR DESCRIPTION
Setting `max-width: 100%` (in https://github.com/holoviz/panel/pull/7425) inadvertently caused all kinds of issues for table rendering. This PR backs out of this change.

Fixes https://github.com/holoviz/panel/issues/7606, Fixes https://github.com/holoviz/panel/issues/7543, Fixes https://github.com/holoviz/panel/issues/7593