### PR TITLE
Allow dispatching events as soon as WebSocket connects

### DIFF
--- a/panel/io/document.py
+++ b/panel/io/document.py
@@ -571,7 +571,7 @@ def hold(doc: Document | None = None, policy: HoldPolicyType = 'combine', comm: 
             if comm is not None:
                 from .notebook import push
                 push(doc, comm)
-            if state._loaded.get(doc):
+            if state._connected.get(doc):
                 doc.unhold()
             else:
                 doc.callbacks._hold = None

--- a/panel/io/reload.py
+++ b/panel/io/reload.py
@@ -240,7 +240,7 @@ def _reload(module_paths, changes):
     for doc, loc in state._locations.items():
         if not doc.session_context:
             continue
-        elif state._connected.get(doc):
+        elif state._loaded.get(doc):
             loc.reload = True
         else:
             def reload_session(event, loc=loc):

--- a/panel/io/reload.py
+++ b/panel/io/reload.py
@@ -240,7 +240,7 @@ def _reload(module_paths, changes):
     for doc, loc in state._locations.items():
         if not doc.session_context:
             continue
-        elif state._loaded.get(doc):
+        elif state._connected.get(doc):
             loc.reload = True
         else:
             def reload_session(event, loc=loc):


### PR DESCRIPTION
Previously we waited to dispatch held events until after the app was fully loaded (i.e. all on_load callbacks completed). However there could be race conditions where no events were triggered after the onload callbacks so we would fail to actually send the updates made inside the onload callbacks to the frontend. This PR instead tracks when the WebSocket connects and allows dispatching events immediately thereafter.