### PR TITLE
Add guard in case ImportedStyleSheet.url is undefined

### DIFF
--- a/panel/io/resources.py
+++ b/panel/io/resources.py
@@ -282,7 +282,10 @@ def component_resource_path(component, attr, path):
     return f'{component_path}{component.__module__}/{component.__name__}/{attr}/{rel_path}'
 
 def patch_stylesheet(stylesheet, dist_url):
-    url = stylesheet.url
+    try:
+        url = stylesheet.url
+    except Exception:
+        return
     if url.startswith(CDN_DIST+dist_url) and dist_url != CDN_DIST:
         patched_url = url.replace(CDN_DIST+dist_url, dist_url)
     elif url.startswith(CDN_DIST) and dist_url != CDN_DIST:

--- a/panel/pane/base.py
+++ b/panel/pane/base.py
@@ -570,7 +570,7 @@ class ModelPane(Pane):
         if self._bokeh_model is not None and 'stylesheets' in params:
             css = getattr(self._bokeh_model, '__css__', [])
             params['stylesheets'] = [
-                ImportedStyleSheet(url=ss) for ss in css
+                ImportedStyleSheet(url=ss) for ss in css if ss
             ] + params['stylesheets']
         return super()._process_param_change(params)
 

--- a/panel/reactive.py
+++ b/panel/reactive.py
@@ -229,6 +229,8 @@ class Syncable(Renderable):
             else:
                 css_cache = {}
             for stylesheet in stylesheets:
+                if not stylesheet:
+                    continue
                 if isinstance(stylesheet, str) and (stylesheet.split('?')[0].endswith('.css') or stylesheet.startswith('http')):
                     if stylesheet in css_cache:
                         conv_stylesheet = css_cache[stylesheet]
@@ -1605,7 +1607,7 @@ class ReactiveCustomBase(Reactive):
                     for ss in css
                 ]
             props['stylesheets'] = [
-                ImportedStyleSheet(url=ss) for ss in css
+                ImportedStyleSheet(url=ss) for ss in css if ss
             ] + props['stylesheets']
         return props
 
@@ -1884,7 +1886,7 @@ class ReactiveHTML(ReactiveCustomBase, metaclass=ReactiveHTMLMetaclass):
                     for ss in css
                 ]
             props['stylesheets'] = [
-                ImportedStyleSheet(url=ss) for ss in css
+                ImportedStyleSheet(url=ss) for ss in css if ss
             ] + props['stylesheets']
         return props
 

--- a/panel/widgets/tables.py
+++ b/panel/widgets/tables.py
@@ -1856,9 +1856,10 @@ class Tabulator(BaseTable):
     def _process_param_change(self, params):
         if 'theme' in params or 'stylesheets' in params:
             theme_url = self._get_theme(params.pop('theme', self.theme))
-            params['stylesheets'] = params.get('stylesheets', self.stylesheets) + [
-                ImportedStyleSheet(url=theme_url)
-            ]
+            if theme_url:
+                params['stylesheets'] = params.get('stylesheets', self.stylesheets) + [
+                    ImportedStyleSheet(url=theme_url)
+                ]
         params = Reactive._process_param_change(self, params)
         if 'disabled' in params:
             params['editable'] = not params.pop('disabled') and len(self.indexes) <= 1


### PR DESCRIPTION
I still haven't quite been able to track down when and why this happens but this adds a few guards to ensure that we don't error due to an empty stylesheet.