### PR TITLE
doc: include the holoviz sidebar

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -326,4 +326,9 @@ def setup(app) -> None:
     nbbuild.setup(app)
     app.add_config_value('grid_item_link_domain', '', 'html')
 
+    # hv_sidebar_dropdown
+    app.add_config_value('nbsite_hv_sidebar_dropdown', {}, 'html')
+    app.connect("html-page-context", add_hv_sidebar_dropdown_context)
+
+
 grid_item_link_domain = gallery_endpoint


### PR DESCRIPTION
Alternatively the `setup` could be refactored to something like as follows to avoid the one inherited from `nbsite` (panel doesn't do `remove_mystnb_static` apparently, I'm not sure how important that is).

```
from nbsite.shared_conf import setup as nbsite_setup

def setup(app):
    # panel custom stuff
    # ...

    nbsite_setup(app)

    # panel custom stuff
    # ...    
```