### PR TITLE
ci: Update Bokeh pin to also account for dev versions

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -31,7 +31,7 @@ nomkl = "*"
 pip = "*"
 # Required
 bleach = "*"
-bokeh = ">=3.5.0,<3.7.0"
+bokeh = ">=3.5.0,<3.7.0a0"
 linkify-it-py = "*"
 markdown = "*"
 markdown-it-py = "*"


### PR DESCRIPTION
We pull in the bokeh RC version, which fails the CI until https://github.com/holoviz/panel/pull/7724 is merged.