### PR TITLE
Do not sync ESM component parameters mapped to None

### DIFF
--- a/panel/custom.py
+++ b/panel/custom.py
@@ -170,7 +170,10 @@ class ReactiveESMMetaclass(ReactiveMetaBase):
         # Create model with unique name
         ReactiveMetaBase._name_counter[name] += 1
         model_name = f'{name}{ReactiveMetaBase._name_counter[name]}'
-        ignored = [p for p in Reactive.param if not issubclass(type(mcs.param[p].owner), ReactiveESMMetaclass)]
+        ignored = [
+            p for p in Reactive.param
+            if not issubclass(type(mcs.param[p].owner), ReactiveESMMetaclass)
+        ]
         mcs._data_model = construct_data_model(
             mcs, name=model_name, ignore=ignored, extras={'esm_constants': param.Dict}
         )
@@ -426,10 +429,10 @@ class ReactiveESM(ReactiveCustomBase, metaclass=ReactiveESMMetaclass):
         ]
         for k, v in self.param.values().items():
             p = self.param[k]
-            is_viewable = is_viewable_param(p)
-            if (k in ignored and k != 'name') or ((p.precedence or 0) < 0) or is_viewable:
-                if is_viewable and k in props:
-                    props.pop(k)
+            if is_viewable_param(p) or type(self)._property_mapping.get(k, "") is None:
+                props.pop(k, None)
+                continue
+            elif (k in ignored and k != 'name') or ((p.precedence or 0) < 0):
                 continue
             if k in props:
                 props.pop(k)
@@ -486,7 +489,7 @@ class ReactiveESM(ReactiveCustomBase, metaclass=ReactiveESMMetaclass):
         children = {}
         for k, v in self.param.values().items():
             p = self.param[k]
-            if not is_viewable_param(p):
+            if not is_viewable_param(p) or type(self)._property_mapping.get(k, "") is None:
                 continue
             children[k] = self._get_child_model(v, doc, root, parent, comm)
         return children

--- a/panel/io/datamodel.py
+++ b/panel/io/datamodel.py
@@ -183,7 +183,7 @@ def construct_data_model(parameterized, name=None, ignore=[], types={}, extras={
         ptype = types.get(pname, type(p))
         prop = PARAM_MAPPING.get(ptype)
         if isinstance(parameterized, Syncable):
-            pname = parameterized._rename.get(pname, pname)
+            pname = parameterized._property_mapping.get(pname, pname)
         if pname == 'name' or pname is None:
             continue
         nullable = getattr(p, 'allow_None', False)


### PR DESCRIPTION
Internally in panel we use the `_rename` class variable to rename parameters. However ESM components were not correctly respecting this behavior.