### PR TITLE
Trigger resize event on editable template

### DIFF
--- a/panel/template/editable/__init__.py
+++ b/panel/template/editable/__init__.py
@@ -140,6 +140,7 @@ class EditableTemplate(VanillaTemplate):
           }
           window.muuriGrid.refreshItems();
           window.muuriGrid.layout();
+          window.dispatchEvent(new Event('resize'));
         """, args={'roots': [root for root in doc.roots if 'main' in root.tags]}))
         return doc
 


### PR DESCRIPTION
Ensures that all the cells are laid out correctly (e.g. avoiding overlap issues).