### PR TITLE
enh: Add option to disable FileDropper previews

### DIFF
--- a/examples/reference/widgets/FileDropper.ipynb
+++ b/examples/reference/widgets/FileDropper.ipynb
@@ -32,7 +32,7 @@
     "* **`max_files`** (int): Maximum number of files that can be uploaded if `multiple=True`.\n",
     "* **`max_total_file_size`** (str): Maximum size of all uploaded files, as a string with units given in KB or MB, e.g. 5MB or 750KB.\n",
     "* **`mime_type`** (dict[str, str]): A dictionary containing the mimetypes for each of the uploaded files indexed by their filename.\n",
-    "* **`plugins`** (list[str]): List of plugins to enable in the FileDropper. The following plugins are available:\n",
+    "* **`previews`** (list[str]): List of previews to enable in the FileDropper. The following previews are available:\n",
     "    * `image`: Adds support for image previews.\n",
     "    * `pdf`: Adds support for PDF previews.\n",
     "* **`multiple`** (bool): Whether to allow uploading multiple files.\n",

--- a/panel/models/file_dropper.py
+++ b/panel/models/file_dropper.py
@@ -44,7 +44,7 @@ class FileDropper(InputWidget):
 
     layout = Nullable(Enum("integrated", "compact", "circle", default="compact"))
 
-    plugins = List(String)
+    previews = List(String)
 
     __javascript_raw__ = [
         f"{config.npm_cdn}/filepond-plugin-image-preview/dist/filepond-plugin-image-preview.js",

--- a/panel/models/file_dropper.ts
+++ b/panel/models/file_dropper.ts
@@ -45,11 +45,11 @@ export class FileDropperView extends InputWidgetView {
 
   override initialize(): void {
     super.initialize()
-    const {plugins} = this.model
-    if (plugins.includes("image")) {
+    const {previews} = this.model
+    if (previews.includes("image")) {
       (window as any).FilePond.registerPlugin((window as any).FilePondPluginImagePreview)
     }
-    if (plugins.includes("pdf")) {
+    if (previews.includes("pdf")) {
       (window as any).FilePond.registerPlugin((window as any).FilePondPluginPdfPreview)
     }
     (window as any).FilePond.registerPlugin((window as any).FilePondPluginFileValidateType);
@@ -170,7 +170,7 @@ export namespace FileDropper {
     max_total_file_size: p.Property<string | null>
     mime_type: p.Property<any>
     multiple: p.Property<boolean>
-    plugins: p.Property<string[]>
+    previews: p.Property<string[]>
   }
 }
 
@@ -196,7 +196,7 @@ export class FileDropper extends InputWidget {
       mime_type:           [ Any,                  {} ],
       multiple:            [ Bool,               true ],
       layout:              [ Nullable(DropperLayout), null ],
-      plugins:             [ List(Str), [ "image", "pdf" ]],
+      previews:            [ List(Str), [ "image", "pdf" ]],
     }))
   }
 }

--- a/panel/widgets/input.py
+++ b/panel/widgets/input.py
@@ -364,10 +364,10 @@ class FileDropper(Widget):
     multiple = param.Boolean(default=False, doc="""
         Whether to allow uploading multiple files.""")
 
-    plugins = param.ListSelector(default=["image", "pdf"],
+    previews = param.ListSelector(default=["image", "pdf"],
         objects=["image", "pdf"], doc="""
-        List of plugins to enable in the FileDropper. The following
-        plugins are available:
+        List of previews to enable in the FileDropper.
+        The following previews are available:
         - image: Adds support for image previews.
         - pdf: Adds support for PDF previews.""")
 


### PR DESCRIPTION
I had a case where I did not want to show a PDF after a file upload. 

![image](https://github.com/user-attachments/assets/8988e001-589a-4764-85ce-4a04b12583eb)

``` python
import panel as pn

pn.widgets.FileDropper(plugins=["image", "validate"], sizing_mode="stretch_width").servable()
```
