### PR TITLE
Prevent overflow in ChatStep with break word

### DIFF
--- a/panel/dist/css/chat_step.css
+++ b/panel/dist/css/chat_step.css
@@ -30,6 +30,7 @@
   font-size: 1.25em;
   padding-block: 0px;
   padding-inline: 7px;
+  word-break: break-word;
 }
 
 .step-avatar-container {


### PR DESCRIPTION
The labels were bleeding off; this PR makes it so that it starts a new line instead.

<img width="1072" alt="Screenshot 2025-03-11 at 10 06 25 AM" src="https://github.com/user-attachments/assets/d2a03784-cb92-4a47-8fa1-8a47ace4e017" />

<img width="1072" alt="Screenshot 2025-03-11 at 10 06 19 AM" src="https://github.com/user-attachments/assets/ec72a283-935d-4cc9-af5b-89789f2f263d" />
