### PR TITLE
fix LiteralInput error message

### DIFF
--- a/panel/tests/widgets/test_input.py
+++ b/panel/tests/widgets/test_input.py
@@ -2,6 +2,7 @@ from datetime import date, datetime, time as dt_time
 from pathlib import Path
 
 import numpy as np
+import param
 import pytest
 
 from bokeh.models.widgets import FileInput as BkFileInput
@@ -251,8 +252,7 @@ def test_literal_input_inheritance():
         The `DictInput` allows entering a dictionary value using a text input box.
         """
 
-    DictInput.param.type.default = dict
-
+        type = param.ClassSelector(default=dict, class_=(type, tuple))
 
     with pytest.raises(ValueError) as ex:
         DictInput(value="not a dict")

--- a/panel/tests/widgets/test_input.py
+++ b/panel/tests/widgets/test_input.py
@@ -244,6 +244,21 @@ def test_literal_input(document, comm):
     with pytest.raises(ValueError):
         literal.value = []
 
+def test_literal_input_inheritance():
+    """LiteralInput should be able to be subclassed as done in panel-material-ui."""
+    class DictInput(LiteralInput):
+        """
+        The `DictInput` allows entering a dictionary value using a text input box.
+        """
+
+    DictInput.param.type.default = dict
+
+
+    with pytest.raises(ValueError) as ex:
+        DictInput(value="not a dict")
+
+    assert str(ex.value) == "DictInput expected dict type, but value 'not a dict' is of type str."
+
 def test_static_text(document, comm):
 
     text = StaticText(value='ABC', name='Text:')

--- a/panel/widgets/input.py
+++ b/panel/widgets/input.py
@@ -1194,7 +1194,7 @@ class LiteralInput(Widget):
             if event:
                 self.value = event.old
             types = repr(self.type) if isinstance(self.type, tuple) else self.type.__name__
-            raise ValueError(f'LiteralInput expected {types} type but value {new} '
+            raise ValueError(f'{self.__class__.__name__} expected {types} type, but value \'{new}\' '
                              f'is of type {type(new).__name__}.')
 
     def _process_property_change(self, msg):


### PR DESCRIPTION
The LiteralInput error message was misleading when subclasssed as `DictInput`. This PR fixes the issue.