### PR TITLE
Disable Tabulator internal auto-resize

### DIFF
--- a/panel/models/tabulator.ts
+++ b/panel/models/tabulator.ts
@@ -393,7 +393,7 @@ export class DataTabulatorView extends HTMLBoxView {
   override connect_signals(): void {
     super.connect_signals()
 
-    this._debounced_redraw = debounce(() => this._resize_redraw(), 20, false)
+    this._debounced_redraw = debounce(() => this._resize_redraw(), 50, false)
     const {
       configuration, layout, columns, groupby, visible, download,
       children, expanded, cell_styles, hidden_columns, page_size,
@@ -815,6 +815,7 @@ export class DataTabulatorView extends HTMLBoxView {
       ...this.model.configuration,
       index: "_index",
       nestedFieldSeparator: false,
+      autoResize: false,
       movableColumns: false,
       selectableRows,
       columns: this.getColumns(),


### PR DESCRIPTION
`Tabulator.js` by default enables various resize observers that re-render when the container or the page is resized. These potentially trigger multiple times in an resize event which can be very slow for large tables. In Bokeh/Panel we already handle resize events via the `after_resize` method on each model, so Tabulator is resized 2-3x on a window resize event because both our resize handling and the automatic resize handling that Tabulator installs is enabled.

#### Before

![tabulator_resize_before](https://github.com/user-attachments/assets/fe6cdd31-8b04-401f-b098-f6835151d563)

#### After

![table_resize_after](https://github.com/user-attachments/assets/d13bf2e7-33b1-4325-a868-f7ee6b135854)

