### PR TITLE
Fix visible range on objects set in Feed

### DIFF
--- a/panel/layout/feed.py
+++ b/panel/layout/feed.py
@@ -78,6 +78,11 @@ class Feed(Column):
         self._last_synced = None
         self.param.watch(self._trigger_view_latest, 'objects')
 
+    @param.depends("objects", watch=True)
+    def _reset_visible_range(self):
+        with edit_readonly(self):
+            self.visible_range = None
+
     @param.depends("visible_range", "load_buffer", watch=True)
     def _trigger_get_objects(self):
         if self.visible_range is None:

--- a/panel/tests/ui/layout/test_feed.py
+++ b/panel/tests/ui/layout/test_feed.py
@@ -164,11 +164,13 @@ def test_feed_dynamic_objects(page):
 def test_feed_reset_visible_range(page):
     feed = Feed(*list(range(ITEMS)), load_buffer=20, height=50, view_latest=True)
     serve_component(page, feed)
+
     wait_until(lambda: int(page.locator('pre').last.inner_text() or 0) == 99, page)
 
     # set objects to 20
     feed.objects = feed.objects[:20]
-    assert feed.visible_range is None
 
-    # assert objects still visible
-    wait_until(lambda: page.locator('pre').count() == 20, page)
+    # assert view reset
+    wait_until(lambda: (
+        int(page.locator('pre').last.inner_text() or 0) == 19
+    ), page)

--- a/panel/tests/ui/layout/test_feed.py
+++ b/panel/tests/ui/layout/test_feed.py
@@ -160,3 +160,15 @@ def test_feed_dynamic_objects(page):
 
     wait_until(lambda: expect(page.locator('pre').first).to_have_text('0'))
     wait_until(lambda: page.locator('pre').count() > 10, page)
+
+def test_feed_reset_visible_range(page):
+    feed = Feed(*list(range(ITEMS)), load_buffer=20, height=50, view_latest=True)
+    serve_component(page, feed)
+    wait_until(lambda: int(page.locator('pre').last.inner_text() or 0) == 99, page)
+
+    # set objects to 20
+    feed.objects = feed.objects[:20]
+    assert feed.visible_range is None
+
+    # assert objects still visible
+    wait_until(lambda: page.locator('pre').count() == 20, page)


### PR DESCRIPTION
Previously, the items would not show if the length of the objects was set drastically different than the original length.