### PR TITLE
Undo automatic update_layout call on React child mount

### DIFF
--- a/panel/models/reactive_esm.ts
+++ b/panel/models/reactive_esm.ts
@@ -268,7 +268,6 @@ export class ReactiveESMView extends HTMLBoxView {
       children = [children]
     }
     if (children.every((model: UIElement) => this._mounted.get(child)?.has(model.id))) {
-      this.update_layout()
       for (const cb of this._lifecycle_handlers.get("mounted") || []) {
         cb(child)
       }


### PR DESCRIPTION
Reverts an update_layout call I added thinking there was an issue React components when in actuality it was a general regression in Bokeh 3.7.x.