### PR TITLE
Update README with typo fix / small layout improvement

### DIFF
--- a/examples/apps/django/README.md
+++ b/examples/apps/django/README.md
@@ -23,8 +23,9 @@ conda install -c conda-forge bokeh-django django==5 django-channels panel
 Based on a standard Django app template, the sliders app shows how to
 integrate panel with a Django view.
 
-:::{note} currently there is no interaction
-between param and Django models. :::
+:::{note}
+Currently there is no interaction between param and Django models.
+:::
 
 Additions/modifications to django2 app template:
 


### PR DESCRIPTION
Current doc has a typo: 'Not' instead of 'Note'.

"Not that currently there is no interaction between param and Django models."


Used Markdown syntax so the Note: is formatted in the same style as in section 2 of the AWS doc below.

:::{note} :::

https://panel.holoviz.org/how_to/deployment/aws.html

https://github.com/holoviz/panel/blob/main/doc/how_to/deployment/aws.md