### PR TITLE
Update Plotly.ipynb with correct URL in the doc

### DIFF
--- a/examples/reference/panes/Plotly.ipynb
+++ b/examples/reference/panes/Plotly.ipynb
@@ -8,7 +8,7 @@
     "\n",
     "It uses [plotly.js](https://plotly.com/javascript/) **version {{PLOTLY_VERSION}}**  \n",
     "\n",
-    "Please remember that to use the Plotly pane in a Jupyter notebook, you must activate the [Panel extension](https://panel.holoviz.org/developer_guide/extensions.html#extension-plugins) and include `\"plotly\"` as an argument. This step ensures that plotly.js is properly set up."
+    "Please remember that to use the Plotly pane in a Jupyter notebook, you must activate the [Panel extension](https://panel.holoviz.org/api/cheatsheet.html#pn-extension) and include `\"plotly\"` as an argument. This step ensures that plotly.js is properly set up."
    ]
   },
   {


### PR DESCRIPTION
Updated the Panel extension link in the doc to https://panel.holoviz.org/api/cheatsheet.html#pn-extension as discussed with Hoxbro in https://github.com/holoviz/panel/pull/8194