### PR TITLE
fix: LaTeX rendering in Markdown pane for Pyodide

### DIFF
--- a/panel/io/resources.py
+++ b/panel/io/resources.py
@@ -25,7 +25,7 @@ from typing import (
 import bokeh.embed.wrappers
 
 from bokeh.embed.bundle import (
-    CSS_RESOURCES as BkCSS_RESOURCES, URL, Bundle as BkBundle,
+    CSS_RESOURCES as BkCSS_RESOURCES, URL, Bundle as BkBundle, _any,
     _bundle_extensions, _use_mathjax, bundle_models, extension_dirs,
 )
 from bokeh.model import Model
@@ -37,6 +37,7 @@ from jinja2.loaders import FileSystemLoader
 from markupsafe import Markup
 
 from ..config import config, panel_extension as extension
+from ..models.markup import HTML as PanelHTML
 from ..util import _descendents, isurl, url_path
 from .state import state
 
@@ -449,6 +450,11 @@ def bundled_files(model: Model, file_type: str = 'javascript') -> list[str]:
             files.append(url)
     return files
 
+def _panel_use_mathjax(roots) -> bool:
+    """Whether any model in roots is a Panel HTML model (may need MathJax)."""
+    return _any(roots, lambda obj: isinstance(obj, PanelHTML))
+
+
 def bundle_resources(
     roots,
     resources: BkResources,
@@ -471,7 +477,11 @@ def bundle_resources(
     if isinstance(enable_mathjax, bool):
         use_mathjax = enable_mathjax
     elif roots:
-        use_mathjax = _use_mathjax(roots) or 'mathjax' in ext._loaded_extensions
+        use_mathjax = (
+            _use_mathjax(roots) or
+            _panel_use_mathjax(roots) or
+            'mathjax' in ext._loaded_extensions
+        )
     else:
         use_mathjax = 'mathjax' in ext._loaded_extensions
 

--- a/panel/io/resources.py
+++ b/panel/io/resources.py
@@ -37,7 +37,6 @@ from jinja2.loaders import FileSystemLoader
 from markupsafe import Markup
 
 from ..config import config, panel_extension as extension
-from ..models.markup import HTML as PanelHTML
 from ..util import _descendents, isurl, url_path
 from .state import state
 

--- a/panel/io/resources.py
+++ b/panel/io/resources.py
@@ -452,6 +452,7 @@ def bundled_files(model: Model, file_type: str = 'javascript') -> list[str]:
 
 def _panel_use_mathjax(roots) -> bool:
     """Whether any model in roots is a Panel HTML model (may need MathJax)."""
+    from ..models.markup import HTML as PanelHTML
     return _any(roots, lambda obj: isinstance(obj, PanelHTML))
 
 


### PR DESCRIPTION
Closes #8421

## Problem

`bokeh-mathjax` was excluded from the JS bundle in Pyodide/convert contexts,
causing `$$…$$` content to render as raw text. Bokeh's `_use_mathjax()` only
inspects its own model types (Div, TextAnnotation, etc.) and does not recognise
Panel's `HTML` model, which `Markdown`, `HTML`, and `Str` panes use.

## Fix

Added `_panel_use_mathjax(roots)` in `panel/io/resources.py` that detects
Panel's `HTML` Bokeh model using bokeh's own `_any()` tree walker. 

```python
def _panel_use_mathjax(roots) -> bool:
    """Whether any model in roots is a Panel HTML model (may need MathJax)."""
    from ..models.markup import HTML as PanelHTML
    from bokeh.embed.bundle import _any
    return _any(roots, lambda obj: isinstance(obj, PanelHTML))
```

