### PR TITLE
Factor out sizing mode mixin and force height of ChatFeed to stretch

### DIFF
--- a/panel/chat/feed.py
+++ b/panel/chat/feed.py
@@ -27,7 +27,6 @@ from ..layout import (
     Column, Feed, ListPanel, WidgetBox,
 )
 from ..layout.card import Card
-from ..layout.spacer import VSpacer
 from ..pane.image import SVG, ImageBase
 from ..pane.markup import HTML, Markdown
 from ..util import to_async_gen
@@ -273,12 +272,13 @@ class ChatFeed(ListPanel):
             load_buffer=self.load_buffer,
             auto_scroll_limit=self.auto_scroll_limit,
             scroll_button_threshold=self.scroll_button_threshold,
+            height=None,
             view_latest=self.view_latest,
             css_classes=["chat-feed-log"],
             stylesheets=self._stylesheets,
+            height_policy="max",
             **linked_params
         )
-        self._chat_log.height = None
         card_params = linked_params.copy()
         card_stylesheets = (
             self._stylesheets +
@@ -307,7 +307,6 @@ class ChatFeed(ListPanel):
         # we have a card for the title
         self._card = self._card_type(
             self._chat_log,
-            VSpacer(),
             **card_params
         )
 

--- a/panel/layout/base.py
+++ b/panel/layout/base.py
@@ -243,8 +243,7 @@ class Panel(Reactive, SizingModeMixin):
                     width=msg.get('width', model.width),
                     min_width=msg.get('min_width', model.min_width),
                     margin=msg.get('margin', model.margin)
-                ),
-                self._direction
+                )
             ))
         else:
             old_children = None
@@ -312,7 +311,7 @@ class Panel(Reactive, SizingModeMixin):
         objects, _ = self._get_objects(model, [], doc, root, comm)
         props = self._get_properties(doc)
         props[self._property_mapping['objects']] = objects
-        props.update(self._compute_sizing_mode(objects, props, self._direction))
+        props.update(self._compute_sizing_mode(objects, props))
         model.update(**props)
         self._link_props(model, self._linked_properties, doc, root, comm)
         return model


### PR DESCRIPTION
Factoring out the sizing_mode mix-in class allows downstream libraries to emulate the behavior of Panel layouts more easily. Additionally we fix some workarounds used to force the Feed inside the ChatFeed to stretch in height.