### PR TITLE
build: Remove bokeh-sampledata for pyodide wheel dependency

### DIFF
--- a/scripts/build_pyodide_wheels.py
+++ b/scripts/build_pyodide_wheels.py
@@ -108,13 +108,11 @@ for item in zin.infolist():
     ):
         continue
     elif filename.startswith("bokeh-") and filename.endswith("METADATA"):
-        # Replace tornado dependency with bokeh-sampledata
+        # Remove tornado dependency
         buffer = "\n".join(
             [
-                line if not (
-                    "Requires-Dist:" in line and "tornado" in line
-                ) else "Requires-Dist: bokeh-sampledata"
-                for line in buffer.decode("utf-8").split("\n")
+                line for line in buffer.decode("utf-8").split("\n")
+                if "Requires-Dist: tornado" not in line
             ]
         ).encode("utf-8")
     zout.writestr(item, buffer)


### PR DESCRIPTION
Resolves https://github.com/holoviz/panel/issues/8136

This was added in https://github.com/holoviz/panel/pull/6883, not entirely sure why, likely to be compatible with old versions of Bokeh, which included the sampledata. 

Likely, we need to update some Jupyterlite notebook too. 