### PR TITLE
Upgrade Quill to version 2.0.2 and fix toolbar editing and nested lists

### DIFF
--- a/panel/models/quill.py
+++ b/panel/models/quill.py
@@ -13,12 +13,12 @@ class QuillInput(HTMLBox):
     """
 
     __css_raw__ = [
-        'https://cdn.jsdelivr.net/npm/quill@2.0.3/dist/quill.bubble.css',
-        'https://cdn.jsdelivr.net/npm/quill@2.0.3/dist/quill.snow.css',
+        'https://cdn.jsdelivr.net/npm/quill@2.0.2/dist/quill.bubble.css',
+        'https://cdn.jsdelivr.net/npm/quill@2.0.2/dist/quill.snow.css',
     ]
 
     __javascript_raw__ = [
-        'https://cdn.jsdelivr.net/npm/quill@2.0.3/dist/quill.js',
+        'https://cdn.jsdelivr.net/npm/quill@2.0.2/dist/quill.js',
     ]
 
     @classproperty
@@ -35,7 +35,7 @@ class QuillInput(HTMLBox):
 
     __js_require__ = {
         'paths': {
-            'Quill': 'https://cdn.jsdelivr.net/npm/quill@2.0.3/dist/quill',
+            'Quill': 'https://cdn.jsdelivr.net/npm/quill@2.0.2/dist/quill',
         },
         'exports': {
             'Quill': 'Quill'

--- a/panel/models/quill.py
+++ b/panel/models/quill.py
@@ -13,12 +13,12 @@ class QuillInput(HTMLBox):
     """
 
     __css_raw__ = [
-        'https://cdn.quilljs.com/1.3.7/quill.bubble.css',
-        'https://cdn.quilljs.com/1.3.7/quill.snow.css'
+        'https://cdn.jsdelivr.net/npm/quill@2.0.3/dist/quill.bubble.css',
+        'https://cdn.jsdelivr.net/npm/quill@2.0.3/dist/quill.snow.css',
     ]
 
     __javascript_raw__ = [
-        'https://cdn.quilljs.com/1.3.7/quill.js',
+        'https://cdn.jsdelivr.net/npm/quill@2.0.3/dist/quill.js',
     ]
 
     @classproperty
@@ -35,7 +35,7 @@ class QuillInput(HTMLBox):
 
     __js_require__ = {
         'paths': {
-            'Quill': 'https://cdn.quilljs.com/1.3.7/quill',
+            'Quill': 'https://cdn.jsdelivr.net/npm/quill@2.0.3/dist/quill',
         },
         'exports': {
             'Quill': 'Quill'

--- a/panel/models/quill.ts
+++ b/panel/models/quill.ts
@@ -155,7 +155,7 @@ export class QuillInputView extends HTMLBoxView {
     this._editor = (this.shadow_el.querySelector(".ql-editor") as HTMLDivElement)
     this._toolbar = (this.shadow_el.querySelector(".ql-toolbar") as HTMLDivElement)
 
-    const delta = this.quill.clipboard.convert(this.model.text)
+    const delta = this.quill.clipboard.convert({ html: this.model.text })
     this.quill.setContents(delta)
 
     this.quill.on("text-change", () => {
@@ -163,7 +163,7 @@ export class QuillInputView extends HTMLBoxView {
         return
       }
       this._editing = true
-      this.model.text = this._editor.innerHTML
+      this.model.text = this.quill.getSemanticHTML()
       this._editing = false
     })
     if (!this.model.disabled) {
@@ -181,7 +181,7 @@ export class QuillInputView extends HTMLBoxView {
       this.container.style.visibility = "visible"
     }
 
-    const delta = this.quill.clipboard.convert(this.model.text)
+    const delta = this.quill.clipboard.convert({ html: this.model.text })
     this.quill.setContents(delta)
 
     this.invalidate_layout()

--- a/panel/models/quill.ts
+++ b/panel/models/quill.ts
@@ -115,22 +115,22 @@ export class QuillInputView extends HTMLBoxView {
       const rootNode = (this.quill.root.getRootNode() as ShadowRoot)
       const range = getNativeRange(rootNode)
       if (!!range) {
-	// If there was a cached selection when the user clicked on the toolbar
-	if (blurred_selection !== null) {
-	  if (timeout) {
-	    clearTimeout(timeout)
-	  }
-	  timeout = setTimeout(() => {
-	    if (!blurred_selection) {
-	      return
-	    }
-	    this._editor.focus()
-	    blurred_selection = null
-	  }, 50)
-	  return blurred_selection
-	} else {
-	  return this.quill.selection.normalizeNative(range)
-	}
+        // If there was a cached selection when the user clicked on the toolbar
+        if (blurred_selection !== null) {
+          if (timeout) {
+            clearTimeout(timeout)
+          }
+          timeout = setTimeout(() => {
+            if (!blurred_selection) {
+              return
+            }
+            this._editor.focus()
+            blurred_selection = null
+          }, 50)
+          return blurred_selection
+        } else {
+          return this.quill.selection.normalizeNative(range)
+        }
       }
       return null
     }
@@ -180,11 +180,11 @@ export class QuillInputView extends HTMLBoxView {
     this._editor.addEventListener("blur", (e) => {
       let root = (e.relatedTarget as any)
       while (root !== null && root.parentElement !== null) {
-	root = root.parentElement
-	if (root === this._toolbar || root === this.quill.theme.tooltip.root) {
-	  blurred_selection = this.quill.selection.getNativeRange()
-	  return
-	}
+        root = root.parentElement
+        if (root === this._toolbar || root === this.quill.theme.tooltip.root) {
+          blurred_selection = this.quill.selection.getNativeRange()
+          return
+        }
       }
       blurred_selection = null
     })

--- a/panel/models/quill.ts
+++ b/panel/models/quill.ts
@@ -95,9 +95,6 @@ export class QuillInputView extends HTMLBoxView {
       }
     }
 
-    let blurred_selection: any = null
-    let timeout: any = null
-
     /**
      * Original implementation uses document.active element which does not work in Native Shadow.
      * Replace document.activeElement with shadowRoot.activeElement

--- a/panel/models/quill.ts
+++ b/panel/models/quill.ts
@@ -155,7 +155,7 @@ export class QuillInputView extends HTMLBoxView {
     this._editor = (this.shadow_el.querySelector(".ql-editor") as HTMLDivElement)
     this._toolbar = (this.shadow_el.querySelector(".ql-toolbar") as HTMLDivElement)
 
-    const delta = this.quill.clipboard.convert({ html: this.model.text })
+    const delta = this.quill.clipboard.convert({html: this.model.text})
     this.quill.setContents(delta)
 
     this.quill.on("text-change", () => {
@@ -181,7 +181,7 @@ export class QuillInputView extends HTMLBoxView {
       this.container.style.visibility = "visible"
     }
 
-    const delta = this.quill.clipboard.convert({ html: this.model.text })
+    const delta = this.quill.clipboard.convert({html: this.model.text})
     this.quill.setContents(delta)
 
     this.invalidate_layout()

--- a/panel/tests/ui/widgets/test_texteditor.py
+++ b/panel/tests/ui/widgets/test_texteditor.py
@@ -111,7 +111,6 @@ def test_texteditor_regression_preserve_formatting_on_view_change(page):
     # inner_html() in Quill v2 not longer contains the semantic HTML but:
     # <ol><li data-list="bullet"><span class="ql-ui" contenteditable="false"></span>aaa</li>...
     # We just count the number of closed li tags
-    assert html == expected
     assert html.count('</li>') == expected.count('</li>')
 
     page.locator('button', has_text='1').click()

--- a/panel/tests/ui/widgets/test_texteditor.py
+++ b/panel/tests/ui/widgets/test_texteditor.py
@@ -149,3 +149,25 @@ def test_texteditor_space(page):
     serve_component(page, widget)
 
     wait_until(lambda: widget.value == f'<p>{text}</p>', page)
+
+
+def test_texteditor_nested_lists(page):
+    nested_bullets = """
+    <ul>
+    <li>Coffee</li>
+    <li>Tea
+        <ul>
+        <li>Black</li>
+        <li>Green</li>
+        </ul>
+    </li>
+    <li>Milk</li>
+    </ul>
+    """
+
+    widget = TextEditor(value=nested_bullets)
+
+    serve_component(page, widget)
+
+    expected = '<ul><li>Coffee</li><li>Tea<ul><li>Black</li><li>Green</li></ul></li><li>Milk</li></ul>'
+    wait_until(lambda: widget.value == expected, page)

--- a/panel/tests/ui/widgets/test_texteditor.py
+++ b/panel/tests/ui/widgets/test_texteditor.py
@@ -62,7 +62,7 @@ def test_texteditor_enter_value(page):
     wait_until(lambda: widget.value == '<p>test</p>', page)
 
 
-def test_texteditor_regression_copy_paste(page):
+def test_texteditor_regression_copy_paste(page, browser):
     # https://github.com/holoviz/panel/issues/5545
     widget = TextEditor()
     html = HTML('test')
@@ -77,7 +77,13 @@ def test_texteditor_regression_copy_paste(page):
     page.locator('.ql-editor').press(f'{ctrl_key}+KeyV')
 
     expect(page.locator('.ql-container')).to_have_text('test')
-    wait_until(lambda: widget.value == '<p>test</p>', page)
+    # Quill v2 changed the way copied content is parsed and can preserve
+    # more of the copied html.
+    expected = '<p><span style="color: rgb(33, 37, 41);">test</span></p>'
+    if browser.browser_type.name == 'firefox':
+        # Copy/paste on firefox works a bit differently
+        expected = '<p>test</p>'
+    wait_until(lambda: widget.value == expected, page)
 
 
 def test_texteditor_regression_preserve_formatting_on_view_change(page):
@@ -102,7 +108,11 @@ def test_texteditor_regression_preserve_formatting_on_view_change(page):
     wait_until(lambda: widget.value == expected, page)
 
     html = page.locator('.ql-editor').inner_html()
+    # inner_html() in Quill v2 not longer contains the semantic HTML but:
+    # <ol><li data-list="bullet"><span class="ql-ui" contenteditable="false"></span>aaa</li>...
+    # We just count the number of closed li tags
     assert html == expected
+    assert html.count('</li>') == expected.count('</li>')
 
     page.locator('button', has_text='1').click()
     wait_until(lambda: w_radio.value == 1, page)
@@ -111,7 +121,7 @@ def test_texteditor_regression_preserve_formatting_on_view_change(page):
     wait_until(lambda: w_radio.value == 0, page)
 
     html = page.locator('.ql-editor').inner_html()
-    assert html == expected
+    assert html.count('</li>') == expected.count('</li>')
     wait_until(lambda: widget.value == expected, page)
 
 

--- a/panel/tests/ui/widgets/test_texteditor.py
+++ b/panel/tests/ui/widgets/test_texteditor.py
@@ -137,3 +137,15 @@ def test_texteditor_regression_click_toolbar_cursor_stays_in_place(page):
     page.locator('.ql-bold').click()
     editor.press('B')
     wait_until(lambda: widget.value == '<p>A</p><p><strong>B</strong></p>', page)
+
+
+def test_texteditor_space(page):
+    # Quill 2.0.3 has &nbsp; instead of white spaces, this tests aims
+    # at preventing us from introducing this weird behavior.
+    # https://github.com/slab/quill/issues/4509
+    text = 'text with space'
+    widget = TextEditor(value=text)
+
+    serve_component(page, widget)
+
+    wait_until(lambda: widget.value == f'<p>{text}</p>', page)


### PR DESCRIPTION
Fixes https://github.com/holoviz/panel/issues/7524
Fixes https://github.com/holoviz/panel/issues/7460

By upgrading Quill to version 2.0.2. Note the latest is 2.0.3 but has a weird bug that replaces all white spaces with `nbsp;`. The test `test_texteditor_nested_lists` failed before this PR and now passes. I've also run the tests locally on Firefox and they all pass, one needed some adjustment.

Keeping it a bit in Draft mode as I'd like to test it on a real app (I'm moderately confident on Quill's robustness and v2 still doesn't support the virtual DOM).