### PR TITLE
Wait for animation frame before measuring Tabulator page size

### DIFF
--- a/panel/models/tabulator.ts
+++ b/panel/models/tabulator.ts
@@ -570,8 +570,8 @@ export class DataTabulatorView extends HTMLBoxView {
       return
     }
     this.redraw(true, true)
-    this.restore_scroll()
-    this.recompute_page_size()
+    this.restore_scroll();
+    (window as any).requestAnimationFrame(() => this.recompute_page_size())
   }
 
   override stylesheets(): StyleSheetLike[] {


### PR DESCRIPTION
In some setups the Tabulator page size calculation doesn't perform well and you end up with an incorrectly measured page size. This aims to improve that by delaying the measurement of the row height until after an animation frame.