### PR TITLE
fix: Use `importlib.reload` for autoreload

### DIFF
--- a/panel/io/reload.py
+++ b/panel/io/reload.py
@@ -1,5 +1,6 @@
 import asyncio
 import fnmatch
+import importlib
 import logging
 import os
 import pathlib
@@ -235,7 +236,7 @@ def _reload(module_paths, changes):
 
     for module in modules_to_delete:
         if module in sys.modules:
-            del sys.modules[module]
+            importlib.reload(sys.modules[module])
 
     for doc, loc in state._locations.items():
         if not doc.session_context:


### PR DESCRIPTION
I have had a problem when auto-reloading an app as it would error out after the first time. This will reload the module instead of deleting it and having the app import it again. 

Cannot recreate with a MRE, but this is the error I see:

![image](https://github.com/user-attachments/assets/243fe655-3118-4911-8cc9-fe8a8c4c10e2)
