### PR TITLE
enh: Add small help text when reactive_esm compile fails

### DIFF
--- a/panel/models/reactive_esm.ts
+++ b/panel/models/reactive_esm.ts
@@ -771,9 +771,14 @@ export default {render}`
         },
       ).code
     } catch (e) {
-      if (e instanceof SyntaxError && this.dev) {
-        this.compile_error = e
-        return null
+      if (e instanceof SyntaxError) {
+        if (this.dev) {
+          this.compile_error = e
+          return null
+        } else {
+          e.message = `${e.message}. See more information with '--dev' flag.`
+          throw e
+        }
       } else {
         throw e
       }


### PR DESCRIPTION
Not obvious that you get a better error message when running with `--dev`. 

![image](https://github.com/user-attachments/assets/6c1fa104-269a-4178-8956-1632c25d4c0c)
