### PR TITLE
Ensure ReactComponent children are sized correctly

### DIFF
--- a/panel/styles/models/esm.less
+++ b/panel/styles/models/esm.less
@@ -1,4 +1,4 @@
-.error-wrapper {
+.error-wrapper, .child-wrapper {
   display: contents;
 }
 


### PR DESCRIPTION
ReactComponent creates wrappers to render children into, these should not break the layout flow so they must set `display: contents`