### PR TITLE
Set cursor as pointer in the connection lost toast

### DIFF
--- a/doc/how_to/deployment/index.md
+++ b/doc/how_to/deployment/index.md
@@ -81,6 +81,7 @@ Panel can be used with just about any cloud provider that can launch a Python pr
 :hidden:
 :maxdepth: 2
 
+anaconda_notebooks
 aws
 azure
 binder

--- a/panel/dist/css/notifications.css
+++ b/panel/dist/css/notifications.css
@@ -9,4 +9,5 @@
 
 .reconnect {
   font-weight: 600;
+  cursor: pointer;
 }


### PR DESCRIPTION
Tiny change to set the cursor as pointer on the "Click here" link in the connection lost toast.
<img width="331" height="131" alt="image" src="https://github.com/user-attachments/assets/bed86a0e-89fd-481f-973d-bbc79a8cc995" />
