### PR TITLE
Ensure in process events are cleaned up after they are applied

### DIFF
--- a/panel/tests/test_reactive.py
+++ b/panel/tests/test_reactive.py
@@ -383,6 +383,17 @@ def test_property_change_does_not_boomerang(document, comm):
     assert model.value == 'B'
     assert text_input.value == 'C'
 
+def test_in_process_change_event_cleaned_up(document, comm):
+    checkbox = Checkbox(value=True)
+
+    model = checkbox.get_root(document, comm)
+    assert model.ref['id'] in checkbox._models
+
+    with set_curdoc(document):
+        checkbox._process_events({'active': True})
+
+    assert document not in checkbox._in_process__events
+
 def test_reactive_html_basic():
 
     class Test(ReactiveHTML):


### PR DESCRIPTION
Components internally keep track of changes that arrived from the frontend to avoid the event boomeranging. These should be cleaned up after events triggered from that change have been processed to ensure that the same change can subsequently be applied. In some scenarios that was not happening meaning that if a later event applied the same change it might get dropped.