### PR TITLE
Add es_module_shims config option to disable es-module-shims polyfill

### DIFF
--- a/doc/api/config.md
+++ b/doc/api/config.md
@@ -180,6 +180,14 @@ Where to save json files for embedded state.
 
 Default: './' | Type: String
 
+### `es_module_shims` (`PANEL_ES_MODULE_SHIMS`)
+
+Whether to load the es-module-shims polyfill. Set to False
+if you only target browsers with native import map support
+(Chrome 89+, Firefox 108+, Safari 16.4+).
+
+Default: True | Type: Boolean
+
 ### `exception_handler`
 
 General exception handler for events.

--- a/panel/config.py
+++ b/panel/config.py
@@ -344,6 +344,11 @@ class _config(_base_config):
     _disable_validation = param.Boolean(default=False, doc="""
         Whether to disable bokeh validation, speeding up applications.""")
 
+    _es_module_shims = param.Boolean(default=True, doc="""
+        Whether to load the es-module-shims polyfill. Set to False
+        if you only target browsers with native import map support
+        (Chrome 89+, Firefox 108+, Safari 16.4+).""")
+
     # Global parameters that are shared across all sessions
     _globals: ClassVar[set[str]] = {
         'admin_plugins', 'autoreload', 'comms', 'cookie_path', 'cookie_secret',
@@ -351,7 +356,8 @@ class _config(_base_config):
         'oauth_secret', 'oauth_jwt_user', 'oauth_redirect_uri',
         'oauth_encryption_key', 'oauth_extra_params', 'npm_cdn',
         'layout_compatibility', 'oauth_refresh_tokens', 'oauth_guest_endpoints',
-        'oauth_optional', 'admin', 'index_titles', 'disable_validation'
+        'oauth_optional', 'admin', 'index_titles', 'disable_validation',
+        'es_module_shims'
     }
 
     _truthy = ['True', 'true', '1', True, 1]
@@ -525,6 +531,10 @@ class _config(_base_config):
     @property
     def disable_validation(self):
         return self._disable_validation
+
+    @property
+    def es_module_shims(self):
+        return os.environ.get('PANEL_ES_MODULE_SHIMS', self._es_module_shims) in self._truthy
 
     @property
     def embed(self):

--- a/panel/models/esm.py
+++ b/panel/models/esm.py
@@ -58,7 +58,10 @@ class ReactiveESM(HTMLBox):
 
     @classproperty
     def __javascript__(cls):
-        return bundled_files(cls)
+        files = bundled_files(cls)
+        if not config.es_module_shims:
+            files = [f for f in files if 'es-module-shims' not in f]
+        return files
 
 
 class ReactComponent(ReactiveESM):

--- a/panel/tests/io/test_resources.py
+++ b/panel/tests/io/test_resources.py
@@ -81,6 +81,11 @@ def test_resources_server():
         'static/js/bokeh-mathjax.min.js'
     ]
 
+def test_resources_cdn_no_es_module_shims():
+    resources = Resources(mode='cdn', minified=True)
+    with config.set(es_module_shims=False):
+        assert not any('es-module-shims' in f for f in resources.js_files)
+
 def test_resources_config_css_files(document):
     resources = Resources(mode='cdn')
     with set_curdoc(document):


### PR DESCRIPTION
This is a follow-up of https://github.com/holoviz/panel/pull/8408

In our company everybody is on the latest chrome and we don't really need this es-module-shim.
Would be great if we had a flag to just skip it all together.