### PR TITLE
Move Material color definition into material.css

### DIFF
--- a/panel/theme/css/material.css
+++ b/panel/theme/css/material.css
@@ -1,5 +1,6 @@
 /* Variables */
-:host {
+:host,
+:root {
   --handle-width: 16px;
   --handle-height: 16px;
   --switch-size: 16px;
@@ -7,6 +8,8 @@
   --padding-vertical: 10px;
   --mdc-on-surface: inherit;
   --current-background-color: var(--mdc-theme-background);
+  --bokeh-base-font: Roboto, sans-serif, Verdana;
+  color: var(--mdc-theme-on-background);
 }
 
 :host-context(.mdc-top-app-bar) .bk-menu {

--- a/panel/theme/css/material_variables.css
+++ b/panel/theme/css/material_variables.css
@@ -1,6 +1,5 @@
 :host,
 :root {
-  --bokeh-base-font: Roboto, sans-serif, Verdana;
   --mdc-theme-surface: var(
     --design-surface-color,
     var(
@@ -76,5 +75,4 @@
   --mdc-shape-small: 4px;
   --mdc-shape-medium: 4px;
   --mdc-shape-large: 0px;
-  color: var(--mdc-theme-on-background);
 }


### PR DESCRIPTION
Having it in `material-variables.css` causes issues when you want to use the variables definition but not the material.css file.