### PR TITLE
Tabulator improve uniformity between column configuration

### DIFF
--- a/examples/reference/widgets/Tabulator.ipynb
+++ b/examples/reference/widgets/Tabulator.ipynb
@@ -858,6 +858,37 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## MultiIndex columns\n",
+    "\n",
+    "When a DataFrame has MultiIndex columns, grouping is automatically performed based on the column levels, and the configuration of each column can be customized as shown below:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "columns = pd.MultiIndex.from_tuples(\n",
+    "    [(\"Group 1\", \"A\"), (\"Group 1\", \"B\"), (\"Group 2\", \"C\"), (\"Group 2\", \"D\"), (\"E\", \"\")]\n",
+    ")\n",
+    "multicolumn_df = pd.DataFrame(np.random.randn(4, 5), columns=columns)\n",
+    "pn.widgets.Tabulator(\n",
+    "    multicolumn_df,\n",
+    "    formatters={(\"Group 1\", \"A\"): NumberFormatter(format=\"0.00\")},\n",
+    "    editors={(\"Group 1\", \"B\"): {\"type\": \"number\", \"max\": 10, \"step\": 0.1}},\n",
+    "    titles={\n",
+    "        (\"Group 1\",): \"Group_1\",\n",
+    "        (\"Group 1\", \"B\"): \"b\",\n",
+    "    },\n",
+    "    header_tooltips={(\"Group 1\", \"B\"): \"Tooltips for group 1.b\"},\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Groupby\n",
     "\n",
     "In addition to grouping columns we can also group rows by the values along one or more columns:"

--- a/panel/widgets/tables.py
+++ b/panel/widgets/tables.py
@@ -2078,7 +2078,7 @@ class Tabulator(BaseTable):
                     del col_dict['editorParams']['values']
                     col_dict['editorParams']['valuesLookup'] = True
             if index in self.frozen_columns or field in self.frozen_columns or i in self.frozen_columns:
-                if field in self.frozen_columns:
+                if index != field and field in self.frozen_columns:
                     msg = f"The {index} format should be preferred over the {field}."
                     warn(msg, DeprecationWarning)
                 col_dict['frozen'] = True

--- a/panel/widgets/tables.py
+++ b/panel/widgets/tables.py
@@ -2082,8 +2082,8 @@ class Tabulator(BaseTable):
                     msg = f"The {index} format should be preferred over the {field}."
                     warn(msg, DeprecationWarning)
                 col_dict['frozen'] = True
-            if isinstance(self.widths, dict) and isinstance(_get_value_from_keys(self.widths, index, field), str):
-                col_dict['width'] = self.widths.get(index, self.widths.get(field))
+            if isinstance(self.widths, dict) and (col_width := _get_value_from_keys(self.widths, index, field)) and isinstance(col_width, str):
+                col_dict['width'] = col_width
             col_dict.update(self._get_filter_spec(column))
 
             if index in self.header_tooltips or field in self.header_tooltips:

--- a/panel/widgets/tables.py
+++ b/panel/widgets/tables.py
@@ -87,7 +87,7 @@ def _get_value_from_keys(d:dict, key1, key2, default=None):
     if key1 in d:
         return d[key1]
     if key2 in d:
-        msg = f"The {key1} format should be prefered over the {key2}."
+        msg = f"The {key1} format should be preferred over the {key2}."
         warn(msg, DeprecationWarning)
         return d[key2]
     return default
@@ -2079,7 +2079,7 @@ class Tabulator(BaseTable):
                     col_dict['editorParams']['valuesLookup'] = True
             if index in self.frozen_columns or field in self.frozen_columns or i in self.frozen_columns:
                 if field in self.frozen_columns:
-                    msg = f"The {index} format should be prefered over the {field}."
+                    msg = f"The {index} format should be preferred over the {field}."
                     warn(msg, DeprecationWarning)
                 col_dict['frozen'] = True
             if isinstance(self.widths, dict) and isinstance(_get_value_from_keys(self.widths, index, field), str):

--- a/panel/widgets/tables.py
+++ b/panel/widgets/tables.py
@@ -2012,25 +2012,25 @@ class Tabulator(BaseTable):
             ]
             col_dict: ColumnSpec = dict(field=field)
             if isinstance(self.sortable, dict):
-                col_dict['headerSort'] = self.sortable.get(field, True)
+                col_dict['headerSort'] = self.sortable.get(index, True)
             elif not self.sortable:
                 col_dict['headerSort'] = self.sortable
             if isinstance(self.text_align, str):
                 col_dict['hozAlign'] = self.text_align  # type: ignore
-            elif field in self.text_align:
-                col_dict['hozAlign'] = self.text_align[field]
+            elif index in self.text_align:
+                col_dict['hozAlign'] = self.text_align[index]
             if isinstance(self.header_align, str):
                 col_dict['headerHozAlign'] = self.header_align  # type: ignore
-            elif field in self.header_align:
-                col_dict['headerHozAlign'] = self.header_align[field]  # type: ignore
-            formatter = self.formatters.get(field)
+            elif index in self.header_align:
+                col_dict['headerHozAlign'] = self.header_align[index]  # type: ignore
+            formatter = self.formatters.get(index)
             if isinstance(formatter, str):
                 col_dict['formatter'] = formatter
             elif isinstance(formatter, dict):
                 formatter = dict(formatter)
                 col_dict['formatter'] = formatter.pop('type')
                 col_dict['formatterParams'] = formatter
-            title_formatter = self.title_formatters.get(field)
+            title_formatter = self.title_formatters.get(index)
             if isinstance(title_formatter, str):
                 col_dict['titleFormatter'] = title_formatter
             elif isinstance(title_formatter, dict):
@@ -2050,8 +2050,8 @@ class Tabulator(BaseTable):
                 col_dict['sorter'] = 'number'
             elif dtype.kind == 'b':
                 col_dict['sorter'] = 'boolean'
-            editor = self.editors.get(field)
-            if field in self.editors and editor is None:
+            editor = self.editors.get(index)
+            if index in self.editors and editor is None:
                 col_dict['editable'] = False
             if isinstance(editor, str):
                 col_dict['editor'] = editor
@@ -2062,20 +2062,20 @@ class Tabulator(BaseTable):
             if col_dict.get('editor') in ['select', 'autocomplete']:
                 self.param.warning(
                     f'The {col_dict["editor"]!r} editor has been deprecated, use '
-                    f'instead the "list" editor type to configure column {field!r}'
+                    f'instead the "list" editor type to configure column {index!r}'
                 )
                 col_dict['editor'] = 'list'
                 if col_dict.get('editorParams', {}).get('values', False) is True:
                     del col_dict['editorParams']['values']
                     col_dict['editorParams']['valuesLookup'] = True
-            if field in self.frozen_columns or i in self.frozen_columns:
+            if index in self.frozen_columns or i in self.frozen_columns:
                 col_dict['frozen'] = True
-            if isinstance(self.widths, dict) and isinstance(self.widths.get(field), str):
-                col_dict['width'] = self.widths[field]
+            if isinstance(self.widths, dict) and isinstance(self.widths.get(index), str):
+                col_dict['width'] = self.widths[index]
             col_dict.update(self._get_filter_spec(column))
 
-            if field in self.header_tooltips:
-                col_dict["headerTooltip"] = self.header_tooltips[field]
+            if index in self.header_tooltips:
+                col_dict["headerTooltip"] = self.header_tooltips[index]
 
             if isinstance(index, tuple):
                 children = columns


### PR DESCRIPTION
Improve uniformity for column configuration when column index of the dataframe is a multiindex.

```python
from bokeh.models.widgets.tables import NumberFormatter

import numpy as np
import pandas as pd
import panel as pn

pn.extension("tabulator")

columns = pd.MultiIndex.from_tuples(
    [("Group 1", "A"), ("Group 1", "B"), ("Group 2", "C"), ("Group 2", "D"), ("E", "")]
)
multicolumn_df = pd.DataFrame(np.random.randn(4, 5), columns=columns)
pn.widgets.Tabulator(
    multicolumn_df,
    formatters={("Group 1", "A"): NumberFormatter(format="0.00")},
    editors={("Group 1", "B"): {"type": "number", "max": 10, "step": 0.1}},
    titles={
        ("Group 1",): "Group_1",
        ("Group 1", "B"): "b",
    },
    header_tooltips={"Group 1_B": "Tooltips for group 1.b", ("Group 1", "B"): "Tooltips for group 1.b proposed configuration"},
).servable()
``` 
Actually to configure the formatters, the tuple format should be used while for other options such the header_tooltips options it should be with the "_".

<img width="418" height="182" alt="image" src="https://github.com/user-attachments/assets/87d1ebb8-5569-4ab0-84ef-0a2163010863" />

With the proposed modification, both will be done with the tuple format
<img width="433" height="180" alt="image" src="https://github.com/user-attachments/assets/890b21b4-53ce-40ab-bb7d-8ac6607489d6" />


Related to #7930