### PR TITLE
Correct display Tabulator with multi index and multi index column

### DIFF
--- a/examples/reference/widgets/Tabulator.ipynb
+++ b/examples/reference/widgets/Tabulator.ipynb
@@ -851,7 +851,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "pn.widgets.Tabulator(date_df.iloc[:3], groups={'Group 1': ['A', 'B'], 'Group 2': ['C', 'D']})"
+    "pn.widgets.Tabulator(style_df.iloc[:3], groups={'Group 1': ['A', 'B'], 'Group 2': ['C', 'D']})"
    ]
   },
   {

--- a/panel/tests/widgets/test_tables.py
+++ b/panel/tests/widgets/test_tables.py
@@ -317,6 +317,18 @@ def test_tabulator_multi_index(document, comm):
     assert np.array_equal(model.source.data['C'], np.array(['foo1', 'foo2', 'foo3', 'foo4', 'foo5']))
 
 
+def test_tabulator_multi_index_hide_index(document, comm):
+    df = makeMixedDataFrame()
+    table = Tabulator(df.set_index(['A', 'C']), show_index=False)
+
+    model = table.get_root(document, comm)
+
+    assert model.configuration['columns'] == [
+        {'field': 'B', 'sorter': 'number'},
+        {'field': 'D', 'sorter': 'timestamp'}
+    ]
+
+
 def test_tabulator_multi_index_remote_pagination(document, comm):
     df = makeMixedDataFrame()
     table = Tabulator(df.set_index(['A', 'C']), pagination='remote', page_size=3)
@@ -370,6 +382,9 @@ def test_tabulator_multi_index_columns(document, comm):
             ]},
         ]}
     ]
+    for field in ("index", "A_one_X", "A_one_Y", "A_two_X", "B_two_Y", "B_three_X", "B_three_Y"):
+        assert field in model.source.data
+
 
 def test_tabulator_multi_index_columns_hide_index(document, comm):
     level_1 = ['A', 'A', 'A', 'B', 'B', 'B']
@@ -406,6 +421,98 @@ def test_tabulator_multi_index_columns_hide_index(document, comm):
             ]},
         ]}
     ]
+    for field in ("A_one_X", "A_one_Y", "A_two_X", "B_two_Y", "B_three_X", "B_three_Y"):
+        assert field in model.source.data
+
+
+def test_tabulator_multi_index_multi_index_columns(document, comm):
+    level_1 = ['A', 'A', 'A', 'B', 'B', 'B']
+    level_2 = ['one', 'one', 'two', 'two', 'three', 'three']
+    level_3 = ['X', 'Y', 'X', 'Y', 'X', 'Y']
+
+    # Combine these into a MultiIndex
+    multi_columns = pd.MultiIndex.from_arrays([level_1, level_2, level_3], names=['Level 1', 'Level 2', 'Level 3'])
+
+    # Create multiIndex
+    numbers = [0, 1, 2]
+    colors = ['green', 'purple']
+    multi_index = pd.MultiIndex.from_product([numbers, colors], names=['number', 'color'])
+
+    # Create a DataFrame with MultiIndex as columns and MultiIndex as index
+    df = pd.DataFrame(np.random.randn(6, 6), index=multi_index, columns=multi_columns)
+
+    table = Tabulator(df, show_index=True)
+
+    model = table.get_root(document, comm)
+
+    assert model.configuration['columns'] == [
+        {'field': 'number__', 'sorter': 'number'},
+        {'field': 'color__'},
+        {'title': 'A', 'columns': [
+            {'title': 'one', 'columns': [
+                {'field': 'A_one_X', 'sorter': 'number'},
+                {'field': 'A_one_Y', 'sorter': 'number'},
+            ]},
+            {'title': 'two', 'columns': [
+                {'field': 'A_two_X', 'sorter': 'number'}
+            ]},
+        ]},
+        {'title': 'B', 'columns': [
+            {'title': 'two', 'columns': [
+                {'field': 'B_two_Y', 'sorter': 'number'},
+            ]},
+            {'title': 'three', 'columns': [
+                {'field': 'B_three_X', 'sorter': 'number'},
+                {'field': 'B_three_Y', 'sorter': 'number'}
+            ]},
+        ]}
+    ]
+    for field in ("number__", "color__", "A_one_X", "A_one_Y", "A_two_X", "B_two_Y", "B_three_X", "B_three_Y"):
+        assert field in model.source.data
+
+
+def test_tabulator_multi_index_multi_index_columns_hide_index(document, comm):
+    level_1 = ['A', 'A', 'A', 'B', 'B', 'B']
+    level_2 = ['one', 'one', 'two', 'two', 'three', 'three']
+    level_3 = ['X', 'Y', 'X', 'Y', 'X', 'Y']
+
+    # Combine these into a MultiIndex
+    multi_columns = pd.MultiIndex.from_arrays([level_1, level_2, level_3], names=['Level 1', 'Level 2', 'Level 3'])
+
+    # Create multiIndex
+    numbers = [0, 1, 2]
+    colors = ['green', 'purple']
+    multi_index = pd.MultiIndex.from_product([numbers, colors], names=['number', 'color'])
+
+    # Create a DataFrame with MultiIndex as columns and MultiIndex as index
+    df = pd.DataFrame(np.random.randn(6, 6), index=multi_index, columns=multi_columns)
+
+    table = Tabulator(df, show_index=False)
+
+    model = table.get_root(document, comm)
+
+    assert model.configuration['columns'] == [
+        {'title': 'A', 'columns': [
+            {'title': 'one', 'columns': [
+                {'field': 'A_one_X', 'sorter': 'number'},
+                {'field': 'A_one_Y', 'sorter': 'number'},
+            ]},
+            {'title': 'two', 'columns': [
+                {'field': 'A_two_X', 'sorter': 'number'}
+            ]},
+        ]},
+        {'title': 'B', 'columns': [
+            {'title': 'two', 'columns': [
+                {'field': 'B_two_Y', 'sorter': 'number'},
+            ]},
+            {'title': 'three', 'columns': [
+                {'field': 'B_three_X', 'sorter': 'number'},
+                {'field': 'B_three_Y', 'sorter': 'number'}
+            ]},
+        ]}
+    ]
+    for field in ("A_one_X", "A_one_Y", "A_two_X", "B_two_Y", "B_three_X", "B_three_Y"):
+        assert field in model.source.data
 
 
 def test_tabulator_expanded_content(document, comm):

--- a/panel/tests/widgets/test_tables.py
+++ b/panel/tests/widgets/test_tables.py
@@ -345,12 +345,48 @@ def test_tabulator_multi_index_columns(document, comm):
     # Create a DataFrame with this MultiIndex as columns
     df = pd.DataFrame(np.random.randn(4, 6), columns=multi_index)
 
-    table = Tabulator(df)
+    table = Tabulator(df, show_index=True)
 
     model = table.get_root(document, comm)
 
     assert model.configuration['columns'] == [
         {'field': 'index', 'sorter': 'number'},
+        {'title': 'A', 'columns': [
+            {'title': 'one', 'columns': [
+                {'field': 'A_one_X', 'sorter': 'number'},
+                {'field': 'A_one_Y', 'sorter': 'number'},
+            ]},
+            {'title': 'two', 'columns': [
+                {'field': 'A_two_X', 'sorter': 'number'}
+            ]},
+        ]},
+        {'title': 'B', 'columns': [
+            {'title': 'two', 'columns': [
+                {'field': 'B_two_Y', 'sorter': 'number'},
+            ]},
+            {'title': 'three', 'columns': [
+                {'field': 'B_three_X', 'sorter': 'number'},
+                {'field': 'B_three_Y', 'sorter': 'number'}
+            ]},
+        ]}
+    ]
+
+def test_tabulator_multi_index_columns_hide_index(document, comm):
+    level_1 = ['A', 'A', 'A', 'B', 'B', 'B']
+    level_2 = ['one', 'one', 'two', 'two', 'three', 'three']
+    level_3 = ['X', 'Y', 'X', 'Y', 'X', 'Y']
+
+    # Combine these into a MultiIndex
+    multi_index = pd.MultiIndex.from_arrays([level_1, level_2, level_3], names=['Level 1', 'Level 2', 'Level 3'])
+
+    # Create a DataFrame with this MultiIndex as columns
+    df = pd.DataFrame(np.random.randn(4, 6), columns=multi_index)
+
+    table = Tabulator(df, show_index=False)
+
+    model = table.get_root(document, comm)
+
+    assert model.configuration['columns'] == [
         {'title': 'A', 'columns': [
             {'title': 'one', 'columns': [
                 {'field': 'A_one_X', 'sorter': 'number'},

--- a/panel/widgets/tables.py
+++ b/panel/widgets/tables.py
@@ -2063,24 +2063,23 @@ class Tabulator(BaseTable):
                 col_dict["headerTooltip"] = self.header_tooltips[field]
 
             if isinstance(index, tuple):
-                if columns:
-                    children = columns
+                children = columns
+                last = cast(GroupSpec, children[-1] if len(children) > 0 else children)
+                for group in index[:-1]:
+                    if 'title' in last and last['title'] == group:
+                        new = False
+                        children = last['columns']
+                    else:
+                        new = True
+                        children.append({
+                            'columns': [],
+                            'title': group,
+                        })
                     last = cast(GroupSpec, children[-1])
-                    for group in index[:-1]:
-                        if 'title' in last and last['title'] == group:
-                            new = False
-                            children = last['columns']
-                        else:
-                            new = True
-                            children.append({
-                                'columns': [],
-                                'title': group,
-                            })
-                        last = cast(GroupSpec, children[-1])
-                        if new:
-                            children = last['columns']
-                    children.append(col_dict)
-                    column.title = index[-1]
+                    if new:
+                        children = last['columns']
+                children.append(col_dict)
+                column.title = index[-1]
             elif matching_groups:
                 group = matching_groups[0]
                 if group in groups:

--- a/panel/widgets/tables.py
+++ b/panel/widgets/tables.py
@@ -2064,7 +2064,7 @@ class Tabulator(BaseTable):
 
             if isinstance(index, tuple):
                 children = columns
-                last = cast(GroupSpec, children[-1] if len(children) > 0 else children)
+                last = cast(GroupSpec, children[-1] if len(children) > 0 else {})
                 for group in index[:-1]:
                     if 'title' in last and last['title'] == group:
                         new = False

--- a/panel/widgets/tables.py
+++ b/panel/widgets/tables.py
@@ -231,7 +231,7 @@ class BaseTable(ReactiveData, Widget):
                 elif df.index.nlevels == 1:
                     # Look in the column with the tuple format
                     index_col = tuple([col[: -(df.columns.nlevels - 1)]] + [""] * (df.columns.nlevels - 1))
-                    data: pd.Series | pd.Index = df[index_col]
+                    data = df[index_col]
                 else:
                     data = df.index.get_level_values(self.indexes.index(col))
 


### PR DESCRIPTION
This PR fix #7836, however, there are still some open points with Tabulator and multiple index and/or multiple index column.

- editor is not supported in case of multiple index
- title seems not supported in case of multiple index column
- `indexes` property does not match the index of the dataframe in case of multiple index and multiple index column
