### PR TITLE
Do not dispatch stylesheet patch during load

### DIFF
--- a/panel/io/resources.py
+++ b/panel/io/resources.py
@@ -347,7 +347,7 @@ def patch_model_css(root, dist_url):
         patch_stylesheet(stylesheet, dist_url)
     if doc:
         doc.callbacks._held_events = events
-        if held:
+        if held or not state._loaded.get(doc):
             doc.callbacks._hold = held
         else:
             doc.unhold()


### PR DESCRIPTION
The `patch_model_css` function switches out the stylesheets depending on the resource mode but should not dispatch events unless the app is fully loaded, otherwise in can trigger the dreaded `_pending_writes` error. This ensures we only `unhold` if the page is loaded.