### PR TITLE
Update Plotly.ipynb to include dynamic reference to current Plotly version

### DIFF
--- a/examples/reference/panes/Plotly.ipynb
+++ b/examples/reference/panes/Plotly.ipynb
@@ -6,9 +6,9 @@
    "source": [
     "The Plotly pane displays [Plotly plots](https://plotly.com/python/) within a Panel application. It enhances the speed of plot updates by using binary serialization for array data contained in the Plotly object. \n",
     "\n",
-    "Panel uses [Plotly](https://plotly.com/python/) **version {{PLOTLY_VERSION}}**  \n",
+    "It uses [plotly.js](https://plotly.com/javascript/) **version {{PLOTLY_VERSION}}**  \n",
     "\n",
-    "Please remember that to use the Plotly pane in a Jupyter notebook, you must activate the Panel extension and include `\"plotly\"` as an argument. This step ensures that plotly.js is properly set up."
+    "Please remember that to use the Plotly pane in a Jupyter notebook, you must activate the [Panel extension](https://panel.holoviz.org/developer_guide/extensions.html#extension-plugins) and include `\"plotly\"` as an argument. This step ensures that plotly.js is properly set up."
    ]
   },
   {


### PR DESCRIPTION

Now that https://github.com/holoviz/panel/pull/7447 has been merged, versions of libraries used by Panel can be referred to dynamically in the docs.

This PR is a first iteration of this. It adds the sentence:

Panel uses Plotly version x.

To the docs, by adding the code line:

 "Panel uses [Plotly](https://plotly.com/python/) **version {{PLOTLY_VERSION}}** \n",
    "\n",


Suggestions for alternate / improved phrasing are very welcome. Please chime in @philippjfr , @MarcSkovMadsen , @hoxbro if you have suggestions.

Once the optimal phrasing has emerged, the intention is to apply it to other reference docs, to ensure uniformity between docs.

The intention is  to submit those subsequent doc changes as 1 PR.

Related:

https://github.com/holoviz/panel/pull/7447
https://github.com/holoviz/panel/pull/8182

https://github.com/holoviz/panel/issues/8184