### PR TITLE
ci: Pin jupyterlite-core for now

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -413,7 +413,7 @@ lint-install = 'pre-commit install -t=pre-commit'
 [feature.lite.dependencies]
 pyviz_comms = ">=3.0.6"
 jupyterlab-myst = "*"
-jupyterlite-core = "*"
+jupyterlite-core = "<0.7.0"
 jupyterlite-pyodide-kernel = "*"
 python-build = "*"
 


### PR DESCRIPTION
Currently raises:

<img width="730" height="216" alt="Screenshot From 2025-12-01 11-34-50" src="https://github.com/user-attachments/assets/3ea6a5a9-9b3c-4263-bbe3-88b644f50f8b" />

There seems to be a problem when updating pyodide (0.29.0) to the latest version when using my "no-install panel import" trick, and I haven't figured out why.