### PR TITLE
Delay removal of old ReactComponent children until new children are mounted

### DIFF
--- a/panel/tests/ui/test_custom.py
+++ b/panel/tests/ui/test_custom.py
@@ -1128,9 +1128,13 @@ def test_react_child_no_shadow_dom_remove_lifecycle_hook(page):
     expect(page.locator('h1')).to_have_text("Hello")
 
     with page.expect_console_message() as msg_info:
-        example.child = "New"
+        example.child = "# New"
 
     wait_until(lambda: msg_info.value.args[0].json_value() == "Removed", page)
+
+    expect(page.locator('h1')).to_have_count(1)
+
+    expect(page.locator('h1')).to_have_text("New ¶")
 
 
 class JSDefaultExport(JSComponent):


### PR DESCRIPTION
Ordinarily when a Bokeh components children are modified the old children are removed and the new ones immediately added. However when using React we have to wait until the React component is mounted to render. That means there's a gap between the time the old child is removed and when the new child is rendered, causing visual flicker. By delaying the removal until the new child is added we avoid this issue.

Fixes https://github.com/panel-extensions/panel-material-ui/issues/547