### PR TITLE
Improve robustness of Bokeh/Panel loading in notebooks

### DIFF
--- a/panel/_templates/autoload_panel_js.js
+++ b/panel/_templates/autoload_panel_js.js
@@ -285,8 +285,8 @@ calls it with the rendered model.
           if (Bokeh.Panel == null) {
             Bokeh.Panel = NewBokeh.Panel;
           }
+          root.Bokeh = Bokeh;
         }
-        root.Bokeh = Bokeh;
       });
     }
   }


### PR DESCRIPTION
In JupyterLab and other notebook environments, multiple versions of **Bokeh** and **Panel** can coexist or be loaded at different times (e.g. when opening older notebooks with embedded resources). Previously, Panel’s autoload logic made several assumptions that could lead to inconsistent or broken states when those assumptions didn’t hold.

1. **Existing script skip logic too aggressive**

   * We skipped loading scripts that already existed in the DOM, even if the corresponding global objects (`window.Bokeh` or `window.Bokeh.Panel`) had been deleted or were otherwise unavailable.
   * This meant that if a user or another extension removed `window.Bokeh`, Panel could never recover because the loader would still skip the `<script>` elements for those URLs.

2. **No verification of `window.Bokeh.Panel` presence**

   * Panel only checked for an existing `Bokeh` object and version match, not whether the `Panel` extension had actually been initialized.
   * In practice this could result in `Bokeh` being found, but `Panel` remaining undefined and the app failing to render.

3. **Unnecessary restoration of old Bokeh versions**

   * The previous caching logic always restored `root.Bokeh`, even when reloading or when the cached version lacked `Panel`. This prevented proper re-initialization of the correct version.

### Fixes Applied

* Introduced explicit regexes (`BK_RE`, `PN_RE`) to detect Bokeh and Panel CDN URLs.
* Adjusted **skip logic** to only skip script re-loading if both:

  * The script URL already exists, **and**
  * A valid `Bokeh` (with `Bokeh.Panel`) object is present.
* Updated **bokeh_loaded** detection to verify both `Bokeh.version` *and* `Bokeh.Panel`.
* Reworked version caching to:

  * Maintain versioned copies in `Bokeh.versions`
  * Restore `Bokeh.Panel` when missing
  * Avoid restoring broken or incomplete versions.
