### PR TITLE
Expose date picker `allowInput` option via `allow_input` parameter for date time picker widgets

### DIFF
--- a/examples/reference/widgets/DatetimePicker.ipynb
+++ b/examples/reference/widgets/DatetimePicker.ipynb
@@ -35,6 +35,8 @@
     "* **`enable_time`** (boolean): Enable editing of the time in the widget, default is True\n",
     "* **`enable_seconds`** (boolean): Enable editing of seconds in the widget, default is True\n",
     "* **`military_time`** (boolean): Enable 24 hours time in the widget, default is True\n",
+    "* **``allow_input``** (boolean): Whether the user can enter a date directly into the input field, default is False\n",
+    "\n",
     "\n",
     "##### Display\n",
     "\n",

--- a/examples/reference/widgets/DatetimeRangePicker.ipynb
+++ b/examples/reference/widgets/DatetimeRangePicker.ipynb
@@ -35,6 +35,7 @@
     "* **`enable_time:`** (boolean): Enable editing of the time in the widget, default is True\n",
     "* **`enable_seconds`** (boolean): Enable editing of seconds in the widget, default is True\n",
     "* **`military_time`** (boolean): Whether to display time in 24 hour format, default is True\n",
+    "* **``allow_input``** (boolean): Whether the user can enter a date directly into the input field, default is False\n",
     "\n",
     "##### Display\n",
     "\n",

--- a/panel/models/datetime_picker.py
+++ b/panel/models/datetime_picker.py
@@ -10,6 +10,10 @@ class DatetimePicker(InputWidget):
 
     '''
 
+    allow_input = Bool(default=False, help="""
+    Enable manual date input in the widget.
+    """)
+
     value = Nullable(String, help="""
     The initial or picked date.
     """)

--- a/panel/models/datetime_picker.ts
+++ b/panel/models/datetime_picker.ts
@@ -88,6 +88,7 @@ export class DatetimePickerView extends InputWidgetView {
     super.render()
 
     const options: flatpickr.Options.Options = {
+      allowInput: this.model.allow_input,
       appendTo: this.group_el,
       positionElement: this.input_el,
       defaultDate: this.model.value!,
@@ -232,6 +233,7 @@ export namespace DatetimePicker {
   export type Attrs = p.AttrsOf<Props>
 
   export type Props = InputWidget.Props & {
+    allow_input:    p.Property<boolean>
     value:          p.Property<string | null>
     min_date:       p.Property<string | null>
     max_date:       p.Property<string | null>
@@ -266,6 +268,7 @@ export class DatetimePicker extends InputWidget {
       const DateStr = Str
       const DatesList = List(Or(DateStr, Tuple(DateStr, DateStr)))
       return {
+        allow_input:    [ Bool, false ],
         value:          [ Nullable(Str), null ],
         min_date:       [ Nullable(Str), null ],
         max_date:       [ Nullable(Str), null ],

--- a/panel/widgets/input.py
+++ b/panel/widgets/input.py
@@ -630,6 +630,9 @@ class DateRangePicker(Widget):
 
 class _DatetimePickerBase(Widget):
 
+    allow_input = param.Boolean(default=False, doc="""
+      Enable manual date input in the widget.""")
+
     disabled_dates = param.List(default=None, item_type=(date, str), doc="""
       Dates to make unavailable for selection.""")
 


### PR DESCRIPTION
This exposes the picker (`flatpickr`) `allowInput` config option (https://flatpickr.js.org/options/) via a new `allow_input` parameter/kwarg for the `_DatetimePickerBase` class (`DatetimePicker` and `DatetimeRangePicker` classes). A preview of the behavior when `allow_input` is set to `True`:

```python
import datetime as dt

import panel as pn

pn.extension()

datetime_picker = pn.widgets.DatetimePicker(
    name='Datetime Picker', value=dt.date.today(), allow_input=True,
)

datetime_range_picker = pn.widgets.DatetimeRangePicker(
    name='Datetime Range Picker', value=(dt.datetime(2021, 3, 2, 12, 10), dt.datetime(2021, 3, 2, 12, 22)), allow_input=True,
)

pn.template.FastListTemplate(
    site="Panel",
    title="App",
    main=[
        pn.Column(datetime_picker, height=400), 
        pn.Column(datetime_range_picker, height=400),
    ],
).servable()

```
|`DatetimePicker`|`DatetimeRangePicker`|
|-|-|
|![Image](https://github.com/user-attachments/assets/311bdef7-6cc4-4c05-9d32-af2ce43c2f0a)|![input_date_range](https://github.com/user-attachments/assets/2774d37d-083b-4d0d-86f8-2ca8fc8b4921)|

Fixes #7850

Some possible pending things:

* [x] Check tests (although not totally sure, seems like the failing tests are not related with the changes here?)
* [x] Update docs
