### PR TITLE
Add check for NPM token in build step

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -174,6 +174,15 @@ jobs:
           path: ./${{ env.PACKAGE }}/${{ env.TARBALL }}
       - name: Verify size
         run: python scripts/verify_build_size.py npm
+      - name: Check NPM token
+        run: |
+          echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_API_TOKEN }}" > $HOME/.npmrc
+          if npm whoami >/dev/null 2>&1; then
+            echo "NPM token is valid: $(npm whoami)"
+          else
+            echo "::error::Invalid or expired NPM token."
+            exit 1
+          fi
 
   npm_publish:
     name: Publish NPM


### PR DESCRIPTION
This should cause the build to error out because the NPM token has expired. 