### PR TITLE
.controls has incorrect doc strings for max_width and max_height: both say Minimum instead of Maximum

### DIFF
--- a/panel/viewable.py
+++ b/panel/viewable.py
@@ -105,10 +105,10 @@ class Layoutable(param.Parameterized):
         Minimal height of the component (in pixels) if height is adjustable.""")
 
     max_width = param.Integer(default=None, bounds=(0, None), doc="""
-        Minimal width of the component (in pixels) if width is adjustable.""")
+        Maximum width of the component (in pixels) if width is adjustable.""")
 
     max_height = param.Integer(default=None, bounds=(0, None), doc="""
-        Minimal height of the component (in pixels) if height is adjustable.""")
+        Maximum height of the component (in pixels) if height is adjustable.""")
 
     margin = Margin(default=0, doc="""
         Allows to create additional space around the component. May


### PR DESCRIPTION
In the Layout Tab of .controls, when hovering over the ? info icon of Max width and Max height, the hover text says:

Minimal width / height of the component (in pixels) ... etc.

This should be:

Maxium width / height of the component (in pixels) ... etc.

So currently, the hover text for these 2 elements is identical to those of Min Width and Min height.

Changed "Minimal" to Maximum in the doc strings for max_width and max_height.

+1 for .controls by the way! Great way to understand / iterate what various aspects of a component do.

And .controls itself is a nice example of what Panel can do.


Additional observations: the 'Visible' element at the bottom of the Layout tab does not show a ? icon + hover text yet, although there is a doc string defined for it at line 250 in viewable.py .

 ```python
   visible = param.Boolean(default=True, doc="""
        Whether the component is visible. Setting visible to false will
        hide the component entirely.""")
```

When investigating this further, it was not clear to me how / where the values of labels like 'Max height' , 'Min width' are defined / generated, and inserted together with the ? icon above each control item in the .controls Widgetboxes.

Any hint would really be appreciated! I would like to use it myself in components to show doc strings in this way, but I can't see how to enable this.

I have been trying to find it in the source code of viewable.py and reactive.py, but I have been unable to find a clue. Does it hapen at at a HTML template level? Or CSS? Are they properties of the widgets themselves that can be enabled?

Are the label values as mentioned defined in a dict or map somewhere? Is there a regex that turns the variable min_width into Min width?

Btw, the same issue applies for the 2 control elements ('Value' and 'Disabled') in the first tab of .controls as shown in Checkbox, Toggle, and Switch docs.

Could it be related to the fact that different widgets inherit from different base classes?

If I understand correctly, Checkbox inherits from _BooleanWidget(Widget) which has the docstring below. But it is not shown in the .controls of Checkbox

https://github.com/holoviz/panel/blob/v1.6.1/panel/widgets/input.py#L1486

class _BooleanWidget(Widget):

    value = param.Boolean(default=False, doc="""
        The current value""")


Conversely, in the Select doc, 'Value' does indeed have a ? icon and hover text in the Select doc, in the .controls at the bottom of the doc. But not for the Disabled and Options .controls elements in that doc.

The doc string is in base.py at line 46:

class WidgetBase(param.Parameterized):

...

```python
 value = param.Parameter(allow_None=True, doc="""
        The widget value which the widget type resolves to when used
        as a reactive param reference.""")

    __abstract = True
```

Disabled also has a docstring in base.py, but for Select, that does not result in a ? icon and displaying of the docstring on hovering over the ? icon. From line 118:

```python
class Widget(Reactive, WidgetBase):
    """
    Widgets allow syncing changes in bokeh widget models with the
    parameters on the Widget instance.
    """

    disabled = param.Boolean(default=False, doc="""
       Whether the widget is disabled.""")
```

https://panel.holoviz.org/reference/widgets/Select.html


Another observation; Checkbox, Toggle and Switch are all interchangeable, but this is not mentioned completely in their respective docs.