### PR TITLE
Allow custom title for multiindex column in tabulator

### DIFF
--- a/panel/tests/widgets/test_tables.py
+++ b/panel/tests/widgets/test_tables.py
@@ -441,19 +441,27 @@ def test_tabulator_multi_index_multi_index_columns(document, comm):
     # Create a DataFrame with MultiIndex as columns and MultiIndex as index
     df = pd.DataFrame(np.random.randn(6, 6), index=multi_index, columns=multi_columns)
 
-    table = Tabulator(df, show_index=True)
+    table = Tabulator(
+        df,
+        show_index=True,
+        titles={
+            ("A",): "Title a",
+            ("A", "two"): "Title two",
+            ("A", "two", "X"): "New title",
+        },
+    )
 
     model = table.get_root(document, comm)
 
     assert model.configuration['columns'] == [
         {'field': 'number__', 'sorter': 'number'},
         {'field': 'color__'},
-        {'title': 'A', 'columns': [
+        {'title': 'Title a', 'columns': [
             {'title': 'one', 'columns': [
                 {'field': 'A_one_X', 'sorter': 'number'},
                 {'field': 'A_one_Y', 'sorter': 'number'},
             ]},
-            {'title': 'two', 'columns': [
+            {'title': 'Title two', 'columns': [
                 {'field': 'A_two_X', 'sorter': 'number'}
             ]},
         ]},
@@ -470,6 +478,8 @@ def test_tabulator_multi_index_multi_index_columns(document, comm):
     for field in ("number__", "color__", "A_one_X", "A_one_Y", "A_two_X", "B_two_Y", "B_three_X", "B_three_Y"):
         assert field in model.source.data
 
+    assert(model.columns[4].field == "A_two_X")
+    assert(model.columns[4].title == "New title")
 
 def test_tabulator_multi_index_multi_index_columns_hide_index(document, comm):
     level_1 = ['A', 'A', 'A', 'B', 'B', 'B']

--- a/panel/widgets/tables.py
+++ b/panel/widgets/tables.py
@@ -2075,21 +2075,22 @@ class Tabulator(BaseTable):
             if isinstance(index, tuple):
                 children = columns
                 last = cast(GroupSpec, children[-1] if len(children) > 0 else {})
-                for group in index[:-1]:
-                    if 'title' in last and last['title'] == group:
+                for j, group in enumerate(index[:-1]):
+                    group_title = self.titles.get(index[: j + 1], group)
+                    if 'title' in last and last['title'] == group_title:
                         new = False
                         children = last['columns']
                     else:
                         new = True
                         children.append({
                             'columns': [],
-                            'title': group,
+                            'title': group_title,
                         })
                     last = cast(GroupSpec, children[-1])
                     if new:
                         children = last['columns']
                 children.append(col_dict)
-                column.title = index[-1]
+                column.title = self.titles.get(index, index[-1])
             elif matching_groups:
                 group = matching_groups[0]
                 if group in groups:


### PR DESCRIPTION
Add the ablity to change the title when column index of the dataframe is a multiindex.

```python
import numpy as np
import pandas as pd
import panel as pn

pn.extension("tabulator")

# sinple index, multiple columns
level_1 = ["A", "A", "A", "B", "B", "B"]
level_2 = ["one", "one", "two", "two", "three", "three"]
level_3 = ["X", "Y", "X", "Y", "X", "Y"]

multi_index = pd.MultiIndex.from_arrays(
    [level_1, level_2, level_3],
    names=["Level 1", "Level 2", "Level 3"],
)
df_multiple = pd.DataFrame(np.random.randn(4, 6), columns=multi_index)
table_multiple = pn.widgets.Tabulator(
    df_multiple,
    show_index=True,
    titles={
        ("A",): "For the top level",
        ("A", "one"): "For the next level",
        ("A", "one", "X"): "Tuple title",
    },
)

pn.Column(table_multiple).servable()
``` 
![image](https://github.com/user-attachments/assets/35f8836f-a260-4f92-8848-4b15e003dca1)

Related to #7930 