### PR TITLE
Ensure Markdown code blocks are always left aligned

### DIFF
--- a/panel/dist/css/markdown.css
+++ b/panel/dist/css/markdown.css
@@ -337,6 +337,7 @@ p {
 }
 
 pre {
+  text-align: left;
   white-space: nowrap;
 }
 


### PR DESCRIPTION
Fixes https://github.com/holoviz/panel/issues/7829