### PR TITLE
Ensure references are up-to-date after pyodide syncing

### DIFF
--- a/panel/io/pyodide.py
+++ b/panel/io/pyodide.py
@@ -244,7 +244,7 @@ def _serialize_buffers(obj, buffers={}):
 def _process_document_events(doc: Document, events: list[Any]):
     serializer = Serializer(references=doc.models.synced_references)
     patch_json = PatchJson(events=serializer.encode(events))
-    doc.models.flush_synced()
+    doc.models.flush_synced(lambda model: not serializer.has_ref(model))
 
     buffer_map = {}
     for buffer in serializer.buffers:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -232,6 +232,11 @@ filterwarnings = [
     "ignore:\\*scattermapbox\\* is deprecated! Use \\*scattermap\\* instead" # https://github.com/plotly/plotly.py/issues/4997
 ]
 
+[tool.coverage.run]
+omit = [
+    "panel/io/__/_templates/*.py"
+]
+
 [tool.mypy]
 namespace_packages = true
 explicit_package_bases = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -243,11 +243,6 @@ disable_warnings = [
     "no-data-collected",
 ]
 
-[tool.coverage.run]
-omit = [
-    "panel/io/__/_templates/*.py"
-]
-
 [tool.mypy]
 namespace_packages = true
 explicit_package_bases = true


### PR DESCRIPTION
Since references are now lazily synced we only mark models as non-new if the serializer has synced them.