### PR TITLE
Ensure pyodide does not assume threading

### DIFF
--- a/panel/io/document.py
+++ b/panel/io/document.py
@@ -583,7 +583,7 @@ def hold(doc: Document | None = None, policy: HoldPolicyType = 'combine', comm: 
             push(doc, comm)
         elif not state._connected.get(doc):
             doc.callbacks._hold = None
-        elif threaded and not state._is_pyodide:
+        elif threaded:
             doc.callbacks._hold = None
             doc.add_next_tick_callback(doc.unhold)
             doc.callbacks._hold = policy


### PR DESCRIPTION
Pyodide does not currently support threading and we didn't register the "native" thread, which meant that various pieces of machinery would assume that we were on a thread. This simply ensures that if we are in pyodide the `state._thread_id` matches the `state._current_thread`.