### PR TITLE
More compatibility fixes for plotly 6.0

### DIFF
--- a/panel/models/plotly.py
+++ b/panel/models/plotly.py
@@ -7,10 +7,11 @@ from bokeh.core.properties import (
 from bokeh.events import ModelEvent
 from bokeh.models import ColumnDataSource, LayoutDOM
 
-from ..io.resources import JS_URLS, bundled_files
+from ..config import config
+from ..io.resources import bundled_files
 from ..util import classproperty
 
-PLOTLY_VERSION = '2.35.3'
+PLOTLY_VERSION = '3.0.0'
 
 
 class PlotlyEvent(ModelEvent):
@@ -28,7 +29,7 @@ class PlotlyPlot(LayoutDOM):
     a bokeh plot.
     """
     __css_raw__ = [
-        "https://api.mapbox.com/mapbox-gl-js/v3.0.1/mapbox-gl.css",
+        f"{config.npm_cdn}/maplibre-gl@4.4.1/dist/maplibre-gl.css"
     ]
 
     @classproperty
@@ -36,7 +37,6 @@ class PlotlyPlot(LayoutDOM):
         return bundled_files(cls, 'css')
 
     __javascript_raw__ = [
-        JS_URLS['jQuery'],
         f'https://cdn.plot.ly/plotly-{PLOTLY_VERSION}.min.js'
     ]
 

--- a/panel/pane/plotly.py
+++ b/panel/pane/plotly.py
@@ -156,7 +156,7 @@ class Plotly(ModelPane):
     def _update_figure(self):
         import plotly.graph_objs as go
 
-        if (self.object is None or type(self.object) not in (go.Figure, go.FigureWidget) or
+        if (self.object is None or not isinstance(self.object, (go.Figure, go.FigureWidget)) or
             self.object is self._figure or not self.link_figure):
             return
 

--- a/panel/pane/plotly.py
+++ b/panel/pane/plotly.py
@@ -13,7 +13,7 @@ import param
 from bokeh.models import ColumnDataSource
 from pyviz_comms import JupyterComm
 
-from ..util import lazy_load
+from ..util import lazy_load, try_datetime64_to_datetime
 from ..util.checks import datetime_types, isdatetime
 from ..viewable import Layoutable
 from .base import ModelPane
@@ -257,7 +257,10 @@ class Plotly(ModelPane):
                 continue
             arr = trace[key]
             if isinstance(arr, np.ndarray):
-                arr = arr.astype(str)
+                if arr.dtype.kind == 'M' and arr.ndim == 2 and arr.shape[1] == 1:
+                    arr = [[str(try_datetime64_to_datetime(v[0]))] for v in arr]
+                else:
+                    arr = arr.astype(str)
             elif isinstance(arr, datetime_types):
                 arr = str(arr)
             else:

--- a/panel/pane/plotly.py
+++ b/panel/pane/plotly.py
@@ -258,7 +258,7 @@ class Plotly(ModelPane):
             arr = trace[key]
             if isinstance(arr, np.ndarray):
                 if arr.dtype.kind == 'M' and arr.ndim == 2 and arr.shape[1] == 1:
-                    arr = [[str(try_datetime64_to_datetime(v[0]))] for v in arr]
+                    arr = np.array([[str(try_datetime64_to_datetime(v[0]))] for v in arr])
                 else:
                     arr = arr.astype(str)
             elif isinstance(arr, datetime_types):

--- a/pixi.toml
+++ b/pixi.toml
@@ -134,7 +134,7 @@ holoviews = ">=1.16.0"
 jupyterlab = "*"
 matplotlib-base = "*"
 pillow = "*"
-plotly = ">=4.0"
+plotly = ">=6.0"
 # Optional dependencies - dev
 watchfiles = "*"
 # Test dependencies


### PR DESCRIPTION
- Bump plotly.js version
- Adds maplibre CSS instead of Mapbox CSS
- Fixes datetime conversion
- Drops jQuery