### PR TITLE
Fix cleanup of callbacks when using --reuse_sessions

### DIFF
--- a/panel/io/document.py
+++ b/panel/io/document.py
@@ -103,6 +103,8 @@ def _cleanup_doc(doc, destroy=True):
             pass
     if not destroy:
         doc.callbacks._change_callbacks.clear()
+    elif None not in doc.callbacks._change_callbacks:
+        doc.callbacks._change_callbacks[None] = lambda e: e
 
     # Remove views
     from ..viewable import Viewable

--- a/panel/io/document.py
+++ b/panel/io/document.py
@@ -102,7 +102,10 @@ def _cleanup_doc(doc, destroy=True):
         except Exception:
             pass
     if hasattr(doc.callbacks, '_change_callbacks'):
-        doc.callbacks._change_callbacks.clear()
+        if None in doc.callbacks._change_callbacks:
+            doc.callbacks._change_callbacks[None] = lambda event: event
+        else:
+            doc.callbacks._change_callbacks.clear()
 
     # Remove views
     from ..viewable import Viewable

--- a/panel/io/document.py
+++ b/panel/io/document.py
@@ -101,11 +101,8 @@ def _cleanup_doc(doc, destroy=True):
             callback(None)
         except Exception:
             pass
-    if hasattr(doc.callbacks, '_change_callbacks'):
-        if None in doc.callbacks._change_callbacks:
-            doc.callbacks._change_callbacks[None] = lambda event: event
-        else:
-            doc.callbacks._change_callbacks.clear()
+    if not destroy:
+        doc.callbacks._change_callbacks.clear()
 
     # Remove views
     from ..viewable import Viewable

--- a/panel/io/document.py
+++ b/panel/io/document.py
@@ -102,7 +102,7 @@ def _cleanup_doc(doc, destroy=True):
         except Exception:
             pass
     if hasattr(doc.callbacks, '_change_callbacks'):
-        doc.callbacks._change_callbacks[None] = {}
+        doc.callbacks._change_callbacks.clear()
 
     # Remove views
     from ..viewable import Viewable

--- a/panel/tests/util.py
+++ b/panel/tests/util.py
@@ -422,7 +422,7 @@ def wait_for_regex(stdout, regex, count=1, return_output=False):
         nbsr = NBSR(stdout)
     m = None
     output, found = [], []
-    for _ in range(20):
+    for _ in range(30):
         o = nbsr.readline(0.5)
         if not o:
             continue


### PR DESCRIPTION
This was causing issues because `_change_callbacks` is not nested so the provided dictionary was treated as a callback.