### PR TITLE
Fixes for OAuth via proxy

### DIFF
--- a/panel/tests/ui/test_auth.py
+++ b/panel/tests/ui/test_auth.py
@@ -196,8 +196,8 @@ def test_auth0_oauth_via_proxy(py_file, page):
             py_file.name
         ]
         with run_panel_serve(cmd) as p:
-            port = wait_for_port(p.stdout)
-            page.goto(f"http://localhost:{port}")
+            wait_for_port(p.stdout)
+            page.goto(f"http://localhost:{proxy}/proxy/{app_name}")
 
             page.locator('input[name="username"]').fill(auth0_user)
             page.locator('input[name="password"]').fill(auth0_password)

--- a/panel/tests/ui/test_auth.py
+++ b/panel/tests/ui/test_auth.py
@@ -197,7 +197,7 @@ def test_auth0_oauth_via_proxy(py_file, page):
         ]
         with run_panel_serve(cmd) as p:
             wait_for_port(p.stdout)
-            page.goto(f"http://localhost:{proxy}/proxy/{app_name}")
+            page.goto(f"http://localhost:{proxy}/proxy/")
 
             page.locator('input[name="username"]').fill(auth0_user)
             page.locator('input[name="password"]').fill(auth0_password)

--- a/panel/tests/ui/test_auth.py
+++ b/panel/tests/ui/test_auth.py
@@ -178,6 +178,8 @@ def test_auth0_oauth_via_proxy(py_file, page):
     app = "import panel as pn; pn.pane.Markdown(pn.state.user).servable(title='A')"
     write_file(app, py_file.file)
 
+    app_name = os.path.basename(py_file.name)[:-3]
+
     proxy = os.environ.get('AUTH0_PORT', '5701')
     cookie_secret = os.environ['OAUTH_COOKIE_SECRET']
     encryption_key = os.environ['OAUTH_ENCRYPTION_KEY']
@@ -197,7 +199,7 @@ def test_auth0_oauth_via_proxy(py_file, page):
         ]
         with run_panel_serve(cmd) as p:
             wait_for_port(p.stdout)
-            page.goto(f"http://localhost:{proxy}/proxy/")
+            page.goto(f"http://localhost:{proxy}/proxy/{app_name}")
 
             page.locator('input[name="username"]').fill(auth0_user)
             page.locator('input[name="password"]').fill(auth0_password)


### PR DESCRIPTION
The goal is to address issues mentioned in #3555

For starters, I believe the `test_auth0_oauth_via_proxy` test function does not actually test the proxy mechanism because the page is accessed via the wrong port, bypassing the reverse proxy.

Let's see if the test still passes (I don't want to create an Auth0 account to get a key so I can't check it locally).