### PR TITLE
Gracefully handle ECharts delayed rendering

### DIFF
--- a/panel/models/echarts.ts
+++ b/panel/models/echarts.ts
@@ -80,7 +80,9 @@ export class EChartsView extends HTMLBoxView {
 
   override after_layout(): void {
     super.after_layout()
-    this._chart.resize()
+    if (this._chart != null) {
+      this._chart.resize()
+    }
   }
 
   _plot(): void {


### PR DESCRIPTION
In certain scenarios the ECharts pane does not create the `_chart` in time for `after_layout()` so we guard it.