### PR TITLE
ci: Temp. pin sphinx for now

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -347,3 +347,6 @@ def setup(app) -> None:
 
 
 grid_item_link_domain = gallery_endpoint
+
+# https://github.com/sphinx-doc/sphinx/issues/14089
+autodoc_use_legacy_class_based = True

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -347,6 +347,3 @@ def setup(app) -> None:
 
 
 grid_item_link_domain = gallery_endpoint
-
-# https://github.com/sphinx-doc/sphinx/issues/14089
-autodoc_use_legacy_class_based = True

--- a/pixi.toml
+++ b/pixi.toml
@@ -356,7 +356,6 @@ nbsite = ">=0.8.6rc9"
 selenium = "*"
 numpydoc = "*"
 pydeck = ">=0.8"  # Add back to examples, when it support ipywidgets 8.0
-sphinx = "<9"
 
 [feature.doc.tasks]
 _docs-refmanual = 'sphinx-apidoc -e -o doc/api/ panel/ --ext-autodoc --ext-intersphinx'

--- a/pixi.toml
+++ b/pixi.toml
@@ -356,6 +356,7 @@ nbsite = ">=0.8.6rc9"
 selenium = "*"
 numpydoc = "*"
 pydeck = ">=0.8"  # Add back to examples, when it support ipywidgets 8.0
+sphinx = "<9"
 
 [feature.doc.tasks]
 _docs-refmanual = 'sphinx-apidoc -e -o doc/api/ panel/ --ext-autodoc --ext-intersphinx'


### PR DESCRIPTION
Will try it out CI. 

Building here: 

:heavy_check_mark:  [bb16944](https://github.com/holoviz/panel/pull/8392/commits/bb169445627a00d6e842c8f1e7657a0defaaadde): https://github.com/holoviz/panel/actions/runs/21365786176

:x: [422b850](https://github.com/holoviz/panel/pull/8392/commits/422b85091c08a8afcb841cef3a373289536b6e76): https://github.com/holoviz/panel/actions/runs/21366406276


Caused by a new release of `sphinx-design`, which previously had an upper pin of sphinx 9, and now do not. 