### PR TITLE
Allow nested ReactComponents to ignore the shadow DOM

### DIFF
--- a/panel/custom.py
+++ b/panel/custom.py
@@ -447,7 +447,8 @@ class ReactiveESM(ReactiveCustomBase, metaclass=ReactiveESMMetaclass):
         ignored = [
             p for p in Reactive.param
             if not issubclass(cls.param[p].owner, ReactiveESM) or
-            (p in Viewable.param and p != 'name' and type(Reactive.param[p]) is type(cls.param[p]))
+            (p in Viewable.param and p not in ('name', 'use_shadow_root')
+             and type(Reactive.param[p]) is type(cls.param[p]))
         ]
         for k, v in self.param.values().items():
             p = self.param[k]
@@ -789,6 +790,13 @@ class ReactComponent(ReactiveESM):
 
         CounterButton().servable()
     '''
+
+    use_shadow_root = param.Boolean(default=True, doc="""
+        Whether to render component into a shadow root.
+        This may optionally be disabled but will only take
+        effect if the parent is also a React component.
+        If disabled the component will be rendered into
+        the parent's React DOM tree.""")
 
     __abstract = True
 

--- a/panel/custom.py
+++ b/panel/custom.py
@@ -791,7 +791,7 @@ class ReactComponent(ReactiveESM):
         CounterButton().servable()
     '''
 
-    use_shadow_dom = param.Boolean(default=False, constant=True, doc="""
+    use_shadow_dom = param.Boolean(default=True, constant=True, doc="""
         Whether to render component into a shadow root.
         This may optionally be disabled but will only take
         effect if the parent is also a React component.

--- a/panel/custom.py
+++ b/panel/custom.py
@@ -447,7 +447,7 @@ class ReactiveESM(ReactiveCustomBase, metaclass=ReactiveESMMetaclass):
         ignored = [
             p for p in Reactive.param
             if not issubclass(cls.param[p].owner, ReactiveESM) or
-            (p in Viewable.param and p not in ('name', 'use_shadow_root')
+            (p in Viewable.param and p not in ('name', 'use_shadow_dom')
              and type(Reactive.param[p]) is type(cls.param[p]))
         ]
         for k, v in self.param.values().items():
@@ -791,7 +791,7 @@ class ReactComponent(ReactiveESM):
         CounterButton().servable()
     '''
 
-    use_shadow_root = param.Boolean(default=False, doc="""
+    use_shadow_dom = param.Boolean(default=False, constant=True, doc="""
         Whether to render component into a shadow root.
         This may optionally be disabled but will only take
         effect if the parent is also a React component.
@@ -862,7 +862,7 @@ class ReactComponent(ReactiveESM):
 
     def _get_properties(self, doc: Document | None) -> dict[str, Any]:
         props = super()._get_properties(doc)
-        props['use_shadow_root'] = self.use_shadow_root
+        props['use_shadow_dom'] = self.use_shadow_dom
         return props
 
 
@@ -921,3 +921,8 @@ class AnyWidgetComponent(ReactComponent):
         msg: dict
         """
         self._send_msg(msg)
+
+    def _get_properties(self, doc: Document | None) -> dict[str, Any]:
+        props = super()._get_properties(doc)
+        del props['use_shadow_dom']
+        return props

--- a/panel/custom.py
+++ b/panel/custom.py
@@ -791,7 +791,7 @@ class ReactComponent(ReactiveESM):
         CounterButton().servable()
     '''
 
-    use_shadow_root = param.Boolean(default=True, doc="""
+    use_shadow_root = param.Boolean(default=False, doc="""
         Whether to render component into a shadow root.
         This may optionally be disabled but will only take
         effect if the parent is also a React component.
@@ -859,6 +859,11 @@ class ReactComponent(ReactiveESM):
             'imports': imports_with_deps,
             'scopes': cls._importmap.get('scopes', {})
         }
+
+    def _get_properties(self, doc: Document | None) -> dict[str, Any]:
+        props = super()._get_properties(doc)
+        props['use_shadow_root'] = self.use_shadow_root
+        return props
 
 
 class AnyWidgetComponent(ReactComponent):

--- a/panel/models/esm.py
+++ b/panel/models/esm.py
@@ -64,7 +64,7 @@ class ReactComponent(ReactiveESM):
 
     root_node = bp.Nullable(bp.String)
 
-    use_shadow_root = bp.Bool(True)
+    use_shadow_dom = bp.Bool(True)
 
 
 class AnyWidgetComponent(ReactComponent):

--- a/panel/models/esm.py
+++ b/panel/models/esm.py
@@ -64,6 +64,8 @@ class ReactComponent(ReactiveESM):
 
     root_node = bp.Nullable(bp.String)
 
+    use_shadow_root = bp.Bool(True)
+
 
 class AnyWidgetComponent(ReactComponent):
     """

--- a/panel/models/react_component.ts
+++ b/panel/models/react_component.ts
@@ -262,7 +262,7 @@ async function render(id) {
     }
 
     get use_shadow_root() {
-      return !this.view.model.use_shadow_root || (this.view.react_root === undefined)
+      return this.view.model.use_shadow_root || (this.view.react_root === undefined)
     }
 
     componentDidMount() {

--- a/panel/models/react_component.ts
+++ b/panel/models/react_component.ts
@@ -1,4 +1,7 @@
+import type {StyleSheetLike} from "@bokehjs/core/dom"
+import {InlineStyleSheet} from "@bokehjs/core/dom"
 import type * as p from "@bokehjs/core/properties"
+import {isString} from "@bokehjs/core/util/types"
 import type {Transform} from "sucrase"
 
 import {
@@ -56,15 +59,18 @@ export class ReactComponentView extends ReactiveESMView {
     }
   }
 
-  get root_view(): void {
-    let root = this
-    while (root.parent?.react_root !== undefined) {
+  get root_view(): ReactComponentView {
+    let root: ReactComponentView = this
+    if (this.model.use_shadow_root) {
+      return root
+    }
+    while (root.parent instanceof ReactComponentView) {
       root = root.parent
     }
     return root
   }
 
-  protected _apply_stylesheets(stylesheets: StyleSheetLike[]): void {
+  protected override _apply_stylesheets(stylesheets: StyleSheetLike[]): void {
     const resolved_stylesheets = stylesheets.map((style) => isString(style) ? new InlineStyleSheet(style) : style)
     this._applied_stylesheets.push(...resolved_stylesheets)
     resolved_stylesheets.forEach((stylesheet) => stylesheet.install(this.root_view.shadow_el))

--- a/panel/models/react_component.ts
+++ b/panel/models/react_component.ts
@@ -301,7 +301,7 @@ async function render(id) {
     }
 
     get use_shadow_root() {
-      return this.view.model.use_shadow_root || (this.view.react_root === undefined)
+      return this.view?.model.use_shadow_root || (this.view?.react_root === undefined)
     }
 
     componentDidMount() {
@@ -310,9 +310,11 @@ async function render(id) {
       else if (!this.use_shadow_root) {
         view.patch_container(this.containerRef.current)
         view.model.render_module.then(async (mod) => {
-          this.setState({rendered: await mod.default.render(view.model.id)})
+          this.setState(
+            {rendered: await mod.default.render(view.model.id)},
+            () => this.props.parent.notify_mount(this.props.name, view.model.id)
+          )
         })
-        this.props.parent.notify_mount(this.props.name, view.model.id)
         return
       }
       this.updateElement()
@@ -348,7 +350,7 @@ async function render(id) {
       const class_name = (this.use_shadow_root ?
         "child-wrapper" : this.view.model.class_name.replace(/([a-z])([A-Z])/g, "$1-$2").toLowerCase()
       )
-      return React.createElement('div', {id: this.view.model.id, className: class_name, ref: this.containerRef}, child)
+      return React.createElement('div', {id: this.view?.model.id, className: class_name, ref: this.containerRef}, child)
     }
   }
 

--- a/panel/models/react_component.ts
+++ b/panel/models/react_component.ts
@@ -18,17 +18,17 @@ export class HostedStyleSheet extends InlineStyleSheet {
   }
 
   override replace(css: string, styles?: CSSStyles): void {
-    if (css === ":host") { css = `#${this.host_id}` }
+    css = css.replace(/:host\b/g, '`#${this.host_id}`');
     super.replace(css, styles)
   }
 
   override prepend(css: string, styles?: CSSStyles): void {
-    if (css === ":host") { css = `#${this.host_id}` }
+    css = css.replace(/:host\b/g, '`#${this.host_id}`');
     super.prepend(css, styles)
   }
 
   override append(css: string, styles?: CSSStyles): void {
-    if (css === ":host") { css = `#${this.host_id}` }
+    css = css.replace(/:host\b/g, '`#${this.host_id}`');
     super.append(css, styles)
   }
 
@@ -46,8 +46,9 @@ export class ReactComponentView extends ReactiveESMView {
   override initialize(): void {
     super.initialize()
     if (!this.use_shadow_root) {
+      (this as any).display = new HostedStyleSheet("", "display", false, this.model.id);
       (this as any).style = new HostedStyleSheet("", "style", false, this.model.id);
-      (this as any).parent_style = new HostedStyleSheet("", "parent", true, this.model.id)
+      (this as any).parent_style = new HostedStyleSheet("", "parent", true, this.model.id);
     }
   }
 
@@ -140,7 +141,9 @@ export class ReactComponentView extends ReactiveESMView {
     // React component to ensure anything depending on the DOM
     // structure (e.g. emotion caches) is updated
     super.r_after_render()
-    this.force_update()
+    if (!this.use_shadow_root) {
+      this.force_update()
+    }
   }
 
   override _update_layout(): void {
@@ -477,6 +480,7 @@ async function render(id) {
     }
 
     componentDidMount() {
+      if (!this.props.view.use_shadow_root) { return }
       this.props.view.on_force_update(() => {
         ${init_code}
         this.forceUpdate()

--- a/panel/models/react_component.ts
+++ b/panel/models/react_component.ts
@@ -18,17 +18,17 @@ export class HostedStyleSheet extends InlineStyleSheet {
   }
 
   override replace(css: string, styles?: CSSStyles): void {
-    css = css.replace(/:host\b/g, '`#${this.host_id}`');
+    css = css.replace(/:host\b/g, `#${this.host_id}`);
     super.replace(css, styles)
   }
 
   override prepend(css: string, styles?: CSSStyles): void {
-    css = css.replace(/:host\b/g, '`#${this.host_id}`');
+    css = css.replace(/:host\b/g, `#${this.host_id}`);
     super.prepend(css, styles)
   }
 
   override append(css: string, styles?: CSSStyles): void {
-    css = css.replace(/:host\b/g, '`#${this.host_id}`');
+    css = css.replace(/:host\b/g, `#${this.host_id}`);
     super.append(css, styles)
   }
 

--- a/panel/models/react_component.ts
+++ b/panel/models/react_component.ts
@@ -90,7 +90,7 @@ export class ReactComponentView extends ReactiveESMView {
   override remove(): void {
     super.remove()
     this._force_update_callbacks = []
-    if (this.react_root) {
+    if (this.react_root && this.use_shadow_root) {
       this.react_root.then((root: any) => root.unmount())
     }
   }
@@ -172,10 +172,12 @@ export class ReactComponentView extends ReactiveESMView {
       }
     }
 
-    for (const view of this._child_rendered.keys()) {
-      if (!all_views.includes(view)) {
-        this._child_rendered.delete(view)
-        view.el.remove()
+    if (this.use_shadow_root) {
+      for (const view of this._child_rendered.keys()) {
+	if (!all_views.includes(view)) {
+          this._child_rendered.delete(view)
+          view.el.remove()
+	}
       }
     }
 

--- a/panel/models/react_component.ts
+++ b/panel/models/react_component.ts
@@ -301,17 +301,18 @@ async function render(id) {
     }
 
     componentDidMount() {
-      if (!this.use_shadow_root) {
-        this.view.container = this.containerRef.current
-        this.view._update_stylesheets()
-        this.view.update_layout()
-        this.view.model.render_module.then(async (mod) => {
-          this.setState({rendered: await mod.default.render(this.view.model.id)})
-        })
-        return
-      }
       const view = this.view
       if (view == null) { return }
+      else if (!this.use_shadow_root) {
+        view.container = this.containerRef.current
+        view._update_stylesheets()
+        view.update_layout()
+        view.model.render_module.then(async (mod) => {
+          this.setState({rendered: await mod.default.render(view.model.id)})
+        })
+        this.props.parent.notify_mount(this.props.name, view.model.id)
+        return
+      }
       this.updateElement()
       view.render()
       this.render_callback = (new_views) => {

--- a/panel/models/react_component.ts
+++ b/panel/models/react_component.ts
@@ -51,7 +51,6 @@ export class ReactComponentView extends ReactiveESMView {
     }
   }
 
-
   override render_esm(): void {
     if (this.model.compiled === null || this.model.render_module === null) {
       return

--- a/panel/models/react_component.ts
+++ b/panel/models/react_component.ts
@@ -18,17 +18,17 @@ export class HostedStyleSheet extends InlineStyleSheet {
   }
 
   override replace(css: string, styles?: CSSStyles): void {
-    css = css.replace(/:host\b/g, `#${this.host_id}`);
+    css = css.replace(/:host\b/g, `#${this.host_id}`)
     super.replace(css, styles)
   }
 
   override prepend(css: string, styles?: CSSStyles): void {
-    css = css.replace(/:host\b/g, `#${this.host_id}`);
+    css = css.replace(/:host\b/g, `#${this.host_id}`)
     super.prepend(css, styles)
   }
 
   override append(css: string, styles?: CSSStyles): void {
-    css = css.replace(/:host\b/g, `#${this.host_id}`);
+    css = css.replace(/:host\b/g, `#${this.host_id}`)
     super.append(css, styles)
   }
 
@@ -48,7 +48,7 @@ export class ReactComponentView extends ReactiveESMView {
     if (!this.use_shadow_dom) {
       (this as any).display = new HostedStyleSheet("", "display", false, this.model.id);
       (this as any).style = new HostedStyleSheet("", "style", false, this.model.id);
-      (this as any).parent_style = new HostedStyleSheet("", "parent", true, this.model.id);
+      (this as any).parent_style = new HostedStyleSheet("", "parent", true, this.model.id)
     }
   }
 
@@ -96,7 +96,7 @@ export class ReactComponentView extends ReactiveESMView {
     } else {
       this._applied_stylesheets.forEach((stylesheet) => stylesheet.uninstall())
       for (const cb of (this._lifecycle_handlers.get("remove") || [])) {
-	cb()
+        cb()
       }
       this._child_callbacks.clear()
       this._child_rendered.clear()
@@ -185,10 +185,10 @@ export class ReactComponentView extends ReactiveESMView {
 
     if (this.use_shadow_dom) {
       for (const view of this._child_rendered.keys()) {
-	if (!all_views.includes(view)) {
+        if (!all_views.includes(view)) {
           this._child_rendered.delete(view)
           view.el.remove()
-	}
+        }
       }
     }
 


### PR DESCRIPTION
Currently Bokeh components always create a shadow root that ensures they are isolated from the rest of the page. This isolation is very useful to ensure styling can be well scoped but also has a significant performance penalty. When using custom `ReactComponent`s this performance penalty is compounded by the fact that the shadow DOM boundary layer means that if a `ReactComponent` has children, who are themselves `ReactComponent`s, we still have to create distinct React roots for each child. So now we have nested shadow roots, containing nested React roots.

This PR provides an option to allow children of ReactComponents, that are themselves ReactComponents to be rendered directly into their parents React roots, bypassing the regular Bokeh `View.render` pipeline and instead embedding the child component directly as a React node. This has the major benefit that it is a whole lot faster, but also has the potential to have CSS leak across components in this setup. However, it is not uncommon for a bunch of components or even an entire to be styled very similarly, which means this is a perfectly acceptable approach.

To ensure that CSS and styling still applies:

- We inject the stylesheets on the shadow root of the parent (or parent's parent, ...) 
- We replace `:host` selectors with explicit IDs
- We patch the `View.el` and `View.container` to ensure that HTML attributes are applied to the correct node

Since this has to be enabled explicitly this is fully backwards compatible and I'd like to test this in the wild a bit before documenting the option in more detail.