### PR TITLE
Make it easier to subclass components

### DIFF
--- a/panel/reactive.py
+++ b/panel/reactive.py
@@ -1618,7 +1618,7 @@ class ReactiveCustomBase(Reactive):
         try:
             model.update(**transformed)
         finally:
-            if old:
+            if prev_changing:
                 self._changing[root.ref['id']] = prev_changing
             else:
                 del self._changing[root.ref['id']]

--- a/panel/viewable.py
+++ b/panel/viewable.py
@@ -1261,7 +1261,7 @@ def is_viewable_param(parameter: param.Parameter) -> bool:
     """
     if isinstance(parameter, (Child, Children)):
         return True
-    if isinstance(parameter, param.ClassSelector) and _is_viewable_class_selector(parameter):
+    if isinstance(parameter, param.ClassSelector) and _is_viewable_class_selector(parameter) and parameter.is_instance:
         return True
     if isinstance(parameter, param.List) and _is_viewable_list(parameter):
         return True

--- a/panel/widgets/select.py
+++ b/panel/widgets/select.py
@@ -275,7 +275,7 @@ class Select(SingleSelectBase):
             )
 
     def _process_param_change(self, msg: dict[str, Any]) -> dict[str, Any]:
-        groups_provided = 'groups' in msg
+        groups_provided = msg.get('groups') is not None
         msg = super()._process_param_change(msg)
         if groups_provided or 'options' in msg and self.groups:
             groups: dict[str, list[str | tuple[str, str]]] = self.groups


### PR DESCRIPTION
A number of changes to make it easier to subclass component classes:

- `ChatFeed` and `ChatInterface` component types can now be set as class variables
- Fix issue falsely detecting a non-instance parameter type as a child
- Fix incorrectly detecting groups on Select widget

These changes are needed for the work on `panel-material-ui` so I don't have to reimplement entire classes.