### PR TITLE
Ensure edit_readonly resets class and instance level parameters

### DIFF
--- a/panel/util/parameters.py
+++ b/panel/util/parameters.py
@@ -5,7 +5,7 @@ import inspect
 from collections import defaultdict
 from collections.abc import Iterator
 from contextlib import contextmanager
-from typing import Any
+from typing import Any, cast
 
 import param
 
@@ -34,15 +34,15 @@ def get_method_owner(meth):
 # This functionality should be contributed to param
 # See https://github.com/holoviz/param/issues/379
 @contextmanager
-def edit_readonly(parameterized: param.Parameterized) -> Iterator:
+def edit_readonly(parameterized: param.Parameterized) -> Iterator[None]:
     """
     Temporarily set parameters on Parameterized object to readonly=False
     to allow editing them.
     """
     kls_params = parameterized.param.objects(instance=False)
-    inst_params = parameterized._param__private.params
+    inst_params = cast(dict[str, param.Parameter], parameterized._param__private.params)
     init_inst_params = list(inst_params)
-    updated = defaultdict(list)
+    updated: dict[str, list[str]] = defaultdict(list)
     for pname, pobj in (kls_params | inst_params).items():
         if pobj.readonly:
             if not pobj.constant:


### PR DESCRIPTION
Fixes https://github.com/holoviz/panel/issues/7999

Code adapted from `edit_constant`'s code in Param. Example from the issue:

```python
from panel.util.parameters import edit_readonly
import param

class Container(param.Parameterized):
    constant = param.Number(default=0, constant=True)
    readonly = param.Number(default=1, readonly=True)

obj = Container()

with edit_readonly(obj):
    obj.constant = 2
    obj.readonly = 3


print(f"{obj.constant = }, {obj.param.constant.constant = }, {obj.param.constant.readonly = }")
print(f"{obj.readonly = }, {obj.param.readonly.constant = }, {obj.param.readonly.readonly = }")
```

Output before:
```
obj.constant = 2, obj.param.constant.constant = False, obj.param.constant.readonly = False
obj.readonly = 3, obj.param.readonly.constant = False, obj.param.readonly.readonly = False
```

Output now:
```
obj.constant = 2, obj.param.constant.constant = True, obj.param.constant.readonly = False
obj.readonly = 3, obj.param.readonly.constant = True, obj.param.readonly.readonly = True
```

We should upstream this sort of utility to Param, maybe with some API improvements (e.g. should only act on `readonly` parameters, allow to specify a subset of parameters, make it available on the .param namespace).