### PR TITLE
Ensure correct stylesheet cache is used by theme hooks

### DIFF
--- a/panel/theme/base.py
+++ b/panel/theme/base.py
@@ -18,7 +18,7 @@ from ..io.resources import (
     JS_VERSION, ResourceComponent, component_resource_path, get_dist_path,
     resolve_custom_path,
 )
-from ..io.state import state
+from ..io.state import set_curdoc, state
 from ..util import relative_to
 
 if TYPE_CHECKING:
@@ -135,7 +135,13 @@ class Design(param.Parameterized, ResourceComponent):
                 if (old_models and model in old_models) or model in seen:
                     continue
                 seen.add(model)
-            self._apply_modifiers(o, ref, self.theme, isolated, cache, document)
+            if document:
+                # Theme hook may be applied during callback triggered from a different document
+                # we must set_curdoc to ensure style caches are not shared across documents
+                with set_curdoc(document):
+                    self._apply_modifiers(o, ref, self.theme, isolated, cache, document)
+            else:
+                self._apply_modifiers(o, ref, self.theme, isolated, cache, document)
 
     def _apply_hooks(self, viewable: Viewable, root: Model, changed: Viewable, old_models=None) -> None:
         from ..io.state import state


### PR DESCRIPTION
Theme hooks may be triggered by a change on a different document, if the Panel component is shared between multiple sessions. To ensure that the stylesheet models are not shared between the different sessions we must temporarily set the document while the theme is re-applied.

Fixes https://github.com/holoviz/panel/issues/7884