### PR TITLE
Ensure ESM compile uses _esm path during bundling

### DIFF
--- a/panel/custom.py
+++ b/panel/custom.py
@@ -330,7 +330,7 @@ class ReactiveESM(ReactiveCustomBase, metaclass=ReactiveESMMetaclass):
 
     @classmethod
     def _esm_path(cls, compiled: bool | Literal['compiling'] = True) -> os.PathLike | None:
-        if compiled or not cls._esm:
+        if compiled is True or not cls._esm:
             bundle_path = cls._bundle_path
             if bundle_path:
                 return bundle_path


### PR DESCRIPTION
The `_esm_path` is used to resolve the path of the ESM module at both compile and runtime. During compile time it should point to the `_esm` file, while at runtime it should point to the `_bundle` path. However the code wasn't making a distinction between compile and runtime, resulting in extensions that bundled multiple components clobbering each other.