### PR TITLE
Update Checkbox.ipynb to indicate both Toggle and Switch are interchangeable with Checkbox

### DIFF
--- a/examples/reference/widgets/Checkbox.ipynb
+++ b/examples/reference/widgets/Checkbox.ipynb
@@ -14,7 +14,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The ``Checkbox`` widget allows toggling a single condition between ``True``/``False`` states by ticking a checkbox. This widget is interchangeable with the ``Toggle`` widget.\n",
+    "The ``Checkbox`` widget allows toggling a single condition between ``True``/``False`` states by ticking a checkbox. The `Checkbox` widget allows toggling a single condition between `True`/`False` states by ticking a checkbox. The [``Checkbox``](Checkbox.ipynb), [``Toggle``](Toggle.ipynb), and [``Switch``](Switch.ipynb) widgets are interchangeable.\n",
     "\n",
     "Discover more on using widgets to add interactivity to your applications in the [how-to guides on interactivity](../../how_to/interactivity/index.md). Alternatively, learn [how to set up callbacks and (JS-)links between parameters](../../how_to/links/index.md) or [how to use them as part of declarative UIs with Param](../../how_to/param/index.md).\n",
     "\n",


### PR DESCRIPTION
…ngeable with Checbox.

Textual improvements to clarify all 3 widgets are interchangeable, and adds links to the 2 docs for the other widgets that are interchangeable. See #7737

No entirely sure if the added links are structured correctly, so that they will be converted to correct links when the webpage is generated from the Notebook. The links work when viewing the new version of the file, insofar as clicking on the link leads to the correct Notebook in Github.

See issue https://github.com/holoviz/panel/issues/7737 for request for further explanation on this.