### PR TITLE
Don't attempt to refresh access token if there is no active user session

### DIFF
--- a/panel/auth.py
+++ b/panel/auth.py
@@ -1198,6 +1198,8 @@ class OAuthProvider(BasicAuthProvider):
             state.schedule_task(task, refresh_cb, at=expiry_date)
 
     async def _scheduled_refresh(self, user, refresh_token, application, request, reschedule=True):
+        if not state._active_users.get(user):
+            return None, None, None
         await self._refresh_access_token(user, refresh_token, application, request)
         if user not in state._oauth_user_overrides:
             return None, None, None


### PR DESCRIPTION
The check on `state._active_users` could as well be in `_refresh_access_token`.

Attempt at fixing #8374.

I'm saying it's an attempt because there is still the possibility that `state._active_users` is not reliable enough here. But in any case, if this condition is met, there should definitely be no attempt to refresh the token.