### PR TITLE
Fix CDN requests in server mode for loading.css and es-module-shims

### DIFF
--- a/panel/io/resources.py
+++ b/panel/io/resources.py
@@ -312,6 +312,8 @@ def patch_stylesheet(stylesheet, dist_url):
         patched_url = url.replace(CDN_DIST, dist_url)
     elif url.startswith(LOCAL_DIST) and dist_url.lstrip('./').startswith(LOCAL_DIST):
         patched_url = url.replace(LOCAL_DIST, dist_url)
+    elif url.startswith(LOCAL_DIST) and dist_url != LOCAL_DIST:
+        patched_url = url.replace(LOCAL_DIST, dist_url)
     else:
         return
     version_suffix = f'?v={JS_VERSION}'
@@ -415,11 +417,15 @@ def bundled_files(model: Model, file_type: str = 'javascript') -> list[str]:
     bdir = BUNDLE_DIR / name
     shared = list((JS_URLS if file_type == 'javascript' else CSS_URLS).values())
     files = []
+    npm_cdn_prefixes = (config.npm_cdn, 'https://cdn.jsdelivr.net/npm', 'https://unpkg.com')
     for url in raw_files:
         if url.startswith(CDN_DIST):
             filepath = url.replace(f'{CDN_DIST}bundled/', '')
-        elif url.startswith(config.npm_cdn):
-            filepath = url.replace(config.npm_cdn, '')[1:]
+        elif url.startswith(npm_cdn_prefixes):
+            for prefix in npm_cdn_prefixes:
+                if url.startswith(prefix):
+                    filepath = url.replace(prefix, '')[1:]
+                    break
         else:
             filepath = url_path(url)
         test_filepath = filepath.split('?')[0]

--- a/panel/reactive.py
+++ b/panel/reactive.py
@@ -40,7 +40,7 @@ from param.parameterized import (
 from .io.document import hold, unlocked
 from .io.notebook import push
 from .io.resources import (
-    CDN_DIST, loading_css, patch_stylesheet, process_raw_css,
+    CDN_DIST, get_dist_path, loading_css, patch_stylesheet, process_raw_css,
     resolve_stylesheet,
 )
 from .io.state import set_curdoc, state
@@ -216,7 +216,7 @@ class Syncable(Renderable):
             from .config import config
             stylesheets = [loading_css(
                 config.loading_spinner, config.loading_color, config.loading_max_height
-            ), f'{CDN_DIST}css/loading.css']
+            ), f'{get_dist_path()}css/loading.css']
             stylesheets += process_raw_css(config.raw_css)
             stylesheets += config.css_files
             stylesheets += [

--- a/panel/tests/conftest.py
+++ b/panel/tests/conftest.py
@@ -23,7 +23,8 @@ import pytest
 
 from bokeh.client import pull_session
 from bokeh.document import Document
-from bokeh.io.doc import curdoc, set_curdoc as set_bkdoc
+from bokeh.io.doc import _PATCHED_CURDOCS, curdoc, set_curdoc as set_bkdoc
+from bokeh.io.state import _STATE
 from pyviz_comms import Comm
 
 from panel import config, serve
@@ -467,6 +468,8 @@ def server_cleanup():
     try:
         yield
     finally:
+        _PATCHED_CURDOCS.clear()
+        _STATE.document = None
         state.reset()
         _watched_files.clear()
         _modules.clear()

--- a/panel/tests/conftest.py
+++ b/panel/tests/conftest.py
@@ -469,7 +469,7 @@ def server_cleanup():
         yield
     finally:
         _PATCHED_CURDOCS.clear()
-        _STATE.document = None
+        _STATE.document = Document()
         state.reset()
         _watched_files.clear()
         _modules.clear()

--- a/panel/tests/theme/test_base.py
+++ b/panel/tests/theme/test_base.py
@@ -8,6 +8,11 @@ from panel.viewable import Viewable
 from panel.widgets import FloatSlider, IntSlider, TextInput
 
 
+def _is_loading_css(url):
+    """Check if URL points to loading.css (either CDN or local path)."""
+    base_url = url.split('?')[0]
+    return base_url.endswith(('/dist/css/loading.css', 'panel/css/loading.css'))
+
 def _custom_repr(self):
     try:
         return f"ImportedStyleSheet(url={self.url!r})"
@@ -124,7 +129,7 @@ def test_design_apply(document, comm):
     assert isinstance(s1, str)
     assert 'pn-loading' in s1
     assert isinstance(s2, ImportedStyleSheet)
-    assert s2.url.endswith('/dist/css/loading.css')
+    assert _is_loading_css(s2.url)
     assert isinstance(s3, ImportedStyleSheet)
     assert s3.url.endswith('/dist/bundled/theme/default.css')
     assert isinstance(s4, ImportedStyleSheet)
@@ -143,7 +148,7 @@ def test_design_apply_not_isolated(document, comm):
     assert isinstance(s1, str)
     assert 'pn-loading' in s1
     assert isinstance(s2, ImportedStyleSheet)
-    assert s2.url.endswith('/dist/css/loading.css')
+    assert _is_loading_css(s2.url)
     assert isinstance(s3, ImportedStyleSheet)
     assert s3.url.endswith('foo.css')
     assert s4 == '.bk-input {\n  color: red;\n}\n'
@@ -161,7 +166,7 @@ def test_design_apply_inherited(document, comm):
     assert isinstance(s1, str)
     assert 'pn-loading' in s1
     assert isinstance(s2, ImportedStyleSheet)
-    assert s2.url.endswith('/dist/css/loading.css')
+    assert _is_loading_css(s2.url)
     assert isinstance(s3, ImportedStyleSheet)
     assert s3.url.endswith('/dist/bundled/theme/default.css')
     assert isinstance(s4, ImportedStyleSheet)
@@ -181,7 +186,7 @@ def test_design_apply_url_inherited(document, comm):
     assert isinstance(s1, str)
     assert 'pn-loading' in s1
     assert isinstance(s2, ImportedStyleSheet)
-    assert s2.url.endswith('/dist/css/loading.css')
+    assert _is_loading_css(s2.url)
     assert isinstance(s3, ImportedStyleSheet)
     assert s3.url.endswith('/dist/bundled/theme/default.css')
     assert isinstance(s4, ImportedStyleSheet)
@@ -201,7 +206,7 @@ def test_design_apply_with_dark_theme(document, comm):
     assert isinstance(s1, str)
     assert 'pn-loading' in s1
     assert isinstance(s2, ImportedStyleSheet)
-    assert s2.url.endswith('/dist/css/loading.css')
+    assert _is_loading_css(s2.url)
     assert isinstance(s3, ImportedStyleSheet)
     assert s3.url.endswith('/dist/bundled/theme/dark.css')
     assert isinstance(s4, ImportedStyleSheet)
@@ -222,7 +227,7 @@ def test_design_apply_with_dark_theme_not_isolated(document, comm):
     assert isinstance(s1, str)
     assert 'pn-loading' in s1
     assert isinstance(s2, ImportedStyleSheet)
-    assert s2.url.endswith('/dist/css/loading.css')
+    assert _is_loading_css(s2.url)
     assert isinstance(s3, ImportedStyleSheet)
     assert s3.url.endswith('foo.css')
     assert s4 == '.bk-input {\n  color: red;\n}\n'

--- a/panel/tests/theme/test_base.py
+++ b/panel/tests/theme/test_base.py
@@ -3,7 +3,6 @@ import pathlib
 from bokeh.models import ImportedStyleSheet
 
 from panel.io.resources import CDN_DIST
-from panel.io.state import state
 from panel.theme.base import BOKEH_DARK, Design, Inherit
 from panel.viewable import Viewable
 from panel.widgets import FloatSlider, IntSlider, TextInput
@@ -122,8 +121,6 @@ def test_design_params_url_inherited():
 def test_design_apply(document, comm):
     widget = TextInput()
     model = widget.get_root(document, comm=comm)
-
-    print(">>>", state.curdoc, getattr(state.curdoc, "session_context", None))  # noqa
 
     DesignTest().apply(widget, model)
 

--- a/panel/tests/theme/test_base.py
+++ b/panel/tests/theme/test_base.py
@@ -3,6 +3,7 @@ import pathlib
 from bokeh.models import ImportedStyleSheet
 
 from panel.io.resources import CDN_DIST
+from panel.io.state import state
 from panel.theme.base import BOKEH_DARK, Design, Inherit
 from panel.viewable import Viewable
 from panel.widgets import FloatSlider, IntSlider, TextInput
@@ -121,6 +122,8 @@ def test_design_params_url_inherited():
 def test_design_apply(document, comm):
     widget = TextInput()
     model = widget.get_root(document, comm=comm)
+
+    print(">>>", state.curdoc, getattr(state.curdoc, "session_context", None))  # noqa
 
     DesignTest().apply(widget, model)
 


### PR DESCRIPTION

## Summary

Fixes external CDN requests when running Panel in server mode, ensuring all resources are served locally.

## Problem

When deploying Panel applications in server mode with `PANEL_NPM_CDN` configured to an internal registry, the app still made external network requests to:

1. `https://cdn.holoviz.org/panel/<version>/dist/css/loading.css`
2. `https://cdn.jsdelivr.net/npm/es-module-shims@^1.10.0/dist/es-module-shims.min.js`

This is problematic for air-gapped environments or deployments with strict network policies that require all resources to be served locally.

## Root Causes

### 1. `loading.css` (panel/reactive.py)

The loading stylesheet URL was hardcoded using `CDN_DIST`, which always points to `cdn.holoviz.org` regardless of the resource mode:

```python
stylesheets = [..., f'{CDN_DIST}css/loading.css']
```

### 2. `es-module-shims` (panel/io/resources.py)

This one is more subtle. The `ReactiveESM` class defines `__javascript_raw__` at class definition time (import time), capturing the *default* CDN URL before `PANEL_NPM_CDN` is read:

```python
__javascript_raw__ = [f"{config.npm_cdn}/es-module-shims@^1.10.0/dist/es-module-shims.min.js"]
```

Later, `bundled_files()` checks if URLs start with `config.npm_cdn` to map them to local files. But since `config.npm_cdn` now reflects the custom registry URL while the captured URL still has `cdn.jsdelivr.net`, the check fails and the file isn't served locally.

## Solution

### 1. `loading.css`

Use `get_dist_path()` instead of `CDN_DIST`. This function respects the current resource mode and returns the local path in server mode.

### 2. `es-module-shims`

Expand the prefix matching in `bundled_files()` to recognize all common NPM CDN prefixes:

```python
npm_cdn_prefixes = [
    config.npm_cdn,
    'https://cdn.jsdelivr.net/npm',
    'https://unpkg.com',
]
```

This ensures URLs captured at import time with the default CDN are still correctly mapped to local bundled files, regardless of the runtime `PANEL_NPM_CDN` setting.
