### PR TITLE
Ensure IconButton tooltip timer is cleared on multiple mouseenter events

### DIFF
--- a/panel/models/icon.ts
+++ b/panel/models/icon.ts
@@ -92,10 +92,14 @@ export class ClickableIconView extends ControlView {
     }
     let timer: ReturnType<typeof setTimeout> | undefined
     this.el.addEventListener("mouseenter", () => {
+      if (timer) {
+        clearTimeout(timer)
+      }
       timer = setTimeout(() => toggle_tooltip(true), this.model.tooltip_delay)
     })
     this.el.addEventListener("mouseleave", () => {
       clearTimeout(timer)
+      timer = undefined
       toggle_tooltip(false)
     })
   }

--- a/panel/models/icon.ts
+++ b/panel/models/icon.ts
@@ -97,7 +97,7 @@ export class ClickableIconView extends ControlView {
       }
       timer = setTimeout(() => toggle_tooltip(true), this.model.tooltip_delay)
     })
-    this.el.addEventListener("mouseleave", () => {
+    this.el.addEventListener("pointerleave", () => {
       clearTimeout(timer)
       timer = undefined
       toggle_tooltip(false)


### PR DESCRIPTION
In certain situation it seems like the description tooltip on an `IconButton` wasn't cleared correctly. I wasn't able to reproduce myself but added some handling around avoiding race conditions with multiple mouseenter events firing and using the more reliable pointerleave event.