### PR TITLE
enh: Also raise error if log_level is above default

### DIFF
--- a/panel/command/__init__.py
+++ b/panel/command/__init__.py
@@ -91,7 +91,7 @@ def main(args: list[str] | None = None):
             try:
                 ret = parsed_args.invoke(parsed_args)
             except Exception as e:
-                if config.autoreload or config.log_level in ("ERROR", "CRITICAL"):
+                if config.autoreload or config.log_level in ("DEBUG", "INFO"):
                     raise e
                 die("ERROR: " + str(e))
         else:

--- a/panel/command/__init__.py
+++ b/panel/command/__init__.py
@@ -91,7 +91,7 @@ def main(args: list[str] | None = None):
             try:
                 ret = parsed_args.invoke(parsed_args)
             except Exception as e:
-                if config.autoreload:
+                if config.autoreload or config.log_level in ("ERROR", "CRITICAL"):
                     raise e
                 die("ERROR: " + str(e))
         else:


### PR DESCRIPTION
It can be hard to debug why something is failing with `die`. This makes it so that when you have a higher log level than the default, it will raise the exception.  

Default is WARNING:

https://github.com/holoviz/panel/blob/321d116f6f2c808a9ee90e8c544885f37dd7880c/panel/config.py#L261-L263