### PR TITLE
If ChatStep set to failed, do not set to success on exiting context

### DIFF
--- a/panel/chat/step.py
+++ b/panel/chat/step.py
@@ -157,7 +157,7 @@ class ChatStep(Card):
             self.status = "failed"
             if self.context_exception == "raise":
                 return False
-        else:
+        elif self.status in ("pending", "running"):
             self.status = "success"
         return True  # suppress exception if any
 

--- a/panel/tests/chat/test_step.py
+++ b/panel/tests/chat/test_step.py
@@ -94,6 +94,12 @@ class TestChatStep:
         assert step.title == "Error: 'RuntimeError'", "Title should update to 'Error: 'RuntimeError'' on failure again"
         assert step.objects[0].object == "Testing\nSecond Testing", "Error message should be streamed to the message pane"
 
+    def test_context_manually_set_failed(self):
+        step = ChatStep()
+        with step:
+            step.status = "failed"
+        assert step.status == "failed", "Status should be 'failed' after manually setting it to 'failed'"
+
     def test_context_exception_ignore(self):
         step = ChatStep(context_exception="ignore")
         with step:


### PR DESCRIPTION
Even after https://github.com/holoviz/lumen/pull/1069, I noticed the ChatStep was showing success even when it was explicitly set to failed 