### PR TITLE
Use relative URLs to resolve custom resources

### DIFF
--- a/panel/custom.py
+++ b/panel/custom.py
@@ -355,7 +355,8 @@ class ReactiveESM(ReactiveCustomBase, metaclass=ReactiveESMMetaclass):
         esm_path = cls._esm_path(compiled=compiled is True)
         if esm_path:
             if esm_path == cls._bundle_path and cls.__module__ in sys.modules and server:
-                esm = cls._component_resource_path(esm_path, compiled)
+                # Generate relative path to handle apps served on subpaths
+                esm = (state.rel_path or './') + cls._component_resource_path(esm_path, compiled)
                 if config.autoreload:
                     modified = hashlib.sha256(str(esm_path.stat().st_mtime).encode('utf-8')).hexdigest()
                     esm += f'?{modified}'

--- a/panel/models/reactive_esm.ts
+++ b/panel/models/reactive_esm.ts
@@ -650,7 +650,7 @@ export class ReactiveESM extends HTMLBox {
       }
       let url
       if (this.bundle === "url") {
-	url = this.esm
+        url = this.esm
       } else {
         url = URL.createObjectURL(new Blob([this.compiled], {type: "text/javascript"}))
       }

--- a/panel/models/reactive_esm.ts
+++ b/panel/models/reactive_esm.ts
@@ -650,12 +650,7 @@ export class ReactiveESM extends HTMLBox {
       }
       let url
       if (this.bundle === "url") {
-        const parts = location.pathname.split("/")
-        let path = parts.slice(0, parts.length-1).join("/")
-        if (path.length) {
-          path += "/"
-        }
-        url = `${location.origin}/${path}${this.esm}`
+	url = this.esm
       } else {
         url = URL.createObjectURL(new Blob([this.compiled], {type: "text/javascript"}))
       }


### PR DESCRIPTION
To handle apps served on nested paths and CDN URLs we now no longer try to infer the correct path on the frontend and instead prefix it with the relative URL.