### PR TITLE
Correctly handle empty source files

### DIFF
--- a/panel/io/handlers.py
+++ b/panel/io/handlers.py
@@ -448,7 +448,7 @@ class PanelCodeHandler(CodeHandler):
 
         if runner:
             self._runner = runner
-        elif source:
+        elif source is not None:
             self._runner = PanelCodeRunner(source, filename, argv, package=package)
         else:
             raise ValueError("Must provide source code to PanelCodeHandler")


### PR DESCRIPTION
When serving an empty file it would previously error out saying that no source code was provided. While technically correct, it's valid to provide an empty file.