### PR TITLE
Improve .from_param error message

### DIFF
--- a/panel/tests/widgets/test_base.py
+++ b/panel/tests/widgets/test_base.py
@@ -197,3 +197,13 @@ def test_widget_from_param_instance_with_kwargs():
 
     widget.value = 4.3
     assert test.a == 4.3
+
+
+def test_infer_params_attribute_error():
+    class MyComponent(param.Parameterized):
+        name = param.String(default='World', doc="Name to greet")
+
+    with pytest.raises(ValueError) as excinfo:
+        TextInput.from_param(MyComponent.name, name='Name Input')
+
+    assert str(excinfo.value) == "The parameter provided is not of type <class 'Parameter'>. Its of type <class 'str'>."

--- a/panel/tests/widgets/test_base.py
+++ b/panel/tests/widgets/test_base.py
@@ -206,4 +206,4 @@ def test_infer_params_attribute_error():
     with pytest.raises(ValueError) as excinfo:
         TextInput.from_param(MyComponent.name, name='Name Input')
 
-    assert str(excinfo.value) == "The parameter provided is not of type <class 'Parameter'>. Its of type <class 'str'>."
+    assert str(excinfo.value) == "TextInput.from_param only accepts Parameter types, provided value is of type <class 'str'>."

--- a/panel/widgets/base.py
+++ b/panel/widgets/base.py
@@ -64,13 +64,9 @@ class WidgetBase(param.Parameterized):
         Widget instance linked to the supplied parameter
         """
         from ..param import Param
-        try:
-            return Param.widget(parameter.name, parameter.owner, dict(type=cls, **params))
-        except AttributeError as e:
-            if not isinstance(parameter, param.Parameter):
-                raise ValueError(f"The parameter provided is not of type <class 'Parameter'>. Its of type {type(parameter)}.") from e
-            raise
-
+        if not isinstance(parameter, param.Parameter):
+            raise ValueError(f"{cls.__name__}.from_param only accepts Parameter types, provided value is of type {type(parameter)}.")
+        return Param.widget(parameter.name, parameter.owner, dict(type=cls, **params))
 
     @classmethod
     def _infer_params(cls, values, **params):

--- a/panel/widgets/base.py
+++ b/panel/widgets/base.py
@@ -64,7 +64,13 @@ class WidgetBase(param.Parameterized):
         Widget instance linked to the supplied parameter
         """
         from ..param import Param
-        return Param.widget(parameter.name, parameter.owner, dict(type=cls, **params))
+        try:
+            return Param.widget(parameter.name, parameter.owner, dict(type=cls, **params))
+        except AttributeError as e:
+            if not isinstance(parameter, param.Parameter):
+                raise ValueError(f"The parameter provided is not of type <class 'Parameter'>. Its of type {type(parameter)}.") from e
+            raise
+
 
     @classmethod
     def _infer_params(cls, values, **params):


### PR DESCRIPTION
When running

```python
import panel as pn
import param

pn.extension()

class MyComponent(param.Parameterized):
    name = param.String(default='World', doc="Name to greet")
    
pn.widgets.TextInput.from_param(MyComponent.name, name='Name Input')
```

I see the error message

```bash
Traceback (most recent call last):
  File "/home/jovyan/repos/private/panel/script.py", line 9, in <module>
    pn.widgets.TextInput.from_param(MyComponent.name, name='Name Input')
  File "/home/jovyan/repos/private/panel/panel/widgets/input.py", line 92, in from_param
    return super().from_param(parameter, **params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jovyan/repos/private/panel/panel/widgets/base.py", line 67, in from_param
    return Param.widget(parameter.name, parameter.owner, dict(type=cls, **params))
                        ^^^^^^^^^^^^^^
AttributeError: 'str' object has no attribute 'name'
```

I've been in doubt about this error message so many times.

This PR attempts to provide a more easily understandable error message

```bash
Traceback (most recent call last):
  File "/home/jovyan/repos/private/panel/panel/widgets/base.py", line 68, in from_param
    return Param.widget(parameter.name, parameter.owner, dict(type=cls, **params))
                        ^^^^^^^^^^^^^^
AttributeError: 'str' object has no attribute 'name'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/jovyan/repos/private/panel/script.py", line 9, in <module>
    pn.widgets.TextInput.from_param(MyComponent.name, name='Name Input')
  File "/home/jovyan/repos/private/panel/panel/widgets/input.py", line 92, in from_param
    return super().from_param(parameter, **params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jovyan/repos/private/panel/panel/widgets/base.py", line 71, in from_param
    raise ValueError(f"The parameter provided is not of type <class 'Parameter'>. Its of type {type(parameter)}.") from e
ValueError: The parameter provided is not of type <class 'Parameter'>. Its of type <class 'str'>.
```