### PR TITLE
Improve rendering of ReactComponent children

### DIFF
--- a/panel/models/react_component.ts
+++ b/panel/models/react_component.ts
@@ -54,7 +54,7 @@ export class ReactComponentView extends ReactiveESMView {
   }
 
   protected override _render_code(): string {
-    let render_code = `
+    const render_code = `
 if (rendered) {
   view._changing = true
   let container
@@ -139,6 +139,7 @@ class Child extends React.Component {
       }
     })
   }
+
   render() {
     return React.createElement('div', {
       className: "child-wrapper",

--- a/panel/models/react_component.ts
+++ b/panel/models/react_component.ts
@@ -192,9 +192,14 @@ function react_getter(target, name) {
 
         React.useEffect(() => {
           target.on_child_render(child, () => {
-            set_children(data_model.attributes[child].map((model, i) => (
-              React.createElement(Child, { parent: target, name: child, key: child+i, index: i })
-            )))
+            const current_models = data_model.attributes[child]
+            const previous_models = children_state.map(child => child.props.index)
+            if (current_models.length !== previous_models.length ||
+                current_models.some((model, i) => i !== previous_models[i])) {
+              set_children(current_models.map((model, i) => (
+                React.createElement(Child, { parent: target, name: child, key: child+i, index: i })
+              )))
+            }
           })
         }, [])
         return children_state

--- a/panel/models/react_component.ts
+++ b/panel/models/react_component.ts
@@ -2,7 +2,7 @@ import type * as p from "@bokehjs/core/properties"
 import type {Transform} from "sucrase"
 
 import {
-  ReactiveESM, ReactiveESMView, model_getter, model_setter
+  ReactiveESM, ReactiveESMView, model_getter, model_setter,
 } from "./reactive_esm"
 
 export class ReactComponentView extends ReactiveESMView {
@@ -332,7 +332,7 @@ ${compiled}`
   static {
     this.prototype.default_view = ReactComponentView
     this.define<ReactComponent.Props>(({Nullable, Str}) => ({
-      root_node:  [ Nullable(Str),     null ]
+      root_node:  [ Nullable(Str),     null ],
     }))
   }
 }

--- a/panel/models/reactive_esm.ts
+++ b/panel/models/reactive_esm.ts
@@ -181,12 +181,13 @@ export class ReactiveESMView extends HTMLBoxView {
     ["resize", []],
     ["remove", []],
   ])
-  _module_cache: Map<string, any> = MODULE_CACHE
+  _module_cache: Map<string, any>
   _rendered: boolean = false
   _stale_children: boolean = false
 
   override initialize(): void {
     super.initialize()
+    this._module_cache = MODULE_CACHE
     this._child_callbacks = new Map()
     this.model_proxy = new Proxy(this, {
       get: model_getter,
@@ -476,8 +477,17 @@ export default {render}`
     callbacks.push(callback)
   }
 
-  remove_on_child_render(child: string): void {
-    this._child_callbacks.delete(child)
+  remove_on_child_render(child: string, callback?: (new_views: UIElementView[]) => void): void {
+    if (!this._child_callbacks.has(child)) {
+      return
+    }
+    if (callback === undefined) {
+      this._child_callbacks.delete(child)
+    } else {
+      let callbacks = this._child_callbacks.get(child) || []
+      callbacks = callbacks.filter((cb) => cb !== callback)
+      this._child_callbacks.set(child, callbacks)
+    }
   }
 }
 


### PR DESCRIPTION
There were two main issues with the way `ReactComponent` rendered children:

1. Accumulation of callbacks every time `get_child` was called.
2. For Mui components the emotion cache would become invalid.