### PR TITLE
Ensure Feed and scrollable layout children heights are not fixed

### DIFF
--- a/panel/dist/css/listpanel.css
+++ b/panel/dist/css/listpanel.css
@@ -1,9 +1,12 @@
-:host(.scrollable) {
+:host(.scrollable),
+:host(.scrollable-vertical) {
   overflow: auto;
 }
 
-:host(.scrollable-vertical) {
-  overflow-y: auto;
+:host(.scrollable) > div,
+:host(.scroll) > div,
+:host(.scroll-vertical) > div {
+  max-height: unset;
 }
 
 :host(.scrollable-horizontal) {

--- a/panel/models/feed.ts
+++ b/panel/models/feed.ts
@@ -171,6 +171,11 @@ export class FeedView extends ColumnView {
     return created
   }
 
+  override _update_layout(): void {
+    super._update_layout()
+    this.style.append(":host > div", {max_height: "unset"})
+  }
+
   override render(): void {
     this._rendered = false
     super.render()


### PR DESCRIPTION
Feed and scrollable layouts don't really have a limit on the height of their children but in many cases the children might set `max-height: 100%` to avoid overflow. Here we apply styles that override this default to ensure that the children can be larger than their container.