### PR TITLE
fix: Column updates not working for Bokeh < 3.7

### DIFF
--- a/panel/models/column.ts
+++ b/panel/models/column.ts
@@ -167,7 +167,10 @@ export class ColumnView extends BkColumnView {
     for (let i = 0; i < this.child_views.length; i++) {
       const view = this.child_views[i]
       const is_new = created_views.has(view)
-      const target = view.rendering_target() ?? this.self_target
+      // this.shadow_el is needed for Bokeh < 3.7.0 as this.self_target is not defined
+      // can be removed when our minimum version is Bokeh 3.7.0
+      // https://github.com/holoviz/panel/issues/7943
+      const target = view.rendering_target() ?? this.self_target ?? this.shadow_el
       if (is_new) {
         view.render_to(target)
       } else if (matching_index === null || i > matching_index) {

--- a/panel/models/column.ts
+++ b/panel/models/column.ts
@@ -169,7 +169,7 @@ export class ColumnView extends BkColumnView {
       const is_new = created_views.has(view)
       // this.shadow_el is needed for Bokeh < 3.7.0 as this.self_target is not defined
       // can be removed when our minimum version is Bokeh 3.7.0
-      // https://github.com/holoviz/panel/issues/7943
+      // https://github.com/holoviz/panel/pull/7948
       const target = view.rendering_target() ?? this.self_target ?? this.shadow_el
       if (is_new) {
         view.render_to(target)

--- a/panel/models/reactive_esm.ts
+++ b/panel/models/reactive_esm.ts
@@ -332,7 +332,10 @@ export class ReactiveESMView extends HTMLBoxView {
       this.render_esm()
     }
     for (const element_view of this.element_views) {
-      const target = element_view.rendering_target() ?? this.self_target
+      // this.shadow_el is needed for Bokeh < 3.7.0 as this.self_target is not defined
+      // can be removed when our minimum version is Bokeh 3.7.0
+      // https://github.com/holoviz/panel/pull/7948
+      const target = element_view.rendering_target() ?? this.self_target ?? this.shadow_el
       element_view.render_to(target)
     }
   }


### PR DESCRIPTION
fixes https://github.com/holoviz/panel/issues/7943

The following example does not work for Bokeh versions less than 3.7 because `this.self_target` is not defined.

``` python
import panel as pn

logged_in = False

def update_interface():
    sidebar_controls[:] = [logout_button if logged_in else login_button]

def login_logic(event):
    global logged_in
    logged_in = True
    update_interface()

def logout_logic(event):
    global logged_in
    logged_in = False
    update_interface()


login_button = pn.widgets.Button(name='Login', button_type='primary', width=140)
logout_button = pn.widgets.Button(name='Logout', button_type='warning', width=140)
login_button.on_click(login_logic)
logout_button.on_click(logout_logic)
sidebar_controls = pn.Column(login_button).servable()
```

On main it gives this log:
``` console
Uncaught (in promise) TypeError: target is undefined
    render_to http://localhost:5006/static/js/bokeh.js?v=c4933fc49dd2c1b7548fdd735d2c7781131c19aaffd6e0b5e452b3531ac8fead3d8d12b509e8366d51611d5db74bae323b7523ed021953c783c13023f300a76e:9155
    update_children http://localhost:5006/static/extensions/panel/panel.min.js?v=2c1940937d13777dc0f2c5a890921ff13e98b91a9e9d443a42651d8d0d8b448d:152
    connect_signals http://localhost:5006/static/js/bokeh.js?v=c4933fc49dd2c1b7548fdd735d2c7781131c19aaffd6e0b5e452b3531ac8fead3d8d12b509e8366d51611d5db74bae323b7523ed021953c783c13023f300a76e:47673
    new_slot http://localhost:5006/static/js/bokeh.js?v=c4933fc49dd2c1b7548fdd735d2c7781131c19aaffd6e0b5e452b3531ac8fead3d8d12b509e8366d51611d5db74bae323b7523ed021953c783c13023f300a76e:9287
    emit http://localhost:5006/static/js/bokeh.js?v=c4933fc49dd2c1b7548fdd735d2c7781131c19aaffd6e0b5e452b3531ac8fead3d8d12b509e8366d51611d5db74bae323b7523ed021953c783c13023f300a76e:3184
    emit http://localhost:5006/static/js/bokeh.js?v=c4933fc49dd2c1b7548fdd735d2c7781131c19aaffd6e0b5e452b3531ac8fead3d8d12b509e8366d51611d5db74bae323b7523ed021953c783c13023f300a76e:3193
    _setv http://localhost:5006/static/js/bokeh.js?v=c4933fc49dd2c1b7548fdd735d2c7781131c19aaffd6e0b5e452b3531ac8fead3d8d12b509e8366d51611d5db74bae323b7523ed021953c783c13023f300a76e:2917
    setv http://localhost:5006/static/js/bokeh.js?v=c4933fc49dd2c1b7548fdd735d2c7781131c19aaffd6e0b5e452b3531ac8fead3d8d12b509e8366d51611d5db74bae323b7523ed021953c783c13023f300a76e:2952
    apply_json_patch http://localhost:5006/static/js/bokeh.js?v=c4933fc49dd2c1b7548fdd735d2c7781131c19aaffd6e0b5e452b3531ac8fead3d8d12b509e8366d51611d5db74bae323b7523ed021953c783c13023f300a76e:1239
    _handle_patch http://localhost:5006/static/js/bokeh.js?v=c4933fc49dd2c1b7548fdd735d2c7781131c19aaffd6e0b5e452b3531ac8fead3d8d12b509e8366d51611d5db74bae323b7523ed021953c783c13023f300a76e:11495
    handle http://localhost:5006/static/js/bokeh.js?v=c4933fc49dd2c1b7548fdd735d2c7781131c19aaffd6e0b5e452b3531ac8fead3d8d12b509e8366d51611d5db74bae323b7523ed021953c783c13023f300a76e:11436
    _steady_state_handler http://localhost:5006/static/js/bokeh.js?v=c4933fc49dd2c1b7548fdd735d2c7781131c19aaffd6e0b5e452b3531ac8fead3d8d12b509e8366d51611d5db74bae323b7523ed021953c783c13023f300a76e:11229
    _current_handler http://localhost:5006/static/js/bokeh.js?v=c4933fc49dd2c1b7548fdd735d2c7781131c19aaffd6e0b5e452b3531ac8fead3d8d12b509e8366d51611d5db74bae323b7523ed021953c783c13023f300a76e:11213
    _on_message http://localhost:5006/static/js/bokeh.js?v=c4933fc49dd2c1b7548fdd735d2c7781131c19aaffd6e0b5e452b3531ac8fead3d8d12b509e8366d51611d5db74bae323b7523ed021953c783c13023f300a76e:11186
    onmessage http://localhost:5006/static/js/bokeh.js?v=c4933fc49dd2c1b7548fdd735d2c7781131c19aaffd6e0b5e452b3531ac8fead3d8d12b509e8366d51611d5db74bae323b7523ed021953c783c13023f300a76e:11056
    connect http://localhost:5006/static/js/bokeh.js?v=c4933fc49dd2c1b7548fdd735d2c7781131c19aaffd6e0b5e452b3531ac8fead3d8d12b509e8366d51611d5db74bae323b7523ed021953c783c13023f300a76e:11056
    connect http://localhost:5006/static/js/bokeh.js?v=c4933fc49dd2c1b7548fdd735d2c7781131c19aaffd6e0b5e452b3531ac8fead3d8d12b509e8366d51611d5db74bae323b7523ed021953c783c13023f300a76e:11051
    pull_session http://localhost:5006/static/js/bokeh.js?v=c4933fc49dd2c1b7548fdd735d2c7781131c19aaffd6e0b5e452b3531ac8fead3d8d12b509e8366d51611d5db74bae323b7523ed021953c783c13023f300a76e:11244
    _get_session http://localhost:5006/static/js/bokeh.js?v=c4933fc49dd2c1b7548fdd735d2c7781131c19aaffd6e0b5e452b3531ac8fead3d8d12b509e8366d51611d5db74bae323b7523ed021953c783c13023f300a76e:10980
    add_document_from_session http://localhost:5006/static/js/bokeh.js?v=c4933fc49dd2c1b7548fdd735d2c7781131c19aaffd6e0b5e452b3531ac8fead3d8d12b509e8366d51611d5db74bae323b7523ed021953c783c13023f300a76e:10989
    _embed_items http://localhost:5006/static/js/bokeh.js?v=c4933fc49dd2c1b7548fdd735d2c7781131c19aaffd6e0b5e452b3531ac8fead3d8d12b509e8366d51611d5db74bae323b7523ed021953c783c13023f300a76e:779
    embed_items http://localhost:5006/static/js/bokeh.js?v=c4933fc49dd2c1b7548fdd735d2c7781131c19aaffd6e0b5e452b3531ac8fead3d8d12b509e8366d51611d5db74bae323b7523ed021953c783c13023f300a76e:758
    embed_document http://localhost:5006/example_missing:44
    fn http://localhost:5006/example_missing:47
    fn http://localhost:5006/example_missing:63
    safely http://localhost:5006/static/js/bokeh.js?v=c4933fc49dd2c1b7548fdd735d2c7781131c19aaffd6e0b5e452b3531ac8fead3d8d12b509e8366d51611d5db74bae323b7523ed021953c783c13023f300a76e:11706
    fn http://localhost:5006/example_missing:39
    EventListener.handleEvent* http://localhost:5006/example_missing:67
    <anonymous> http://localhost:5006/example_missing:68
bokeh.js:9155:13
```

Running panel build panel with a 3.6.3 bokeh pin in package.json gives this output:

``` bash
Using nodejs v22.13.0 and npm 10.9.2
Working directory: /home/shh/projects/holoviz/repos/panel/panel
package.json has changed. Running npm install.

changed 1 package, and audited 240 packages in 2s

53 packages are looking for funding
  run `npm fund` for details

found 0 vulnerabilities
TypeScript lib: /home/shh/.local/conda/envs/holoviz/lib/python3.13/site-packages/bokeh/server/static/lib
Using /home/shh/projects/holoviz/repos/panel/panel/tsconfig.json
Compiling styles (9 files)
Compiling TypeScript (84 files)
panel/models/card.ts:46:23 - error TS2416: Property '_stylesheets' in type 'CardView' is not assignable to the same property in base type 'ColumnView'.
  Type '() => Iterable<StyleSheetLike>' is not assignable to type '() => Iterable<StyleSheet>'.
    Call signature return types 'Iterable<StyleSheetLike>' and 'Iterable<StyleSheet>' are incompatible.
      The types returned by '[Symbol.iterator]().next(...)' are incompatible between these types.
        Type 'IteratorResult<StyleSheetLike, any>' is not assignable to type 'IteratorResult<StyleSheet, any>'.
          Type 'IteratorYieldResult<StyleSheetLike>' is not assignable to type 'IteratorResult<StyleSheet, any>'.
            Type 'IteratorYieldResult<StyleSheetLike>' is not assignable to type 'IteratorYieldResult<StyleSheet>'.
              Type 'StyleSheetLike' is not assignable to type 'StyleSheet'.
                Type 'string' is not assignable to type 'StyleSheet'.

46   protected override *_stylesheets(): Iterable<DOM.StyleSheetLike> {
                         ~~~~~~~~~~~~
panel/models/column.ts:170:54 - error TS2339: Property 'self_target' does not exist on type 'ColumnView'.

170       const target = view.rendering_target() ?? this.self_target
                                                         ~~~~~~~~~~~
panel/models/deckgl.ts:198:14 - error TS2551: Property 'rerender' does not exist on type 'DeckGLPlotView'. Did you mean 'rerender_'?

198     if (this.rerender) {
                 ~~~~~~~~

  panel/models/deckgl.ts:196:3
    196   rerender_(): void {
          ~~~~~~~~~
    'rerender_' is declared here.
panel/models/deckgl.ts:199:12 - error TS2551: Property 'rerender' does not exist on type 'DeckGLPlotView'. Did you mean 'rerender_'?

199       this.rerender()
               ~~~~~~~~

  panel/models/deckgl.ts:196:3
    196   rerender_(): void {
          ~~~~~~~~~
    'rerender_' is declared here.
panel/models/layout.ts:61:14 - error TS2551: Property 'rerender' does not exist on type 'DOMView'. Did you mean 'render'?

61     if (view.rerender) {
                ~~~~~~~~

  panel/node_modules/@bokeh/bokehjs/build/js/lib/core/dom_view.d.ts:23:14
    23     abstract render(): void;
                    ~~~~~~
    'render' is declared here.
panel/models/layout.ts:62:12 - error TS2551: Property 'rerender' does not exist on type 'DOMView'. Did you mean 'render'?

62       view.rerender()
              ~~~~~~~~

  panel/node_modules/@bokeh/bokehjs/build/js/lib/core/dom_view.d.ts:23:14
    23     abstract render(): void;
                    ~~~~~~
    'render' is declared here.
panel/models/layout.ts:187:14 - error TS2551: Property 'rerender' does not exist on type 'DOMView'. Did you mean 'render'?

187     if (view.rerender) {
                 ~~~~~~~~

  panel/node_modules/@bokeh/bokehjs/build/js/lib/core/dom_view.d.ts:23:14
    23     abstract render(): void;
                    ~~~~~~
    'render' is declared here.
panel/models/layout.ts:188:12 - error TS2551: Property 'rerender' does not exist on type 'DOMView'. Did you mean 'render'?

188       view.rerender()
               ~~~~~~~~

  panel/node_modules/@bokeh/bokehjs/build/js/lib/core/dom_view.d.ts:23:14
    23     abstract render(): void;
                    ~~~~~~
    'render' is declared here.
panel/models/reactive_esm.ts:335:62 - error TS2339: Property 'self_target' does not exist on type 'ReactiveESMView'.

335       const target = element_view.rendering_target() ?? this.self_target
                                                                 ~~~~~~~~~~~
panel/models/singleselect.ts:31:14 - error TS2551: Property 'rerender' does not exist on type 'SingleSelectView'. Did you mean 'rerender_'?

31     if (this.rerender) {
                ~~~~~~~~

  panel/models/singleselect.ts:29:3
    29   rerender_(): void {
         ~~~~~~~~~
    'rerender_' is declared here.
panel/models/singleselect.ts:32:12 - error TS2551: Property 'rerender' does not exist on type 'SingleSelectView'. Did you mean 'rerender_'?

32       this.rerender()
              ~~~~~~~~

  panel/models/singleselect.ts:29:3
    29   rerender_(): void {
         ~~~~~~~~~
    'rerender_' is declared here.

Linking modules
Output written to /home/shh/projects/holoviz/repos/panel/panel/dist
All done.
```