### PR TITLE
Add scroll_to method in ChatFeed

### DIFF
--- a/panel/chat/feed.py
+++ b/panel/chat/feed.py
@@ -645,6 +645,11 @@ class ChatFeed(ListPanel):
             self.disabled = self._disabled_stack.pop() if self._disabled_stack else False
 
     # Public API
+    def scroll_to(self, index: int):
+        """
+        Scrolls the chat log to the provided index.
+        """
+        self._chat_log.scroll_to(index)
 
     def send(
         self,

--- a/panel/chat/feed.py
+++ b/panel/chat/feed.py
@@ -648,6 +648,11 @@ class ChatFeed(ListPanel):
     def scroll_to(self, index: int):
         """
         Scrolls the chat log to the provided index.
+
+        Arguments
+        ---------
+        index : int
+            The index to scroll to.
         """
         self._chat_log.scroll_to(index)
 


### PR DESCRIPTION
I noticed the [docs mention it](https://panel.holoviz.org/reference/chat/ChatFeed.html#id2), but it's not actually implemented in the ChatFeed (it is in Column)