### PR TITLE
Ensure errors in sync periodic callbacks are logged. 

### DIFF
--- a/panel/io/callbacks.py
+++ b/panel/io/callbacks.py
@@ -86,10 +86,9 @@ class PeriodicCallback(param.Parameterized):
                     if self.count is not None and self.counter > self.count:
                         self.stop()
                 cb = self.callback() if self.running else None
-        except Exception:
-            cb = None
-        if post:
-            self._post_callback()
+        finally:
+            if post:
+                self._post_callback()
         return cb
 
     def _post_callback(self):
@@ -133,9 +132,6 @@ class PeriodicCallback(param.Parameterized):
                         await cb
                 else:
                     await cb
-        except Exception:
-            log.exception('Periodic callback failed.')
-            raise
         finally:
             self._post_callback()
 


### PR DESCRIPTION
Also: Do not duplicate tracebacks in logs for async periodic callbacks.

But: I don't really know what I'm doing :)

While I'm not yet a user of any recent version of Panel ( :sob: ), I tried to test the latest and found the current default situation seems to be:

- exceptions in async periodic callbacks are logged twice: once by panel (https://github.com/holoviz/panel/blob/main/panel/io/callbacks.py#L137), and once by bokeh (https://github.com/bokeh/bokeh/blob/branch-3.7/src/bokeh/util/tornado.py#L141)
- exceptions in sync callbacks are not logged at all (#5540) because exceptions are silently caught by panel (https://github.com/holoviz/panel/blob/main/panel/io/callbacks.py#L89) and never make it to bokeh

I don't know if the desired (default) behavior is to have logging of errors in periodic callbacks come from panel, or bokeh, or both. I'll be happy to change this PR with guidance on the desired behavior!

Before this PR's change in `panel/io/callbacks.py`, the results of the tests added in this PR are:

- async: FAILED [...] assert 6 == 3 (because the error traceback appears twice per call) 
- sync: FAILED [...] assert 0 == 3 (because the error never appears)


Note: I haven't yet gotten myself set up to be able to run all current Panel's tests successfully; I have not yet run tests beyond test_server, nor have I run test_server with fastapi.