### PR TITLE
Set resource mode while bundling notebook assets

### DIFF
--- a/panel/io/notebook.py
+++ b/panel/io/notebook.py
@@ -28,7 +28,6 @@ from bokeh.embed.util import standalone_docs_json_and_render_items
 from bokeh.embed.wrappers import wrap_in_script_tag
 from bokeh.models import Model
 from bokeh.resources import CDN, INLINE
-from bokeh.settings import _Unset, settings
 from bokeh.util.serialization import make_id
 from param.display import (
     register_display_accessor, unregister_display_accessor,
@@ -43,6 +42,7 @@ from .embed import embed_state
 from .model import add_to_doc, diff
 from .resources import (
     PANEL_DIR, Resources, _env, bundle_resources, patch_model_css,
+    set_resource_mode,
 )
 from .state import state
 
@@ -402,11 +402,9 @@ def load_notebook(
     from IPython.display import publish_display_data
 
     resources = INLINE if inline and not state._is_pyodide else CDN
-    prev_resources = settings.resources(default="server")
-    user_resources = settings.resources._user_value is not _Unset
     nb_endpoint = not state._is_pyodide
-    resources = Resources.from_bokeh(resources, notebook=nb_endpoint)
-    try:
+    with set_resource_mode(resources.mode):
+        resources = Resources.from_bokeh(resources, notebook=nb_endpoint)
         bundle = bundle_resources(
             None, resources, notebook=nb_endpoint, reloading=reloading,
             enable_mathjax=enable_mathjax
@@ -423,11 +421,6 @@ def load_notebook(
             reloading=reloading,
             load_timeout=load_timeout
         )
-    finally:
-        if user_resources:
-            settings.resources = prev_resources
-        else:
-            settings.resources.unset_value()
 
     CSS = (PANEL_DIR / '_templates' / 'jupyter.css').read_text(encoding='utf-8')
     shim = '<script type="esms-options">{"shimMode": true}</script>'

--- a/panel/io/resources.py
+++ b/panel/io/resources.py
@@ -32,7 +32,7 @@ from bokeh.embed.bundle import (
 from bokeh.model import Model
 from bokeh.models import ImportedStyleSheet
 from bokeh.resources import Resources as BkResources, _get_server_urls
-from bokeh.settings import settings as _settings
+from bokeh.settings import _Unset, settings as _settings
 from jinja2.environment import Environment
 from jinja2.loaders import FileSystemLoader
 from markupsafe import Markup
@@ -180,7 +180,10 @@ def set_resource_mode(mode):
         yield
     finally:
         RESOURCE_MODE = old_mode
-        _settings.resources.set_value(old_resources)
+        if old_resources is _Unset:
+            _settings.resources.unset_value()
+        else:
+            _settings.resources.set_value(old_resources)
 
 def use_cdn() -> bool:
     return _settings.resources(default="server") != 'server' or state._is_pyodide


### PR DESCRIPTION
Two things:

1. Seemingly we never correctly applied the resource mode while bundling resources (which presumably had some effect on bundling resources for custom components)
2. We already had a context manager to handle it