### PR TITLE
Fix menu parameter on the JSONEditor widget

### DIFF
--- a/panel/models/jsoneditor.ts
+++ b/panel/models/jsoneditor.ts
@@ -33,7 +33,7 @@ export class JSONEditorView extends HTMLBoxView {
       this.editor.options.templates = this.model.templates
     })
     this.on_change([menu], () => {
-      this.editor.options.menu = this.model.menu
+      this.editor.options.mainMenuBar = this.model.menu
     })
     this.on_change([search], () => {
       this.editor.options.search = this.model.search
@@ -64,7 +64,7 @@ export class JSONEditorView extends HTMLBoxView {
     super.render()
     const mode = this.model.disabled ? "view": this.model.mode
     this.editor = new (window as any).JSONEditor(this.shadow_el, {
-      menu: this.model.menu,
+      mainMenuBar: this.model.menu,
       mode,
       onChangeJSON: (json: any) => {
         this.model.data = json


### PR DESCRIPTION
The JS option is called `mainMenuBar` ([doc](https://github.com/josdejong/jsoneditor/blob/master/docs/api.md)):

<img width="1005" height="87" alt="image" src="https://github.com/user-attachments/assets/72f31e4d-2746-401d-b915-df3b5dbca18a" />
