### PR TITLE
Align default and dark theme CSS variable definitions

### DIFF
--- a/panel/theme/css/dark.css
+++ b/panel/theme/css/dark.css
@@ -9,6 +9,8 @@
   --panel-on-background-color: #ffffff;
   --panel-surface-color: #2b3035;
   --panel-on-surface-color: #ffffff;
+  --panel-border-color: #3a3f44;
+  --panel-shadow-color: rgba(10, 14, 18, 0.6);
   --code-bg-color: #263238;
   --code-text-color: #82aaff;
   --primary-bg-color: #0d6efd;

--- a/panel/theme/css/default.css
+++ b/panel/theme/css/default.css
@@ -5,10 +5,12 @@
   --panel-secondary-color: #e1e1e1;
   --panel-on-secondary-color: #090c0;
   --panel-background-color: #ffffff;
+  --panel-background-rgb: 255, 255, 255;
   --panel-on-background-color: #212529;
   --panel-surface-color: #f3f3f3;
   --panel-on-surface-color: #1a1d21;
-  --panel-shadow-color: #3c4043;
+  --panel-border-color: #e0e0e0;
+  --panel-shadow-color: rgba(60, 64, 67, 0.18);
   --code-bg-color: #263238;
   --code-text-color: #82aaff;
   --primary-bg-color: #0d6efd;


### PR DESCRIPTION
- Define new `--panel-border-color`
- Define `--panel-shadow-color` for both light and dark themes
- Add missing `--panel-background-rgb` for default theme