### PR TITLE
Refactor NotificationAreaBase to allow easier subclassing

### DIFF
--- a/panel/io/notifications.py
+++ b/panel/io/notifications.py
@@ -291,6 +291,10 @@ class NotificationArea(NotificationAreaBase, ReactiveHTML):
 
         return Column(msg, duration, ntype, background, button, notifications)
 
+    def clear(self):
+        self._clear += 1
+        self.notifications[:] = []
+
     def send(self, message, duration=3000, type=None, background=None, icon=None):
         """
         Sends a notification to the frontend.

--- a/panel/io/notifications.py
+++ b/panel/io/notifications.py
@@ -55,14 +55,15 @@ class NotificationAreaBase(param.Parameterized):
 
         will trigger a warning on the Bokeh ConnectionLost event.""")
 
+    max_notifications = param.Integer(default=5, doc="""
+        The maximum number of notifications to display at once.""")
+
     notifications = param.List(item_type=Notification)
 
     position = param.Selector(default='bottom-right', objects=[
         'bottom-right', 'bottom-left', 'bottom-center', 'top-left',
         'top-right', 'top-center', 'center-center', 'center-left',
         'center-right'])
-
-    _extension_name = 'notifications'
 
     __abstract = True
 
@@ -149,6 +150,8 @@ class NotificationArea(NotificationAreaBase, ReactiveHTML):
     @classproperty
     def __css__(cls):
         return bundled_files(cls, 'css')
+
+    _extension_name = 'notifications'
 
     _notification_type = Notification
 
@@ -239,23 +242,33 @@ class NotificationArea(NotificationAreaBase, ReactiveHTML):
         return root
 
     @classmethod
-    def demo(cls):
+    def demo(cls, **params):
         """
         Generates a layout which allows demoing the component.
+
+        Parameters
+        ----------
+        **params: dict
+            Additional parameters to pass to the component.
+
+        Returns
+        -------
+        layout: Layout
+            A layout containing the demo components.
         """
         from ..layout import Column
         from ..widgets import (
             Button, ColorPicker, NumberInput, Select, TextInput,
         )
 
-        msg = TextInput(name='Message', value='This is a message')
-        duration = NumberInput(name='Duration', value=0, end=10000)
+        msg = TextInput(name='Message', value='This is a message', **params)
+        duration = NumberInput(name='Duration', value=0, end=10000, **params)
         ntype = Select(
             name='Type', options=['info', 'warning', 'error', 'success', 'custom'],
-            value='info'
+            value='info', **params
         )
-        background = ColorPicker(name='Color', value='#000000')
-        button = Button(name='Notify')
+        background = ColorPicker(name='Color', value='#000000', **params)
+        button = Button(name='Notify', **params)
         notifications = cls()
         button.js_on_click(
             args={

--- a/panel/io/state.py
+++ b/panel/io/state.py
@@ -236,7 +236,7 @@ class _state(param.Parameterized):
     _watch_events: ClassVar[list[asyncio.Event]] = []
 
     # Types
-    _notification_type: ClassVar[type[NotificationAreaBase]] = None
+    _notification_type: ClassVar[type[NotificationAreaBase] | None] = None
 
     def __repr__(self) -> str:
         server_info = []
@@ -1134,15 +1134,17 @@ class _state(param.Parameterized):
         if not (config.notifications and is_session):
             return None if is_session else self._notification
 
-        if self._notification_type is None:
-            from panel.io.notifications import NotificationArea
-            self._notification_type = NotificationArea
         js_events = {}
         if config.ready_notification:
             js_events['document_ready'] = {'type': 'success', 'message': config.ready_notification, 'duration': 3000}
         if config.disconnect_notification:
             js_events['connection_lost'] = {'type': 'error', 'message': config.disconnect_notification}
-        self._notifications[self.curdoc] = notifications = self._notification_type(js_events=js_events)
+
+        if _state._notification_type is None:
+            from panel.io.notifications import NotificationArea
+            _state._notification_type = NotificationArea
+        notifications = _state._notification_type(js_events=js_events)
+        self._notifications[self.curdoc] = notifications
         return notifications
 
     @property

--- a/panel/io/state.py
+++ b/panel/io/state.py
@@ -158,8 +158,8 @@ class _state(param.Parameterized):
     _locations: ClassVar[WeakKeyDictionary[Document, Location]] = WeakKeyDictionary() # Server locations indexed by document
 
     # Notifications
-    _notification_area: ClassVar[NotificationAreaBase | None] = None # Global location, e.g. for notebook context
-    _notification_areas: ClassVar[WeakKeyDictionary[Document, NotificationAreaBase]] = WeakKeyDictionary() # Server notifications indexed by document
+    _notification: ClassVar[NotificationAreaBase | None] = None # Global location, e.g. for notebook context
+    _notifications: ClassVar[WeakKeyDictionary[Document, NotificationAreaBase]] = WeakKeyDictionary() # Server notifications indexed by document
 
     # Templates
     _template: ClassVar[BaseTemplate | None] = None

--- a/panel/io/state.py
+++ b/panel/io/state.py
@@ -59,7 +59,7 @@ if TYPE_CHECKING:
     from .cache import _Stack
     from .callbacks import PeriodicCallback
     from .location import Location
-    from .notifications import NotificationArea
+    from .notifications import NotificationAreaBase
     from .server import StoppableThread
 
     T = TypeVar("T")
@@ -158,8 +158,8 @@ class _state(param.Parameterized):
     _locations: ClassVar[WeakKeyDictionary[Document, Location]] = WeakKeyDictionary() # Server locations indexed by document
 
     # Notifications
-    _notification: ClassVar[NotificationArea | None] = None # Global location, e.g. for notebook context
-    _notifications: ClassVar[WeakKeyDictionary[Document, NotificationArea]] = WeakKeyDictionary() # Server notifications indexed by document
+    _notification_area: ClassVar[NotificationAreaBase | None] = None # Global location, e.g. for notebook context
+    _notification_areas: ClassVar[WeakKeyDictionary[Document, NotificationAreaBase]] = WeakKeyDictionary() # Server notifications indexed by document
 
     # Templates
     _template: ClassVar[BaseTemplate | None] = None
@@ -236,7 +236,7 @@ class _state(param.Parameterized):
     _watch_events: ClassVar[list[asyncio.Event]] = []
 
     # Types
-    _notification_type = None
+    _notification_type: ClassVar[type[NotificationAreaBase]] = None
 
     def __repr__(self) -> str:
         server_info = []
@@ -1122,7 +1122,7 @@ class _state(param.Parameterized):
         return log_terminal
 
     @property
-    def notifications(self) -> NotificationArea | None:
+    def notifications(self) -> NotificationAreaBase | None:
         if self.curdoc is None:
             return self._notification
 

--- a/panel/io/state.py
+++ b/panel/io/state.py
@@ -235,6 +235,9 @@ class _state(param.Parameterized):
     # Watchers
     _watch_events: ClassVar[list[asyncio.Event]] = []
 
+    # Types
+    _notification_type = None
+
     def __repr__(self) -> str:
         server_info = []
         for server, panel, _docs in self._servers.values():
@@ -1131,13 +1134,15 @@ class _state(param.Parameterized):
         if not (config.notifications and is_session):
             return None if is_session else self._notification
 
-        from panel.io.notifications import NotificationArea
+        if self._notification_type is None:
+            from panel.io.notifications import NotificationArea
+            self._notification_type = NotificationArea
         js_events = {}
         if config.ready_notification:
             js_events['document_ready'] = {'type': 'success', 'message': config.ready_notification, 'duration': 3000}
         if config.disconnect_notification:
             js_events['connection_lost'] = {'type': 'error', 'message': config.disconnect_notification}
-        self._notifications[self.curdoc] = notifications = NotificationArea(js_events=js_events)
+        self._notifications[self.curdoc] = notifications = self._notification_type(js_events=js_events)
         return notifications
 
     @property


### PR DESCRIPTION
The base class for `NotificationArea`  was not actually factored in a way that would make it possible to subclass it with a different component.