### PR TITLE
`--index-titles` help string typo fix and `title` call usage change

### DIFF
--- a/doc/tutorials/intermediate/serve.md
+++ b/doc/tutorials/intermediate/serve.md
@@ -197,7 +197,7 @@ options:
   --glob                Process all filename arguments as globs
   --index-titles KEY=VALUE [KEY=VALUE ...]
                         Custom titles to use for Multi Page Apps specified as key=value pairs mapping
-                        from the application page slugto the title to show on the Multi Page App index
+                        from the application page slug to the title to show on the Multi Page App index
                         page.
   --static-dirs KEY=VALUE [KEY=VALUE ...]
                         Static directories to serve specified as key=value pairs mapping from URL route to static file directory.

--- a/panel/command/serve.py
+++ b/panel/command/serve.py
@@ -108,7 +108,7 @@ class Serve(_BkServe):
             metavar="KEY=VALUE",
             nargs='+',
             help= ("Custom titles to use for Multi Page Apps specified as "
-                   "key=value pairs mapping from the application page slug"
+                   "key=value pairs mapping from the application page slug "
                    "to the title to show on the Multi Page App index page."
                    ),
         )),

--- a/panel/io/server.py
+++ b/panel/io/server.py
@@ -598,8 +598,8 @@ class RootHandler(LoginUrlMixin, BkRootHandler):
                     )
                     # Try to get custom application page card title from config
                     # using as default value the application page slug
-                    default_title = slug[1:].replace("_", " ")
-                    title = config.index_titles.get(slug, default_title).title()
+                    default_title = slug[1:].replace("_", " ").title()
+                    title = config.index_titles.get(slug, default_title)
                     apps.append((slug, title))
                 apps = sorted(apps, key=lambda app: app[1])
             self.render(index, prefix=self.prefix, items=apps)


### PR DESCRIPTION
Hi there, checking the docs for the changes I did to the multi-page related pages (https://github.com/holoviz/panel/pull/7916) I noticed a missing space:

![imagen](https://github.com/user-attachments/assets/2ec36e91-026c-4bed-be3e-d582d72b3561)

This PR adds the missing space in the docs and in the help string for the `index-titles` CLI argument definition.

Besides that, this also moves the `title` call done when processing the titles for the index template to only be used for the default title value (which comes from using the app page slug). Thinking about it, preserving the case of the custom value passed via the `--index-titles` flag could make sense. For example, setting as custom title something like `APP Example`:

```
panel serve untitled0.py untitled1.py --index-titles /untitled0="APP Example"
```

* As things are currently working you would get:

![imagen](https://github.com/user-attachments/assets/d628e76b-cd49-4f6a-b8ed-eb599d838cea)

* With the change here, you could then be able to set the custom title preserving the all uppercase `APP`:

![imagen](https://github.com/user-attachments/assets/02a07cba-bc90-493e-86dc-d8009d056ab6)

Let me know if the `title` usage change makes sense and otherwise happy to remove the commit related with it for this PR so only the typo fix is preserved an able to be merged :)

