### PR TITLE
Fix guest endpoint validation for the root

### DIFF
--- a/panel/auth.py
+++ b/panel/auth.py
@@ -984,7 +984,10 @@ class BasicAuthProvider(AuthProvider):
     def _allow_guest(self, uri):
         if config.oauth_optional and not (uri == self._login_endpoint or '?code=' in uri):
             return True
-        return True if uri.replace('/ws', '') in self._guest_endpoints else False
+        for gep in self._guest_endpoints:
+            if uri == gep or uri == gep.rstrip('/') + '/ws':
+                return True
+        return False
 
     @property
     def get_user(self):


### PR DESCRIPTION
Fixes https://github.com/holoviz/panel/issues/8224

`'/ws'` was removed in the uri before checking whether it's part of the user-listed guest endpoints. That worked fine for a named application like `/app/ws` but not for the root endpoint `/ws`, that ended up being converted to the empty string (`''` in `['/']` evaluates to false).