### PR TITLE
Fix default avatar in send/stream

### DIFF
--- a/panel/chat/interface.py
+++ b/panel/chat/interface.py
@@ -690,7 +690,7 @@ class ChatInterface(ChatFeed):
         if not isinstance(value, ChatMessage):
             if user is None:
                 user = self.user
-            if avatar is None:
+            if avatar is None and user == self.user:
                 avatar = self.avatar
         message_params["show_edit_icon"] = message_params.get(
             "show_edit_icon", user == self.user and self.edit_callback is not None)
@@ -739,6 +739,7 @@ class ChatInterface(ChatFeed):
             # ChatMessage cannot set user or avatar when explicitly streaming
             # so only set to the default when not a ChatMessage
             user = user or self.user
-            avatar = avatar or self.avatar
+            if avatar is None and user == self.user:
+                avatar = self.avatar
         message_params["show_edit_icon"] = message_params.get("show_edit_icon", user == self.user and self.edit_callback is not None)
         return super().stream(value, user=user, avatar=avatar, message=message, replace=replace, **message_params)

--- a/panel/tests/chat/test_interface.py
+++ b/panel/tests/chat/test_interface.py
@@ -465,6 +465,18 @@ class TestChatInterface:
         assert msg.user == "Welcoming User"
         assert msg.avatar == "👋"
 
+    @pytest.mark.parametrize("method", ["send", "stream"])
+    async def test_send_stream_auto_avatar(self, chat_interface, method):
+        chat_interface.user = "A"
+        chat_interface.avatar = "H"
+        getattr(chat_interface, method)("Hello", user="S")
+        # will default to first letter on UI
+        assert chat_interface.objects[0].avatar == ""
+
+        getattr(chat_interface, method)("Hello", user="A")
+        assert chat_interface.objects[1].avatar == "H"
+
+
 class TestChatInterfaceWidgetsSizingMode:
     def test_none(self):
         chat_interface = ChatInterface()


### PR DESCRIPTION
When setting `chat_interface.avatar="A"`, it changes all users' avatars if not set explicitly.