### PR TITLE
Avoid panel helper function warnings

### DIFF
--- a/panel/pane/base.py
+++ b/panel/pane/base.py
@@ -75,6 +75,12 @@ def panel(obj: Any, **kwargs) -> Viewable | ServableMixin:
        A Viewable representation of the input object
     """
     if isinstance(obj, (Viewable, ServableMixin)):
+        if kwargs and isinstance(obj, Viewable):
+            obj.param.warning(
+                "The `panel` function is intended to promote non-Viewable objects. "
+                "Since the supplied object is already a Viewable, any keyword "
+                "arguments passed here are ignored."
+            )
         return obj
     elif hasattr(obj, '__panel__'):
         if isinstance(obj, Viewer):
@@ -732,7 +738,7 @@ class ReplacementPane(Pane):
         else:
             # Replace pane entirely
             pane_params = {k: v for k, v in kwargs.items() if k in pane_type.param}
-            pane = panel(object, **pane_params)
+            pane = panel(object, **pane_params) if not isinstance(object, Viewable) else object
             internal = pane is not object
         return pane, internal
 


### PR DESCRIPTION
~~In panel 1.8.0 we started warning when the `panel` helper function was used on an object that is already a `Viewable` but you supplied kwargs~~. Unfortunately we were a little indiscriminate here and the warnings could be generated by Panel itself. This PR restricts precisely when this warning is issued and skips calling `panel` when not necessary.