### PR TITLE
Update doc for components

### DIFF
--- a/panel/pane/alert.py
+++ b/panel/pane/alert.py
@@ -31,7 +31,9 @@ class Alert(Markdown):
     >>> Alert('Some important message', alert_type='warning')
     """
 
-    alert_type = param.Selector(default="primary", objects=ALERT_TYPES)
+    alert_type = param.Selector(default="primary", objects=ALERT_TYPES, doc="""
+        The type of Alert and one of 'primary', 'secondary', 'success', 'danger',
+        'warning', 'info', 'light', 'dark'.""")
 
     priority: ClassVar[float | bool | None] = 0
 

--- a/panel/pane/vega.py
+++ b/panel/pane/vega.py
@@ -161,7 +161,11 @@ class Vega(ModelPane):
 
     theme = param.Selector(default=None, allow_None=True, objects=[
         'excel', 'ggplot2', 'quartz', 'vox', 'fivethirtyeight', 'dark',
-        'latimes', 'urbaninstitute', 'googlecharts'])
+        'latimes', 'urbaninstitute', 'googlecharts'], doc="""
+        A theme to apply to the plot. Must be one of 'excel', 'ggplot2',
+        'quartz', 'vox', 'fivethirtyeight', 'dark', 'latimes',
+        'urbaninstitute', or 'googlecharts'.
+        """)
 
     priority: ClassVar[float | bool | None] = 0.8
 

--- a/panel/pane/vtk/vtk.py
+++ b/panel/pane/vtk/vtk.py
@@ -70,7 +70,9 @@ class AbstractVTK(Pane):
     orientation_widget = param.Boolean(default=False, doc="""
       Activate/Deactivate the orientation widget display.""")
 
-    interactive_orientation_widget = param.Boolean(default=True, constant=True)
+    interactive_orientation_widget = param.Boolean(default=True, constant=True, doc="""
+        If True the orientation widget is clickable and allows to rotate
+        the scene in one of the orthographic projections.""")
 
     __abstract = True
 
@@ -595,7 +597,8 @@ class VTKVolume(AbstractVTK):
     nan_opacity = param.Number(default=1., bounds=(0., 1.), doc="""
         Opacity applied to nan values in slices""")
 
-    origin = param.Tuple(default=None, length=3, allow_None=True)
+    origin = param.Tuple(default=None, length=3, allow_None=True, doc="""
+        Origin of the volume in the scene.""")
 
     render_background = param.Color(default='#52576e', doc="""
         Allows to specify the background color of the 3D rendering.

--- a/panel/widgets/indicators.py
+++ b/panel/widgets/indicators.py
@@ -202,11 +202,14 @@ class LoadingSpinner(BooleanIndicator):
     >>> LoadingSpinner(value=True, color='primary', bgcolor='light', width=100, height=100)
     """
 
-    bgcolor = param.Selector(default='light', objects=['dark', 'light'])
+    bgcolor = param.Selector(default='light', objects=['dark', 'light'], doc="""
+        The color of spinner background segment, either 'light' or 'dark'.""")
 
     color = param.Selector(default='dark', objects=[
         'primary', 'secondary', 'success', 'info', 'danger', 'warning',
-        'light', 'dark'])
+        'light', 'dark'], doc="""
+        The color of the spinning segment, one of 'primary', 'secondary',
+        'success', 'info', 'warn', 'danger', 'light', 'dark'.""")
 
     size = param.Integer(default=125, doc="""
         Size of the spinner in pixels.""")
@@ -285,7 +288,9 @@ class Progress(ValueIndicator):
 
     bar_color = param.Selector(default='success', objects=[
         'primary', 'secondary', 'success', 'info', 'danger', 'warning',
-        'light', 'dark'])
+        'light', 'dark'], doc="""
+        The color of the bar, one of 'primary', 'secondary', 'success',
+        'info', 'warning', 'danger', 'light', 'dark'.""")
 
     max = param.Integer(default=100, doc="The maximum value of the progress bar.")
 
@@ -1119,7 +1124,8 @@ class Trend(SyncableData, Indicator):
     data = param.Parameter(doc="""
       The plot data declared as a dictionary of arrays or a DataFrame.""")
 
-    layout = param.Selector(default="column", objects=["column", "row"])
+    layout = param.Selector(default="column", objects=["column", "row"], doc="""
+        The layout of the indicator, either 'column' or 'row'.""")
 
     plot_x = param.String(default="x", doc="""
       The name of the key in the plot_data to use on the x-axis.""")

--- a/panel/widgets/input.py
+++ b/panel/widgets/input.py
@@ -504,9 +504,11 @@ class DatePicker(Widget):
     end = param.CalendarDate(default=None, doc="""
         Inclusive upper bound of the allowed date selection""")
 
-    disabled_dates = param.List(default=None, item_type=(date, str))
+    disabled_dates = param.List(default=None, item_type=(date, str), doc="""
+        Dates to make unavailable for selection; others will be available.""")
 
-    enabled_dates = param.List(default=None, item_type=(date, str))
+    enabled_dates = param.List(default=None, item_type=(date, str), doc="""
+        Dates to make available for selection; others will be unavailable.""")
 
     width = param.Integer(default=300, allow_None=True, doc="""
       Width of this component. If sizing_mode is set to stretch
@@ -573,9 +575,11 @@ class DateRangePicker(Widget):
     end = param.CalendarDate(default=None, doc="""
         Inclusive upper bound of the allowed date selection""")
 
-    disabled_dates = param.List(default=None, item_type=(date, str))
+    disabled_dates = param.List(default=None, item_type=(date, str), doc="""
+        Dates to make unavailable for selection; others will be available.""")
 
-    enabled_dates = param.List(default=None, item_type=(date, str))
+    enabled_dates = param.List(default=None, item_type=(date, str), doc="""
+        Dates to make available for selection; others will be unavailable.""")
 
     width = param.Integer(default=300, allow_None=True, doc="""
       Width of this component. If sizing_mode is set to stretch
@@ -1158,7 +1162,8 @@ class LiteralInput(Widget):
     """)
 
     type = param.ClassSelector(default=None, class_=(type, tuple),
-                               is_instance=True)
+                               is_instance=True, doc="""
+        A Python literal type (e.g. list, dict, set, int, float, bool, str).""")
 
     value = param.Parameter(default=None)
 

--- a/panel/widgets/select.py
+++ b/panel/widgets/select.py
@@ -49,7 +49,8 @@ if TYPE_CHECKING:
 
 class SelectBase(Widget):
 
-    options = param.ClassSelector(default=[], class_=(dict, list))
+    options = param.ClassSelector(default=[], class_=(dict, list), doc="""
+        A list or dictionary of options to select from.""")
 
     __abstract = True
 

--- a/panel/widgets/slider.py
+++ b/panel/widgets/slider.py
@@ -46,7 +46,8 @@ if TYPE_CHECKING:
 
 class _SliderBase(Widget):
 
-    bar_color = param.Color(default="#e6e6e6", doc="""""")
+    bar_color = param.Color(default="#e6e6e6", doc="""
+        Color of the slider bar as a hexadecimal RGB value.""")
 
     direction = param.Selector(default='ltr', objects=['ltr', 'rtl'], doc="""
         Whether the slider should go from left-to-right ('ltr') or

--- a/panel/widgets/tables.py
+++ b/panel/widgets/tables.py
@@ -1211,13 +1211,18 @@ class Tabulator(BaseTable):
 
     layout = param.Selector(default='fit_data_table', objects=[
         'fit_data', 'fit_data_fill', 'fit_data_stretch', 'fit_data_table',
-        'fit_columns'])
+        'fit_columns'], doc="""
+        Describes the column layout mode with one of the following options
+        'fit_columns', 'fit_data', 'fit_data_stretch', 'fit_data_fill',
+        'fit_data_table'.""")
 
     initial_page_size = param.Integer(default=20, bounds=(1, None), doc="""
         Initial page size if page_size is None and therefore automatically set.""")
 
     pagination = param.Selector(default=None, allow_None=True,
-                                      objects=['local', 'remote'])
+                                      objects=['local', 'remote'], doc="""
+        Set to 'local or 'remote' to enable pagination; by default pagination
+        is disabled with the value set to None.""")
 
     page = param.Integer(default=1, doc="""
         Currently selected page (indexed starting at 1), if pagination is enabled.""")


### PR DESCRIPTION
This PR is related to #7984 .
I used text from https://panel.holoviz.org/ to update missing doc.

For components, the update table indicated in #7984 becomes:

Component | Parameter Name| Status
-- | -- | --
panel.pane.alert.Alert | alert_type |  Done
panel.pane.plot.RGGPlot | dpi | Deprecate since v1.0.0 ?
panel.pane.vega.Vega | theme | Done
panel.pane.vtk.vtk.VTKVolume | interactive_orientation_widget | Done
panel.pane.vtk.vtk.VTKVolume | origin | Done
panel.widgets.input.ArrayInput | type | Done
panel.widgets.input.LiteralInput | type | Done
panel.widgets.select.AutocompleteInput | options | Done
panel.widgets.select.CheckBoxGroup | options | Done
panel.widgets.select.CheckButtonGroup | options | Done
panel.widgets.select.CrossSelector | options | Done
panel.widgets.player.DiscretePlayer | options | Done
panel.widgets.select.MultiChoice | options | Done
panel.widgets.select.MultiSelect | options | Done
panel.widgets.select.RadioBoxGroup | options | Done
panel.widgets.select.RadioButtonGroup | options | Done
panel.widgets.select.Select | options | Done
panel.widgets.select.ToggleGroup | options | Done
panel.widgets.slider.DateRangeSlider | bar_color | Done
panel.widgets.slider.DatetimeRangeSlider | bar_color | Done
panel.widgets.slider.DateSlider | bar_color | Done
panel.widgets.slider.DatetimeSlider | bar_color | Done
panel.widgets.slider.EditableFloatSlider | bar_color | Done
panel.widgets.slider.EditableIntSlider | bar_color | Done
panel.widgets.slider.EditableRangeSlider | bar_color | Done
panel.widgets.slider.FloatSlider | bar_color | Done
panel.widgets.slider.IntRangeSlider | bar_color | Done
panel.widgets.slider.IntSlider | bar_color | Done
panel.widgets.indicators.Progress | bar_color | Done
panel.widgets.slider.RangeSlider | bar_color | Done
panel.widgets.input.DatePicker | disabled_dates | Done
panel.widgets.input.DateRangePicker | disabled_dates | Done
panel.widgets.input.DatePicker | enabled_dates | Done
panel.widgets.input.DateRangePicker | enabled_dates | Done
panel.widgets.input.DatetimePicker | mode | 
panel.widgets.input.DatetimeRangePicker | mode | 
panel.widgets.indicators.LoadingSpinner | bgcolor | Done
panel.widgets.indicators.LoadingSpinner | color | Done
panel.widgets.tables.Tabulator | layout | Done
panel.widgets.indicators.Trend | layout | Done
panel.widgets.tables.Tabulator | pagination | Done
