### PR TITLE
Ensure Modal resources aren't loaded by default

### DIFF
--- a/panel/config.py
+++ b/panel/config.py
@@ -693,6 +693,7 @@ class panel_extension(_pyviz_extension):
         'gridstack': ['GridStack'],
         'katex': ['katex'],
         'mathjax': ['MathJax'],
+        'modal': ['A11yDialog'],
         'perspective': ["customElements.get('perspective-viewer')"],
         'plotly': ['Plotly'],
         'tabulator': ['Tabulator'],

--- a/panel/layout/modal.py
+++ b/panel/layout/modal.py
@@ -8,7 +8,6 @@ import param
 
 from pyviz_comms import JupyterComm
 
-from ..models.modal import ModalDialogEvent
 from ..util import lazy_load
 from ..util.warnings import PanelUserWarning, warn
 from .base import ListPanel
@@ -52,6 +51,7 @@ class Modal(ListPanel):
 
     @param.depends("open", watch=True)
     def _open(self):
+        from ..models.modal import ModalDialogEvent
         if not self._models:
             msg = "To use the Modal, you must use '.servable' in a server setting or output the Modal in Jupyter Notebook."
             warn(msg, category=PanelUserWarning)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -262,6 +262,7 @@ module = [
     "mdit_py_emoji.*",
     "memray.*",
     "myst_parser.*",
+    "pamela.*",
     "param.*",
     "playwright.*",
     "plotly.*",


### PR DESCRIPTION
Importing the model by default causes the resources to be always loaded. This PR ensures we only import the `panel.models.modal` module if needed and also ensure that the resource is loaded before we try rendering the modal.