### PR TITLE
Fix ESM component module resolution

### DIFF
--- a/panel/custom.py
+++ b/panel/custom.py
@@ -34,7 +34,7 @@ from .pane.base import PaneBase  # noqa
 from .reactive import (  # noqa
     Reactive, ReactiveCustomBase, ReactiveHTML, ReactiveMetaBase,
 )
-from .util import camel_to_kebab, classproperty
+from .util import classproperty
 from .util.checks import import_available
 from .viewable import (  # noqa
     Child, Children, Layoutable, Viewable, Viewer, is_viewable_param,
@@ -429,7 +429,7 @@ class ReactiveESM(ReactiveCustomBase, metaclass=ReactiveESMMetaclass):
         data_props['esm_constants'] = self._constants
         props.update({
             'bundle': bundle_hash,
-            'class_name': camel_to_kebab(cls.__name__),
+            'class_name': cls.__name__,
             'data': self._data_model(**{p: v for p, v in data_props.items() if p not in ignored}),
             'dev': config.autoreload or getattr(self, '_debug', False),
             'esm': self._render_esm(not config.autoreload, server=is_session),

--- a/panel/models/reactive_esm.ts
+++ b/panel/models/reactive_esm.ts
@@ -213,7 +213,7 @@ export class ReactiveESMView extends HTMLBoxView {
       this.invalidate_render()
     })
     this.on_change(class_name, () => {
-      this.container.className = this.model.class_name.replace(/([a-z])([A-Z])/g, '$1-$2').toLowerCase()
+      this.container.className = this.model.class_name.replace(/([a-z])([A-Z])/g, "$1-$2").toLowerCase()
     })
     const child_props = this.model.children.map((child: string) => this.model.data.properties[child])
     this.on_change(child_props, () => {

--- a/panel/models/reactive_esm.ts
+++ b/panel/models/reactive_esm.ts
@@ -213,7 +213,7 @@ export class ReactiveESMView extends HTMLBoxView {
       this.invalidate_render()
     })
     this.on_change(class_name, () => {
-      this.container.className = this.model.class_name
+      this.container.className = this.model.class_name.replace(/([a-z])([A-Z])/g, '$1-$2').toLowerCase()
     })
     const child_props = this.model.children.map((child: string) => this.model.data.properties[child])
     this.on_change(child_props, () => {
@@ -658,8 +658,8 @@ export class ReactiveESM extends HTMLBox {
       }
       try {
         let initialize
-        if (this.bundle != null && (mod.default || {}).hasOwnProperty(this.name)) {
-          mod = mod.default[(this.name as any)]
+        if (this.bundle != null && (mod.default || {}).hasOwnProperty(this.class_name)) {
+          mod = mod.default[(this.class_name as any)]
         }
         if (mod.initialize) {
           initialize = mod.initialize


### PR DESCRIPTION
Previously we used the `Model.name` to determine the name of the JS module inside a bundle. However the `name` seemingly is sometimes overwritten making this approach brittle. Instead we now use the `class_name` property, which was previously kebab case but is now passed through directly and only transformed into kebab case client-side.