### PR TITLE
Fix XSS vulnerabilities in authentication templates

### DIFF
--- a/panel/_templates/basic_login.html
+++ b/panel/_templates/basic_login.html
@@ -84,7 +84,7 @@
         <p> Login to access your application</p>
       </div>
       <div id="error-message" class="form-group">
-        <p style="color:rgb(255, 0, 0);font-weight:bold" class="errormessage">{{errormessage}}</p>
+        <p style="color:rgb(255, 0, 0);font-weight:bold" class="errormessage">{{errormessage|escape}}</p>
       </div>
       <p></p>
       <!--Email Input-->

--- a/panel/_templates/error.html
+++ b/panel/_templates/error.html
@@ -83,7 +83,7 @@
     <div class="content">
       <section class="error-message">
       {% block content %}
-      <h3>{{ error_msg }}</h3>
+      <h3>{{ error_msg|escape }}</h3>
       {% if oauth_logout_link %}
       <a href="{{ oauth_logout_link }}">Logout</a>
       {% endif %}


### PR DESCRIPTION
- Add |escape filter to error_msg in error.html template
- Add |escape filter to errormessage in basic_login.html template

These variables can contain user-controlled input that was being rendered without HTML escaping, allowing XSS attacks through malformed URLs like: http://localhost:5006/login?next=%FF%FE%3C%73%63%72%69%70%74%3E%61%6C%65%72%74%28%32%30%33%29%3C%2F%73%63%72%69%70%74%3E

Fixes: holoviz/panel#8016