### PR TITLE
Update doc for DateRangeSlider and DateTimeRangeSlider

### DIFF
--- a/examples/reference/widgets/DateRangeSlider.ipynb
+++ b/examples/reference/widgets/DateRangeSlider.ipynb
@@ -36,10 +36,9 @@
     "##### Display\n",
     "\n",
     "* **``bar_color``** (color): Color of the slider bar as a hexadecimal RGB value\n",
-    "* **``callback_policy``** (str, **DEPRECATED**): Policy to determine when slider events are triggered (one of 'continuous', 'throttle', 'mouseup')\n",
-    "* **``callback_throttle``** (int): Number of milliseconds to pause between callback calls as the slider is moved\n",
     "* **``direction``** (str): Whether the slider should go from left to right ('ltr') or right to left ('rtl')\n",
     "* **``disabled``** (boolean): Whether the widget is editable\n",
+    "* **``format``** (str): Formatter to apply to the slider value\n",
     "* **``name``** (str): The title of the widget\n",
     "* **``orientation``** (str): Whether the slider should be displayed in a 'horizontal' or 'vertical' orientation.\n",
     "* **``tooltips``** (boolean): Whether to display tooltips on the slider handle\n",
@@ -80,6 +79,29 @@
    "outputs": [],
    "source": [
     "date_range_slider.value"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "A custom format string may be used to format the slider values:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "str_format = pn.widgets.DateRangeSlider(\n",
+    "    name='Date Range Slider',\n",
+    "    start=dt.datetime(2017, 1, 1), end=dt.datetime(2019, 1, 1),\n",
+    "    value=(dt.datetime(2017, 1, 1), dt.datetime(2018, 1, 10)),\n",
+    "    step=2,\n",
+    "    format='%Y-%m-%d'\n",
+    ")\n",
+    "str_format"
    ]
   },
   {

--- a/examples/reference/widgets/DatetimeRangeSlider.ipynb
+++ b/examples/reference/widgets/DatetimeRangeSlider.ipynb
@@ -36,10 +36,9 @@
     "##### Display\n",
     "\n",
     "* **``bar_color``** (color): Color of the slider bar as a hexadecimal RGB value\n",
-    "* **``callback_policy``** (str, **DEPRECATED**): Policy to determine when slider events are triggered (one of 'continuous', 'throttle', 'mouseup')\n",
-    "* **``callback_throttle``** (int): Number of milliseconds to pause between callback calls as the slider is moved\n",
     "* **``direction``** (str): Whether the slider should go from left to right ('ltr') or right to left ('rtl')\n",
     "* **``disabled``** (boolean): Whether the widget is editable\n",
+    "* **``format``** (str): Formatter to apply to the slider value\n",
     "* **``name``** (str): The title of the widget\n",
     "* **``orientation``** (str): Whether the slider should be displayed in a 'horizontal' or 'vertical' orientation.\n",
     "* **``tooltips``** (boolean): Whether to display tooltips on the slider handle\n",
@@ -79,6 +78,30 @@
    "outputs": [],
    "source": [
     "datetime_range_slider.value"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "A custom format string may be used to format the slider values:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "str_format = pn.widgets.DatetimeRangeSlider(\n",
+    "    name='Datetime Range Slider',\n",
+    "    start=dt.datetime(2017, 1, 1), end=dt.datetime(2019, 1, 1),\n",
+    "    value=(dt.datetime(2017, 1, 1), dt.datetime(2018, 1, 10)),\n",
+    "    step=10000,\n",
+    "    format='%Y-%m-%dT%H:%M:%S'\n",
+    ")\n",
+    "\n",
+    "str_format"
    ]
   },
   {


### PR DESCRIPTION
Remove deprecated keyword as indicated in #7725 
Add an example with the format keyword (similar to what is indicated for `FloatSlider` or `IntSlider`)