### PR TITLE
Improve ListLike and NamedListLike to better match Python list behavior

### DIFF
--- a/panel/layout/base.py
+++ b/panel/layout/base.py
@@ -8,7 +8,7 @@ from collections import defaultdict, namedtuple
 from collections.abc import (
     Generator, Iterable, Iterator, Mapping,
 )
-from typing import TYPE_CHECKING, Any, ClassVar
+from typing import TYPE_CHECKING, Any, ClassVar, overload
 
 import param
 
@@ -398,45 +398,15 @@ class ListLike(param.Parameterized):
     def __contains__(self, obj: Viewable) -> bool:
         return obj in self.objects
 
-    def __setitem__(self, index: int | slice, panes: Iterable[Any]) -> None:
-        new_objects = list(self)
-        name = type(self).__name__
-        if not isinstance(index, slice):
-            start, end = index, index+1
-            if start > len(self.objects):
-                raise IndexError(
-                    f'Index {end} out of bounds on {name} containing '
-                    f'{len(self.objects)} objects.'
-                )
-            panes = [panes]
-        else:
-            start = index.start or 0
-            end = len(self) if index.stop is None else index.stop
-            if index.start is None and index.stop is None:
-                if not isinstance(panes, list):
-                    raise IndexError(
-                        'Expected a list of objects to replace the '
-                        f'objects in the {name}, got a '
-                        f'{type(panes).__name__} type.'
-                    )
-                expected = len(panes)
-                new_objects = [None]*expected # type: ignore
-                end = expected
-            elif end > len(self.objects):
-                raise IndexError(
-                    f'Index {end} out of bounds on {name} containing '
-                    f'{len(self.objects)} objects.'
-                )
-            else:
-                expected = end-start
-            if not isinstance(panes, list) or len(panes) != expected:
-                raise IndexError(
-                    f'Expected a list of {expected} objects to set '
-                    f'on the {name} to match the supplied slice.'
-                )
-        for i, pane in zip(range(start, end), panes):
-            new_objects[i] = pane
+    @overload
+    def __setitem__(self, index: int, panes: Any) -> None: ...
 
+    @overload
+    def __setitem__(self, index: slice, panes: Iterable[Any]) -> None: ...
+
+    def __setitem__(self, index, panes) -> None:
+        new_objects = list(self)
+        new_objects[index] = panes
         self.objects = new_objects
 
     def clone(self, *objects: Any, **params: Any) -> ListLike:
@@ -502,19 +472,19 @@ class ListLike(param.Parameterized):
         new_objects.extend(objects)
         self.objects = new_objects
 
-    def index(self, object) -> int:
+    def index(self, obj: Viewable) -> int:
         """
         Returns the integer index of the supplied object in the list of objects.
 
         Parameters
         ----------
-        obj (object): Panel component to look up the index for.
+        obj (Viewable): Panel component to look up the index for.
 
         Returns
         -------
         index (int): Integer index of the object in the layout.
         """
-        return self.objects.index(object)
+        return self.objects.index(obj)
 
     def insert(self, index: int, obj: Any) -> None:
         """
@@ -529,7 +499,7 @@ class ListLike(param.Parameterized):
         new_objects.insert(index, obj)
         self.objects = new_objects
 
-    def pop(self, index: int) -> Viewable:
+    def pop(self, index: int = -1) -> Viewable:
         """
         Pops an item from the layout by index.
 
@@ -660,46 +630,18 @@ class NamedListLike(param.Parameterized):
         objects = zip(self._names, self.objects)
         return self.clone(*added, *objects)
 
-    def __setitem__(self, index: int | slice, panes: Iterable[Any]) -> None:
+    @overload
+    def __setitem__(self, index: int, panes: Any) -> None: ...
+
+    @overload
+    def __setitem__(self, index: slice, panes: Iterable[Any]) -> None: ...
+
+    def __setitem__(self, index, panes):
         new_objects = list(self)
-        name = type(self).__name__
-        if not isinstance(index, slice):
-            if index > len(self.objects):
-                raise IndexError(
-                    f'Index {index} out of bounds on {name} '
-                    f'containing {len(self.objects)} objects.'
-                )
-            start, end = index, index+1
-            panes = [panes]
+        if isinstance(index, slice):
+            new_objects[index], self._names[index] = self._to_objects_and_names(panes)
         else:
-            start = index.start or 0
-            end = len(self.objects) if index.stop is None else index.stop
-            if index.start is None and index.stop is None:
-                if not isinstance(panes, list):
-                    raise IndexError(
-                        'Expected a list of objects to replace '
-                        f'the objects in the {name}, got a '
-                        f'{type(panes).__name__} type.'
-                    )
-                expected = len(panes)
-                new_objects = [None]*expected # type: ignore
-                self._names = [None]*len(panes)
-                end = expected
-            else:
-                expected = end-start
-                nobjs = len(self.objects)
-                if end > nobjs:
-                    raise IndexError(
-                        f'Index {end} out of bounds on {name} '
-                        'containing {nobjs} objects.'
-                    )
-            if not isinstance(panes, list) or len(panes) != expected:
-                raise IndexError(
-                    f'Expected a list of {expected} objects to set '
-                    f'on the {name} to match the supplied slice.'
-                )
-        for i, pane in zip(range(start, end), panes):
-            new_objects[i], self._names[i] = self._to_object_and_name(pane)
+            new_objects[index], self._names[index] = self._to_object_and_name(panes)
         self.objects = new_objects
 
     def clone(self, *objects: Any, **params: Any) -> NamedListLike:
@@ -780,7 +722,7 @@ class NamedListLike(param.Parameterized):
         self._names.insert(index, new_name)
         self.objects = new_objects
 
-    def pop(self, index: int) -> Viewable:
+    def pop(self, index: int = -1) -> Viewable:
         """
         Pops an item from the tabs by index.
 
@@ -794,7 +736,7 @@ class NamedListLike(param.Parameterized):
         self.objects = new_objects
         return obj
 
-    def remove(self, pane: Viewable) -> None:
+    def remove(self, pane: Viewable, /) -> None:
         """
         Removes an object from the tabs.
 
@@ -805,9 +747,11 @@ class NamedListLike(param.Parameterized):
         new_objects = list(self)
         if pane in new_objects:
             index = new_objects.index(pane)
-        new_objects.remove(pane)
-        self._names.pop(index)
-        self.objects = new_objects
+            new_objects.remove(pane)
+            self._names.pop(index)
+            self.objects = new_objects
+        else:
+            raise ValueError(f'{pane!r} is not in list')
 
     def reverse(self) -> None:
         """

--- a/panel/tests/layout/test_base.py
+++ b/panel/tests/layout/test_base.py
@@ -285,8 +285,11 @@ def test_layout_setitem_replace_all(panel, document, comm):
     assert p1._models == {}
     assert p2._models == {}
 
+    layout[:] = [div3]
+    assert model.children == [div3]
 
-@pytest.mark.parametrize('panel', [Column, Row])
+
+@pytest.mark.parametrize('panel', [Column, Row, Tabs])
 def test_layout_setitem_replace_all_error(panel, document, comm):
     div1 = Div()
     div2 = Div()
@@ -294,7 +297,7 @@ def test_layout_setitem_replace_all_error(panel, document, comm):
     layout.get_root(document, comm=comm)
 
     div3 = Div()
-    with pytest.raises(IndexError):
+    with pytest.raises(TypeError):
         layout[:] = div3
 
 
@@ -318,16 +321,17 @@ def test_layout_setitem_replace_slice(panel, document, comm):
 
 
 @pytest.mark.parametrize('panel', [Column, Row])
-def test_layout_setitem_replace_slice_error(panel, document, comm):
+def test_layout_setitem_replace_slice_resize(panel, document, comm):
     div1 = Div()
     div2 = Div()
     div3 = Div()
     layout = panel(div1, div2, div3)
-    layout.get_root(document, comm=comm)
+    model = layout.get_root(document, comm=comm)
 
     div3 = Div()
-    with pytest.raises(IndexError):
-        layout[1:] = [div3]
+    layout[1:] = [div3]
+    assert len(layout) == 2
+    assert model.children == [div1, div3]
 
 
 @pytest.mark.parametrize('panel', [Column, Row])
@@ -337,11 +341,12 @@ def test_layout_setitem_replace_slice_out_of_bounds(panel, document, comm):
     div3 = Div()
     layout = panel(div1, div2, div3)
     layout.get_root(document, comm=comm)
+    model = layout.get_root(document, comm=comm)
 
-    div3 = Div()
-    with pytest.raises(IndexError):
-        layout[3:4] = [div3]
-
+    div4 = Div()
+    layout[3:4] = [div4]
+    assert len(layout) == 4
+    assert model.children == [div1, div2, div3, div4]
 
 @pytest.mark.parametrize('panel', [Column, Row])
 def test_layout_pop(panel, document, comm):

--- a/panel/tests/layout/test_tabs.py
+++ b/panel/tests/layout/test_tabs.py
@@ -573,17 +573,6 @@ def test_tabs_setitem_replace_all(document, comm):
     assert p2._models == {}
 
 
-def test_tabs_setitem_replace_all_error(document, comm):
-    div1 = Div()
-    div2 = Div()
-    layout = Tabs(div1, div2)
-    layout.get_root(document, comm=comm)
-
-    div3 = Div()
-    with pytest.raises(IndexError):
-        layout[:] = div3
-
-
 def test_tabs_setitem_replace_slice(document, comm):
     div1 = Div()
     div2 = Div()
@@ -608,29 +597,29 @@ def test_tabs_setitem_replace_slice(document, comm):
     assert p3._models == {}
 
 
-def test_tabs_setitem_replace_slice_error(document, comm):
+def test_tabs_setitem_replace_slice_resize(document, comm):
     div1 = Div()
     div2 = Div()
     div3 = Div()
     layout = Tabs(div1, div2, div3)
-    layout.get_root(document, comm=comm)
+    model = layout.get_root(document, comm=comm)
 
     div3 = Div()
-    with pytest.raises(IndexError):
-        layout[1:] = [div3]
-
+    layout[1:] = [div3]
+    assert len(layout) == 2
+    assert [t.child for t in model.tabs] == [div3, div2]
 
 def test_tabs_setitem_replace_slice_out_of_bounds(document, comm):
     div1 = Div()
     div2 = Div()
     div3 = Div()
     layout = Tabs(div1, div2, div3)
-    layout.get_root(document, comm=comm)
+    model = layout.get_root(document, comm=comm)
 
-    div3 = Div()
-    with pytest.raises(IndexError):
-        layout[3:4] = [div3]
-
+    div4 = Div()
+    layout[3:4] = [div4]
+    assert len(layout) == 4
+    assert [t.child for t in model.tabs] == [div1, div2, div3, div4]
 
 def test_tabs_pop(document, comm):
     div1 = Div()


### PR DESCRIPTION
- Allow slice assignment with different-length sequences
- Set default index in pop() to -1
- Fix NamedListLike.remove()
- Minor typing and naming improvements 

Built-in list behavior:
```python
x = ['a', 'b', 'c', 'd']
x[2:] = ['e']
assert x == ['a', 'b', 'e']
```

Previously, similar operations with `Feed` would raise an error:

```python
x = Feed(['a', 'b', 'c', 'd'])
x[2:] = ['e']
```

All positive use-cases are preserved, so this should not introduce breaking changes.