### PR TITLE
Handle --ico-path CLI argument

### DIFF
--- a/panel/_templates/base.html
+++ b/panel/_templates/base.html
@@ -22,8 +22,12 @@ that accepts these same parameters.
   {% block inner_head %}
     <meta charset="utf-8">
     <title>{% block title %}{{ title | e if title else "Panel App" }}{% endblock %}</title>
+    {% if apple_icon is not defined -%}
     <link rel="apple-touch-icon" sizes="180x180" href="{{ dist_url }}images/apple-touch-icon.png">
-    {% if app_favicon is not defined %} <link rel="icon" type="image/png" sizes="32x32" href="{{ dist_url }}images/favicon.ico"> {% endif %}
+    {%- endif %}
+    {% if app_favicon is not defined -%}
+    <link rel="icon" type="image/png" sizes="32x32" href="{{ dist_url }}images/favicon.ico">
+    {%- endif %}
     {% if manifest_url %}<link rel="manifest" href="{{ manifest_url }}">{% endif %}
     {% if theme_name == "dark"%}<style>html { background-color: #121212 }</style>{% endif %}
   {%  block preamble -%}{%- endblock %}

--- a/panel/_templates/base.html
+++ b/panel/_templates/base.html
@@ -30,7 +30,14 @@ that accepts these same parameters.
     {%- endif %}
     {% if manifest_url %}<link rel="manifest" href="{{ manifest_url }}">{% endif %}
     {% if theme_name == "dark"%}<style>html { background-color: #121212 }</style>{% endif %}
-  {%  block preamble -%}{%- endblock %}
+  {%  block preamble -%}
+    {% if apple_icon is not defined -%}
+    <link rel="apple-touch-icon" href="{{apple_icon}}">
+    {%- endif %}
+    {% if app_favicon -%}
+    <link rel="icon" href="{{app_favicon}}">
+    {%- endif %}
+  {%- endblock %}
   {%  block resources %}
     <style>
       html, body {

--- a/panel/command/serve.py
+++ b/panel/command/serve.py
@@ -29,6 +29,7 @@ from bokeh.command.util import build_single_handler_applications
 from bokeh.core.validation import silence
 from bokeh.core.validation.warnings import EMPTY_LAYOUT
 from bokeh.server.contexts import ApplicationContext
+from bokeh.settings import settings
 from tornado.ioloop import PeriodicCallback
 from tornado.web import StaticFileHandler
 
@@ -357,6 +358,8 @@ class Serve(_BkServe):
         # Handle tranquilized functions in the supplied functions
         kwargs['extra_patterns'] = patterns = kwargs.get('extra_patterns', [])
 
+        if args.ico_path:
+            settings.ico_path.set_value(args.ico_path)
         static_dirs = parse_vars(args.static_dirs) if args.static_dirs else {}
         patterns += get_static_routes(static_dirs)
 

--- a/panel/command/serve.py
+++ b/panel/command/serve.py
@@ -38,6 +38,7 @@ from ..config import config
 from ..io.document import _cleanup_doc
 from ..io.liveness import LivenessHandler
 from ..io.reload import record_modules, watch
+from ..io.resources import DIST_DIR
 from ..io.rest import REST_PROVIDERS
 from ..io.server import INDEX_HTML, get_static_routes, set_curdoc
 from ..io.state import state
@@ -360,6 +361,8 @@ class Serve(_BkServe):
 
         if args.ico_path:
             settings.ico_path.set_value(args.ico_path)
+        else:
+            kwargs["ico_path"] = DIST_DIR / "images" / "favicon.ico"
         static_dirs = parse_vars(args.static_dirs) if args.static_dirs else {}
         patterns += get_static_routes(static_dirs)
 

--- a/panel/io/server.py
+++ b/panel/io/server.py
@@ -44,7 +44,6 @@ from bokeh.server.views.autoload_js_handler import (
 from bokeh.server.views.doc_handler import DocHandler as BkDocHandler
 from bokeh.server.views.root_handler import RootHandler as BkRootHandler
 from bokeh.server.views.static_handler import StaticHandler
-from bokeh.settings import settings
 from bokeh.util.serialization import make_id
 from bokeh.util.token import (
     generate_jwt_token, generate_session_id, get_token_payload,
@@ -244,8 +243,8 @@ def html_page_for_render_items(
         base = BASE_TEMPLATE,
         macros = MACROS,
     ))
-    if "app_favicon" not in context and not settings.ico_path().startswith(str(DIST_DIR)):
-        context["app_favicon"] = "/favicon.ico"
+    if "app_favicon" not in context:
+        context["app_favicon"] = (state.rel_path or "/") + "favicon.ico"
 
     if len(render_items) == 1:
         context["doc"] = context["docs"][0]

--- a/panel/io/server.py
+++ b/panel/io/server.py
@@ -44,6 +44,7 @@ from bokeh.server.views.autoload_js_handler import (
 from bokeh.server.views.doc_handler import DocHandler as BkDocHandler
 from bokeh.server.views.root_handler import RootHandler as BkRootHandler
 from bokeh.server.views.static_handler import StaticHandler
+from bokeh.settings import settings
 from bokeh.util.serialization import make_id
 from bokeh.util.token import (
     generate_jwt_token, generate_session_id, get_token_payload,
@@ -242,6 +243,8 @@ def html_page_for_render_items(
         base = BASE_TEMPLATE,
         macros = MACROS,
     ))
+    if "app_favicon" not in context and not settings.ico_path().endswith("bokeh.ico"):
+        context["app_favicon"] = "/favicon.ico"
 
     if len(render_items) == 1:
         context["doc"] = context["docs"][0]

--- a/panel/io/server.py
+++ b/panel/io/server.py
@@ -69,8 +69,9 @@ from .loading import LOADING_INDICATOR_CSS_CLASS
 from .logging import LOG_SESSION_CREATED
 from .reload import record_modules
 from .resources import (
-    BASE_TEMPLATE, CDN_DIST, COMPONENT_PATH, ERROR_TEMPLATE, LOCAL_DIST,
-    Resources, _env, bundle_resources, patch_model_css, resolve_custom_path,
+    BASE_TEMPLATE, CDN_DIST, COMPONENT_PATH, DIST_DIR, ERROR_TEMPLATE,
+    LOCAL_DIST, Resources, _env, bundle_resources, patch_model_css,
+    resolve_custom_path,
 )
 from .session import generate_session
 from .state import set_curdoc, state
@@ -243,7 +244,7 @@ def html_page_for_render_items(
         base = BASE_TEMPLATE,
         macros = MACROS,
     ))
-    if "app_favicon" not in context and not settings.ico_path().endswith("bokeh.ico"):
+    if "app_favicon" not in context and not settings.ico_path().startswith(str(DIST_DIR)):
         context["app_favicon"] = "/favicon.ico"
 
     if len(render_items) == 1:
@@ -1066,6 +1067,9 @@ def get_server(
 
     if 'index' not in opts:
         opts['index'] = INDEX_HTML
+
+    if 'ico_path' not in opts:
+        opts['ico_path'] = DIST_DIR / "images" / "favicon.ico"
 
     if address is not None:
         opts['address'] = address

--- a/panel/io/server.py
+++ b/panel/io/server.py
@@ -244,7 +244,7 @@ def html_page_for_render_items(
         macros = MACROS,
     ))
     if "app_favicon" not in context:
-        context["app_favicon"] = (state.rel_path or "/") + "favicon.ico"
+        context["app_favicon"] = (f"{state.rel_path}/" if state.rel_path else "./") + "favicon.ico"
 
     if len(render_items) == 1:
         context["doc"] = context["docs"][0]

--- a/panel/template/base.py
+++ b/panel/template/base.py
@@ -630,7 +630,7 @@ class BasicTemplate(BaseTemplate):
         URI of logo to add to the header (if local file, logo is
         base64 encoded as URI). Default is '', i.e. not shown.""")
 
-    favicon = param.String(default=FAVICON_URL, doc="""
+    favicon = param.String(default=None, doc="""
         URI of favicon to add to the document head (if local file, favicon is
         base64 encoded as URI).""")
 
@@ -701,6 +701,12 @@ class BasicTemplate(BaseTemplate):
             template = _env.get_template(str(self._template.relative_to(Path(__file__).parent)))
         except (jinja2.exceptions.TemplateNotFound, ValueError):
             template = parse_template(tmpl_string)
+
+        if 'favicon' not in params and type(self).favicon is None:
+            if _settings.ico_path().endswith("bokeh.ico"):
+                params['favicon'] = FAVICON_URL
+            else:
+                params['favicon'] = _settings.ico_path()
 
         if 'header' not in params:
             params['header'] = ListLike()

--- a/panel/template/base.py
+++ b/panel/template/base.py
@@ -28,7 +28,7 @@ from ..io.model import add_to_doc
 from ..io.notebook import render_template
 from ..io.notifications import NotificationArea, NotificationAreaBase
 from ..io.resources import (
-    BUNDLE_DIR, CDN_DIST, JS_VERSION, ResourceComponent, _env,
+    BUNDLE_DIR, CDN_DIST, DIST_DIR, JS_VERSION, ResourceComponent, _env,
     component_resource_path, get_dist_path, loading_css, parse_template,
     resolve_custom_path, use_cdn,
 )
@@ -703,8 +703,8 @@ class BasicTemplate(BaseTemplate):
             template = parse_template(tmpl_string)
 
         if 'favicon' not in params and type(self).favicon is None:
-            if _settings.ico_path().endswith("bokeh.ico"):
-                params['favicon'] = FAVICON_URL
+            if _settings.ico_path().startswith(str(DIST_DIR)):
+                params['favicon'] = "/favicon.ico"
             else:
                 params['favicon'] = _settings.ico_path()
 

--- a/panel/template/base.py
+++ b/panel/template/base.py
@@ -804,7 +804,7 @@ class BasicTemplate(BaseTemplate):
         elif self.favicon:
             favicon = self.favicon
         else:
-            favicon = (state.rel_path or "/") + "favicon.ico"
+            favicon = (f"{state.rel_path}/" if state.rel_path else "./") + "favicon.ico"
         self._render_variables['app_logo'] = logo
         if favicon:
             self._render_variables['app_favicon'] = favicon

--- a/panel/template/base/base.html
+++ b/panel/template/base/base.html
@@ -6,6 +6,9 @@
     {%- if app_favicon %}
     <link rel="icon" href="{{ app_favicon }}" type="{{favicon_type}}">
     {% endif -%}
+    {%- if apple_icon %}
+    <link rel="apple-touch-icon" href="{{ apple_icon }}" type="{{apple_icon_type}}">
+    {% endif -%}
     {%- if manifest %}
     <link rel="manifest" href="{{ manifest }}">
     {% endif -%}

--- a/panel/tests/test_server.py
+++ b/panel/tests/test_server.py
@@ -99,28 +99,44 @@ def test_server_root_handler():
 
     assert 'href="./app"' in r.content.decode('utf-8')
 
-def test_server_ico_handling(port):
+@pytest.mark.parametrize('path', ["/app", "/nested/app"])
+def test_server_ico_handling(path, port):
     md = Markdown('# Favicon test')
 
     ico_path = DIST_DIR / "images" / "icon-32x32.png"
     r = serve_and_request(
-        {'app': md}, ico_path=ico_path, port=port
+        {path: md}, ico_path=ico_path, port=port, suffix=path
     )
 
-    assert '<link rel="icon" href="/favicon.ico"' in r.content.decode('utf-8')
+    dots = path.count('/')*'.'
+    assert f'<link rel="icon" href="{dots}/favicon.ico"' in r.content.decode('utf-8')
     ico = requests.get(f"http://localhost:{port}/favicon.ico")
     assert ico.content == ico_path.read_bytes()
 
-def test_server_template_ico_handling(port):
+def test_server_ico_handling_with_prefix(port):
+    md = Markdown('# Favicon test')
+
+    ico_path = DIST_DIR / "images" / "icon-32x32.png"
+    r = serve_and_request(
+        {'app': md}, ico_path=ico_path, port=port, prefix='/prefix', suffix='/prefix/app'
+    )
+
+    assert '<link rel="icon" href="./favicon.ico"' in r.content.decode('utf-8')
+    ico = requests.get(f"http://localhost:{port}/favicon.ico")
+    assert ico.content == ico_path.read_bytes()
+
+@pytest.mark.parametrize('path', ["/app", "/nested/app"])
+def test_server_template_ico_handling(path, port):
     def app():
         return BootstrapTemplate()
 
     ico_path = DIST_DIR / "images" / "icon-32x32.png"
     r = serve_and_request(
-        {'app': app}, ico_path=ico_path, port=port
+        {path: app}, ico_path=ico_path, port=port, suffix=path
     )
 
-    assert '<link rel="icon" href="/favicon.ico"' in r.content.decode('utf-8')
+    dots = path.count('/')*'.'
+    assert f'<link rel="icon" href="{dots}/favicon.ico"' in r.content.decode('utf-8')
     ico = requests.get(f"http://localhost:{port}/favicon.ico")
     assert ico.content == ico_path.read_bytes()
 
@@ -941,6 +957,21 @@ def test_server_template_custom_resources_on_proxy(reverse_proxy):
 
     with open(pathlib.Path(__file__).parent / 'assets' / 'custom.css', encoding='utf-8') as f:
         assert f.read() == r.content.decode('utf-8').replace('\r\n', '\n')
+
+@reverse_proxy_available
+def test_server_ico_path_on_proxy(reverse_proxy):
+    md = Markdown('# Favicon test')
+
+    ico_path = DIST_DIR / "images" / "icon-32x32.png"
+    port, proxy = reverse_proxy
+    r = serve_and_request(
+        {'app': md}, port=port, proxy=proxy, ico_path=ico_path,
+        suffix="/proxy/app"
+    )
+
+    assert '<link rel="icon" href="./favicon.ico"' in r.content.decode('utf-8')
+    ico = requests.get(f"http://localhost:{proxy}/proxy/favicon.ico")
+    assert ico.content == ico_path.read_bytes()
 
 def test_server_template_custom_resources_with_prefix(port):
     template = CustomBootstrapTemplate()

--- a/panel/tests/test_server.py
+++ b/panel/tests/test_server.py
@@ -99,6 +99,30 @@ def test_server_root_handler():
 
     assert 'href="./app"' in r.content.decode('utf-8')
 
+def test_server_ico_handling(port):
+    md = Markdown('# Favicon test')
+
+    ico_path = DIST_DIR / "images" / "icon-32x32.png"
+    r = serve_and_request(
+        {'app': md}, ico_path=ico_path, port=port
+    )
+
+    assert '<link rel="icon" href="/favicon.ico"' in r.content.decode('utf-8')
+    ico = requests.get(f"http://localhost:{port}/favicon.ico")
+    assert ico.content == ico_path.read_bytes()
+
+def test_server_template_ico_handling(port):
+    def app():
+        return BootstrapTemplate()
+
+    ico_path = DIST_DIR / "images" / "icon-32x32.png"
+    r = serve_and_request(
+        {'app': app}, ico_path=ico_path, port=port
+    )
+
+    assert '<link rel="icon" href="/favicon.ico"' in r.content.decode('utf-8')
+    ico = requests.get(f"http://localhost:{port}/favicon.ico")
+    assert ico.content == ico_path.read_bytes()
 
 def test_server_template_static_resources(server_implementation):
     template = BootstrapTemplate()


### PR DESCRIPTION
`bokeh serve` CLI allows setting an `--ico-path` to control the favicon. Since we perform our own handling of favicons this option was ignored. We now hook into the mechanism.