### PR TITLE
enh: Add header tooltip to Tabulator

### DIFF
--- a/panel/models/tabulator.ts
+++ b/panel/models/tabulator.ts
@@ -1039,6 +1039,9 @@ export class DataTabulatorView extends HTMLBoxView {
       if (tab_column.title == null) {
         tab_column.title = column.title
       }
+      if (tab_column.headerTooltip === undefined) {
+        tab_column.headerTooltip = true
+      }
       if (tab_column.width == null && column.width != null && column.width != 0) {
         tab_column.width = column.width
       }

--- a/panel/models/tabulator.ts
+++ b/panel/models/tabulator.ts
@@ -1039,7 +1039,6 @@ export class DataTabulatorView extends HTMLBoxView {
       if (tab_column.title == null) {
         tab_column.title = column.title
       }
-      tab_column.headerTooltip = true
       if (tab_column.width == null && column.width != null && column.width != 0) {
         tab_column.width = column.width
       }

--- a/panel/models/tabulator.ts
+++ b/panel/models/tabulator.ts
@@ -1039,6 +1039,7 @@ export class DataTabulatorView extends HTMLBoxView {
       if (tab_column.title == null) {
         tab_column.title = column.title
       }
+      tab_column.headerTooltip = true
       if (tab_column.width == null && column.width != null && column.width != 0) {
         tab_column.width = column.width
       }

--- a/panel/widgets/tables.py
+++ b/panel/widgets/tables.py
@@ -2071,8 +2071,6 @@ class Tabulator(BaseTable):
 
             if field in self.header_tooltips:
                 col_dict["headerTooltip"] = self.header_tooltips[field]
-            else:
-                col_dict["headerTooltip"] = field
 
             if isinstance(index, tuple):
                 children = columns

--- a/panel/widgets/tables.py
+++ b/panel/widgets/tables.py
@@ -2071,6 +2071,8 @@ class Tabulator(BaseTable):
 
             if field in self.header_tooltips:
                 col_dict["headerTooltip"] = self.header_tooltips[field]
+            else:
+                col_dict["headerTooltip"] = field
 
             if isinstance(index, tuple):
                 children = columns


### PR DESCRIPTION
I don't see any reason why this shouldn't be enabled all the time. 

~We likely need to update the CSS so the font type matches the tabulator font.~ Does not seem to be easy [ref](https://stackoverflow.com/questions/60850754/how-to-apply-css-to-tooltips-in-tabulator). 

![image](https://github.com/user-attachments/assets/5a19aaee-93b3-4b6b-bc16-081fca3090e6)


``` python
import pandas as pd
import panel as pn

pn.extension('tabulator')

data = {
    "This is a very long column name that should be truncated": [1, 2, 3],
    "Another extremely long header that will not fit normally": [4, 5, 6],
    "Short": [7, 8, 9]
}
pn.widgets.Tabulator(pd.DataFrame(data), widths=dict.fromkeys(data, 150)).servable()
```