### PR TITLE
Ensure layout is computed after child mount and orderly cleanup of roots

### DIFF
--- a/panel/models/react_component.ts
+++ b/panel/models/react_component.ts
@@ -141,15 +141,12 @@ class Child extends React.PureComponent {
     this.view.after_render()
     this.render_callback = (new_views) => {
       const view = this.view
-      if (view == null) {
-        return
-      }
-      this.forceUpdate()
       if (new_views.includes(view)) {
         view.render()
         view.after_render()
-      } else if (view.force_update) {
-        view.force_update()
+      } else {
+        this.forceUpdate()
+        if (view.force_update) { view.force_update() }
       }
     }
     this.props.parent.on_child_render(this.props.name, this.render_callback)

--- a/panel/models/react_component.ts
+++ b/panel/models/react_component.ts
@@ -10,10 +10,14 @@ export class ReactComponentView extends ReactiveESMView {
   declare style_cache: HTMLHeadElement
   model_getter = model_getter
   model_setter = model_setter
+  react_root: any
 
   _force_update_callbacks: (() => void)[] = []
 
   override render_esm(): void {
+    if (this.model.compiled === null || this.render_module === null) {
+      return
+    }
     if (this.model.usesMui) {
       if (this.model.root_node) {
         this.style_cache = document.head
@@ -22,7 +26,14 @@ export class ReactComponentView extends ReactiveESMView {
         this.shadow_el.insertBefore(this.style_cache, this.container)
       }
     }
-    super.render_esm()
+    this.accessed_properties = []
+    for (const lf of this._lifecycle_handlers.keys()) {
+      (this._lifecycle_handlers.get(lf) || []).splice(0)
+    }
+    this.model.disconnect_watchers(this)
+    this.render_module.then((mod: any) => {
+      this.react_root = mod.default.render()
+    })
   }
 
   on_force_update(cb: () => void): void {
@@ -35,7 +46,18 @@ export class ReactComponentView extends ReactiveESMView {
     }
   }
 
+  override remove(): void {
+    super.remove()
+    this._force_update_callbacks = []
+    if (this.react_root) {
+      this.react_root.unmount()
+    }
+  }
+
   override render(): void {
+    if (this.react_root) {
+      this.react_root.unmount()
+    }
     this._force_update_callbacks = []
     super.render()
   }
@@ -95,7 +117,7 @@ const view = Bokeh.index.find_one_by_id('${this.model.id}')
 
 ${import_code}
 
-class Child extends React.Component {
+class Child extends React.PureComponent {
 
   constructor(props) {
     super(props)
@@ -104,7 +126,8 @@ class Child extends React.Component {
 
   get view() {
     const child = this.props.parent.model.data[this.props.name]
-    const model = this.props.index == null ? child : child[this.props.index]
+    const children = Array.isArray(child) ? child : [child]
+    const model = children.find(m => (this.props.id === undefined) || (m.id === this.props.id))
     return this.props.parent.get_child_view(model)
   }
 
@@ -115,7 +138,7 @@ class Child extends React.Component {
 
   componentDidMount() {
     this.view.render()
-    this.view.r_after_render()
+    this.view.after_render()
     this.render_callback = (new_views) => {
       const view = this.view
       if (view == null) {
@@ -124,12 +147,13 @@ class Child extends React.Component {
       this.forceUpdate()
       if (new_views.includes(view)) {
         view.render()
-        view.r_after_render()
+        view.after_render()
       } else if (view.force_update) {
         view.force_update()
       }
     }
     this.props.parent.on_child_render(this.props.name, this.render_callback)
+    this.props.parent.notify_mount(this.props.name, this.view.model.id)
   }
 
   componentWillUnmount() {
@@ -151,7 +175,12 @@ class Child extends React.Component {
 }
 
 function react_getter(target, name) {
-  if (name == "useState") {
+  if (name === "useMount") {
+    return (callback) => React.useEffect(() => {
+      target.model_proxy.on('lifecycle:mounted', callback)
+      return () => target.model_proxy.off('lifecycle:mounted', callback)
+    }, [])
+  } if (name == "useState") {
     return (prop) => {
       const data_model = target.model.data
       const propPath = prop.split(".")
@@ -188,18 +217,18 @@ function react_getter(target, name) {
       const data_model = target.model.data
       const value = data_model.attributes[child]
       if (Array.isArray(value)) {
-        const [children_state, set_children] = React.useState(value.map((model, i) =>
-          React.createElement(Child, { parent: target, name: child, key: child+i, index: i })
-        ))
+        const [children_state, set_children] = React.useState(value.map((model, i) => (
+          React.createElement(Child, { parent: target, name: child, key: model.id, id: model.id })
+        )))
 
         React.useEffect(() => {
           target.on_child_render(child, () => {
             const current_models = data_model.attributes[child]
-            const previous_models = children_state.map(child => child.props.index)
+            const previous_models = children_state.map(child => child.props.id)
             if (current_models.length !== previous_models.length ||
-                current_models.some((model, i) => i !== previous_models[i])) {
+                current_models.some((model, i) => model.id !== previous_models[i])) {
               set_children(current_models.map((model, i) => (
-                React.createElement(Child, { parent: target, name: child, key: child+i, index: i })
+                React.createElement(Child, {parent: target, name: child, key: model.id, id: model.id})
               )))
             }
           })
@@ -251,6 +280,7 @@ class Component extends React.Component {
 
   componentDidMount() {
     this.props.view.on_force_update(() => {
+      ${init_code}
       this.forceUpdate()
     })
     this.props.view._changing = false
@@ -289,6 +319,7 @@ function render() {
     } catch(e) {
       view.render_error(e)
     }
+    return root
   }
 }
 

--- a/panel/models/react_component.ts
+++ b/panel/models/react_component.ts
@@ -142,6 +142,7 @@ class Child extends React.PureComponent {
     this.render_callback = (new_views) => {
       const view = this.view
       if (new_views.includes(view)) {
+        if (this.props.id === undefined) { this.forceUpdate() }
         view.render()
         view.after_render()
       } else {

--- a/panel/models/reactive_esm.ts
+++ b/panel/models/reactive_esm.ts
@@ -269,7 +269,7 @@ export class ReactiveESMView extends HTMLBoxView {
     }
     if (children.every((model: UIElement) => this._mounted.get(child)?.has(model.id))) {
       this.update_layout()
-      for (const cb of this._lifecycle_handlers.get('mounted') || []) {
+      for (const cb of this._lifecycle_handlers.get("mounted") || []) {
         cb(child)
       }
     }
@@ -343,7 +343,7 @@ export class ReactiveESMView extends HTMLBoxView {
       this.render_error(this.model.compile_error)
     } else {
       if (this.render_module == null) {
-	this.init_module()
+        this.init_module()
       }
       this.render_esm()
     }


### PR DESCRIPTION
- Pre-compile render code
- Track React root component and unmount it before re-render
- Add `mounted` lifecycle handler and `model.useMount` to register callbacks whenever children are fully mounted
- Assign `Child` components per id (rather than per index)