### PR TITLE
Ensure child component parameters are declared

### DIFF
--- a/panel/chat/feed.py
+++ b/panel/chat/feed.py
@@ -286,19 +286,19 @@ class ChatFeed(ListPanel):
             self.param.card_params.rx().get('stylesheets', [])
         )
         card_params.update(
-            margin=self.param.margin,
             align=self.param.align,
-            header=self.param.header,
-            height=self.param.height,
-            hide_header=self.param.header.rx().rx.in_((None, "")),
             collapsible=False,
             css_classes=["chat-feed"] + self.param.css_classes.rx(),
+            header=self.header,
             header_css_classes=["chat-feed-header"],
+            height=self.param.height,
+            hide_header=self.param.header.rx().rx.in_((None, "")),
+            margin=self.param.margin,
             max_height=self.param.max_height,
             min_height=self.param.min_height,
-            title_css_classes=["chat-feed-title"],
             styles={"padding": "0px"},
-            stylesheets=card_stylesheets
+            stylesheets=card_stylesheets,
+            title_css_classes=["chat-feed-title"],
         )
         card_overrides = self.card_params.copy()
         card_overrides.pop('stylesheets', None)
@@ -309,6 +309,7 @@ class ChatFeed(ListPanel):
             self._chat_log,
             **card_params
         )
+        self.link(self._card, header='header')
 
         # handle async callbacks using this trick
         self.param.watch(self._prepare_response, '_callback_trigger')

--- a/panel/chat/message.py
+++ b/panel/chat/message.py
@@ -32,7 +32,7 @@ from ..pane.markup import (
 from ..pane.media import Audio, Video
 from ..pane.placeholder import Placeholder
 from ..param import ParamFunction
-from ..viewable import ServableMixin, Viewable
+from ..viewable import Children, ServableMixin, Viewable
 from ..widgets.base import Widget
 from ..widgets.icon import ToggleIcon
 from .icon import ChatCopyIcon, ChatReactionIcons
@@ -188,10 +188,10 @@ class ChatMessage(Pane):
     edited = param.Event(doc="""
         An event that is triggered when the message is edited.""")
 
-    footer_objects = param.List(doc="""
+    footer_objects = Children(default=[], doc="""
         A list of objects to display in the column of the footer of the message.""")
 
-    header_objects = param.List(doc="""
+    header_objects = Children(default=[], doc="""
         A list of objects to display in the row of the header of the message.""")
 
     max_width = param.Integer(default=1200, bounds=(0, None), allow_None=True)

--- a/panel/chat/step.py
+++ b/panel/chat/step.py
@@ -13,6 +13,7 @@ from ..pane.image import ImageBase
 from ..pane.markup import HTML, HTMLBasePane, Markdown
 from ..pane.placeholder import Placeholder
 from ..util import edit_readonly
+from ..viewable import Child
 from ..widgets.indicators import BooleanStatus
 from .utils import (
     avatar_lookup, build_avatar_pane, serialize_recursively, stream_to,
@@ -53,9 +54,6 @@ class ChatStep(Card):
         If "ignore", the exception will be ignored.
         """)
 
-    success_title = param.String(default=None, doc="""
-        Title to display when status is success.""")
-
     default_badges = param.Dict(default=DEFAULT_STATUS_BADGES, doc="""
         Mapping from status to default status badge; keys must be one of
         'pending', 'running', 'success', 'failed'.
@@ -67,7 +65,7 @@ class ChatStep(Card):
     failed_title = param.String(default=None, doc="""
         Title to display when status is failed.""")
 
-    header = param.Parameter(doc="""
+    header = Child(doc="""
         A Panel component to display in the header bar of the Card.
         Will override the given title if defined.""", readonly=True)
 
@@ -85,6 +83,9 @@ class ChatStep(Card):
     status = param.Selector(default="pending", objects=[
         "pending", "running", "success", "failed"])
 
+    success_title = param.String(default=None, doc="""
+        Title to display when status is success.""")
+
     title = param.String(default="", constant=True, doc="""
         The title of the chat step. Will redirect to default_title on init.
         After, it cannot be set directly; instead use the *_title params.""")
@@ -98,8 +99,7 @@ class ChatStep(Card):
         "running_title": None,
         "success_title": None,
         "failed_title": None,
-        "status": None,
-        **Card._rename,
+        "status": None
     }
 
     _stylesheets: ClassVar[list[str]] = [f"{CDN_DIST}css/chat_step.css"]

--- a/panel/layout/card.py
+++ b/panel/layout/card.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, ClassVar
 import param
 
 from ..models import Card as BkCard
+from ..viewable import Child
 from .base import Column, Row
 
 if TYPE_CHECKING:
@@ -44,7 +45,7 @@ class Card(Column):
     css_classes = param.List(default=['card'], doc="""
         CSS classes to apply to the overall Card.""")
 
-    header = param.Parameter(doc="""
+    header = Child(doc="""
         A Panel component to display in the header bar of the Card.
         Will override the given title if defined.""")
 

--- a/panel/tests/chat/test_feed.py
+++ b/panel/tests/chat/test_feed.py
@@ -48,9 +48,9 @@ class TestChatFeed:
 
     def test_update_header(self):
         chat_feed = ChatFeed(header="1")
-        assert chat_feed._card.header == "1"
+        assert chat_feed._card.header.object == "1"
         chat_feed.header = "2"
-        assert chat_feed._card.header == "2"
+        assert chat_feed._card.header.object == "2"
         chat_feed.header = HTML("<b>3</b>")
         assert chat_feed._card.header.object == "<b>3</b>"
 
@@ -73,7 +73,7 @@ class TestChatFeed:
             "hide_header": False
         }
         assert chat_feed._card.header_background == "red"
-        assert chat_feed._card.header == "Test"
+        assert chat_feed._card.header.object == "Test"
         assert not chat_feed._card.hide_header
 
     async def test_send(self, chat_feed):


### PR DESCRIPTION
For consistency we declare all child elements as `Child` or `Children` parameters.