### PR TITLE
Do not schedule model updates if document is on hold

### DIFF
--- a/panel/io/document.py
+++ b/panel/io/document.py
@@ -551,7 +551,7 @@ def hold(doc: Document | None = None, policy: HoldPolicyType = 'combine', comm: 
         The Comm to dispatch events on when the context manager exits.
     """
     doc = doc or state.curdoc
-    if doc is None:
+    if doc is None or not state._loaded.get(doc):
         yield
         return
     held = doc.callbacks.hold_value

--- a/panel/io/state.py
+++ b/panel/io/state.py
@@ -303,7 +303,7 @@ class _state(param.Parameterized):
             self._thread_id in (self._current_thread, None) and
             (not (doc and doc.session_context and getattr(doc.session_context, 'session', None))
              or self._loaded.get(doc))
-        )
+        ) or doc.callbacks.hold_value
 
     @param.depends('_busy_counter', watch=True)
     def _update_busy_counter(self):


### PR DESCRIPTION
The `hold` decorator and context manager is an important tool for batching updates, however until now it was less effective than it could have been. Internally in Panel whenever a model update is to be applied we check whether we can safely apply it, i.e. if the socket is unblocked and the event can actually be pushed to the frontend. However, when the document is on hold this check is superfluous because we are not dispatching anything until the document is no longer on hold anyway.

This all has the effect that before despite the fact that we asked for events to be batched before they would actually be scheduled on the async loop and be dispatched separately. This small changes fixes this ensuring that when you ask for an event to be held, it is actually batched together. This should have significant performance implications where `hold` was used.