### PR TITLE
type: Fix type checking

### DIFF
--- a/panel/io/datamodel.py
+++ b/panel/io/datamodel.py
@@ -6,10 +6,10 @@ from functools import partial
 from typing import Any
 from weakref import WeakKeyDictionary
 
-import bokeh
 import bokeh.core.properties as bp
 import param as pm
 
+from bokeh.core.property.bases import Property
 from bokeh.model import DataModel, Model
 from bokeh.models import ColumnDataSource
 
@@ -20,7 +20,7 @@ from .notebook import push
 from .state import set_curdoc, state
 
 
-class Parameterized(bokeh.core.property.bases.Property):
+class Parameterized(Property):
     """ Accept a Parameterized object.
 
     This property only exists to support type validation, e.g. for "accepts"
@@ -38,7 +38,7 @@ class Parameterized(bokeh.core.property.bases.Property):
         raise ValueError(msg)
 
 
-class PolarsDataFrame(bokeh.core.property.bases.Property):
+class PolarsDataFrame(Property):
     """ Accept Polars DataFrame values.
 
     This property only exists to support type validation, e.g. for "accepts"
@@ -58,7 +58,7 @@ class PolarsDataFrame(bokeh.core.property.bases.Property):
         raise ValueError(msg)
 
 
-class ParameterizedList(bokeh.core.property.bases.Property):
+class ParameterizedList(Property):
     """ Accept a list of Parameterized objects.
 
     This property only exists to support type validation, e.g. for "accepts"


### PR DESCRIPTION
This was indirectly imported via `import bokeh.core.properties as bp`, which made it work, but a new release of mypy now flags this as an error. 