### PR TITLE
Ensure ESM model definition can be loaded dynamically

### DIFF
--- a/panel/custom.py
+++ b/panel/custom.py
@@ -188,6 +188,7 @@ class ReactiveESMMetaclass(ReactiveMetaBase):
             p for p in Reactive.param
             if not issubclass(type(mcs.param[p].owner), ReactiveESMMetaclass)
         ]
+        mcs._data_model__initialized = not (state.curdoc and state.curdoc.session_context)
         mcs._data_model = construct_data_model(
             mcs, name=model_name, ignore=ignored, extras={'esm_constants': param.Dict}
         )
@@ -494,7 +495,13 @@ class ReactiveESM(ReactiveCustomBase, metaclass=ReactiveESMMetaclass):
         else:
             bundle_hash = None
         data_props['esm_constants'] = self._constants
+        if cls._data_model__initialized:
+            defs = []
+        else:
+            defs = [cls._data_model]
+            cls._data_model__initialized = True
         props.update({
+            '_defs': defs,
             'bundle': bundle_hash,
             'css_bundle': css_bundle,
             'class_name': cls.__name__,

--- a/panel/models/esm.py
+++ b/panel/models/esm.py
@@ -32,6 +32,8 @@ class ESMEvent(DataEvent):
 
 class ReactiveESM(HTMLBox):
 
+    _defs = bp.List(bp.Any)
+
     css_bundle = bp.Nullable(bp.String)
 
     bundle = bp.Nullable(bp.String)

--- a/panel/models/reactive_esm.ts
+++ b/panel/models/reactive_esm.ts
@@ -582,6 +582,7 @@ export namespace ReactiveESM {
   export type Attrs = p.AttrsOf<Props>
 
   export type Props = HTMLBox.Props & {
+    _defs: p.Property<any[]>
     css_bundle: p.Property<string | null>
     bundle: p.Property<string | null>
     children: p.Property<any>
@@ -931,6 +932,7 @@ export default {render}`
   static {
     this.prototype.default_view = ReactiveESMView
     this.define<ReactiveESM.Props>(({Any, Array, Bool, Nullable, Str}) => ({
+      _defs:       [ Array(Any),          [] ],
       css_bundle:  [ Nullable(Str),     null ],
       bundle:      [ Nullable(Str),     null ],
       children:    [ Array(Str),          [] ],


### PR DESCRIPTION
When an ESM model is imported for the first time while an app is already running the bokeh `DataModel` definition, which is usually included in the serialized `Document` on page load, will not be initialized. This leads to an inscrutable error saying that the Model could not be resolved on the frontend. Here we introduce a flag on the class definition that indicates whether the model is initialized by checking whether we are in a server context when the `ReactiveESM` class is defined. If so we include the definition on the `ReactiveESM` model that holds the DataModel instance and by declaring it on a property with a trailing underscore (`_defs`) we ensure the model definition is unserialized before the instance of that model is deserialized.