### PR TITLE
Serve index.html when serving static directory

### DIFF
--- a/panel/io/server.py
+++ b/panel/io/server.py
@@ -902,7 +902,7 @@ def get_static_routes(static_dirs):
         if not os.path.isdir(path):
             raise ValueError(f"Cannot serve non-existent path {path}")
         patterns.append(
-            (rf"{slug}/(.*)", AuthenticatedStaticFileHandler, {"path": path})
+            (rf"{slug}/(.*)", AuthenticatedStaticFileHandler, {"path": path, "default_filename": "index.html"})
         )
     patterns.append((
         f'/{COMPONENT_PATH}(.*)', ComponentResourceHandler, {}

--- a/panel/tests/test_server.py
+++ b/panel/tests/test_server.py
@@ -89,6 +89,15 @@ def test_server_static_dirs():
     with open(__file__, encoding='utf-8') as f:
         assert f.read() == r.content.decode('utf-8').replace('\r\n', '\n')
 
+def test_server_static_dirs_index():
+    html = Markdown('# Title')
+
+    static = {'tests': os.path.dirname(INDEX_HTML)}
+
+    r = serve_and_request(html, static_dirs=static, suffix="/tests/")
+
+    with open(INDEX_HTML, encoding='utf-8') as f:
+        assert f.read() == r.content.decode('utf-8').replace('\r\n', '\n')
 
 def test_server_root_handler():
     html = Markdown('# Title')


### PR DESCRIPTION
From the example described in [Serving static files](https://panel.holoviz.org/how_to/server/static_files.html), when user go to `http://localhost:5006/assets/` it will serve the index.html file inside the folder. Otherwise only the address `http://localhost:5006/assets/index.html` is valid