### PR TITLE
Interactive widgets in header- fixes #8353

### DIFF
--- a/panel/models/card.ts
+++ b/panel/models/card.ts
@@ -200,8 +200,13 @@ export class CardView extends ColumnView {
   }
 
   _toggle_button(e: MouseEvent): void {
-    for (const path of e.composedPath()) {
-      if (path instanceof HTMLInputElement) {
+    const is_panel_widget = (el: EventTarget): boolean =>
+      el instanceof HTMLElement &&
+      Array.from(el.classList).some((c) => c.startsWith("bk-panel-models-widgets-"))
+
+    for (const el of e.composedPath()) {
+      // If the click came from any Panel widget in the header, don't toggle.
+      if (is_panel_widget(el)) {
         return
       }
     }

--- a/panel/models/card.ts
+++ b/panel/models/card.ts
@@ -201,8 +201,9 @@ export class CardView extends ColumnView {
 
   _toggle_button(e: MouseEvent): void {
     const is_panel_widget = (el: EventTarget): boolean =>
+      el instanceof HTMLInputElement || (
       el instanceof HTMLElement &&
-      Array.from(el.classList).some((c) => c.startsWith("bk-panel-models-widgets-"))
+	Array.from(el.classList).some((c) => c.startsWith("bk-panel-models-widgets-")))
 
     for (const el of e.composedPath()) {
       // If the click came from any Panel widget in the header, don't toggle.

--- a/panel/models/card.ts
+++ b/panel/models/card.ts
@@ -202,7 +202,7 @@ export class CardView extends ColumnView {
   _toggle_button(e: MouseEvent): void {
     const is_panel_widget = (el: EventTarget): boolean =>
       el instanceof HTMLInputElement || (
-      el instanceof HTMLElement &&
+        el instanceof HTMLElement &&
 	Array.from(el.classList).some((c) => c.startsWith("bk-panel-models-widgets-")))
 
     for (const el of e.composedPath()) {

--- a/panel/tests/ui/layout/test_card.py
+++ b/panel/tests/ui/layout/test_card.py
@@ -187,7 +187,7 @@ def test_card_scrollable(page):
 def test_card_widget_not_collapsed(page, card_components):
     # Fixes https://github.com/holoviz/panel/issues/7045
     w1, w2 = card_components
-    card = Card(w1, header=Row(w2))
+    card = Card("content", title="MyTitle", header=Row(w1, w2))
 
     serve_component(page, card)
 
@@ -198,6 +198,10 @@ def test_card_widget_not_collapsed(page, card_components):
 
     text_input.press("F")
     text_input.press("Enter")
+
+    slider_input = page.locator('.noUi-base')
+    expect(slider_input).to_have_count(1)
+    slider_input.click()
 
     wait_until(lambda: w2.value == 'F', page)
     assert not card.collapsed


### PR DESCRIPTION
Previous behavior:  Previous #7057 specifically allowed TextInput objects in Card Headers, but the fix was specific to the TextInput widget and did not support any other interactive widgets (e.g. Select, Button, Slider, etc).  

This PR, described in #8353 , generalizes based on CSS class to stop propagation of clicks which begin in any object which begins with `bk-panel-models-widgets-`  which could be tweaked if needed to catch the right level of specificity (I defer to the repo owners; please provide feedback).

UI test has been updated (this updated test with a slider in the header was previously failing)

Linted and ran UI tests locally with no regressions, but this is my first PR on this repo!