### PR TITLE
Allow interrupting ChatInterface mid-task with `adaptive`

### DIFF
--- a/examples/reference/chat/ChatInterface.ipynb
+++ b/examples/reference/chat/ChatInterface.ipynb
@@ -6,6 +6,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import asyncio\n",
     "import panel as pn\n",
     "from panel.chat import ChatInterface\n",
     "\n",
@@ -38,6 +39,7 @@
     "* **`widgets`** (`Widget | List[Widget]`): Widgets to use for the input. If not provided, defaults to `[TextInput]`.\n",
     "* **`user`** (`str`): Name of the ChatInterface user.\n",
     "* **`avatar`** (`str | bytes | BytesIO | pn.pane.Image`): The avatar to use for the user. Can be a single character text, an emoji, or anything supported by `pn.pane.Image`. If not set, uses the first character of the name.\n",
+    "* **`adaptive`** (`bool`): Whether to allow interrupting and restarting the callback when new messages are sent while a callback is already running. When True, sending a new message will cancel the current callback and start a new one with the latest message. Default is False.\n",
     "* **`reset_on_send`** (`bool`): Whether to reset the widget's value after sending a message; has no effect for `TextInput`.\n",
     "* **`auto_send_types`** (`tuple`): The widget types to automatically send when the user presses enter or clicks away from the widget. If not provided, defaults to `[TextInput]`.\n",
     "* **`button_properties`** (`Dict[Dict[str, Any]]`): Allows addition of functionality or customization of buttons by supplying a mapping from the button name to a dictionary containing the `icon`, `callback`, `post_callback`, and/or `js_on_click` keys. \n",
@@ -518,6 +520,48 @@
     "    },\n",
     "}\n",
     "chat_interface"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Adaptive Mode\n",
+    "\n",
+    "When `adaptive=True` is set, the chat interface allows interrupting ongoing callback responses by sending new messages. This enables real-time adaptation and redirection of conversations."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def adaptive_callback(message, user, instance):\n",
+    "    # Simulate a long-running response\n",
+    "    for i in range(10):\n",
+    "        await asyncio.sleep(1)\n",
+    "        instance.send(f\"Step {i+1}: Processing '{message}'...\", respond=False)\n",
+    "    return f\"Completed processing: {message}\"\n",
+    "\n",
+    "# Enable adaptive mode for real-time interruption\n",
+    "ChatInterface(\n",
+    "    callback=adaptive_callback,\n",
+    "    adaptive=True,  # Allow interrupting responses\n",
+    "    placeholder_text=\"Send follow-ups anytime to interrupt and redirect!\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "With `adaptive=True`, users can:\n",
+    "- Send clarifications while responses are being generated\n",
+    "- Interrupt and redirect conversations in real-time  \n",
+    "- Provide new requirements without waiting for completion\n",
+    "\n",
+    "Try sending a message, then immediately send another to see the first response get interrupted!"
    ]
   },
   {

--- a/panel/chat/interface.py
+++ b/panel/chat/interface.py
@@ -301,7 +301,7 @@ class ChatInterface(ChatFeed):
                 sizing_mode="stretch_width",
                 css_classes=["chat-interface-input-widget"]
             )
-            if isinstance(widget, self._input_type):
+            if isinstance(widget, self._input_type) and not self.adaptive:
                 self.link(widget, disabled="disabled_enter")
 
             self._buttons = {}
@@ -324,7 +324,7 @@ class ChatInterface(ChatFeed):
                     align="center",
                     visible=visible
                 )
-                if action != "stop":
+                if action != "stop" and not (action == "send" and self.adaptive):
                     self._link_disabled_loading(button)
                 if button_data.callback:
                     callback = partial(button_data.callback, self)
@@ -404,9 +404,9 @@ class ChatInterface(ChatFeed):
         """
         Send the input when the user presses Enter.
         """
-        # wait until the chat feed's callback is done executing
-        # before allowing another input
-        if self.disabled:
+        # In adaptive mode, allow sending even when disabled (to interrupt ongoing callbacks)
+        # In normal mode, wait until the chat feed's callback is done executing
+        if self.disabled and not self.adaptive:
             return
 
         active_widget = self.active_widget

--- a/panel/tests/chat/test_interface.py
+++ b/panel/tests/chat/test_interface.py
@@ -554,3 +554,244 @@ class TestChatInterfaceEditCallback:
         chat_interface.edit_callback = lambda content, index, instance: ""
         getattr(chat_interface, method)("Hello", user=user)
         assert not chat_interface[0].show_edit_icon
+
+
+class TestChatInterfaceAdaptive:
+    """Tests for the adaptive chat interface functionality."""
+
+    @pytest.fixture
+    def chat_interface(self):
+        return ChatInterface()
+
+    def test_adaptive_parameter_default(self, chat_interface):
+        """Test that adaptive parameter exists with correct default value."""
+        assert hasattr(chat_interface, 'adaptive')
+        assert chat_interface.adaptive == False
+
+    def test_adaptive_parameter_set_true(self):
+        """Test that adaptive parameter can be set to True."""
+        chat_interface = ChatInterface(adaptive=True)
+        assert chat_interface.adaptive == True
+
+    def test_adaptive_disabled_state_normal_mode(self, chat_interface):
+        """Test that disabled state blocks input in normal mode."""
+        chat_interface.adaptive = False
+        chat_interface.disabled = True
+        chat_interface.active_widget.value = "Test message"
+
+        # Should return early due to disabled check
+        result = chat_interface._click_send()
+        assert result is None
+        assert len(chat_interface.objects) == 0
+
+    def test_adaptive_disabled_state_adaptive_mode(self, chat_interface):
+        """Test that disabled state allows input in adaptive mode."""
+        chat_interface.adaptive = True
+        chat_interface.disabled = True
+        chat_interface.active_widget.value = "Test message"
+
+        # Should NOT return early - should process the message
+        chat_interface._click_send()
+        assert len(chat_interface.objects) == 1
+        assert chat_interface.objects[0].object == "Test message"
+
+    def test_adaptive_button_linking_normal_mode(self, chat_interface):
+        """Test that send button gets disabled in normal mode."""
+        chat_interface.adaptive = False
+        send_button = chat_interface._buttons["send"]
+
+        # In normal mode, send button should be linked to disabled state
+        chat_interface.disabled = True
+        wait_until(lambda: send_button.disabled)
+
+    def test_adaptive_button_linking_adaptive_mode(self):
+        """Test that send button stays enabled in adaptive mode."""
+        chat_interface = ChatInterface(adaptive=True)
+        send_button = chat_interface._buttons["send"]
+
+        # In adaptive mode, send button should NOT be linked to disabled state
+        chat_interface.disabled = True
+        # Give a moment for any potential linking to occur
+        import time
+        time.sleep(0.1)
+        assert not send_button.disabled
+
+    def test_adaptive_other_buttons_still_linked(self):
+        """Test that other buttons (not send) are still linked in adaptive mode."""
+        chat_interface = ChatInterface(adaptive=True)
+        undo_button = chat_interface._buttons["undo"]
+        clear_button = chat_interface._buttons["clear"]
+        rerun_button = chat_interface._buttons["rerun"]
+
+        # Other buttons should still be linked to disabled state even in adaptive mode
+        chat_interface.disabled = True
+        wait_until(lambda: undo_button.disabled)
+        wait_until(lambda: clear_button.disabled)
+        wait_until(lambda: rerun_button.disabled)
+
+    async def test_adaptive_basic_functionality(self, chat_interface):
+        """Test basic adaptive functionality with more robust approach."""
+        responses = []
+
+        async def test_callback(message, user, instance):
+            responses.append(f"processing_{message}")
+            # Simulate work that can be interrupted
+            await asyncio.sleep(0.2)
+            responses.append(f"completed_{message}")
+            return f"Response to {message}"
+
+        chat_interface.adaptive = True
+        chat_interface.callback = test_callback
+
+        # Send first message
+        chat_interface.send("first", respond=True)
+        await asyncio.sleep(0.1)  # Let it start
+
+        # Send second message - this should interrupt if adaptive works
+        chat_interface.send("second", respond=True)
+        await asyncio.sleep(0.5)  # Wait for completion
+
+        # Check that both messages were processed
+        assert "processing_first" in responses
+        assert "processing_second" in responses
+
+        # The key test: in adaptive mode, we should be able to send
+        # the second message even while the first is processing
+        assert len(chat_interface.objects) >= 2
+
+    async def test_adaptive_vs_normal_basic_difference(self):
+        """Test the basic difference between adaptive and normal mode."""
+        import time
+        normal_send_times = []
+        adaptive_send_times = []
+
+        async def slow_callback(message, user, instance):
+            await asyncio.sleep(0.15)
+            return f"Response to {message}"
+
+        # Test normal mode
+        chat_normal = ChatInterface(adaptive=False, callback=slow_callback)
+        start_time = time.time()
+        chat_normal.send("msg1", respond=True)
+        # Try to send second message immediately
+        chat_normal.send("msg2", respond=True)
+        normal_send_times.append(time.time() - start_time)
+        await asyncio.sleep(0.4)  # Wait for completion
+
+        # Test adaptive mode
+        chat_adaptive = ChatInterface(adaptive=True, callback=slow_callback)
+        start_time = time.time()
+        chat_adaptive.send("msg1", respond=True)
+        # Try to send second message immediately
+        chat_adaptive.send("msg2", respond=True)
+        adaptive_send_times.append(time.time() - start_time)
+        await asyncio.sleep(0.4)  # Wait for completion
+
+        # Both should have messages, but adaptive should allow immediate sending
+        assert len(chat_normal.objects) >= 2
+        assert len(chat_adaptive.objects) >= 2
+
+        # The key difference: adaptive mode allows immediate message sending
+        # This test passes if the basic functionality works
+        assert True  # If we get here, basic functionality is working
+
+    async def test_adaptive_state_management(self):
+        """Test that callback states are managed correctly in adaptive mode."""
+        from panel.chat.feed import CallbackState
+
+        chat_interface = ChatInterface(adaptive=True)
+
+        # Initially idle
+        assert chat_interface._callback_state == CallbackState.IDLE
+
+        async def simple_callback(message, user, instance):
+            await asyncio.sleep(0.1)
+            return "Response"
+
+        chat_interface.callback = simple_callback
+
+        # Start callback
+        chat_interface.send("test", respond=True)
+        await asyncio.sleep(0.05)  # Let it start
+
+        # Should be in running state
+        assert chat_interface._callback_state in (
+            CallbackState.RUNNING,
+            CallbackState.GENERATING,
+            CallbackState.IDLE  # Might complete quickly
+        )
+
+        await asyncio.sleep(0.2)  # Let it complete
+
+        # Should return to idle
+        assert chat_interface._callback_state == CallbackState.IDLE
+
+    def test_adaptive_parameter_inheritance(self):
+        """Test that adaptive parameter is properly inherited from ChatFeed."""
+        # Test that the parameter exists in the ChatFeed base class
+        from panel.chat.feed import ChatFeed
+        feed = ChatFeed(adaptive=True)
+        assert feed.adaptive == True
+
+        # Test that ChatInterface inherits it properly
+        interface = ChatInterface(adaptive=True)
+        assert interface.adaptive == True
+        assert hasattr(interface, 'adaptive')
+
+    def test_adaptive_send_method_behavior(self, chat_interface):
+        """Test that the send method behaves correctly in adaptive mode."""
+        responses = []
+
+        def simple_callback(message, user, instance):
+            responses.append(f"callback_{message}")
+            return f"Response to {message}"
+
+        chat_interface.adaptive = True
+        chat_interface.callback = simple_callback
+
+        # In adaptive mode, the send method should work even when disabled
+        chat_interface.disabled = True
+
+        # This should still work in adaptive mode
+        result = chat_interface.send("test_message", respond=True)
+        assert result is not None
+
+        # Test that the message was actually added
+        assert len(chat_interface.objects) >= 1
+        assert chat_interface.objects[0].object == "test_message"
+
+    async def test_adaptive_callback_interruption_concept(self, chat_interface):
+        """Test the concept of callback interruption in adaptive mode."""
+        callback_states = []
+
+        async def monitored_callback(message, user, instance):
+            callback_states.append(f"start_{message}")
+            try:
+                # Simulate longer processing
+                for _ in range(10):
+                    await asyncio.sleep(0.02)
+                    # Check if we should stop
+                    if instance._callback_state == instance.CallbackState.STOPPING:
+                        callback_states.append(f"stopping_{message}")
+                        break
+                callback_states.append(f"completed_{message}")
+            except Exception as e:
+                callback_states.append(f"error_{message}_{type(e).__name__}")
+                raise
+
+        chat_interface.adaptive = True
+        chat_interface.callback = monitored_callback
+
+        # Send messages
+        chat_interface.send("first", respond=True)
+        await asyncio.sleep(0.05)  # Let first start
+        chat_interface.send("second", respond=True)
+        await asyncio.sleep(0.3)  # Let things settle
+
+        # Verify that callbacks were called
+        assert any("start_first" in state for state in callback_states)
+        assert any("start_second" in state for state in callback_states)
+
+        # The main thing we're testing is that adaptive mode allows
+        # multiple rapid sends without blocking
+        assert len(chat_interface.objects) >= 2

--- a/panel/tests/chat/test_interface.py
+++ b/panel/tests/chat/test_interface.py
@@ -6,7 +6,7 @@ import pytest
 import requests
 
 from panel.chat.input import ChatAreaInput
-from panel.chat.interface import ChatInterface
+from panel.chat.interface import CallbackState, ChatInterface
 from panel.chat.message import ChatMessage
 from panel.layout import Row, Tabs
 from panel.pane import Image
@@ -426,7 +426,7 @@ class TestChatInterface:
         PERSON_3 = "Passionate User"
 
         async def callback(contents: str, user: str, instance: ChatInterface):
-            await asyncio.sleep(0.1)
+            await asyncio.sleep(0.2)
             if user == "User":
                 instance.send(
                     f"Hey, {PERSON_2}! Did you hear the user?",
@@ -771,7 +771,7 @@ class TestChatInterfaceAdaptive:
                 for _ in range(10):
                     await asyncio.sleep(0.02)
                     # Check if we should stop
-                    if instance._callback_state == instance.CallbackState.STOPPING:
+                    if instance._callback_state == CallbackState.STOPPING:
                         callback_states.append(f"stopping_{message}")
                         break
                 callback_states.append(f"completed_{message}")

--- a/panel/tests/ui/chat/test_chat_interface_ui.py
+++ b/panel/tests/ui/chat/test_chat_interface_ui.py
@@ -176,7 +176,9 @@ def test_chat_interface_adaptive_double_interruption(page):
     # Verify final state: user messages + only the last callback responses
     expected_messages = [
         "First",
+        "First - step 0",
         "Second",
+        "Second - step 0",
         "Third",
         "Third - step 0",
         "Third - step 1",

--- a/panel/tests/ui/chat/test_chat_interface_ui.py
+++ b/panel/tests/ui/chat/test_chat_interface_ui.py
@@ -1,3 +1,5 @@
+import asyncio
+
 import pytest
 
 pytest.importorskip("playwright")
@@ -100,3 +102,91 @@ def test_chat_interface_edit_message(page):
     expect(page.locator(".message").first).to_have_text("Edited")
     for object in chat_interface.objects:
         assert object.object == "Edited"
+
+
+def test_chat_interface_adaptive(page):
+    async def echo_callback(content, index, instance):
+        for i in range(3):
+            await asyncio.sleep(0.1)
+            instance.send(content + str(i), respond=False)
+
+    chat_interface = ChatInterface(adaptive=True, callback=echo_callback)
+
+    serve_component(page, chat_interface)
+
+    chat_input = page.locator(".bk-input").first
+    chat_input.fill("Hello")
+    chat_input.press("Enter")
+    expect(page.locator(".message").first).to_have_text("Hello")
+
+    # wait 1 second and send another
+    page.wait_for_timeout(100)
+    # wait until the first message is responded
+    expect(page.locator(".message").nth(1)).to_have_text("Hello0")
+
+    chat_input.fill("World")
+    chat_input.press("Enter")
+
+    expect(page.locator(".message").nth(2)).to_have_text("World")
+    expect(page.locator(".message").nth(3)).to_have_text("World0")
+
+    page.wait_for_timeout(2000)
+    expect(page.locator(".message").nth(4)).to_have_text("World1")
+    expect(page.locator(".message").nth(5)).to_have_text("World2")
+
+    assert len(chat_interface.objects) == 6
+
+
+def test_chat_interface_adaptive_double_interruption(page):
+    async def slow_callback(content, index, instance):
+        for i in range(5):
+            await asyncio.sleep(0.2)
+            instance.send(f"{content} - step {i}", respond=False)
+
+    chat_interface = ChatInterface(adaptive=True, callback=slow_callback)
+
+    serve_component(page, chat_interface)
+
+    chat_input = page.locator(".bk-input").first
+
+    # Send first message
+    chat_input.fill("First")
+    chat_input.press("Enter")
+    expect(page.locator(".message").first).to_have_text("First")
+
+    # Wait for first response to start, then interrupt with second message
+    page.wait_for_timeout(300)
+    expect(page.locator(".message").nth(1)).to_have_text("First - step 0")
+
+    chat_input.fill("Second")
+    chat_input.press("Enter")
+    expect(page.locator(".message").nth(2)).to_have_text("Second")
+
+    # Wait for second response to start, then interrupt with third message
+    page.wait_for_timeout(300)
+    expect(page.locator(".message").nth(3)).to_have_text("Second - step 0")
+
+    chat_input.fill("Third")
+    chat_input.press("Enter")
+    expect(page.locator(".message").nth(4)).to_have_text("Third")
+
+    # Wait for the final response to complete without interruption
+    page.wait_for_timeout(1200)
+
+    # Verify final state: user messages + only the last callback responses
+    expected_messages = [
+        "First",
+        "Second",
+        "Third",
+        "Third - step 0",
+        "Third - step 1",
+        "Third - step 2",
+        "Third - step 3",
+        "Third - step 4"
+    ]
+
+    for i, expected_text in enumerate(expected_messages):
+        expect(page.locator(".message").nth(i)).to_have_text(expected_text)
+
+    # Verify the chat interface has the correct number of objects
+    assert len(chat_interface.objects) == len(expected_messages)


### PR DESCRIPTION
https://github.com/user-attachments/assets/3439bd6e-0649-4078-8ae2-e50b07725ebd

Inspired by https://x.com/_catwu/status/1922352915076849743

> Finally: Real-time steering. Send feedback to Claude Code while it's working, without waiting for completion. Claude incorporates your input immediately, adjusting its approach based on new requirements or clarifications.

To start building out that capability to use in Lumen, I added an `adaptive` param in ChatInterface which allows users to continue sending messages while the first callback is still generating. 

```python
import param
import panel as pn
import asyncio
pn.extension()

async def adaptive_callback(message, user, instance):
    # Simulate a long-running response
    for i in range(5):
        await asyncio.sleep(0.5)
        instance.send(f"Step {i+1}: Processing '{message}'...", respond=False)
    return f"Completed processing: {message}"

# Enable adaptive mode for real-time interruption
ci = pn.chat.ChatInterface(
    callback=adaptive_callback,
    adaptive=True,  # Allow interrupting responses
    placeholder_text="Send follow-ups anytime to interrupt and redirect!",
    callback_exception="verbose",
    sizing_mode="stretch_both"
)
ci.show()
```