### PR TITLE
compat: pin libsqlite for now

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -156,6 +156,7 @@ polars = "*"
 reacton = "*"
 scipy = "*"
 textual = "*"
+libsqlite = "!=3.49.*" # 2025-02; Breaks diskcache tests, https://github.com/conda-forge/sqlite-feedstock/issues/130 (remove dependency after problem is solved)
 
 [feature.test-unit-task.tasks] # So it is not showing up in the test-ui environment
 test-unit = 'pytest panel/tests -n logical --dist loadgroup'


### PR DESCRIPTION
Same problem as seen in HoloViews with Ibis (https://github.com/holoviz/holoviews/pull/6513)

![image](https://github.com/user-attachments/assets/e137e288-e712-44a9-9b3d-e9051ba2ce28)
