### PR TITLE
Allow ESM components to load CSS bundles

### DIFF
--- a/panel/io/server.py
+++ b/panel/io/server.py
@@ -630,7 +630,7 @@ class ComponentResourceHandler(StaticFileHandler):
 
     _resource_attrs = [
         '__css__', '__javascript__', '__js_module__', '__javascript_modules__',  '_resources',
-        '_css', '_js', 'base_css', 'css', '_stylesheets', 'modifiers', '_bundle_path'
+        '_css', '_js', 'base_css', 'css', '_stylesheets', 'modifiers', '_bundle_path', '_bundle_css'
     ]
 
     def initialize(self, path: str | Literal['root'] = 'root', default_filename: str | None = None):

--- a/panel/models/esm.py
+++ b/panel/models/esm.py
@@ -32,6 +32,8 @@ class ESMEvent(DataEvent):
 
 class ReactiveESM(HTMLBox):
 
+    css_bundle = bp.Nullable(bp.String)
+
     bundle = bp.Nullable(bp.String)
 
     class_name = bp.String()

--- a/panel/models/reactive_esm.ts
+++ b/panel/models/reactive_esm.ts
@@ -4,6 +4,7 @@ import type {Transform} from "sucrase"
 import {ModelEvent, server_event} from "@bokehjs/core/bokeh_events"
 import {div} from "@bokehjs/core/dom"
 import type {StyleSheetLike} from "@bokehjs/core/dom"
+import {ImportedStyleSheet} from "@bokehjs/core/dom"
 import type * as p from "@bokehjs/core/properties"
 import type {Attrs} from "@bokehjs/core/types"
 import type {LayoutDOM} from "@bokehjs/models/layouts/layout_dom"
@@ -201,6 +202,13 @@ export class ReactiveESMView extends HTMLBoxView {
     const stylesheets = super.stylesheets()
     if (this.model.dev) {
       stylesheets.push(error_css)
+    }
+    if (this.model.css_bundle) {
+      if (this.model.bundle === "url") {
+	stylesheets.push(new ImportedStyleSheet(this.model.css_bundle))
+      } else {
+	stylesheets.push(this.model.css_bundle)
+      }
     }
     return stylesheets
   }
@@ -477,6 +485,7 @@ export namespace ReactiveESM {
   export type Attrs = p.AttrsOf<Props>
 
   export type Props = HTMLBox.Props & {
+    css_bundle: p.Property<string | null>
     bundle: p.Property<string | null>
     children: p.Property<any>
     class_name: p.Property<string>
@@ -689,6 +698,7 @@ export class ReactiveESM extends HTMLBox {
   static {
     this.prototype.default_view = ReactiveESMView
     this.define<ReactiveESM.Props>(({Any, Array, Bool, Nullable, Str}) => ({
+      css_bundle:  [ Nullable(Str),     null ],
       bundle:      [ Nullable(Str),     null ],
       children:    [ Array(Str),          [] ],
       class_name:  [ Str,                 "" ],

--- a/panel/models/reactive_esm.ts
+++ b/panel/models/reactive_esm.ts
@@ -205,9 +205,9 @@ export class ReactiveESMView extends HTMLBoxView {
     }
     if (this.model.css_bundle) {
       if (this.model.bundle === "url") {
-	stylesheets.push(new ImportedStyleSheet(this.model.css_bundle))
+        stylesheets.push(new ImportedStyleSheet(this.model.css_bundle))
       } else {
-	stylesheets.push(this.model.css_bundle)
+        stylesheets.push(this.model.css_bundle)
       }
     }
     return stylesheets


### PR DESCRIPTION
Currently we support the ability to compile a JS bundle to be loaded by JS components. However sometimes you want to bundle additional resources, such as a separate CSS bundle and any associated assets (e.g. images, fonts etc.). This PR makes it possible to:

- Load a CSS bundle that sits alongside the JS bundle
- Tell `esbuild` to load and bundle additional assets using the `--file-loaders` argument