### PR TITLE
Cache ESM render modules

### DIFF
--- a/panel/models/anywidget_component.ts
+++ b/panel/models/anywidget_component.ts
@@ -140,20 +140,6 @@ export class AnyWidgetComponentView extends ReactiveESMView {
     }
   }
 
-  protected override _render_code(): string {
-    return `
-const view = Bokeh.index.find_one_by_id('${this.model.id}')
-
-function render() {
-  const out = Promise.resolve(view.render_fn({
-    view, model: view.adapter, data: view.model.data, el: view.container
-  }) || null)
-  view.destroyer = out
-  out.then(() => view.after_rendered())
-}
-
-export default {render}`
-  }
 
   override after_rendered(): void {
     this.render_children()
@@ -175,6 +161,22 @@ export class AnyWidgetComponent extends ReactiveESM {
 
   constructor(attrs?: Partial<AnyWidgetComponent.Attrs>) {
     super(attrs)
+  }
+
+  protected override _render_code(): string {
+    return `
+function render(id) {
+  const view = Bokeh.index.find_one_by_id(id)
+  if (!view) { return }
+
+  const out = Promise.resolve(view.render_fn({
+    view, model: view.adapter, data: view.model.data, el: view.container
+  }) || null)
+  view.destroyer = out
+  out.then(() => view.after_rendered())
+}
+
+export default {render}`
   }
 
   protected override _run_initializer(initialize: (props: any) => void): void {

--- a/panel/models/anywidget_component.ts
+++ b/panel/models/anywidget_component.ts
@@ -140,7 +140,6 @@ export class AnyWidgetComponentView extends ReactiveESMView {
     }
   }
 
-
   override after_rendered(): void {
     this.render_children()
     this._rendered = true

--- a/panel/models/react_component.ts
+++ b/panel/models/react_component.ts
@@ -15,7 +15,7 @@ export class ReactComponentView extends ReactiveESMView {
   _force_update_callbacks: (() => void)[] = []
 
   override render_esm(): void {
-    if (this.model.compiled === null || this.render_module === null) {
+    if (this.model.compiled === null || this.model.render_module === null) {
       return
     }
     if (this.model.usesMui) {
@@ -31,8 +31,8 @@ export class ReactComponentView extends ReactiveESMView {
       (this._lifecycle_handlers.get(lf) || []).splice(0)
     }
     this.model.disconnect_watchers(this)
-    this.render_module.then((mod: any) => {
-      this.react_root = mod.default.render()
+    this.model.render_module.then((mod: any) => {
+      this.react_root = mod.default.render(this.model.id)
     })
   }
 
@@ -50,13 +50,13 @@ export class ReactComponentView extends ReactiveESMView {
     super.remove()
     this._force_update_callbacks = []
     if (this.react_root) {
-      this.react_root.unmount()
+      this.react_root.then((root: any) => root.unmount())
     }
   }
 
   override render(): void {
     if (this.react_root) {
-      this.react_root.unmount()
+      this.react_root.then((root: any) => root.unmount())
     }
     this._force_update_callbacks = []
     super.render()
@@ -73,253 +73,6 @@ export class ReactComponentView extends ReactiveESMView {
       }
     }
     this._rendered = true
-  }
-
-  protected override _render_code(): string {
-    let import_code
-    const cache_key = (this.model.bundle === "url") ? this.model.esm : (this.model.bundle || `${this.model.class_name}-${this.model.esm.length}`)
-    if (this.model.bundle) {
-      import_code = `
-const ns = await view._module_cache.get("${cache_key}")
-const {React, createRoot} = ns.default`
-    } else {
-      import_code = `
-import * as React from "react"
-import { createRoot } from "react-dom/client"`
-    }
-    let init_code = ""
-    let render_code = ""
-    if (this.model.usesMui) {
-      if (this.model.bundle) {
-        import_code = `
-const ns = await view._module_cache.get("${cache_key}")
-const {CacheProvider, React, createCache, createRoot} = ns.default`
-      } else {
-        import_code = `
-${import_code}
-import createCache from "@emotion/cache"
-import { CacheProvider } from "@emotion/react"`
-      }
-      const css_key = this.model.id.replace("-", "").replace(/\d/g, (digit) => String.fromCharCode(digit.charCodeAt(0) + 49)).toLowerCase()
-      init_code = `
-this.mui_cache = createCache({
-  key: 'css-${css_key}',
-  prepend: true,
-  container: view.style_cache,
-})`
-      render_code = `
-  if (rendered) {
-    rendered = React.createElement(CacheProvider, {value: this.mui_cache}, rendered)
-  }`
-    }
-    return `
-const view = Bokeh.index.find_one_by_id('${this.model.id}')
-
-${import_code}
-
-class Child extends React.PureComponent {
-
-  constructor(props) {
-    super(props)
-    this.render_callback = null
-  }
-
-  get view() {
-    const child = this.props.parent.model.data[this.props.name]
-    const model = this.props.index == null ? child : child[this.props.index]
-    return this.props.parent.get_child_view(model)
-  }
-
-  get element() {
-    const view = this.view
-    return view == null ? null : view.el
-  }
-
-  componentDidMount() {
-    this.props.parent.rerender_(this.view)
-    this.render_callback = (new_views) => {
-      const view = this.view
-      if (!view) {
-        return
-      } else if (new_views.includes(view)) {
-        if (this.props.id === undefined) { this.forceUpdate() }
-        this.props.parent.rerender_(view)
-      } else {
-        this.forceUpdate()
-        if (view.force_update) { view.force_update() }
-      }
-    }
-    this.props.parent.on_child_render(this.props.name, this.render_callback)
-    this.props.parent.notify_mount(this.props.name, this.view.model.id)
-  }
-
-  componentWillUnmount() {
-    if (this.render_callback) {
-      this.props.parent.remove_on_child_render(this.props.name, this.render_callback)
-    }
-  }
-
-  render() {
-    return React.createElement('div', {
-      className: "child-wrapper",
-      ref: (ref) => {
-        if (ref != null && this.view != null) {
-          ref.appendChild(this.element)
-        }
-      }
-    })
-  }
-}
-
-function react_getter(target, name) {
-  if (name === "useMount") {
-    return (callback) => React.useEffect(() => {
-      target.model_proxy.on('lifecycle:mounted', callback)
-      return () => target.model_proxy.off('lifecycle:mounted', callback)
-    }, [])
-  } if (name == "useState") {
-    return (prop) => {
-      const data_model = target.model.data
-      const propPath = prop.split(".")
-      let targetModel = data_model
-      let resolvedProp = null
-
-      for (let i = 0; i < propPath.length - 1; i++) {
-        if (targetModel && targetModel.properties && propPath[i] in targetModel.properties) {
-          targetModel = targetModel[propPath[i]]
-        } else {
-          // Stop if any part of the path is missing
-          targetModel = null
-          break
-        }
-      }
-      if (targetModel && targetModel.attributes && propPath[propPath.length - 1] in targetModel.attributes) {
-        resolvedProp = propPath[propPath.length - 1]
-      }
-      if (resolvedProp && targetModel) {
-        const [value, setValue] = React.useState(targetModel.attributes[resolvedProp])
-
-        react_proxy.on(prop, () => setValue(targetModel.attributes[resolvedProp]))
-
-        React.useEffect(() => {
-            targetModel.setv({ [resolvedProp]: value })
-        }, [value])
-
-        return [value, setValue]
-      }
-      throw ReferenceError("Could not resolve " + prop + " on " + target.model.class_name)
-    }
-  } else if (name === "get_child") {
-    return (child) => {
-      const data_model = target.model.data
-      const value = data_model.attributes[child]
-      if (Array.isArray(value)) {
-        const [children_state, set_children] = React.useState(value.map((model, i) =>
-          React.createElement(Child, { parent: target, name: child, key: child+i, index: i })
-        ))
-        React.useEffect(() => {
-          target.on_child_render(child, () => {
-            const current_models = data_model.attributes[child]
-            const previous_models = children_state.map(child => child.props.index)
-            if (current_models.length !== previous_models.length ||
-                current_models.some((model, i) => i !== previous_models[i])) {
-              set_children(current_models.map((model, i) => (
-                React.createElement(Child, { parent: target, name: child, key: child+i, index: i })
-              )))
-            }
-          })
-        }, [])
-        return children_state
-      } else {
-        return React.createElement(Child, {parent: target, name: child})
-      }
-    }
-  }
-  return target.model_getter(target, name)
-}
-
-const react_proxy = new Proxy(view, {
-  get: react_getter,
-  set: view.model_setter
-})
-
-class ErrorBoundary extends React.Component {
-  constructor(props) {
-    super(props)
-    // initialize the error state
-    this.state = { hasError: false }
-  }
-
-  // if an error happened, set the state to true
-  static getDerivedStateFromError(error) {
-    return { hasError: true }
-  }
-
-  componentDidCatch(error) {
-    this.props.view.render_error(error)
-  }
-
-  render() {
-    if (this.state.hasError) {
-      return React.createElement('div')
-    }
-    return React.createElement('div', {className: "error-wrapper"}, this.props.children)
-  }
-}
-
-class Component extends React.Component {
-
-  constructor(props) {
-    super(props)
-    ${init_code}
-  }
-
-  componentDidMount() {
-    this.props.view.on_force_update(() => {
-      ${init_code}
-      this.forceUpdate()
-    })
-    this.props.view._changing = false
-    this.props.view.after_rendered()
-  }
-
-  render() {
-    let rendered = React.createElement(this.props.view.render_fn, this.props)
-    if (this.props.view.model.dev) {
-       rendered = React.createElement(ErrorBoundary, {view}, rendered)
-    }
-    ${render_code}
-    return rendered
-  }
-}
-
-function render() {
-  const props = {view, model: react_proxy, data: view.model.data, el: view.container}
-  const rendered = React.createElement(Component, props)
-  if (rendered) {
-    view._changing = true
-    let container
-    if (view.model.root_node) {
-      container = document.querySelector(view.model.root_node)
-      if (container == null) {
-        container = document.createElement("div")
-        container.id = view.model.root_node.replace("#", "")
-        document.body.append(container)
-      }
-    } else {
-      container = view.container
-    }
-    const root = createRoot(container)
-    try {
-      root.render(rendered)
-    } catch(e) {
-      view.render_error(e)
-    }
-    return root
-  }
-}
-
-export default {render}`
   }
 }
 
@@ -348,6 +101,258 @@ export class ReactComponent extends ReactiveESM {
     return false
   }
 
+  protected override _render_code(): string {
+    let import_code
+    const cache_key = (this.bundle === "url") ? this.esm : (this.bundle || `${this.class_name}-${this.esm.length}`)
+    if (this.bundle) {
+      import_code = `
+const ns = await view._module_cache.get("${cache_key}")
+const {React, createRoot} = ns.default`
+    } else {
+      import_code = `
+import * as React from "react"
+import { createRoot } from "react-dom/client"`
+    }
+    let init_code = ""
+    let render_code = ""
+    if (this.usesMui) {
+      if (this.bundle) {
+        import_code = `
+const ns = await view._module_cache.get("${cache_key}")
+const {CacheProvider, React, createCache, createRoot} = ns.default`
+      } else {
+        import_code = `
+${import_code}
+import createCache from "@emotion/cache"
+import { CacheProvider } from "@emotion/react"`
+      }
+      init_code = `
+const css_key = id.replace("-", "").replace(/\d/g, (digit) => String.fromCharCode(digit.charCodeAt(0) + 49)).toLowerCase()
+this.mui_cache = createCache({
+  key: 'css-'+css_key,
+  prepend: true,
+  container: view.style_cache,
+})`
+      render_code = `
+  if (rendered) {
+    rendered = React.createElement(CacheProvider, {value: this.mui_cache}, rendered)
+  }`
+    }
+    return `
+async function render(id) {
+  const view = Bokeh.index.find_one_by_id(id)
+  if (view == null) {
+    return null
+  }
+
+  ${import_code}
+
+  class Child extends React.PureComponent {
+
+    constructor(props) {
+      super(props)
+      this.render_callback = null
+    }
+
+    get view() {
+      const child = this.props.parent.model.data[this.props.name]
+      const model = this.props.index == null ? child : child[this.props.index]
+      return this.props.parent.get_child_view(model)
+    }
+
+    get element() {
+      const view = this.view
+      return view == null ? null : view.el
+    }
+
+    componentDidMount() {
+      const view = this.view
+      if (view == null) { return }
+      this.props.parent.rerender_(view)
+      this.render_callback = (new_views) => {
+        const view = this.view
+        if (!view) {
+          return
+        } else if (new_views.includes(view)) {
+          if (this.props.id === undefined) { this.forceUpdate() }
+          this.props.parent.rerender_(view)
+        } else {
+          this.forceUpdate()
+          if (view.force_update) { view.force_update() }
+        }
+      }
+      this.props.parent.on_child_render(this.props.name, this.render_callback)
+      this.props.parent.notify_mount(this.props.name, view.model.id)
+    }
+
+    componentWillUnmount() {
+      if (this.render_callback) {
+        this.props.parent.remove_on_child_render(this.props.name, this.render_callback)
+      }
+    }
+
+    render() {
+      return React.createElement('div', {
+        className: "child-wrapper",
+        ref: (ref) => {
+          if (ref != null && this.view != null) {
+            ref.appendChild(this.element)
+          }
+        }
+      })
+    }
+  }
+
+  function react_getter(target, name) {
+    if (name === "useMount") {
+      return (callback) => React.useEffect(() => {
+        target.model_proxy.on('lifecycle:mounted', callback)
+        return () => target.model_proxy.off('lifecycle:mounted', callback)
+      }, [])
+    } if (name == "useState") {
+      return (prop) => {
+        const data_model = target.model.data
+        const propPath = prop.split(".")
+        let targetModel = data_model
+        let resolvedProp = null
+
+        for (let i = 0; i < propPath.length - 1; i++) {
+          if (targetModel && targetModel.properties && propPath[i] in targetModel.properties) {
+            targetModel = targetModel[propPath[i]]
+          } else {
+            // Stop if any part of the path is missing
+            targetModel = null
+            break
+          }
+        }
+        if (targetModel && targetModel.attributes && propPath[propPath.length - 1] in targetModel.attributes) {
+          resolvedProp = propPath[propPath.length - 1]
+        }
+        if (resolvedProp && targetModel) {
+          const [value, setValue] = React.useState(targetModel.attributes[resolvedProp])
+
+          react_proxy.on(prop, () => setValue(targetModel.attributes[resolvedProp]))
+
+          React.useEffect(() => {
+              targetModel.setv({ [resolvedProp]: value })
+          }, [value])
+
+          return [value, setValue]
+        }
+        throw ReferenceError("Could not resolve " + prop + " on " + target.model.class_name)
+      }
+    } else if (name === "get_child") {
+      return (child) => {
+        const data_model = target.model.data
+        const value = data_model.attributes[child]
+        if (Array.isArray(value)) {
+          const [children_state, set_children] = React.useState(value.map((model, i) =>
+            React.createElement(Child, { parent: target, name: child, key: child+i, index: i })
+          ))
+          React.useEffect(() => {
+            target.on_child_render(child, () => {
+              const current_models = data_model.attributes[child]
+              const previous_models = children_state.map(child => child.props.index)
+              if (current_models.length !== previous_models.length ||
+                  current_models.some((model, i) => i !== previous_models[i])) {
+                set_children(current_models.map((model, i) => (
+                  React.createElement(Child, { parent: target, name: child, key: child+i, index: i })
+                )))
+              }
+            })
+          }, [])
+          return children_state
+        } else {
+          return React.createElement(Child, {parent: target, name: child})
+        }
+      }
+    }
+    return target.model_getter(target, name)
+  }
+
+  const react_proxy = new Proxy(view, {
+    get: react_getter,
+    set: view.model_setter
+  })
+
+  class ErrorBoundary extends React.Component {
+  constructor(props) {
+    super(props)
+    // initialize the error state
+    this.state = { hasError: false }
+  }
+
+  // if an error happened, set the state to true
+  static getDerivedStateFromError(error) {
+    return { hasError: true }
+  }
+
+  componentDidCatch(error) {
+    this.props.view.render_error(error)
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return React.createElement('div')
+    }
+    return React.createElement('div', {className: "error-wrapper"}, this.props.children)
+  }
+  }
+
+  class Component extends React.Component {
+
+    constructor(props) {
+      super(props)
+      ${init_code}
+    }
+
+    componentDidMount() {
+      this.props.view.on_force_update(() => {
+        ${init_code}
+        this.forceUpdate()
+      })
+      this.props.view._changing = false
+      this.props.view.after_rendered()
+    }
+
+    render() {
+      let rendered = React.createElement(this.props.view.render_fn, this.props)
+      if (this.props.view.model.dev) {
+        rendered = React.createElement(ErrorBoundary, {view}, rendered)
+      }
+      ${render_code}
+      return rendered
+    }
+  }
+
+  const props = {view, model: react_proxy, data: view.model.data, el: view.container}
+  const rendered = React.createElement(Component, props)
+  if (rendered) {
+    view._changing = true
+    let container
+    if (view.model.root_node) {
+      container = document.querySelector(view.model.root_node)
+      if (container == null) {
+        container = document.createElement("div")
+        container.id = view.model.root_node.replace("#", "")
+        document.body.append(container)
+      }
+    } else {
+      container = view.container
+    }
+    const root = createRoot(container)
+    try {
+      root.render(rendered)
+    } catch(e) {
+      view.render_error(e)
+    }
+    return root
+  }
+}
+
+export default {render}`
+  }
+
   override compile(): string | null {
     const compiled = super.compile()
     if (this.bundle) {
@@ -359,6 +364,11 @@ export class ReactComponent extends ReactiveESM {
 import * as React from "react"
 
 ${compiled}`
+  }
+
+  protected override get _render_cache_key() {
+    const cache_key = (this.bundle === "url") ? this.esm : (this.bundle || `${this.class_name}-${this.esm.length}`)
+    return `react-${this.usesMui}-${cache_key}`
   }
 
   static override __module__ = "panel.models.esm"

--- a/panel/models/reactive_esm.ts
+++ b/panel/models/reactive_esm.ts
@@ -170,7 +170,6 @@ export class ReactiveESMView extends HTMLBoxView {
   accessed_children: string[] = []
   compiled_module: any = null
   model_proxy: any
-  render_module: Promise<any> | null = null
   _changing: boolean = false
   _child_callbacks: Map<string, ((new_views: UIElementView[]) => void)[]>
   _child_rendered: Map<UIElementView, boolean> = new Map()
@@ -195,18 +194,6 @@ export class ReactiveESMView extends HTMLBoxView {
       get: model_getter,
       set: model_setter,
     })
-  }
-
-  init_module(): void {
-    if (this.model.compile_error) {
-      return
-    }
-    const code = this._render_code()
-    const render_url = URL.createObjectURL(
-      new Blob([code], {type: "text/javascript"}),
-    )
-    // @ts-ignore
-    this.render_module = importShim(render_url)
   }
 
   override async lazy_initialize(): Promise<void> {
@@ -341,31 +328,8 @@ export class ReactiveESMView extends HTMLBoxView {
     if (this.model.compile_error) {
       this.render_error(this.model.compile_error)
     } else {
-      if (this.render_module == null) {
-        this.init_module()
-      }
       this.render_esm()
     }
-  }
-
-  protected _render_code(): string {
-    return `
-const view = Bokeh.index.find_one_by_id('${this.model.id}')
-
-function render() {
-  const output = view.render_fn({
-    view: view, model: view.model_proxy, data: view.model.data, el: view.container
-  })
-
-  Promise.resolve(output).then((out) => {
-    if (out instanceof Element) {
-      view.container.replaceChildren(out)
-    }
-    view.after_rendered()
-  })
-}
-
-export default {render}`
   }
 
   after_rendered(): void {
@@ -384,7 +348,7 @@ export default {render}`
   }
 
   render_esm(): void {
-    if (this.model.compiled === null || this.render_module === null) {
+    if (this.model.compiled === null || this.model.render_module === null) {
       return
     }
     this.accessed_properties = []
@@ -392,7 +356,7 @@ export default {render}`
       (this._lifecycle_handlers.get(lf) || []).splice(0)
     }
     this.model.disconnect_watchers(this)
-    this.render_module.then((mod: any) => mod.default.render())
+    this.model.render_module.then((mod: any) => mod.default.render(this.model.id))
   }
 
   render_children() {
@@ -546,6 +510,7 @@ export class ReactiveESM extends HTMLBox {
   compiled_module: Promise<any> | null = null
   compile_error: Error | null = null
   model_proxy: any
+  render_module: Promise<any> | null = null
   sucrase_transforms: Transform[] = ["typescript"]
   _destroyer: any | null = null
   _esm_watchers: any = {}
@@ -693,6 +658,49 @@ export class ReactiveESM extends HTMLBox {
     }
   }
 
+  init_module(): void {
+    if (this.compile_error) {
+      return
+    } else if (MODULE_CACHE.has(this._render_cache_key)) {
+      this.render_module = MODULE_CACHE.get(this._render_cache_key)
+    } else {
+      const code = this._render_code()
+      const render_url = URL.createObjectURL(
+	new Blob([code], {type: "text/javascript"}),
+      )
+      // @ts-ignore
+      this.render_module = importShim(render_url)
+      MODULE_CACHE.set(this.data.type, this.render_module)
+    }
+  }
+
+  protected _render_code(): string {
+    return `
+function render(id) {
+  const view = Bokeh.index.find_one_by_id(id)
+  if (view == null) {
+    return null
+  }
+
+  const output = view.render_fn({
+    view: view, model: view.model_proxy, data: view.model.data, el: view.container
+  })
+
+  Promise.resolve(output).then((out) => {
+    if (out instanceof Element) {
+      view.container.replaceChildren(out)
+    }
+    view.after_rendered()
+  })
+}
+
+export default {render}`
+  }
+
+  protected get _render_cache_key() {
+    return 'reactive_esm'
+  }
+
   compile(): string | null {
     if (this.bundle != null) {
       return this.esm
@@ -764,6 +772,7 @@ export class ReactiveESM extends HTMLBox {
         if (initialize) {
           this._run_initializer(initialize)
         }
+	this.init_module()
         return mod
       } catch (e: any) {
         if (this.dev) {

--- a/panel/models/reactive_esm.ts
+++ b/panel/models/reactive_esm.ts
@@ -666,7 +666,7 @@ export class ReactiveESM extends HTMLBox {
     } else {
       const code = this._render_code()
       const render_url = URL.createObjectURL(
-	new Blob([code], {type: "text/javascript"}),
+        new Blob([code], {type: "text/javascript"}),
       )
       // @ts-ignore
       this.render_module = importShim(render_url)
@@ -698,7 +698,7 @@ export default {render}`
   }
 
   protected get _render_cache_key() {
-    return 'reactive_esm'
+    return "reactive_esm"
   }
 
   compile(): string | null {
@@ -772,7 +772,7 @@ export default {render}`
         if (initialize) {
           this._run_initializer(initialize)
         }
-	this.init_module()
+        this.init_module()
         return mod
       } catch (e: any) {
         if (this.dev) {


### PR DESCRIPTION
ESM components create ESM modules that contain the rendering logic. These modules were previously created on each `View` because they templated the `id` of the `Model` that was being rendered. However, we can simply pass the `id` to the render function instead and then cache the render module, reducing the number of dynamically created modules significantly.