### PR TITLE
enh: Use direct `html.escape` import

### DIFF
--- a/panel/io/convert.py
+++ b/panel/io/convert.py
@@ -9,6 +9,7 @@ import pathlib
 import uuid
 
 from collections.abc import Sequence
+from html import escape
 from typing import (
     IO, Any, Literal, cast,
 )
@@ -28,7 +29,7 @@ from bokeh.util.serialization import make_id
 from packaging.requirements import Requirement
 
 from .. import __version__, config
-from ..util import base_version, escape
+from ..util import base_version
 from .application import Application, build_single_handler_application
 from .document import MockSessionContext
 from .loading import LOADING_INDICATOR_CSS_CLASS

--- a/panel/io/notebook.py
+++ b/panel/io/notebook.py
@@ -13,6 +13,7 @@ import warnings
 from collections.abc import Iterator
 from contextlib import contextmanager
 from functools import partial
+from html import escape
 from typing import TYPE_CHECKING, Any, Literal
 
 import bokeh
@@ -38,7 +39,7 @@ from pyviz_comms import (
     JupyterCommManager as _JupyterCommManager, nb_mime_js,
 )
 
-from ..util import _descendents, escape
+from ..util import _descendents
 from .embed import embed_state
 from .model import add_to_doc, diff
 from .resources import (

--- a/panel/io/profile.py
+++ b/panel/io/profile.py
@@ -10,12 +10,12 @@ from collections.abc import Callable, Iterator
 from contextlib import contextmanager
 from cProfile import Profile
 from functools import wraps
+from html import escape
 from typing import (
     TYPE_CHECKING, Literal, ParamSpec, TypeVar,
 )
 
 from ..config import config
-from ..util import escape
 from .state import state
 
 if TYPE_CHECKING:

--- a/panel/pane/image.py
+++ b/panel/pane/image.py
@@ -9,6 +9,7 @@ import base64
 import struct
 
 from collections.abc import Mapping
+from html import escape
 from io import BytesIO
 from pathlib import PurePath
 from typing import TYPE_CHECKING, Any, ClassVar
@@ -17,7 +18,7 @@ import param
 
 from ..models import PDF as _BkPDF
 from ..util import _descendents, isfile, isurl
-from .markup import HTMLBasePane, escape
+from .markup import HTMLBasePane
 
 if TYPE_CHECKING:
     from bokeh.model import Model

--- a/panel/pane/markup.py
+++ b/panel/pane/markup.py
@@ -9,6 +9,7 @@ import json
 import textwrap
 
 from collections.abc import Mapping
+from html import escape
 from typing import TYPE_CHECKING, Any, ClassVar
 
 import param  # type: ignore
@@ -16,7 +17,7 @@ import param  # type: ignore
 from ..config import config
 from ..io.resources import CDN_DIST
 from ..models.markup import HTML as _BkHTML, JSON as _BkJSON, HTMLStreamEvent
-from ..util import HTML_SANITIZER, escape, prefix_length
+from ..util import HTML_SANITIZER, prefix_length
 from .base import ModelPane
 
 if TYPE_CHECKING:

--- a/panel/pane/plot.py
+++ b/panel/pane/plot.py
@@ -9,6 +9,7 @@ import sys
 from collections.abc import Mapping
 from contextlib import contextmanager
 from functools import partial
+from html import escape
 from io import BytesIO
 from typing import TYPE_CHECKING, Any, ClassVar
 
@@ -21,7 +22,6 @@ from bokeh.themes import Theme
 
 from ..io import remove_root, state
 from ..io.notebook import push
-from ..util import escape
 from ..viewable import Layoutable
 from .base import Pane
 from .image import (

--- a/panel/reactive.py
+++ b/panel/reactive.py
@@ -19,6 +19,7 @@ import uuid
 from collections import Counter, defaultdict, namedtuple
 from collections.abc import Callable, Mapping, Sequence
 from functools import lru_cache, partial
+from html import escape
 from pprint import pformat
 from typing import (
     TYPE_CHECKING, Any, ClassVar, TypeAlias,
@@ -48,7 +49,7 @@ from .models.reactive_html import (
     DOMEvent, ReactiveHTML as _BkReactiveHTML, ReactiveHTMLParser,
 )
 from .util import (
-    HTML_SANITIZER, classproperty, edit_readonly, escape, updating,
+    HTML_SANITIZER, classproperty, edit_readonly, updating,
 )
 from .util.checks import import_available
 from .viewable import (

--- a/panel/tests/pane/test_image.py
+++ b/panel/tests/pane/test_image.py
@@ -1,6 +1,7 @@
 import os
 
 from base64 import b64decode, b64encode
+from html import escape
 from io import BytesIO, StringIO
 from pathlib import Path
 
@@ -11,7 +12,6 @@ from requests.exceptions import MissingSchema
 from panel.pane import (
     AVIF, GIF, ICO, JPG, PDF, PNG, SVG, WebP,
 )
-from panel.pane.markup import escape
 
 AVIF_FILE = 'https://assets.holoviz.org/panel/samples/avif_sample.avif'
 JPG_FILE = 'https://assets.holoviz.org/panel/samples/jpg_sample.jpg'

--- a/panel/viewable.py
+++ b/panel/viewable.py
@@ -22,6 +22,7 @@ import typing
 import uuid
 
 from collections.abc import Callable, Mapping
+from html import escape
 from typing import (
     IO, TYPE_CHECKING, Any, ClassVar,
 )
@@ -51,7 +52,7 @@ from .io.notebook import (
 from .io.resources import set_resource_mode
 from .io.save import save
 from .io.state import set_curdoc, state
-from .util import escape, param_reprs
+from .util import param_reprs
 from .util.parameters import get_params_to_inherit
 
 if TYPE_CHECKING:

--- a/panel/widgets/indicators.py
+++ b/panel/widgets/indicators.py
@@ -24,6 +24,7 @@ import sys
 import time
 
 from collections.abc import Mapping
+from html import escape
 from math import pi
 from typing import TYPE_CHECKING, Any, ClassVar
 
@@ -41,7 +42,7 @@ from ..models import (
 )
 from ..pane.markup import Str
 from ..reactive import SyncableData
-from ..util import PARAM_NAME_PATTERN, escape, updating
+from ..util import PARAM_NAME_PATTERN, updating
 from ..viewable import Viewable
 from .base import Widget
 

--- a/panel/widgets/input.py
+++ b/panel/widgets/input.py
@@ -10,6 +10,7 @@ import json
 from base64 import b64decode
 from collections.abc import Iterable, Mapping
 from datetime import date, datetime, time as dt_time
+from html import escape
 from typing import (
     TYPE_CHECKING, Any, ClassVar, Type,
 )
@@ -34,9 +35,7 @@ from ..models import (
     DatetimePicker as _bkDatetimePicker, TextAreaInput as _bkTextAreaInput,
     TextInput as _BkTextInput, TimePicker as _BkTimePicker,
 )
-from ..util import (
-    escape, lazy_load, param_reprs, try_datetime64_to_datetime,
-)
+from ..util import lazy_load, param_reprs, try_datetime64_to_datetime
 from .base import CompositeWidget, Widget
 
 if TYPE_CHECKING:


### PR DESCRIPTION
This confused me. When seeing this `html.escape` import I instantly knows this is from the stdlib.

I have left the original import for now. 