### PR TITLE
Do not dispatch events on (un)hold when Document is not initialized

### DIFF
--- a/panel/io/document.py
+++ b/panel/io/document.py
@@ -569,7 +569,10 @@ def hold(doc: Document | None = None, policy: HoldPolicyType = 'combine', comm: 
             if comm is not None:
                 from .notebook import push
                 push(doc, comm)
-            doc.unhold()
+            if state._loaded.get(doc):
+                doc.unhold()
+            else:
+                doc.callbacks._hold = None
 
 @contextmanager
 def immediate_dispatch(doc: Document | None = None):


### PR DESCRIPTION
The `hold` decorator should not try to dispatch events when the Document is not yet fully initialized (since this likely leads to the dreaded pending writes error).