### PR TITLE
Do not generate pyodide resources file unless necessary

### DIFF
--- a/panel/io/convert.py
+++ b/panel/io/convert.py
@@ -552,8 +552,11 @@ def convert_app(
 
     # resources unpacked into emscripten MEMFS
     app_resources = {**wheels2pack, **resources_validated}
-    app_resources_packfile = f'{app_name}.resources.zip'
-    pack_files(app_resources, os.path.join(dest_path, app_resources_packfile))
+    if app_resources:
+        app_resources_packfile = f'{app_name}.resources.zip'
+        pack_files(app_resources, os.path.join(dest_path, app_resources_packfile))
+    else:
+        app_resources_packfile = None
 
     # try to convert the app to a standalone package
     try:


### PR DESCRIPTION
The conversion code was generating a resources file even when there were no additional resources to include.