### PR TITLE
Add freeze parameter to hold() to defer model recomputation

### DIFF
--- a/panel/io/document.py
+++ b/panel/io/document.py
@@ -13,7 +13,7 @@ import time
 import weakref
 
 from collections.abc import Callable, Iterator, Sequence
-from contextlib import contextmanager
+from contextlib import ExitStack, contextmanager
 from functools import partial, wraps
 from typing import TYPE_CHECKING, Any
 from weakref import WeakKeyDictionary
@@ -539,7 +539,12 @@ def dispatch_events(events, doc: Document | None = None):
         doc.callbacks._held_events = events
 
 @contextmanager
-def hold(doc: Document | None = None, policy: HoldPolicyType = 'combine', comm: Comm | None = None):
+def hold(
+    doc: Document | None = None,
+    policy: HoldPolicyType = 'combine',
+    comm: Comm | None = None,
+    freeze: bool = False,
+):
     """
     Context manager that holds events on a particular Document
     allowing them all to be collected and dispatched when the context
@@ -556,39 +561,50 @@ def hold(doc: Document | None = None, policy: HoldPolicyType = 'combine', comm: 
         dispatched when the context manager exits.
     comm: Comm
         The Comm to dispatch events on when the context manager exits.
+    freeze: bool
+        Whether to freeze the Document model references for the
+        duration of the hold. When True, defers expensive model graph
+        recomputation (``doc.models.recompute()``) until the hold
+        exits, which can significantly speed up batch updates that
+        modify many models. Safe to nest with the per-model
+        ``freeze_doc`` calls used internally, since Bokeh's freeze
+        mechanism is reference-counted.
     """
     doc = doc or state.curdoc
     if doc is None:
         yield
         return
-    threaded = state._current_thread != state._thread_id
-    held = doc.callbacks.hold_value
-    try:
-        if policy is None:
-            doc.unhold()
-            yield
-        elif threaded:
-            doc.hold(policy)
-            yield
-        else:
-            with unlocked(policy=policy):
-                if not doc.callbacks.hold_value:
-                    doc.hold(policy)
+    with ExitStack() as stack:
+        if freeze and hasattr(doc, 'models'):
+            stack.enter_context(doc.models.freeze())
+        threaded = state._current_thread != state._thread_id
+        held = doc.callbacks.hold_value
+        try:
+            if policy is None:
+                doc.unhold()
                 yield
-    finally:
-        if held:
-            doc.callbacks._hold = held
-        elif comm is not None:
-            from .notebook import push
-            push(doc, comm)
-        elif not state._connected.get(doc):
-            doc.callbacks._hold = None
-        elif threaded:
-            doc.callbacks._hold = None
-            doc.add_next_tick_callback(doc.unhold)
-            doc.callbacks._hold = policy
-        else:
-            doc.unhold()
+            elif threaded:
+                doc.hold(policy)
+                yield
+            else:
+                with unlocked(policy=policy):
+                    if not doc.callbacks.hold_value:
+                        doc.hold(policy)
+                    yield
+        finally:
+            if held:
+                doc.callbacks._hold = held
+            elif comm is not None:
+                from .notebook import push
+                push(doc, comm)
+            elif not state._connected.get(doc):
+                doc.callbacks._hold = None
+            elif threaded:
+                doc.callbacks._hold = None
+                doc.add_next_tick_callback(doc.unhold)
+                doc.callbacks._hold = policy
+            else:
+                doc.unhold()
 
 @contextmanager
 def immediate_dispatch(doc: Document | None = None):

--- a/panel/io/document.py
+++ b/panel/io/document.py
@@ -562,13 +562,14 @@ def hold(
     comm: Comm
         The Comm to dispatch events on when the context manager exits.
     freeze: bool
-        Whether to freeze the Document model references for the
-        duration of the hold. When True, defers expensive model graph
-        recomputation (``doc.models.recompute()``) until the hold
-        exits, which can significantly speed up batch updates that
-        modify many models. Safe to nest with the per-model
-        ``freeze_doc`` calls used internally, since Bokeh's freeze
-        mechanism is reference-counted.
+        **Experimental.** Whether to freeze the Document model
+        references for the duration of the hold. When True, defers
+        expensive model graph recomputation
+        (``doc.models.recompute()``) until the hold exits, which can
+        significantly speed up batch updates that modify many models.
+        Safe to nest with the per-model ``freeze_doc`` calls used
+        internally, since Bokeh's freeze mechanism is
+        reference-counted.
     """
     doc = doc or state.curdoc
     if doc is None:


### PR DESCRIPTION
## Context

This is related to https://discourse.holoviz.org/t/batching-doc-models-freeze/9100. With the example there (and depending on the number of plots on the screen) I observe 2x (or more) speedup in some cases. **This is meant for discussion and trying it out, not to be merged.**

I also found https://github.com/bokeh/bokeh/issues/11707 where there appear to be mixed opinions about this approach.

## Summary

This adds an optional `freeze` parameter to the `hold()` context manager that wraps the entire held block in `doc.models.freeze()`, deferring Bokeh's model graph recomputation until the hold exits.

Decided to make this opt-in for now, I don't know if it should be always on?

## Motivation

When batch-updating many models inside `hold()` (e.g., updating data sources on N plots), each individual model update currently triggers Bokeh model reference bookkeeping independently. The existing `freeze_doc()` helper (introduced in PR #5864) only freezes when an individual model update changes model *references* (e.g., adding/removing children from a layout). For plain data updates on existing models, `freeze_doc` correctly determines there are no reference changes and skips the freeze entirely.

This means there is currently no way for users to get a document-level freeze that spans all updates within a `hold()` block.

### History of freeze inside hold

- PR #4989 (May 2023) first introduced `doc.models.freeze()` nested inside `hold()` in the layout update path (`Panel._update_model`) to speed up dynamic layout updates
- PR #5864 (Nov 2023) replaced the unconditional `doc.models.freeze()` with the conditional `freeze_doc()` that inspects whether updated properties actually contain model references, to avoid unnecessary freezing — this was about avoiding the cost of *unconditional* freezing on every property change, not about removing the concept
- Neither PR provided a document-level freeze spanning the entire `hold()` block; the freeze was always scoped to individual `_update_model` calls

### What this PR adds

A `freeze: bool = False` parameter on `hold()`. When `True`, enters `doc.models.freeze()` for the duration of the hold block. Since Bokeh's freeze mechanism is reference-counted (`_freeze_count`), this nests safely with the per-model `freeze_doc()` calls used internally — inner freezes simply increment/decrement the count, and `recompute()` only runs once when the outermost freeze exits.

**Note**: Mostly the changes here are just indentation, hide whitespace changes on GitHub for easier review.

Usage:
```python
with pn.io.hold(doc, freeze=True):
    for plot in plots:
        plot.object = new_figure()
```