### PR TITLE
Add `--titles` flag to `panel serve` to allow customizing names in the index page cards for multi-page apps and update documentation

### DIFF
--- a/doc/how_to/streamlit_migration/multipage_apps.md
+++ b/doc/how_to/streamlit_migration/multipage_apps.md
@@ -7,8 +7,27 @@ that you *serve*
 panel serve home.py page1.py page2.ipynb
 ```
 
-You can specify the *home* page with the `--index` flag.
+Besides that, a couple of useful flags to further configure a multi-page deployment are:
 
-```bash
-panel serve home.py page1.py page2.ipynb --index=home
-```
+* `--index`: Set as site index the application page of your preference. For example, to leave
+  the *home* application page as index you can pass `--index=home`
+
+  ```bash
+  panel serve home.py page1.py page2.ipynb --index=app
+  ```
+
+  The `--index` flag also supports a path to a custom Jinja template to be used as index.
+  For this template, the following variables will be available:
+
+  * `PANEL_CDN`: URL to the Holoviz Panel CDN.
+  * `prefix`: The base URL from where applications are being served.
+  * `items`: List of tuples with the application page slug and title to display.
+
+* `--titles`: Set the titles for the application items shown in the default index page as cards.
+  By default, the titles shown are the application page slug as a title (without slash and first
+  letter upper case). You can use this flag the to, for example, show instead of `Page1` and `Page2`
+  different titles like `Page 1` and `Page 2`
+
+  ```bash
+  panel serve home.py page1.py page2.ipynb --titles Home "Page 1" "Page 2"
+  ```

--- a/doc/tutorials/intermediate/serve.md
+++ b/doc/tutorials/intermediate/serve.md
@@ -56,6 +56,31 @@ It will look something like
 
 ![Panel serve multi page app](../../_static/images/panel-serve-multipage-app.png)
 
+Besides that, a couple of useful flags to further configure a multi-page deployment are:
+
+* `--index`: Set as site index the application page of your preference. For example, to leave
+  the *app* application page as index you can pass `--index=app`
+
+  ```bash
+  panel serve app.py app2.ipynb --dev --index=app
+  ```
+
+  The `--index` flag also supports a path to a custom Jinja template to be used as index.
+  For this template, the following variables will be available:
+
+  * `PANEL_CDN`: URL to the Holoviz Panel CDN.
+  * `prefix`: The base URL from where applications are being served.
+  * `items`: List of tuples with the application page slug and title to display.
+
+* `--titles`: Set the titles for the application items shown in the default index page as cards.
+  By default, the titles shown are the application page slug as a title (without slash and first
+  letter upper case). You can use this flag the to, for example, show instead of `App` and `App2`
+  different titles like `Application` and `Application 2`
+
+  ```bash
+  panel serve app.py app2.ipynb --dev --titles Application "Application 2"
+  ```
+
 :::{note}
 You can also use one or more [*globs*](https://en.wikipedia.org/wiki/Glob_(programming)) to serve a long or dynamic list of apps. For example `apps/*`, `pages/*.py`, `examples/*.ipynb` or `docs/*.md`.
 :::
@@ -80,7 +105,7 @@ usage: panel serve [-h] [--port PORT] [--address ADDRESS] [--unix-socket UNIX-SO
                    [--include-cookies INCLUDE_COOKIES [INCLUDE_COOKIES ...]] [--cookie-secret COOKIE_SECRET] [--index INDEX]
                    [--disable-index] [--disable-index-redirect] [--num-procs N] [--session-token-expiration N]
                    [--websocket-max-message-size BYTES] [--websocket-compression-level LEVEL] [--websocket-compression-mem-level LEVEL]
-                   [--glob] [--static-dirs KEY=VALUE [KEY=VALUE ...]] [--basic-auth BASIC_AUTH] [--oauth-provider OAUTH_PROVIDER]
+                   [--glob] [--titles [TITLES ...]] [--static-dirs KEY=VALUE [KEY=VALUE ...]] [--basic-auth BASIC_AUTH] [--oauth-provider OAUTH_PROVIDER]
                    [--oauth-key OAUTH_KEY] [--oauth-secret OAUTH_SECRET] [--oauth-redirect-uri OAUTH_REDIRECT_URI]
                    [--oauth-extra-params OAUTH_EXTRA_PARAMS] [--oauth-jwt-user OAUTH_JWT_USER] [--oauth-encryption-key OAUTH_ENCRYPTION_KEY]
                    [--oauth-error-template OAUTH_ERROR_TEMPLATE] [--oauth-expiry-days OAUTH_EXPIRY_DAYS] [--oauth-refresh-tokens]
@@ -168,6 +193,8 @@ options:
   --websocket-compression-mem-level LEVEL
                         Set the Tornado WebSocket compression mem_level
   --glob                Process all filename arguments as globs
+  --titles [TITLES ...]
+                        List of custom titles to use for Multi Page Apps.
   --static-dirs KEY=VALUE [KEY=VALUE ...]
                         Static directories to serve specified as key=value pairs mapping from URL route to static file directory.
   --basic-auth BASIC_AUTH

--- a/panel/_templates/index.html
+++ b/panel/_templates/index.html
@@ -191,18 +191,18 @@
     </section>
     <section id="cards">
       <ul class="cards-grid">
-        {% for item in sorted(items, key=lambda item: item[1:].replace("_", " ").title()) %}
+        {% for slug, title in items %}
         <li class="card">
-          <a class="card-link" href=".{{ item }}" id="{{ item }}">
+          <a class="card-link" href=".{{ slug }}" id="{{ slug }}">
             <div class="gallery-item">
-              <object data="thumbnails{{ item }}.png" type="image/png">
+              <object data="thumbnails{{ slug }}.png" type="image/png">
                 <svg class="card-image" xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-window" viewBox="0 0 16 16">
                   <path d="M2.5 4a.5.5 0 1 0 0-1 .5.5 0 0 0 0 1zm2-.5a.5.5 0 1 1-1 0 .5.5 0 0 1 1 0zm1 .5a.5.5 0 1 0 0-1 .5.5 0 0 0 0 1z"/>
                   <path d="M2 1a2 2 0 0 0-2 2v10a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V3a2 2 0 0 0-2-2H2zm13 2v2H1V3a1 1 0 0 1 1-1h12a1 1 0 0 1 1 1zM2 14a1 1 0 0 1-1-1V6h14v7a1 1 0 0 1-1 1H2z"/>
                 </svg>
               </object>
               <div class="card-content">
-                <h2 class="card-header">{{ item[1:].replace("_", " ").title() }}</h2>
+                <h2 class="card-header">{{ title }}</h2>
               </div>
             </div>
           </a>

--- a/panel/command/serve.py
+++ b/panel/command/serve.py
@@ -104,6 +104,12 @@ class Serve(_BkServe):
 
     args = (
         tuple((arg, arg_obj) for arg, arg_obj in _BkServe.args if arg != '--dev') + (
+        ('--titles', Argument(
+            action  = 'store',
+            nargs   = '*',
+            help    = "List of custom titles to use for Multi Page Apps.",
+            default=[],
+        )),
         ('--static-dirs', Argument(
             metavar="KEY=VALUE",
             nargs='+',
@@ -374,6 +380,10 @@ class Serve(_BkServe):
                     f"The specified application {index!r} could not be "
                     "found."
                 )
+
+        # Handle custom titles for Multi Page Apps
+        if len(args.titles):
+            config.titles = args.titles
 
         # Handle tranquilized functions in the supplied functions
         if args.rest_provider in REST_PROVIDERS:

--- a/panel/config.py
+++ b/panel/config.py
@@ -224,6 +224,9 @@ class _config(_base_config):
     throttled = param.Boolean(default=False, doc="""
         If sliders and inputs should be throttled until release of mouse.""")
 
+    titles = param.List(default=[], doc="""
+        Custom titles to use for Multi Page Apps.""")
+
     _admin = param.Boolean(default=False, doc="Whether the admin panel is enabled.")
 
     _admin_endpoint = param.String(default=None, doc="Name to use for the admin endpoint.")

--- a/panel/io/server.py
+++ b/panel/io/server.py
@@ -584,15 +584,26 @@ class RootHandler(LoginUrlMixin, BkRootHandler):
             redirect_to = f".{app_names[0]}"
             self.redirect(redirect_to)
         else:
-            apps = sorted(self.applications.keys())
             if self.index is None:
+                apps = sorted(self.applications.keys())
                 index = "app_index.html"
             else:
                 index = self.index
-                apps = [
-                    app if self.request.uri.endswith('/') or not self.prefix else f"{self.prefix}{app}"
-                    for app in apps
-                ]
+                apps = []
+                for idx, slug in enumerate(self.applications.keys()):
+                    slug = (
+                        slug
+                        if self.request.uri.endswith("/") or not self.prefix
+                        else f"{self.prefix}{slug}"
+                    )
+                    # Try to get custom application page card title from config
+                    # using as default value the application page slug
+                    title = slug[1:].replace("_", " ").title()
+                    possible_title = config.titles[idx : idx + 1]
+                    if len(possible_title):
+                        title = possible_title[0].title()
+                    apps.append((slug, title))
+                apps = sorted(apps, key=lambda app: app[1])
             self.render(index, prefix=self.prefix, items=apps)
 
     def render(self, *args, **kwargs):


### PR DESCRIPTION
This adds a new `--titles` flag to the `panel serve` command to pass a custom list of titles for multi-page apps index card items. This also changes the base `index.html` template to be able to use the values passed as titles via the new flag.

A preview:

* Without custom titles:
```
panel server untitled0.py untitled1.py
```

* With custom titles:
```
panel server untitled0.py untitled1.py --titles titled0 titled1
```

![Image](https://github.com/user-attachments/assets/24568bf9-07cc-42f6-b12a-072476aba246)

Note:

Currently, the changes to the base index template done in this PR cause the `items` variable passed to become a list of tuples. Not totally sure if the template variables definitions should try to ensure some backwards compatibility. If that is the case, using a list of tuple could be changed to for example pass the titles as a new variable.

Fixes #7863 
Related to #5128 