### PR TITLE
Update index.md to change the Markdown title in the doc from APIs to …

### DIFF
--- a/doc/explanation/api/index.md
+++ b/doc/explanation/api/index.md
@@ -1,4 +1,4 @@
-# APIs
+# Overview of Panel APIs
 
 Panel can be used to make a simple app in minutes, but you can also create complex apps with fully customized behavior and appearance. You can even flexibly integrate GUI support into long-term, large-scale software projects, while keeping your GUI code fully separate from the core code for your project.
 


### PR DESCRIPTION
…Overview of Panel APIs

Update doc / explanation / api / index.md to change the Markdown title in the doc from APIs to Overview of Panel APIs.

Is the title shown in the breadcrumb trail based on the Markdown title or the filename?

In the latter case, the filename should also be changed, to improve clarity and avoid duplication, as described in this issue: https://github.com/holoviz/panel/issues/7663 .

Proposed new filename: overview_of_apis.md

https://github.com/holoviz/panel/blob/main/doc/explanation/api/index.md?plain=1