### PR TITLE
Do not strictly enforce resource resolution in pyodide

### DIFF
--- a/panel/io/resources.py
+++ b/panel/io/resources.py
@@ -518,7 +518,7 @@ class ResourceComponent:
             is_file = bundlepath.is_file()
         except Exception:
             is_file = False
-        if is_file:
+        if is_file or (state._is_pyodide and not isurl(resource)):
             return f'{prefixed_dist}bundled/{resource_path}'
         elif isurl(resource):
             return resource


### PR DESCRIPTION
In our optimized pyodide wheels we do not ship various resources, which means that when we attempt to resolve the resources it will error. Therefore we do not enforce the strict resolution and simply assume the file(s) will be present.