### PR TITLE
Trigger param.Event on value change

### DIFF
--- a/panel/param.py
+++ b/panel/param.py
@@ -552,11 +552,11 @@ class Param(Pane):
         if hasattr(param, 'Event') and isinstance(p_obj, param.Event):
             def event(change):
                 parameterized.param.trigger(p_name)
-            watcher = widget.param.watch(event, 'clicks')
+            watcher = widget.param.watch(event, 'value')
         elif isinstance(p_obj, param.Action):
             def action(change):
                 value(parameterized)
-            watcher = widget.param.watch(action, 'clicks')
+            watcher = widget.param.watch(action, 'value')
         elif onkeyup and hasattr(widget, 'value_input'):
             watcher = widget.param.watch(link_widget, 'value_input')
         elif throttled and hasattr(widget, 'value_throttled'):

--- a/panel/tests/test_param.py
+++ b/panel/tests/test_param.py
@@ -396,7 +396,7 @@ def test_action_param(document, comm):
 
     # Check that the action is actually executed
     pn_button = test_pane.layout[1]
-    pn_button.clicks = 1
+    pn_button.param.trigger('value')
 
     assert test.b == 2
 
@@ -632,7 +632,7 @@ def test_param_event_parameter(document, comm):
     test = Test()
     test_pane = Param(test)
 
-    test_pane._widgets['e']._process_events({'clicks': 1})
+    test_pane._widgets['e']._process_event({'clicks': 1})
 
     # Check that a watcher was set on the button that depends on e
     assert l == [1]


### PR DESCRIPTION
The handling here was outdated, because Button and other action-like widgets now trigger via the 'value', not clicks.