### PR TITLE
Update extra dependecy pin for bokeh-fastapi

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,7 @@ recommended = [
     'plotly',
 ]
 fastapi = [
-    'bokeh-fastapi >= 0.1.1',
+    'bokeh-fastapi >= 0.1.2,<0.2.0',
     'fastapi[standard]',
 ]
 dev = [


### PR DESCRIPTION
Should have been updated a while ago, 0.1.1 has issues and 0.2.0 may introduce compatibility changes.