### PR TITLE
Add missing doc docstrings

### DIFF
--- a/examples/reference/panes/Vega.ipynb
+++ b/examples/reference/panes/Vega.ipynb
@@ -25,7 +25,7 @@
     "* **``debounce``** (int or dict): The debounce timeout to apply to selection events, either specified as a single integer value (in milliseconds) or a dictionary that declares a debounce value per event. Debouncing ensures that events are only dispatched N milliseconds after a user is done interacting with the plot.\n",
     "* **``object``** (dict or altair Chart): Either a dictionary containing a Vega or Vega-Lite plot specification, or an Altair Chart.\n",
     "* **``show_actions``** (boolean): Whether to show the chart actions menu, such as save, edit, etc.\n",
-    "* **``theme``** (str): A theme to apply to the plot. Must be one of 'excel', 'ggplot2', 'quartz', 'vox', 'fivethirtyeight', 'dark', 'latimes', 'urbaninstitute', or 'googlecharts'.\n",
+    "* **``theme``** (str): A theme to apply to the plot. Must be one of 'excel', 'ggplot2', 'quartz', 'vox', 'fivethirtyeight', 'dark', 'latimes', 'urbaninstitute', 'googlecharts', 'powerbi', 'carbonwhite', 'carbong10', 'carbong90', or 'carbong100'.\n",
     "\n",
     "Readonly parameters:\n",
     "\n",

--- a/panel/chat/icon.py
+++ b/panel/chat/icon.py
@@ -54,7 +54,8 @@ class ChatReactionIcons(CompositeWidget):
     value = param.List(default=[], doc="The active reactions.")
 
     default_layout = param.ClassSelector(
-        default=Column, class_=Panel, is_instance=False)
+        default=Column, class_=Panel, is_instance=False, doc="""
+        The layout to use for the icons. Defaults to Column, which stacks the icons vertically.""")
 
     _stylesheets: ClassVar[list[str]] = [f"{CDN_DIST}css/chat_reaction_icons.css"]
 

--- a/panel/chat/step.py
+++ b/panel/chat/step.py
@@ -81,7 +81,7 @@ class ChatStep(Card):
         Title to display when status is running.""")
 
     status = param.Selector(default="pending", objects=[
-        "pending", "running", "success", "failed"])
+        "pending", "running", "success", "failed"], doc="""The status of the chat step.""")
 
     success_title = param.String(default=None, doc="""
         Title to display when status is success.""")

--- a/panel/interact.py
+++ b/panel/interact.py
@@ -69,7 +69,9 @@ class interactive(Pane):
     manual_update = param.Boolean(default=False, doc="""
         Whether to update manually by clicking on button.""")
 
-    manual_name = param.String(default='Run Interact')
+    manual_name = param.String(default='Run Interact', doc="""
+        The name of the button to run the interact function manually.
+        Only used if manual_update is True.""")
 
     _pane = param.ClassSelector(class_=Viewable)
 

--- a/panel/io/notifications.py
+++ b/panel/io/notifications.py
@@ -58,12 +58,14 @@ class NotificationAreaBase(param.Parameterized):
     max_notifications = param.Integer(default=5, doc="""
         The maximum number of notifications to display at once.""")
 
-    notifications = param.List(item_type=Notification)
+    notifications = param.List(item_type=Notification, doc="""
+        A list of notifications to display in the notification area.""")
 
     position = param.Selector(default='bottom-right', objects=[
         'bottom-right', 'bottom-left', 'bottom-center', 'top-left',
         'top-right', 'top-center', 'center-center', 'center-left',
-        'center-right'])
+        'center-right'], doc="""
+        Position of the notification area on the screen (e.g., 'top-right', 'bottom-left').""")
 
     __abstract = True
 
@@ -126,7 +128,14 @@ class NotificationArea(NotificationAreaBase, ReactiveHTML):
              'color': 'white'
          }
         },
-    ])
+    ], doc="""
+        A list of notification types, each defined by a dictionary with keys:
+        - 'type': The type of notification (e.g., 'info', 'warning').
+        - 'background': The background color of the notification.
+        - 'icon': An icon configuration dictionary with keys:
+            - 'className': The CSS class for the icon.
+            - 'tagName': The HTML tag for the icon.
+            - 'color': The color of the icon.""")
 
     __javascript_raw__ = [f"{config.npm_cdn}/notyf@3/notyf.min.js"]
 

--- a/panel/models/vega.py
+++ b/panel/models/vega.py
@@ -17,10 +17,8 @@ from ..io.resources import bundled_files
 from ..util import classproperty
 
 VegaThemeType = Literal[
-    'excel', 'ggplot2', 'quartz', 'vox',
-    'fivethirtyeight', 'dark', 'latimes',
-    'urbaninstitute', 'googlecharts'
-]
+        'excel', 'ggplot2', 'quartz', 'vox', 'fivethirtyeight', 'dark',
+        'latimes', 'urbaninstitute', 'googlecharts', 'powerbi', 'carbonwhite', 'carbong10', 'carbong90', 'carbong100']
 VegaTheme = enumeration(VegaThemeType)
 
 class VegaEvent(ModelEvent):

--- a/panel/pane/alert.py
+++ b/panel/pane/alert.py
@@ -31,7 +31,8 @@ class Alert(Markdown):
     >>> Alert('Some important message', alert_type='warning')
     """
 
-    alert_type = param.Selector(default="primary", objects=ALERT_TYPES)
+    alert_type = param.Selector(default="primary", objects=ALERT_TYPES, doc="""
+        The type of alert to display, which determines the styling and icon.""")
 
     priority: ClassVar[float | bool | None] = 0
 

--- a/panel/pane/plot.py
+++ b/panel/pane/plot.py
@@ -400,7 +400,8 @@ class RGGPlot(PNG):
 
     width = param.Integer(default=400)
 
-    dpi = param.Integer(default=144, bounds=(1, None))
+    dpi = param.Integer(default=144, bounds=(1, None), doc="""
+        Scales the dpi of the ggplot figure.""")
 
     _rerender_params = PNG._rerender_params + ['object', 'dpi', 'width', 'height']
 

--- a/panel/pane/vega.py
+++ b/panel/pane/vega.py
@@ -161,7 +161,8 @@ class Vega(ModelPane):
 
     theme = param.Selector(default=None, allow_None=True, objects=[
         'excel', 'ggplot2', 'quartz', 'vox', 'fivethirtyeight', 'dark',
-        'latimes', 'urbaninstitute', 'googlecharts'])
+        'latimes', 'urbaninstitute', 'googlecharts', 'powerbi', 'carbonwhite', 'carbong10', 'carbong90', 'carbong100'], doc="""
+        The Vega theme to apply to the plot. If None, no theme is applied.""")
 
     priority: ClassVar[float | bool | None] = 0.8
 

--- a/panel/pane/vtk/vtk.py
+++ b/panel/pane/vtk/vtk.py
@@ -70,7 +70,9 @@ class AbstractVTK(Pane):
     orientation_widget = param.Boolean(default=False, doc="""
       Activate/Deactivate the orientation widget display.""")
 
-    interactive_orientation_widget = param.Boolean(default=True, constant=True)
+    interactive_orientation_widget = param.Boolean(default=True, constant=True, doc="""
+        If True, the orientation widget will be interactive and allow
+        to change the camera orientation by dragging it.""")
 
     __abstract = True
 
@@ -595,7 +597,9 @@ class VTKVolume(AbstractVTK):
     nan_opacity = param.Number(default=1., bounds=(0., 1.), doc="""
         Opacity applied to nan values in slices""")
 
-    origin = param.Tuple(default=None, length=3, allow_None=True)
+    origin = param.Tuple(default=None, length=3, allow_None=True, doc="""
+        Origin of the volume in the scene coordinates.
+        If None, the origin is set to (0, 0, 0)""")
 
     render_background = param.Color(default='#52576e', doc="""
         Allows to specify the background color of the 3D rendering.

--- a/panel/template/base.py
+++ b/panel/template/base.py
@@ -572,9 +572,13 @@ class TemplateActions(ReactiveHTML):
     as opening and closing a modal.
     """
 
-    open_modal = param.Integer(default=0)
+    open_modal = param.Integer(default=0, doc="""
+        The number of times the open modal action has been triggered.
+        This is used to trigger the open modal script.""")
 
-    close_modal = param.Integer(default=0)
+    close_modal = param.Integer(default=0, doc="""
+        The number of times the close modal action has been triggered.
+        This is used to trigger the close modal script.""")
 
     _template: ClassVar[str] = ""
 

--- a/panel/template/editable/__init__.py
+++ b/panel/template/editable/__init__.py
@@ -28,7 +28,11 @@ class TemplateEditor(ReactiveHTML):
     the current layout state with Python.
     """
 
-    layout = param.List()
+    layout = param.List(doc="""
+        The current layout of the template, which is updated by the editor.
+        It is a list of dictionaries with the keys 'id', 'width', 'height', and 'visible'.
+        The 'id' corresponds to the component's model id, while 'width' and 'height'
+        are in percentage of the grid cell size.""")
 
     _scripts = {
         'render': """

--- a/panel/tests/test_docstrings.py
+++ b/panel/tests/test_docstrings.py
@@ -1,0 +1,54 @@
+import pytest
+
+from panel.viewable import Viewable
+
+
+## Find child classes of MaterialComponent
+def find_child_classes(cls):
+    """
+    Recursively find all child classes of MaterialComponent.
+    """
+    child_classes = []
+    for subclass in cls.__subclasses__():
+        child_classes.append(subclass)
+        child_classes.extend(find_child_classes(subclass))
+    return child_classes
+
+def find_topmost_defining_class(cls, param_name):
+    """
+    Find the topmost parent class in the MRO that defines the parameter.
+    Parameters
+    ----------
+    cls : type
+        The class to start searching from.
+    param_name : str
+        The name of the parameter to search for.
+    Returns
+    -------
+    type
+        The topmost parent class that defines the parameter.
+    """
+    for base in reversed(cls.mro()):
+        if hasattr(base, 'param') and param_name in getattr(base, 'param', {}):
+            return base
+    return cls
+
+child_classes = find_child_classes(Viewable)
+
+@pytest.mark.parametrize("child_class", child_classes)
+def test_component_parameters_have_doc_attributes_set(child_class):
+    """Test to ensure all parameters in component subclasses have docstrings set.
+    Prints the topmost parent class that defines the parameter if missing docstring.
+    """
+
+    for name in child_class.param:
+        if name.startswith('_'):
+            continue
+        parameter = child_class.param[name]
+        if not parameter.doc:
+            topmost_class = find_topmost_defining_class(child_class, name)
+            message = (
+                f"Parameter '{name}' in class '{topmost_class.__module__}.{topmost_class.__name__}' "
+                "has no `doc` string."
+            )
+            raise AssertionError(message)

--- a/panel/theme/fast.py
+++ b/panel/theme/fast.py
@@ -139,9 +139,11 @@ class FastWrapper(ReactiveHTML):
     using the Fast design system have access to the Fast CSS variables.
     """
 
-    object = Child()
+    object = Child(doc="""
+        The Panel component to wrap with the Fast design provider.""")
 
-    style = param.ClassSelector(class_=FastStyle)
+    style = param.ClassSelector(class_=FastStyle, doc="""
+        The style to apply to the Fast design provider""")
 
     _template = '<div id="fast-wrapper" class="fast-wrapper">${object}</div>'
 

--- a/panel/widgets/debugger.py
+++ b/panel/widgets/debugger.py
@@ -107,11 +107,14 @@ class CheckFilter(logging.Filter):
 
 class DebuggerButtons(ReactiveHTML):
 
-    terminal_output = param.String()
+    terminal_output = param.String(doc="""
+        The output of the terminal, which is updated by the debugger widget.""")
 
-    debug_name = param.String()
+    debug_name = param.String(doc="""
+        The name of the debugger, used to save the terminal output to a file.""")
 
-    clears = param.Integer(default=0)
+    clears = param.Integer(default=0, doc="""
+        The number of times the terminal has been cleared.""")
 
     _template: ClassVar[str] = """
     <div style="display: flex;">

--- a/panel/widgets/indicators.py
+++ b/panel/widgets/indicators.py
@@ -202,11 +202,13 @@ class LoadingSpinner(BooleanIndicator):
     >>> LoadingSpinner(value=True, color='primary', bgcolor='light', width=100, height=100)
     """
 
-    bgcolor = param.Selector(default='light', objects=['dark', 'light'])
+    bgcolor = param.Selector(default='light', objects=['dark', 'light'], doc="""
+        The background color of the spinner, one of 'dark', 'light'.""")
 
     color = param.Selector(default='dark', objects=[
         'primary', 'secondary', 'success', 'info', 'danger', 'warning',
-        'light', 'dark'])
+        'light', 'dark'], doc="""
+        The color of the spinner.""")
 
     size = param.Integer(default=125, doc="""
         Size of the spinner in pixels.""")
@@ -285,7 +287,8 @@ class Progress(ValueIndicator):
 
     bar_color = param.Selector(default='success', objects=[
         'primary', 'secondary', 'success', 'info', 'danger', 'warning',
-        'light', 'dark'])
+        'light', 'dark'], doc="""
+        The color of the progress bar.""")
 
     max = param.Integer(default=100, doc="The maximum value of the progress bar.")
 
@@ -1119,7 +1122,9 @@ class Trend(SyncableData, Indicator):
     data = param.Parameter(doc="""
       The plot data declared as a dictionary of arrays or a DataFrame.""")
 
-    layout = param.Selector(default="column", objects=["column", "row"])
+    layout = param.Selector(default="column", objects=["column", "row"], doc="""
+        The layout of the indicator, either a column (text and plot on top of each other)
+        or a row (text and plot after each other).""")
 
     plot_x = param.String(default="x", doc="""
       The name of the key in the plot_data to use on the x-axis.""")

--- a/panel/widgets/input.py
+++ b/panel/widgets/input.py
@@ -504,9 +504,11 @@ class DatePicker(Widget):
     end = param.CalendarDate(default=None, doc="""
         Inclusive upper bound of the allowed date selection""")
 
-    disabled_dates = param.List(default=None, item_type=(date, str))
+    disabled_dates = param.List(default=None, item_type=(date, str), doc="""
+        Dates to make unavailable for selection.""")
 
-    enabled_dates = param.List(default=None, item_type=(date, str))
+    enabled_dates = param.List(default=None, item_type=(date, str), doc="""
+        Dates to make available for selection.""")
 
     width = param.Integer(default=300, allow_None=True, doc="""
       Width of this component. If sizing_mode is set to stretch
@@ -573,9 +575,11 @@ class DateRangePicker(Widget):
     end = param.CalendarDate(default=None, doc="""
         Inclusive upper bound of the allowed date selection""")
 
-    disabled_dates = param.List(default=None, item_type=(date, str))
+    disabled_dates = param.List(default=None, item_type=(date, str), doc="""
+        Dates to make unavailable for selection.""")
 
-    enabled_dates = param.List(default=None, item_type=(date, str))
+    enabled_dates = param.List(default=None, item_type=(date, str), doc="""
+        Dates to make available for selection.""")
 
     width = param.Integer(default=300, allow_None=True, doc="""
       Width of this component. If sizing_mode is set to stretch
@@ -764,7 +768,8 @@ class DatetimePicker(_DatetimePickerBase):
 
     value = param.Date(default=None)
 
-    mode = param.String('single', constant=True)
+    mode = param.String('single', constant=True, doc="""
+        The mode of the datetime picker, which is always 'single' for this widget.""")
 
     def _serialize_value(self, value):
         if isinstance(value, str) and value:
@@ -799,7 +804,8 @@ class DatetimeRangePicker(_DatetimePickerBase):
     value = param.DateRange(default=None, doc="""
         The current value""")
 
-    mode = param.String('range', constant=True)
+    mode = param.String('range', constant=True, doc="""
+        The mode of the datetime picker, which is always 'range' for this widget.""")
 
     def _serialize_value(self, value):
         if isinstance(value, str) and value:
@@ -1158,7 +1164,7 @@ class LiteralInput(Widget):
     """)
 
     type = param.ClassSelector(default=None, class_=(type, tuple),
-                               is_instance=True)
+                               is_instance=True, doc="The type of input for the literal input widget.")
 
     value = param.Parameter(default=None)
 

--- a/panel/widgets/misc.py
+++ b/panel/widgets/misc.py
@@ -119,7 +119,7 @@ class FileDownload(IconMixin):
     description = param.String(default=None, doc="""
         An HTML string describing the function of this component.""")
 
-    _clicks = param.Integer(default=0)
+    _clicks = param.Integer(default=0, doc="Internal counter for button clicks.")
 
     _transfers = param.Integer(default=0)
 

--- a/panel/widgets/select.py
+++ b/panel/widgets/select.py
@@ -49,7 +49,7 @@ if TYPE_CHECKING:
 
 class SelectBase(Widget):
 
-    options = param.ClassSelector(default=[], class_=(dict, list))
+    options = param.ClassSelector(default=[], class_=(dict, list), doc="List or dict of selectable options.")
 
     __abstract = True
 
@@ -177,7 +177,7 @@ class Select(SingleSelectBase):
     """
 
     description = param.String(default=None, doc="""
-        An HTML string describing the function of this component.""")
+        A description of the widget, which will be displayed as a tooltip.""")
 
     disabled_options = param.List(default=[], nested_refs=True, doc="""
         Optional list of ``options`` that are disabled, i.e. unusable and

--- a/panel/widgets/slider.py
+++ b/panel/widgets/slider.py
@@ -46,7 +46,10 @@ if TYPE_CHECKING:
 
 class _SliderBase(Widget):
 
-    bar_color = param.Color(default="#e6e6e6", doc="""""")
+    bar_color = param.Color(default="#e6e6e6", doc="""
+        The color of the slider bar. Accepts any valid CSS color string.
+        Default is '#e6e6e6'.
+        """)
 
     direction = param.Selector(default='ltr', objects=['ltr', 'rtl'], doc="""
         Whether the slider should go from left-to-right ('ltr') or

--- a/panel/widgets/tables.py
+++ b/panel/widgets/tables.py
@@ -1198,13 +1198,23 @@ class Tabulator(BaseTable):
 
     layout = param.Selector(default='fit_data_table', objects=[
         'fit_data', 'fit_data_fill', 'fit_data_stretch', 'fit_data_table',
-        'fit_columns'])
+        'fit_columns'], doc="Describes the column layout mode")
 
     initial_page_size = param.Integer(default=20, bounds=(1, None), doc="""
         Initial page size if page_size is None and therefore automatically set.""")
 
     pagination = param.Selector(default=None, allow_None=True,
-                                      objects=['local', 'remote'])
+                                      objects=['local', 'remote'], doc="""
+        Defines the pagination mode of the Tabulator.
+
+          - None
+              No pagination is applied, all rows are rendered.
+          - 'local' (client-side)
+              Pagination is applied locally, i.e. the entire DataFrame
+              is loaded and then paginated.
+          - 'remote' (server-side)
+              Pagination is applied remotely, i.e. only the current page
+              is loaded from the server.""")
 
     page = param.Integer(default=1, doc="""
         Currently selected page (indexed starting at 1), if pagination is enabled.""")


### PR DESCRIPTION
Adds missing `doc` attribute values.

I also discovered the Vega `theme` list was not up to date. The new list was tested manually by scrolling through

```python
import panel as pn

pn.extension("vega")

vega_lite_plot = {
  "$schema": "https://vega.github.io/schema/vega-lite/v5.json",
  "data": {"url": "https://raw.githubusercontent.com/vega/vega/master/docs/data/barley.json"},
  "mark": "bar",
  "encoding": {
    "x": {"aggregate": "sum", "field": "yield", "type": "quantitative"},
    "y": {"field": "variety", "type": "nominal"},
    "color": {"field": "site", "type": "nominal"}
  }
}

vega_pane = pn.pane.Vega(vega_lite_plot, sizing_mode="stretch_width", height=400)
pn.Column(
    "# Vega-Lite Example",
    "This is a simple bar chart created using Vega-Lite.",
    vega_pane, vega_pane.param.theme,
    sizing_mode="stretch_width",
).servable()
```