### PR TITLE
Ensure JSONEditor data changes are propagated when the keys of a dict are reordered

### DIFF
--- a/panel/models/jsoneditor.ts
+++ b/panel/models/jsoneditor.ts
@@ -67,11 +67,11 @@ export class JSONEditorView extends HTMLBoxView {
       menu: this.model.menu,
       mode,
       onChangeJSON: (json: any) => {
-        this.model.data = json
+        this.model.trigger_event(new JSONEditEvent(json))
       },
       onChangeText: (text: any) => {
         try {
-          this.model.data = JSON.parse(text)
+          this.model.trigger_event(new JSONEditEvent(JSON.parse(text)))
         } catch (e) {
           console.warn(e)
         }

--- a/panel/widgets/misc.py
+++ b/panel/widgets/misc.py
@@ -339,4 +339,9 @@ class JSONEditor(Widget):
             "panel.models.jsoneditor", "JSONEditor", isinstance(comm, JupyterComm)
         )
         model = super()._get_model(doc, root, parent, comm)
+        self._register_events('json_edit', model=model, doc=doc, comm=comm)
         return model
+
+    def _process_event(self, event) -> None:
+        if event.event_name == 'json_edit':
+            self.value  = event.data


### PR DESCRIPTION
Noticed that re-ordering the keys of a dict in the JSONEditor was not triggering a `value` change. Turns out this is because in the front-end a Python dict is a JS `Object`, and that when two `Object`s are compared by Bokeh the order of the keys does not matter. I saw in the code that there was an unused `JSONEditEvent`. Not sure why it was added in the first place, maybe to fix that issue 🙃 . Anyway, that's my starting point for now.