### PR TITLE
Ensure --reuse-sessions caches --index app

### DIFF
--- a/panel/command/serve.py
+++ b/panel/command/serve.py
@@ -325,7 +325,7 @@ class Serve(_BkServe):
                 applications['/'] = applications[f'/{index}']
         return super().customize_applications(args, applications)
 
-    def warm_applications(self, applications, reuse_sessions, error=True, initialize_session=True):
+    def warm_applications(self, applications, reuse_sessions, error=True, initialize_session=True, index=None):
         from ..io.session import generate_session
         for path, app in applications.items():
             try:
@@ -341,6 +341,10 @@ class Serve(_BkServe):
                 else:
                     state._session_key_funcs[path] = lambda r: r.path
                     state._sessions[path] = session
+                    if index and index.endswith('.py'):
+                        index_path, _ = os.path.splitext(os.path.basename(index))
+                        if path == f'/{index_path}':
+                            state._sessions['/'] = session
                     session.block_expiration()
                 state._on_load(None)
             _cleanup_doc(session.document, destroy=not reuse_sessions)
@@ -453,10 +457,10 @@ class Serve(_BkServe):
             if config.autoreload:
                 with record_modules(list(applications.values())):
                     self.warm_applications(
-                        applications, args.reuse_sessions, error=False, initialize_session=initialize_session
+                        applications, args.reuse_sessions, error=False, initialize_session=initialize_session, index=kwargs['index']
                     )
             else:
-                self.warm_applications(applications, args.reuse_sessions, initialize_session=initialize_session)
+                self.warm_applications(applications, args.reuse_sessions, initialize_session=initialize_session, index=kwargs['index'])
 
         # Disable Tornado's autoreload
         if args.dev:


### PR DESCRIPTION
When initializing an --index app we should cache the session if --reuse-sessions is enabled.