### PR TITLE
Allow resolving change handlers and useState for nested refs

### DIFF
--- a/panel/custom.py
+++ b/panel/custom.py
@@ -511,7 +511,9 @@ class ReactiveESM(ReactiveCustomBase, metaclass=ReactiveESMMetaclass):
         children = self._get_children(model.data, doc, root, model, comm)
         model.data.update(**children)
         model.children = list(children)  # type: ignore
-        self._models[root.ref['id']] = (model, parent)
+        ref = root.ref['id']
+        self._models[ref] = (model, parent)
+        self._patch_datamodel_ref(model.data, ref)
         self._link_props(props['data'], self._linked_properties, doc, root, comm)
         self._register_events('dom_event', 'data_event', model=model, doc=doc, comm=comm)
         self._setup_autoreload()
@@ -572,7 +574,7 @@ class ReactiveESM(ReactiveCustomBase, metaclass=ReactiveESMMetaclass):
     def _send_msg(self, data: Any) -> None:
         """
         Sends data to the frontend which can be observed on the frontend
-        with the `model.on_msg("msg:custom", callback)` API.
+        with the `model.on("msg:custom", callback)` API.
 
         Parameters
         ----------

--- a/panel/models/anywidget_component.ts
+++ b/panel/models/anywidget_component.ts
@@ -67,7 +67,7 @@ class AnyWidgetModelAdapter {
         }
       }
       if (targetModel && targetModel.attributes && propPath[propPath.length - 1] in targetModel.attributes) {
-        targetModel.setv({ [propPath[propPath.length - 1]]: this.data_changes[key] })
+        targetModel.setv({[propPath[propPath.length - 1]]: this.data_changes[key]})
       } else {
         console.warn(`Skipping '${key}': Final property '${propPath[propPath.length - 1]}' not found.`)
       }

--- a/panel/models/anywidget_component.ts
+++ b/panel/models/anywidget_component.ts
@@ -44,9 +44,9 @@ class AnyWidgetModelAdapter {
   }
 
   set(name: string, value: any) {
-    if (name in this.model.data.attributes) {
+    if (name.split(".")[0] in this.model.data.attributes) {
       this.data_changes = {...this.data_changes, [name]: value}
-    } else if (name.split(".")[0] in this.model.attributes) {
+    } else if (name in this.model.attributes) {
       this.model_changes = {...this.model_changes, [name]: value}
     }
   }

--- a/panel/models/reactive_esm.ts
+++ b/panel/models/reactive_esm.ts
@@ -614,7 +614,7 @@ export class ReactiveESM extends HTMLBox {
       const remaining = []
       for (const [wview, cb] of this._esm_watchers[p]) {
         if (wview === view) {
-          prop.change.disconnect(cb)
+          prop?.change.disconnect(cb)
         } else {
           remaining.push([wview, cb])
         }

--- a/panel/models/reactive_esm.ts
+++ b/panel/models/reactive_esm.ts
@@ -534,78 +534,78 @@ export class ReactiveESM extends HTMLBox {
       this._esm_watchers[prop] = [[view, cb]]
     }
 
-    const propPath = prop.split(".");
-    let target: any = this.data;
-    let resolvedProp: string | null = null;
+    const propPath = prop.split(".")
+    let target: any = this.data
+    let resolvedProp: string | null = null
     for (let i = 0; i < propPath.length - 1; i++) {
       if (target && target.properties && propPath[i] in target.properties) {
-        target = target[propPath[i]];
+        target = target[propPath[i]]
       } else {
         // Break if any level of the path is invalid
-        target = null;
-        break;
+        target = null
+        break
       }
     }
 
     if (target && target.properties && propPath[propPath.length - 1] in target.properties) {
-      resolvedProp = propPath[propPath.length - 1];
+      resolvedProp = propPath[propPath.length - 1]
     }
 
     // Attach watcher if property is found
     if (resolvedProp && target) {
-      target.property(resolvedProp).change.connect(cb);
+      target.property(resolvedProp).change.connect(cb)
     } else if (prop in this.properties) {
-      this.property(prop).change.connect(cb);
+      this.property(prop).change.connect(cb)
     }
   }
 
   unwatch(view: ReactiveESMView | null, prop: string, cb: any): boolean {
     if (!(prop in this._esm_watchers)) {
-      return false;
+      return false
     }
 
     // Filter out the specific callback for this view
-    const remaining = [];
+    const remaining = []
     for (const [wview, wcb] of this._esm_watchers[prop]) {
       if (wview !== view || wcb !== cb) {
-        remaining.push([wview, wcb]);
+        remaining.push([wview, wcb])
       }
     }
 
     // Update or delete watcher list
     if (remaining.length > 0) {
-      this._esm_watchers[prop] = remaining;
+      this._esm_watchers[prop] = remaining
     } else {
-      delete this._esm_watchers[prop];
+      delete this._esm_watchers[prop]
     }
 
     // Resolve nested properties
-    const propPath = prop.split(".");
-    let target: any = this.data;
-    let resolvedProp: string | null = null;
+    const propPath = prop.split(".")
+    let target: any = this.data
+    let resolvedProp: string | null = null
 
     for (let i = 0; i < propPath.length - 1; i++) {
       if (target && target.properties && propPath[i] in target.properties) {
-        target = target[propPath[i]];
+        target = target[propPath[i]]
       } else {
         // Stop if the path does not exist
-        target = null;
-        break;
+        target = null
+        break
       }
     }
 
     if (target && target.properties && propPath[propPath.length - 1] in target.properties) {
-      resolvedProp = propPath[propPath.length - 1];
+      resolvedProp = propPath[propPath.length - 1]
     }
 
     // Detach watcher if property is found
     if (resolvedProp && target) {
-      return target.property(resolvedProp).change.disconnect(cb);
+      return target.property(resolvedProp).change.disconnect(cb)
     } else if (prop in this.properties) {
-      return this.property(prop).change.disconnect(cb);
+      return this.property(prop).change.disconnect(cb)
     }
 
-    return false;
+    return false
   }
 
   disconnect_watchers(view: ReactiveESMView): void {

--- a/panel/models/reactive_esm.ts
+++ b/panel/models/reactive_esm.ts
@@ -81,7 +81,7 @@ export function model_getter(target: ReactiveESMView, name: string) {
         if (p.startsWith("change:")) {
           p = p.slice("change:".length)
         }
-        if (p in model.attributes || p in model.data.attributes) {
+        if (p in model.attributes || p.split(".")[0] in model.data.attributes) {
           model.unwatch(target, p, callback)
           continue
         } else if (p === "msg:custom") {
@@ -108,7 +108,7 @@ export function model_getter(target: ReactiveESMView, name: string) {
         if (p.startsWith("change:")) {
           p = p.slice("change:".length)
         }
-        if (p in model.attributes || p in model.data.attributes) {
+        if (p in model.attributes || p.split(".")[0] in model.data.attributes) {
           model.watch(target, p, callback)
           continue
         } else if (p === "msg:custom") {
@@ -533,34 +533,79 @@ export class ReactiveESM extends HTMLBox {
     } else {
       this._esm_watchers[prop] = [[view, cb]]
     }
-    if (prop in this.data.properties) {
-      this.data.property(prop).change.connect(cb)
+
+    const propPath = prop.split(".");
+    let target: any = this.data;
+    let resolvedProp: string | null = null;
+    for (let i = 0; i < propPath.length - 1; i++) {
+      if (target && target.properties && propPath[i] in target.properties) {
+        target = target[propPath[i]];
+      } else {
+        // Break if any level of the path is invalid
+        target = null;
+        break;
+      }
+    }
+
+    if (target && target.properties && propPath[propPath.length - 1] in target.properties) {
+      resolvedProp = propPath[propPath.length - 1];
+    }
+
+    // Attach watcher if property is found
+    if (resolvedProp && target) {
+      target.property(resolvedProp).change.connect(cb);
     } else if (prop in this.properties) {
-      this.property(prop).change.connect(cb)
+      this.property(prop).change.connect(cb);
     }
   }
 
   unwatch(view: ReactiveESMView | null, prop: string, cb: any): boolean {
     if (!(prop in this._esm_watchers)) {
-      return false
+      return false;
     }
-    const remaining = []
+
+    // Filter out the specific callback for this view
+    const remaining = [];
     for (const [wview, wcb] of this._esm_watchers[prop]) {
       if (wview !== view || wcb !== cb) {
-        remaining.push([wview, cb])
+        remaining.push([wview, wcb]);
       }
     }
+
+    // Update or delete watcher list
     if (remaining.length > 0) {
-      this._esm_watchers[prop] = remaining
+      this._esm_watchers[prop] = remaining;
     } else {
-      delete this._esm_watchers[prop]
+      delete this._esm_watchers[prop];
     }
-    if (prop in this.data.properties) {
-      return this.data.property(prop).change.disconnect(cb)
+
+    // Resolve nested properties
+    const propPath = prop.split(".");
+    let target: any = this.data;
+    let resolvedProp: string | null = null;
+
+    for (let i = 0; i < propPath.length - 1; i++) {
+      if (target && target.properties && propPath[i] in target.properties) {
+        target = target[propPath[i]];
+      } else {
+        // Stop if the path does not exist
+        target = null;
+        break;
+      }
+    }
+
+    if (target && target.properties && propPath[propPath.length - 1] in target.properties) {
+      resolvedProp = propPath[propPath.length - 1];
+    }
+
+    // Detach watcher if property is found
+    if (resolvedProp && target) {
+      return target.property(resolvedProp).change.disconnect(cb);
     } else if (prop in this.properties) {
-      return this.property(prop).change.disconnect(cb)
+      return this.property(prop).change.disconnect(cb);
     }
-    return false
+
+    return false;
   }
 
   disconnect_watchers(view: ReactiveESMView): void {

--- a/panel/reactive.py
+++ b/panel/reactive.py
@@ -2103,10 +2103,7 @@ class ReactiveHTML(ReactiveCustomBase, metaclass=ReactiveHTMLMetaclass):
 
         ref = root.ref['id']
         data_model: DataModel = model.data # type: ignore
-        for v in data_model.properties_with_values():
-            if isinstance(v, DataModel):
-                v.tags.append(f"__ref:{ref}")
-        self._patch_datamodel_ref(data_model.properties_with_values(), ref)
+        self._patch_datamodel_ref(data_model, ref)
         model.update(children=self._get_children(doc, root, model, comm))
         self._register_events('dom_event', model=model, doc=doc, comm=comm)
         self._link_props(data_model, self._linked_properties, doc, root, comm)


### PR DESCRIPTION
What makes `ReactiveESM` components so powerful is that changes on parameters can easily be watched in JS. We already support serializing nested parameters, i.e. parameters which themselves hold a `Parameterized`. In Python you can already use `pn.depends` to set up watchers on such nested dependencies. This PR now makes it possible to do the same in JS using the `model.on`/`model.off` callback registration methods as well as the `model.useState` helper for React components, i.e. let's say I have a class like:

```python
class Child(param.Parameterized):

    value = param.Integer(default=1)

class Parent(JSComponent):

    child = param.ClassSelector(class_=Child)
```

I can now register callbacks for value changes on the `child` with:

```javascript
model.on('child.value', (value) => console.log(`The child value parameter changed to ${value}`))
```

or equivalently generate a React state variable with

```javascript
const [child_value, setChildValue] = model.useState('child.value')
```

This means a developer no longer has to shove all the state onto parent object and can instead write better object-oriented code.