### PR TITLE
enh(echarts): Support custom ticklabel formatter

### DIFF
--- a/panel/models/echarts.ts
+++ b/panel/models/echarts.ts
@@ -89,6 +89,11 @@ export class EChartsView extends HTMLBoxView {
     if ((window as any).echarts == null) {
       return
     }
+    const series = this.model.data.series[0]
+    if (typeof series.axisLabel.formatter === "string") {
+      const format = new Function("return (" + series.axisLabel.formatter + ")")();
+      series.axisLabel.formatter = format
+    }
     this._chart.setOption(this.model.data, this.model.options)
   }
 


### PR DESCRIPTION
Resolves https://github.com/holoviz/panel/issues/7936

This could be generalized to a custom model. Currently, this is hardcoded to this one instance. 

![image](https://github.com/user-attachments/assets/c376b8fc-98ad-4ef5-99ae-65ac77d912ef)


<details>
<summary>Details</summary>


``` python
import panel as pn
pn.extension("echarts")


code_js = """
(value) => {
   if (value === -180) {
     return '';
   }
   return value + '';
}
"""

w1 = pn.indicators.Gauge(
    name="Roll",
    value=0,
    start_angle=-90,
    end_angle=270,
    bounds=(-180, 180),
    format="{value} Degs",
    colors=[(0.25, "red"), (0.75, "green"), (1, "red")],
    custom_opts={
        "splitNumber": 12,
        "axisLabel": {"formatter": code_js},
    },
)

code_js = """
(value) => {
   if (value === 360) {
     return '';
   }
   return value + '';
}
"""
w2 = pn.indicators.Gauge(
    name="Heading",
    value=0,
    start_angle=90,
    end_angle=-270,
    bounds=(0, 360),
    format="{value} Degs",
    custom_opts={
        "splitNumber": 12,
        "labelLayout": {"hideOverlap": True},
        "axisLabel": {"formatter": code_js},
    },
)


pn.Row(w1, w2).servable()
```


</details>

