### PR TITLE
Fix notebook reading by explicitly using UTF-8 encoding

### DIFF
--- a/panel/io/jupyter_server_extension.py
+++ b/panel/io/jupyter_server_extension.py
@@ -243,7 +243,7 @@ class PanelJupyterHandler(PanelBaseHandler):
         if self.request.arguments.get('kernel'):
             requested_kernel = self.request.arguments.pop('kernel')[0].decode('utf-8')
         elif notebook_path.suffix == '.ipynb':
-            with open(notebook_path) as f:
+            with open(notebook_path, encoding='utf-8') as f:
                 nb = json.load(f)
             requested_kernel = nb.get('metadata', {}).get('kernelspec', {}).get('name')
         else:


### PR DESCRIPTION
This PR fixes a decoding error that occurs when Panel reads a Jupyter notebook file while previewing a Panel app in JupyterLab. The code currently opens the .ipynb file using the system’s default text encoding, which may not be UTF-8. On systems where the default encoding is something else, decoding can fail and produce a 500 error.

Fixes #8302 