### PR TITLE
Pin pyviz_comms in JupyterLite

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -274,6 +274,7 @@ lint-install = 'pre-commit install -t=pre-commit'
 # =================== LITE ====================
 # =============================================
 [feature.lite.dependencies]
+pyviz_comms = ">=3.0.6"
 jupyterlab-myst = "*"
 jupyterlite-core = "*"
 jupyterlite-pyodide-kernel = "*"


### PR DESCRIPTION
Address JupyterLab extension and pyviz_comms version divergence.

Proper fix is here: https://github.com/holoviz/pyviz_comms/pull/140/files