### PR TITLE
Fix handling of rel_path in ESM components

### DIFF
--- a/panel/custom.py
+++ b/panel/custom.py
@@ -377,7 +377,7 @@ class ReactiveESM(ReactiveCustomBase, metaclass=ReactiveESMMetaclass):
         if esm_path:
             if esm_path == cls._bundle_path and cls.__module__ in sys.modules and server:
                 # Generate relative path to handle apps served on subpaths
-                esm = (state.rel_path or './') + cls._component_resource_path(esm_path, compiled)
+                esm = ('' if state.rel_path else './') + cls._component_resource_path(esm_path, compiled)
                 if config.autoreload:
                     modified = hashlib.sha256(str(esm_path.stat().st_mtime).encode('utf-8')).hexdigest()
                     esm += f'?{modified}'

--- a/panel/io/state.py
+++ b/panel/io/state.py
@@ -1125,7 +1125,10 @@ class _state(param.Parameterized):
     @rel_path.setter
     def rel_path(self, value: str | None):
         if value is None:
-            return
+            if self.curdoc:
+                self._rel_paths.pop(self.curdoc, None)
+            else:
+                self._rel_path = ''
         elif self.curdoc:
             self._rel_paths[self.curdoc] = value
         else:

--- a/panel/tests/test_custom.py
+++ b/panel/tests/test_custom.py
@@ -5,8 +5,10 @@ import param
 from bokeh.plotting import figure
 
 from panel.custom import PyComponent, ReactiveESM
+from panel.io.state import state
 from panel.layout import Row
 from panel.pane import Bokeh, Markdown
+from panel.util import edit_readonly
 from panel.viewable import Child, Children
 
 
@@ -65,6 +67,25 @@ def test_reactive_esm_sync_dataframe(document, comm):
     expected = {"index": np.array([0]), "1": np.array([2])}
     for col, values in model.data.df.items():
         np.testing.assert_array_equal(values, expected.get(col))
+
+
+class ESMBundle(ReactiveESM):
+
+    _bundle_path = "esm.js"
+
+
+def test_esm_bundle_resource_path():
+    assert ESMBundle._render_esm(compiled=True, server = True) == "./components/panel.tests.test_custom/ESMBundle/_bundle_path/esm.js"
+
+
+def test_esm_bundle_resource_rel_path():
+    with edit_readonly(state):
+        state.rel_path = ".."
+    try:
+        assert ESMBundle._render_esm(compiled=True, server = True) == "../components/panel.tests.test_custom/ESMBundle/_bundle_path/esm.js"
+    finally:
+        with edit_readonly(state):
+            state.rel_path = None
 
 
 class ESMWithChildren(ReactiveESM):

--- a/panel/tests/test_custom.py
+++ b/panel/tests/test_custom.py
@@ -75,14 +75,14 @@ class ESMBundle(ReactiveESM):
 
 
 def test_esm_bundle_resource_path():
-    assert ESMBundle._render_esm(compiled=True, server = True) == "./components/panel.tests.test_custom/ESMBundle/_bundle_path/esm.js"
+    assert ESMBundle._render_esm(compiled=True, server=True) == "./components/panel.tests.test_custom/ESMBundle/_bundle_path/esm.js"
 
 
 def test_esm_bundle_resource_rel_path():
     with edit_readonly(state):
         state.rel_path = ".."
     try:
-        assert ESMBundle._render_esm(compiled=True, server = True) == "../components/panel.tests.test_custom/ESMBundle/_bundle_path/esm.js"
+        assert ESMBundle._render_esm(compiled=True, server=True) == "../components/panel.tests.test_custom/ESMBundle/_bundle_path/esm.js"
     finally:
         with edit_readonly(state):
             state.rel_path = None


### PR DESCRIPTION
When an app was served on a nested path the handling inside ESM components did not correctly resolve the URL based on the `rel_path`. This fixes the problem and adds tests.