### PR TITLE
Fix embed_state merging for same-name Select widgets

### DIFF
--- a/panel/io/embed.py
+++ b/panel/io/embed.py
@@ -220,7 +220,7 @@ def embed_state(panel, model, doc, max_states=1000, max_opts=3,
     from ..links import Link
     from ..models.state import State
     from ..pane import PaneBase
-    from ..widgets import DiscreteSlider, Widget
+    from ..widgets import DiscreteSlider, Select, Widget
 
     ref = model.ref['id']
     if isinstance(panel, PaneBase) and ref in panel.layout._models:
@@ -279,8 +279,10 @@ def embed_state(panel, model, doc, max_states=1000, max_opts=3,
             if not isinstance(w_model, w_type):
                 w_model = w_model.select_one({'type': w_type})
 
-        # If there is a widget with the same name, merge with it
-        if widget.name and widget.name in merged:
+        # If there is a widget with the same name, merge with it.
+        # Select widgets are excluded because independent selects often
+        # share display names but should not be synchronized.
+        if widget.name and widget.name in merged and not isinstance(widget, Select):
             merged[widget.name][0].append(w)
             merged[widget.name][1].append(w_model)
             continue

--- a/panel/tests/io/test_embed.py
+++ b/panel/tests/io/test_embed.py
@@ -559,7 +559,7 @@ def test_embed_selects_with_same_name_not_merged(document, comm):
 
     panel = Row(s1, s2, t1, t2)
     with config.set(embed=True):
-      model = panel.get_root(document, comm)
+        model = panel.get_root(document, comm)
     state_model = embed_state(panel, model, document)
 
     assert state_model is not None

--- a/panel/tests/io/test_embed.py
+++ b/panel/tests/io/test_embed.py
@@ -548,6 +548,26 @@ def test_embed_merged_sliders(document, comm):
     ]
 
 
+def test_embed_selects_with_same_name_not_merged(document, comm):
+    s1 = Select(name='test', options=['A', 'B'])
+    t1 = StaticText()
+    s1.param.watch(lambda event: setattr(t1, 'value', event.new), 'value')
+
+    s2 = Select(name='test', options=['1', '2'])
+    t2 = StaticText()
+    s2.param.watch(lambda event: setattr(t2, 'value', event.new), 'value')
+
+    panel = Row(s1, s2, t1, t2)
+    with config.set(embed=True):
+      model = panel.get_root(document, comm)
+    state_model = embed_state(panel, model, document)
+
+    assert state_model is not None
+    assert set(state_model.state) == {'A', 'B'}
+    assert set(state_model.state['A']) == {'1', '2'}
+    assert set(state_model.state['B']) == {'1', '2'}
+
+
 def test_save_embed_bytesio():
     checkbox = Checkbox()
     string = Str()


### PR DESCRIPTION
## Summary
This PR fixes an embedding bug where independent `Select` widgets with the same display name were incorrectly merged during state export.

## Problem
`embed_state` currently merges widgets by shared `name`.  
That behavior is useful for intentionally synchronized widgets, but incorrect for independent `Select` widgets that commonly reuse labels (e.g. "test", "category").

As a result, embedded state generation can miss valid combinations for independent selects.

## Solution
- Import `Select` in `panel/io/embed.py`
- Exclude `Select` widgets from the name-based merge path
- Keep existing merge behavior unchanged for other widget types

## Tests
Added regression test in `panel/tests/io/test_embed.py`:

- `test_embed_selects_with_same_name_not_merged`

This test verifies two independent same-name `Select` widgets are embedded as a full cross-product of states, rather than being merged.

## Why this is safe
- Scope is narrow and type-specific (`Select` only)
- Existing merge semantics for non-`Select` widgets are preserved
- Regression coverage ensures the reported case remains fixed

Fixes #8335