### PR TITLE
Allow defining root node for ReactComponent

### DIFF
--- a/examples/reference/custom_components/ReactComponent.ipynb
+++ b/examples/reference/custom_components/ReactComponent.ipynb
@@ -283,6 +283,70 @@
   },
   {
    "cell_type": "markdown",
+   "id": "b821b14e",
+   "metadata": {},
+   "source": [
+    "## Send Events from Python to JavaScript\n",
+    "\n",
+    "Equivalently, events from Python can be sent to JavaScript using the `ReactComponent._send_msg` method. To define a handler to receive these messages register a callback with `model.on('msg:custom', callback)`:\n",
+    "\n",
+    "In this simple example, we send a message containing the current date and time and display it in the component (note the serializer turns our datetime object into a timestamp):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dbaaf046",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import datetime\n",
+    "\n",
+    "from panel.custom import ReactComponent\n",
+    "\n",
+    "\n",
+    "class PythonToJSExample(ReactComponent):\n",
+    "\n",
+    "    _esm = \"\"\"\n",
+    "    export function render({ model }) {\n",
+    "      const [value, setValue] = React.useState(null)\n",
+    "\n",
+    "      model.on('msg:custom', (msg) => {\n",
+    "        setValue(new Date(msg).toLocaleString())\n",
+    "      })\n",
+    "\n",
+    "      return <div>{value}</div>\n",
+    "    }\n",
+    "    \"\"\"\n",
+    "\n",
+    "    def send_event(self):\n",
+    "        self._send_msg(datetime.datetime.now())\n",
+    "\n",
+    "py2js = PythonToJSExample()\n",
+    "\n",
+    "py2js"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1ac07d2e",
+   "metadata": {},
+   "source": [
+    "Sending messages as events rather than state changes provides more control over state synchronization between Python and JavaScript."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "28aabb6e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "py2js.send_event()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "8dd62b24-2a26-49ff-8aad-386178128167",
    "metadata": {},
    "source": [
@@ -571,12 +635,55 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bf8087ea-c135-4edb-bb3a-e864f7b7be3e",
+   "id": "06dc3bd5",
    "metadata": {},
    "source": [
     ":::note\n",
     "You can change the `item_type` to a specific subtype of `Viewable` or a tuple of `Viewable` subtypes.\n",
     ":::\n",
+    "\n",
+    "## Rendering into a specific DOM element\n",
+    "\n",
+    "You can render the component into a specific DOM element by providing a `root_node` to the underlying `ReactComponent` model. This allows you to render things outside of the regular DOM hierarchy.\n",
+    "\n",
+    "The `root_node` should be a valid CSS selector for the DOM element you want to render into, if it doesn't exist it will be created and appended to the document body.\n",
+    "\n",
+    "In this example we render the component into a div with the id `custom-root` which we then place in the upper right corner of the document."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2076e701",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import panel as pn\n",
+    "\n",
+    "from panel.custom import ReactComponent\n",
+    "\n",
+    "\n",
+    "class RootNodeExample(ReactComponent):\n",
+    "\n",
+    "    _esm = \"\"\"\n",
+    "    export function render({ model }) {\n",
+    "      return <div style={{backgroundColor: \"red\", position: \"absolute\", top: 0, right: 0}}>Hello</div>\n",
+    "    }\n",
+    "    \"\"\"\n",
+    "\n",
+    "    def _get_properties(self, doc):\n",
+    "        props = super()._get_properties(doc)\n",
+    "        props[\"root_node\"] = \"#custom-root\"\n",
+    "        return props\n",
+    "    \n",
+    "RootNodeExample()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bf8087ea-c135-4edb-bb3a-e864f7b7be3e",
+   "metadata": {},
+   "source": [
     "\n",
     "## Using React Hooks\n",
     "\n",

--- a/panel/custom.py
+++ b/panel/custom.py
@@ -743,7 +743,6 @@ class ReactComponent(ReactiveESM):
     _bokeh_model = _BkReactComponent
 
     _react_version = '18.3.1'
-    _root_node = None
 
     @classproperty  # type: ignore
     def _exports__(cls) -> ExportSpec:  # type: ignore
@@ -800,12 +799,6 @@ class ReactComponent(ReactiveESM):
             'imports': imports_with_deps,
             'scopes': cls._importmap.get('scopes', {})
         }
-
-    def _get_properties(self, doc: Document | None) -> dict[str, Any]:
-        props = super()._get_properties(doc)
-        if self._root_node:
-            props['root_node'] = self._root_node
-        return props
 
 
 class AnyWidgetComponent(ReactComponent):

--- a/panel/custom.py
+++ b/panel/custom.py
@@ -743,6 +743,7 @@ class ReactComponent(ReactiveESM):
     _bokeh_model = _BkReactComponent
 
     _react_version = '18.3.1'
+    _root_node = None
 
     @classproperty  # type: ignore
     def _exports__(cls) -> ExportSpec:  # type: ignore
@@ -799,6 +800,13 @@ class ReactComponent(ReactiveESM):
             'imports': imports_with_deps,
             'scopes': cls._importmap.get('scopes', {})
         }
+
+    def _get_properties(self, doc: Document | None) -> dict[str, Any]:
+        props = super()._get_properties(doc)
+        if self._root_node:
+            props['root_node'] = self._root_node
+        return props
+
 
 class AnyWidgetComponent(ReactComponent):
     '''

--- a/panel/models/esm.py
+++ b/panel/models/esm.py
@@ -62,6 +62,8 @@ class ReactComponent(ReactiveESM):
     Renders jsx/tsx based ESM bundles using React.
     """
 
+    root_node = bp.Nullable(bp.String)
+
 
 class AnyWidgetComponent(ReactComponent):
     """

--- a/panel/models/react_component.ts
+++ b/panel/models/react_component.ts
@@ -1,4 +1,4 @@
-import * as p from "@bokehjs/core/properties"
+import type * as p from "@bokehjs/core/properties"
 import type {Transform} from "sucrase"
 
 import {

--- a/panel/models/react_component.ts
+++ b/panel/models/react_component.ts
@@ -14,10 +14,10 @@ export class ReactComponentView extends ReactiveESMView {
   override render_esm(): void {
     if (this.model.usesMui) {
       if (this.model.root_node) {
-	this.style_cache = document.head
+        this.style_cache = document.head
       } else {
-	this.style_cache = document.createElement("head")
-	this.shadow_el.insertBefore(this.style_cache, this.container)
+        this.style_cache = document.createElement("head")
+        this.shadow_el.insertBefore(this.style_cache, this.container)
       }
     }
     super.render_esm()

--- a/panel/models/react_component.ts
+++ b/panel/models/react_component.ts
@@ -44,8 +44,8 @@ if (rendered) {
   if (view.model.root_node) {
     container = document.querySelector(view.model.root_node)
     if (container == null) {
-      container = document.createElement('div')
-      container.id = view.model.root_node.replace('#', '')
+      container = document.createElement("div")
+      container.id = view.model.root_node.replace("#", "")
       document.body.append(container)
     }
   } else {


### PR DESCRIPTION
Allows rendering `ReactComponent` into a defined root node, i.e. not inline into the shadow DOM component. This makes it possible to define globally rendered components.