### PR TITLE
fix: Jupyterlite not having narwhals as depends

### DIFF
--- a/scripts/jupyterlite/extra_packages.json
+++ b/scripts/jupyterlite/extra_packages.json
@@ -1,4 +1,3 @@
 [
-  "https://cdn.holoviz.org/panel/wheels/panel-1.5.5-py3-none-any.whl",
-  "pyodide-http"
+  "https://cdn.holoviz.org/panel/wheels/panel-1.5.5-py3-none-any.whl"
 ]

--- a/scripts/jupyterlite/package-lock.json
+++ b/scripts/jupyterlite/package-lock.json
@@ -9,9 +9,10 @@
       }
     },
     "node_modules/pyodide": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/pyodide/-/pyodide-0.27.0.tgz",
-      "integrity": "sha512-0O992noCKqv8lPw4+QFWw8d8yrNWVtQ6zPhWNg/RNYbFohiwmV6SGlVh5fWk/4pOxyhgHbayq+ur8JoR/r5U9A==",
+      "version": "0.27.5",
+      "resolved": "https://registry.npmjs.org/pyodide/-/pyodide-0.27.5.tgz",
+      "integrity": "sha512-nXErpLzEdtQolt+sNQ/5mKuN9XTUwhxR2MRhRhZ6oDRGpYLXrOp5+kkTPGEwK+wn1ZA8+poNmoxKTj2sq/p9og==",
+      "license": "Apache-2.0",
       "dependencies": {
         "ws": "^8.5.0"
       },
@@ -20,9 +21,10 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
-      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+      "version": "8.18.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.2.tgz",
+      "integrity": "sha512-DMricUmwGZUVr++AEAe2uiVM7UoO9MAVZMDu05UQOaUII0lp+zOzLLU4Xqh/JvTqklB1T4uELaaPBKyjE1r4fQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       },

--- a/scripts/jupyterlite/patch_lock.py
+++ b/scripts/jupyterlite/patch_lock.py
@@ -17,9 +17,9 @@ def calculate_sha256(file_path):
     return sha256_hash.hexdigest()
 
 
-with open("package.json") as f:
+with open("package-lock.json") as f:
     package = json.load(f)
-pyodide_version = package["dependencies"]["pyodide"].removeprefix("^")
+pyodide_version = package["packages"]["node_modules/pyodide"]["version"]
 
 path = "pyodide-lock.json"
 url = f"https://cdn.jsdelivr.net/pyodide/v{pyodide_version}/full"
@@ -41,6 +41,11 @@ for whl_file in whl_files:
     package["file_name"] = os.path.basename(whl_file)
     package["sha256"] = calculate_sha256(whl_file)
     package["imports"] = [name]
+
+# Can be removed when micropip 0.9.0 is part of pyodide
+bokeh_req = data["packages"]["bokeh"]["depends"]
+if "narwhals" not in bokeh_req:
+    bokeh_req.append("narwhals")
 
 
 with open(path, "w") as f:


### PR DESCRIPTION
Bumping pyodide version and adding a workaround until micropip 0.9.0 is released because of https://github.com/pyodide/micropip/issues/171