### PR TITLE
Add OAuth provider (Auth0) logout url to error template

### DIFF
--- a/panel/_templates/error.html
+++ b/panel/_templates/error.html
@@ -63,6 +63,7 @@
       .error-message {
         max-width: 80%;
         padding-bottom: 10%;
+        text-align: center;
       }
       {% block extra_style %}{% endblock %}
     </style>
@@ -83,6 +84,9 @@
       <section class="error-message">
       {% block content %}
       <h3>{{ error_msg }}</h3>
+      {% if oauth_logout_link %}
+      <a href="{{ oauth_logout_link }}">Logout</a>
+      {% endif %}
       {% endblock %}
       </section>
     </div>


### PR DESCRIPTION
Hi, so this is an initial implementation following the first solution described at https://github.com/holoviz/panel/issues/8017#issue-3203289180. With the changes here you will be able to see a `Logout` link in the error page if you are using Auth0 as OAuth provider:

![imagen](https://github.com/user-attachments/assets/d9270c28-6525-4d32-a301-6ea18afba66b)

## Notes:

From a quick check of the supported OAuth providers, I think the only one that also supports a `logout` URL is Okta: https://developer.okta.com/docs/api/openapi/okta-oauth/oauth/tag/OrgAS/#tag/OrgAS/operation/logout, should support for it added here too? Not completely sure from where the value of `id_token_hint` could be retrieved but if worthy let me know and I will check.

Fixes #8017