### PR TITLE
Ensure correct Ace build is bundled

### DIFF
--- a/panel/models/ace.py
+++ b/panel/models/ace.py
@@ -26,9 +26,8 @@ class AcePlot(HTMLBox):
 
     __tarball__ = {
         'tar': 'https://registry.npmjs.org/ace-builds/-/ace-builds-1.40.1.tgz',
-        'src': 'package/src-min/',
-        'dest': 'ajax/libs/1.40.1',
-        'exclude': ['*snippets/*']
+        'src': 'package/src-min-noconflict/',
+        'dest': 'ace-builds@1.40.1/src-min-noconflict'
     }
 
     @classproperty


### PR DESCRIPTION
Ensure that we bundle the CodeEditor Ace dependency into the correct place.