### PR TITLE
ButtonIcon default active_icon to check mark

### DIFF
--- a/panel/widgets/icon.py
+++ b/panel/widgets/icon.py
@@ -126,6 +126,8 @@ class ButtonIcon(_ClickableIcon, _ClickButton, TooltipMixin):
     }
 
     def __init__(self, **params):
+        if "active_icon" not in params:
+            params["active_icon"] = "check"
         click_handler = params.pop('on_click', None)
         super().__init__(**params)
         if click_handler:


### PR DESCRIPTION
```typescript
  get_active_icon(): string {
    return this.model.active_icon !== "" ? this.model.active_icon : `${this.model.icon}-filled`
  }
```
I noticed if I used an icon without `filled`, like `reset`, the button icon disappears completely for the toggle duration.

I'm not sure how to check if a "filled" version of the tabler icon exists, so perhaps for the button icon, default to `check`?
