### PR TITLE
Fix multichoice dark theme background issue

### DIFF
--- a/panel/dist/css/multichoice.css
+++ b/panel/dist/css/multichoice.css
@@ -1,0 +1,9 @@
+.choices__list--dropdown,
+.choices__list[aria-expanded] {
+  background-color: var(--background-color);
+  border: 1px solid var(--background-text-color);
+}
+.choices__list--dropdown .choices__item--selectable.is-highlighted,
+.choices__list[aria-expanded] .choices__item--selectable.is-highlighted {
+  background-color: var(--surface-color);
+}

--- a/panel/widgets/select.py
+++ b/panel/widgets/select.py
@@ -921,6 +921,8 @@ class MultiChoice(_MultiSelectBase):
 
     _widget_type: ClassVar[type[Model]] = _BkMultiChoice
 
+    _stylesheets: ClassVar[list[str]] = [f'{CDN_DIST}css/multichoice.css']
+
 
 class AutocompleteInput(SingleSelectBase):
     """


### PR DESCRIPTION
## Issue

```python
import panel as pn

pn.extension()

pn.config.theme="dark"

multi_choice = pn.widgets.MultiChoice(name='MultiSelect', value=['Apple', 'Pear'],
    options=['Apple', 'Banana', 'Pear', 'Strawberry'],
)

pn.Column(multi_choice, height=200).servable()
```

![image](https://github.com/user-attachments/assets/bc629ccc-f2c6-4936-84ed-96d25e6752a9)

This also a problem in dark themed notebook. And in the docs when viewing with dark theme.

## Tests of fix

I've tested the fix via

```python
import panel as pn

pn.extension()

pn.config.theme="dark"

css_fix = """
.choices__list--dropdown, .choices__list[aria-expanded]{
    background-color: var(--background-color);
    border:1px solid  var(--background-text-color);
}
.choices__list--dropdown .choices__item--selectable.is-highlighted, .choices__list[aria-expanded] .choices__item--selectable.is-highlighted  {
    background-color: var(--surface-color);
}
"""

pn.widgets.MultiChoice._stylesheets.append(css_fix)

multi_choice = pn.widgets.MultiChoice(name='MultiSelect', value=['Apple', 'Pear'],
    options=['Apple', 'Banana', 'Pear', 'Strawberry'],
)

pn.Column(multi_choice, height=200).servable()
```

![image](https://github.com/user-attachments/assets/7e2d33ca-a7fd-48d0-b738-45c251964de8)

![image](https://github.com/user-attachments/assets/a216ad54-b404-4e59-bf98-83eb624d929e)
