### PR TITLE
fix: Enable mathjax if extension is loaded

### DIFF
--- a/panel/config.py
+++ b/panel/config.py
@@ -878,7 +878,10 @@ class panel_extension(_pyviz_extension):
                 nb_loaded = True
             else:
                 with param.logging_level('ERROR'):
-                    hv.plotting.Renderer.load_nb(config.inline)
+                    hv.plotting.Renderer.load_nb(
+                        config.inline,
+                        enable_mathjax="mathjax" in panel_extension._loaded_extensions
+                    )
                     nb_loaded = True
 
         # Disable simple ids, old state and multiple tabs in notebooks can cause IDs to clash


### PR DESCRIPTION
Fixes part of the problem observed here: https://github.com/holoviz/holoviews/issues/6643

We call `pn.extension("mathjax")` if `enable_mathjax` is true, this is to make sure it is available in a server setting, but in a notebook, this was set to false during the first run, and then it is never injected into the notebook again for some reason.

``` python
import holoviews as hv

hv.extension("bokeh", enable_mathjax=True)

hv.Rectangles([[0, 0, 1, 1]]).opts(ylabel=r"$$\alpha$$")
```