### PR TITLE
Configure proxy tests

### DIFF
--- a/panel/tests/conftest.py
+++ b/panel/tests/conftest.py
@@ -33,7 +33,7 @@ from panel.io.reload import (
 )
 from panel.io.state import set_curdoc, state
 from panel.pane import HTML, Markdown
-from panel.tests.util import get_open_ports
+from panel.tests.util import get_open_ports, reverse_proxy as reverse_proxy_ctx
 from panel.theme import Design
 
 CUSTOM_MARKS = ('ui', 'jupyter', 'subprocess', 'docs')
@@ -589,3 +589,9 @@ def df_strings():
     code = [f'{i:02d}' for i in range(len(descr))]
 
     return pd.DataFrame(dict(code=code, descr=descr))
+
+
+@pytest.fixture
+def reverse_proxy():
+    with reverse_proxy_ctx() as (port, proxy):
+        yield port, proxy

--- a/panel/tests/test_server.py
+++ b/panel/tests/test_server.py
@@ -27,7 +27,8 @@ from panel.param import ParamFunction
 from panel.reactive import ReactiveHTML
 from panel.template import BootstrapTemplate
 from panel.tests.util import (
-    get_open_ports, serve_and_request, serve_and_wait, wait_until,
+    get_open_ports, reverse_proxy_available, serve_and_request, serve_and_wait,
+    wait_until,
 )
 from panel.widgets import (
     Button, Tabulator, Terminal, TextInput,
@@ -904,6 +905,7 @@ def test_server_template_custom_resources(port):
     with open(pathlib.Path(__file__).parent / 'assets' / 'custom.css', encoding='utf-8') as f:
         assert f.read() == r.content.decode('utf-8').replace('\r\n', '\n')
 
+@reverse_proxy_available
 def test_server_template_custom_resources_on_proxy(reverse_proxy):
     template = CustomBootstrapTemplate()
 
@@ -924,6 +926,7 @@ def test_server_template_custom_resources_with_prefix(port):
     with open(pathlib.Path(__file__).parent / 'assets' / 'custom.css', encoding='utf-8') as f:
         assert f.read() == r.content.decode('utf-8').replace('\r\n', '\n')
 
+@reverse_proxy_available
 def test_server_template_custom_resources_with_prefix_and_proxy(reverse_proxy):
     (port, proxy) = reverse_proxy
     template = CustomBootstrapTemplate()
@@ -941,6 +944,7 @@ def test_server_template_custom_resources_with_prefix_relative_url(port):
 
     assert 'href="components/panel.tests.test_server/CustomBootstrapTemplate/_css/assets/custom.css"' in r.content.decode('utf-8')
 
+@reverse_proxy_available
 def test_server_template_custom_resources_with_prefix_and_proxy_relative_url(reverse_proxy):
     template = CustomBootstrapTemplate()
 
@@ -956,6 +960,7 @@ def test_server_template_custom_resources_with_subpath_and_prefix_relative_url(p
 
     assert 'href="../components/panel.tests.test_server/CustomBootstrapTemplate/_css/assets/custom.css"' in r.content.decode('utf-8')
 
+@reverse_proxy_available
 def test_server_template_custom_resources_with_subpath_and_prefix_and_proxy_relative_url(reverse_proxy):
     template = CustomBootstrapTemplate()
 

--- a/panel/tests/test_server.py
+++ b/panel/tests/test_server.py
@@ -904,6 +904,17 @@ def test_server_template_custom_resources(port):
     with open(pathlib.Path(__file__).parent / 'assets' / 'custom.css', encoding='utf-8') as f:
         assert f.read() == r.content.decode('utf-8').replace('\r\n', '\n')
 
+def test_server_template_custom_resources_on_proxy(reverse_proxy):
+    template = CustomBootstrapTemplate()
+
+    port, proxy = reverse_proxy
+    r = serve_and_request(
+        {'template': template}, port=port, proxy=proxy,
+        suffix="/proxy/components/panel.tests.test_server/CustomBootstrapTemplate/_css/assets/custom.css"
+    )
+
+    with open(pathlib.Path(__file__).parent / 'assets' / 'custom.css', encoding='utf-8') as f:
+        assert f.read() == r.content.decode('utf-8').replace('\r\n', '\n')
 
 def test_server_template_custom_resources_with_prefix(port):
     template = CustomBootstrapTemplate()
@@ -913,19 +924,43 @@ def test_server_template_custom_resources_with_prefix(port):
     with open(pathlib.Path(__file__).parent / 'assets' / 'custom.css', encoding='utf-8') as f:
         assert f.read() == r.content.decode('utf-8').replace('\r\n', '\n')
 
+def test_server_template_custom_resources_with_prefix_and_proxy(reverse_proxy):
+    (port, proxy) = reverse_proxy
+    template = CustomBootstrapTemplate()
+
+    path = "/proxy/prefix/components/panel.tests.test_server/CustomBootstrapTemplate/_css/assets/custom.css"
+    r = serve_and_request({'template': template}, port=port, proxy=proxy, prefix='/prefix', suffix=path)
+
+    with open(pathlib.Path(__file__).parent / 'assets' / 'custom.css', encoding='utf-8') as f:
+        assert f.read() == r.content.decode('utf-8').replace('\r\n', '\n')
 
 def test_server_template_custom_resources_with_prefix_relative_url(port):
     template = CustomBootstrapTemplate()
 
-    r = serve_and_request({'template': template}, prefix='/prefix', suffix='/prefix/template')
+    r = serve_and_request({'template': template}, prefix='/prefix', port=port, suffix='/prefix/template')
 
     assert 'href="components/panel.tests.test_server/CustomBootstrapTemplate/_css/assets/custom.css"' in r.content.decode('utf-8')
 
+def test_server_template_custom_resources_with_prefix_and_proxy_relative_url(reverse_proxy):
+    template = CustomBootstrapTemplate()
+
+    (port, proxy) = reverse_proxy
+    r = serve_and_request({'template': template}, prefix='/prefix', port=port, proxy=proxy, suffix='/proxy/prefix/template')
+
+    assert 'href="components/panel.tests.test_server/CustomBootstrapTemplate/_css/assets/custom.css"' in r.content.decode('utf-8')
 
 def test_server_template_custom_resources_with_subpath_and_prefix_relative_url(port):
     template = CustomBootstrapTemplate()
 
-    r = serve_and_request({'/subpath/template': template}, prefix='/prefix', suffix='/prefix/subpath/template')
+    r = serve_and_request({'/subpath/template': template}, port=port, prefix='/prefix', suffix='/prefix/subpath/template')
+
+    assert 'href="../components/panel.tests.test_server/CustomBootstrapTemplate/_css/assets/custom.css"' in r.content.decode('utf-8')
+
+def test_server_template_custom_resources_with_subpath_and_prefix_and_proxy_relative_url(reverse_proxy):
+    template = CustomBootstrapTemplate()
+
+    port, proxy = reverse_proxy
+    r = serve_and_request({'/subpath/template': template}, port=port, proxy=proxy, prefix='/prefix', suffix='/proxy/prefix/subpath/template')
 
     assert 'href="../components/panel.tests.test_server/CustomBootstrapTemplate/_css/assets/custom.css"' in r.content.decode('utf-8')
 
@@ -941,7 +976,7 @@ def test_server_component_custom_resources(port):
     component = CustomComponent()
 
     path = "/components/panel.tests.test_server/CustomComponent/__css__/assets/custom.css"
-    r = serve_and_request({'component': component}, suffix=path)
+    r = serve_and_request({'component': component}, suffix=path, port=port)
 
     with open(pathlib.Path(__file__).parent / 'assets' / 'custom.css', encoding='utf-8') as f:
         assert f.read() == r.content.decode('utf-8').replace('\r\n', '\n')
@@ -951,7 +986,8 @@ def test_server_component_custom_resources_with_prefix(port):
     component = CustomComponent()
 
     r = serve_and_request(
-        {'component': component}, prefix='/prefix', suffix="/prefix/components/panel.tests.test_server/CustomComponent/__css__/assets/custom.css"
+        {'component': component}, prefix='/prefix', port=port,
+        suffix="/prefix/components/panel.tests.test_server/CustomComponent/__css__/assets/custom.css"
     )
 
     with open(pathlib.Path(__file__).parent / 'assets' / 'custom.css', encoding='utf-8') as f:
@@ -961,7 +997,7 @@ def test_server_component_custom_resources_with_prefix(port):
 def test_server_component_custom_resources_with_prefix_relative_url(port):
     component = CustomComponent()
 
-    r = serve_and_request({'component': component}, prefix='/prefix', suffix='/prefix/component')
+    r = serve_and_request({'component': component}, port=port, prefix='/prefix', suffix='/prefix/component')
 
     assert f'href="components/panel.tests.test_server/CustomComponent/__css__/assets/custom.css?v={JS_VERSION}"' in r.content.decode('utf-8')
 
@@ -969,7 +1005,7 @@ def test_server_component_custom_resources_with_prefix_relative_url(port):
 def test_server_component_custom_resources_with_subpath_and_prefix_relative_url(port):
     component = CustomComponent()
 
-    r = serve_and_request({'/subpath/component': component}, prefix='/prefix', suffix='/prefix/subpath/component')
+    r = serve_and_request({'/subpath/component': component}, port=port, prefix='/prefix', suffix='/prefix/subpath/component')
 
     assert f'href="../components/panel.tests.test_server/CustomComponent/__css__/assets/custom.css?v={JS_VERSION}"' in r.content.decode('utf-8')
 
@@ -977,7 +1013,7 @@ def test_server_component_custom_resources_with_subpath_and_prefix_relative_url(
 def test_server_component_css_with_prefix_relative_url(port):
     component = Terminal()
 
-    r = serve_and_request({'component': component}, suffix='/component')
+    r = serve_and_request({'component': component}, suffix='/component', port=port)
 
     assert 'href="static/extensions/panel/bundled/terminal/xterm@4.11.0/css/xterm.css' in r.content.decode('utf-8')
 
@@ -985,7 +1021,7 @@ def test_server_component_css_with_prefix_relative_url(port):
 def test_server_component_css_with_subpath_and_prefix_relative_url(port):
     component = Terminal()
 
-    r = serve_and_request({'/subpath/component': component}, prefix='/prefix', suffix='/prefix/subpath/component')
+    r = serve_and_request({'/subpath/component': component}, prefix='/prefix', suffix='/prefix/subpath/component', port=port)
 
     assert 'href="../static/extensions/panel/bundled/terminal/xterm@4.11.0/css/xterm.css' in r.content.decode('utf-8')
 

--- a/panel/tests/util.py
+++ b/panel/tests/util.py
@@ -67,7 +67,7 @@ ON_POSIX = 'posix' in sys.builtin_module_names
 
 linux_only = pytest.mark.skipif(platform.system() != 'Linux', reason="Only supported on Linux")
 unix_only = pytest.mark.skipif(platform.system() == 'Windows', reason="Only supported on unix-like systems")
-reverse_proxy_available = pytest.mark.skipif(check_cli_tool('caddy'), reason="No reverse proxy available")
+reverse_proxy_available = pytest.mark.skipif(not check_cli_tool('caddy'), reason="No reverse proxy available")
 
 from panel.pane.alert import Alert
 from panel.pane.markup import Markdown

--- a/panel/tests/util.py
+++ b/panel/tests/util.py
@@ -24,6 +24,7 @@ from packaging.version import Version
 
 import panel as pn
 
+from panel.io.compile import check_cli_tool
 from panel.io.server import serve
 from panel.io.state import state
 
@@ -66,6 +67,7 @@ ON_POSIX = 'posix' in sys.builtin_module_names
 
 linux_only = pytest.mark.skipif(platform.system() != 'Linux', reason="Only supported on Linux")
 unix_only = pytest.mark.skipif(platform.system() == 'Windows', reason="Only supported on unix-like systems")
+reverse_proxy_available = pytest.mark.skipif(check_cli_tool('caddy'), reason="No reverse proxy available")
 
 from panel.pane.alert import Alert
 from panel.pane.markup import Markdown

--- a/panel/tests/util.py
+++ b/panel/tests/util.py
@@ -511,9 +511,11 @@ def reverse_proxy():
   }}
 }}
 """
+    env = os.environ.copy()
+    env['CADDY_ADMIN'] = 'off'
     process = subprocess.Popen(
         ['caddy', 'run', '--adapter', 'caddyfile', '--config', '-'],
-        stdin=subprocess.PIPE, close_fds=ON_POSIX, text=True
+        stdin=subprocess.PIPE, close_fds=ON_POSIX, text=True, env=env
     )
     process.stdin.write(config)
     process.stdin.close()

--- a/pixi.toml
+++ b/pixi.toml
@@ -176,6 +176,7 @@ pytest-asyncio = "*"
 jupyter_server = "*"
 esbuild = "*"
 packaging = "*"
+caddy = "*"
 
 [feature.test-ui.tasks]
 _install-ui = 'playwright install chromium'

--- a/pixi.toml
+++ b/pixi.toml
@@ -142,6 +142,7 @@ altair = "*"
 anywidget = "*"
 bokeh-fastapi = "*"
 bokeh_sampledata = "*"
+caddy = "*"
 cryptography = "*"
 diskcache = "*"
 fastapi = "*"
@@ -176,7 +177,6 @@ pytest-asyncio = "*"
 jupyter_server = "*"
 esbuild = "*"
 packaging = "*"
-caddy = "*"
 
 [feature.test-ui.tasks]
 _install-ui = 'playwright install chromium'


### PR DESCRIPTION
This PR sets up the tooling to run Panel server tests behind a reverse proxy (in this case we use caddy because it's easy to configure and can be conda installed). This is well overdue since there are various cases related to JupyterHub setups, auth, redirects and index pages that aren't currently working well in this scenario largely because we don't have a testing setup and therefore haven't been able to capture these scenarios well in the current test suite. This PR is primarily intended as a way to easily configure such tests and subsequent PRs will fix issues related to this kind of setup and then add tests to prevent future regressions.