### PR TITLE
Migrate to correct logger interface

### DIFF
--- a/panel/io/handlers.py
+++ b/panel/io/handlers.py
@@ -180,7 +180,7 @@ def capture_code_cell(cell):
 
     if not parses:
         # Skip cell if it cannot be parsed
-        log.warn(
+        log.warning(
             "The following cell did not contain valid Python syntax "
             f"and was skipped:\n\n{cell['source']}"
         )


### PR DESCRIPTION
# PR Summary
This small PR resolves the annoying deprecation warnings of the `logger` library:
```python
DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
```