### PR TITLE
Ensure param.Action does not trigger two events

### DIFF
--- a/panel/param.py
+++ b/panel/param.py
@@ -643,7 +643,7 @@ class Param(Pane):
                     widget.param.unwatch(prev_watcher)
                     def action(event):
                         change.new(parameterized)
-                        watchers[0] = widget.param.watch(action, 'clicks')
+                    watchers[0] = widget.param.watch(action, 'clicks')
                 return
             elif throttled and hasattr(widget, 'value_throttled'):
                 updates['value_throttled'] = change.new

--- a/panel/tests/test_param.py
+++ b/panel/tests/test_param.py
@@ -401,6 +401,24 @@ def test_action_param(document, comm):
     assert test.b == 2
 
 
+def test_action_param_triggers_once(document, comm):
+    class Test(param.Parameterized):
+        a = param.Action(default=lambda x: x.param.trigger('a'))
+        b = param.List(default=[])
+
+        @param.depends('a', watch=True)
+        def _record_a(self):
+            self.b.append(True)
+
+    test = Test()
+    test_pane = Param(test)
+
+    pn_button = test_pane.layout[1]
+    pn_button._process_event(None)
+
+    assert len(test.b) == 1
+
+
 def test_number_param_overrides(document, comm):
     class Test(param.Parameterized):
         a = param.Number(default=0.1, bounds=(0, 1.1))


### PR DESCRIPTION
Fixes https://github.com/holoviz/panel/issues/8292