### PR TITLE
Ensure _bundle_css is added as resource and resolved on baseclass

### DIFF
--- a/panel/custom.py
+++ b/panel/custom.py
@@ -698,7 +698,7 @@ class ReactComponent(ReactiveESM):
     _react_version = '18.3.1'
 
     @classproperty  # type: ignore
-    def _exports__(cls) -> ExportSpec:
+    def _exports__(cls) -> ExportSpec:  # type: ignore
         imports = cls._importmap.get('imports', {})
         exports: dict[str, list[str | tuple[str, ...]]] = {
             "react": ["*React"],

--- a/panel/custom.py
+++ b/panel/custom.py
@@ -308,11 +308,14 @@ class ReactiveESM(ReactiveCustomBase, metaclass=ReactiveESMMetaclass):
 
     @classproperty
     def _bundle_css(cls):
-        esm_path = cls._esm_path(compiled=True)
+        try:
+            esm_path = cls._esm_path(compiled=True)
+        except ValueError:
+            return []
         css_path = esm_path.with_suffix('.css')
         if css_path.is_file():
-            return css_path
-        return None
+            return [css_path]
+        return []
 
     @classmethod
     def _esm_path(cls, compiled: bool = True) -> os.PathLike | None:

--- a/panel/io/resources.py
+++ b/panel/io/resources.py
@@ -663,8 +663,13 @@ class Resources(BkResources):
         """
         from ..reactive import ReactiveCustomBase
         for model in param.concrete_descendents(ReactiveCustomBase).values():
-            if not (getattr(model, resource_type, None) and model._loaded()):
+            cls_files = getattr(model, resource_type, None)
+            if not (cls_files and model._loaded()):
                 continue
+            for cls in model.__mro__[1:]:
+                supcls_files = getattr(cls, resource_type, [])
+                if supcls_files == cls_files:
+                    model = cls
             for resource in getattr(model, resource_type, []):
                 if state.rel_path:
                     resource = resource.lstrip(state.rel_path+'/')
@@ -740,6 +745,7 @@ class Resources(BkResources):
 
         files = super().css_files
         self.extra_resources(files, '__css__')
+        self.extra_resources(files, '_bundle_css')
         css_files = self.adjust_paths([
             css for css in files if self.mode != 'inline' or not is_cdn_url(css)
         ])


### PR DESCRIPTION
This PR introduces two changes to allow resolving the new `_bundle_css` for ESM components.

Specifically we:

- Ensure that the bundle CSS is resolved on the baseclass
- The `_bundle_css` files are added to the document head.