### PR TITLE
fix echarts this.mouse

### DIFF
--- a/panel/models/event-to-object.ts
+++ b/panel/models/event-to-object.ts
@@ -272,6 +272,7 @@ const eventTransformCategories: any = new EventTransformCategories()
 
 Object.keys(eventTypeCategories).forEach((category) => {
   eventTypeCategories[category].forEach((type: any) => {
-    eventTransforms[type] = eventTransformCategories[category]
+    // Bind the method to the eventTransformCategories instance to ensure correct 'this'
+    eventTransforms[type] = eventTransformCategories[category].bind(eventTransformCategories)
   })
 })


### PR DESCRIPTION
Closing #7889

I don't fully understand the fix from GPT 4.1. But its simple and the Echarts events works for me in both edge and firefox after the change.

https://github.com/user-attachments/assets/918a140b-6546-429a-a3e1-d7c9ca835967

## GPT 4.1 explanation

The error described in #fetch (TypeError: this.mouse is not a function at Object.pointer) occurs when handling mouse events like mouseover in ECharts, specifically in Edge (but not Firefox).

Looking at echarts.ts, mouse events are handled by the EChartsView._subscribe() method. For each event in event_config, it attaches a callback that serializes the event using serializeEvent:

The error trace points to a problem inside serializeEvent, specifically when it tries to call this.mouse. In event-to-object.ts, there is a class EventTransformCategories with a mouse method, but the context (this) may be lost if the method is called incorrectly (e.g., as a plain function instead of a method).

Root cause:
If EventTransformCategories.mouse is called without binding to an instance, this is undefined, so this.mouse fails. This can happen if the code does something like elementTransformCategories[category](event)category instead of elementTransformCategories.mouse.call(instance, event).

Why Edge but not Firefox?
Edge may be stricter about this binding in certain contexts, or the event object structure may differ, triggering the bug only in Edge.

How to fix:
Ensure that all methods in EventTransformCategories are called with the correct this context, e.g., by using .call(instance, event) or converting them to static methods if they don't rely on instance state.

Summary:
The bug is caused by incorrect method binding in the event serialization logic, leading to this.mouse is not a function when handling mouse events in Edge. Fix the binding in serializeEvent to resolve the issue.

EChartsView
serializeEvent
EventTransformCategories
Similar code found with 1 license type - V