### PR TITLE
Fix resource resolution when pathname changes

### DIFF
--- a/panel/io/location.py
+++ b/panel/io/location.py
@@ -140,20 +140,24 @@ class Location(Syncable):
     def _sync_pathname(self):
         """
         When in a server context and the pathname is overridden dynamically
-        we need to keep the state.rel_path in sync to ensure that resources
-        are resolved relative to the new URL.
+        we need to keep the state.rel_path and the Document dist_url template
+        variable in sync to ensure that resources are resolved relative to the new URL.
+        Additionally we clear the stylesheets cache which holds now outdated URLs.
         """
         session_context = state.curdoc.session_context
         if not (state._servers and session_context and session_context.server_context):
             return
         for server, _, _ in state._servers.values():
             server_port = server.port if hasattr(server, 'port') else server.config.port
-            if self.port == server_port:
+            if self.port == str(server_port):
                 break
         else:
             return
         prefix = getattr(server, 'prefix', '')
-        state.rel_path = '/'.join(['..'] * self.pathname.replace(prefix, '').strip('/').count('/'))
+        state.rel_path = rel_path = '/'.join(['..'] * self.pathname.replace(prefix, '').strip('/').count('/'))
+        if 'static/extensions/panel/' in state.curdoc._template_variables.get('dist_url', ''):
+            state.curdoc._template_variables['dist_url'] =  f"{rel_path}/static/extensions/panel/"
+        state._stylesheets.pop(state.curdoc, None)
 
     def get_root(
         self, doc: Document | None = None, comm: Comm | None = None,

--- a/panel/io/location.py
+++ b/panel/io/location.py
@@ -148,7 +148,6 @@ class Location(Syncable):
             return
         for server, _, _ in state._servers.values():
             server_port = server.port if hasattr(server, 'port') else server.config.port
-            breakpoint()
             if self.port == server_port:
                 break
         else:

--- a/panel/io/location.py
+++ b/panel/io/location.py
@@ -138,7 +138,20 @@ class Location(Syncable):
 
     @param.depends("pathname", watch=True)
     def _sync_pathname(self):
-        state.rel_path = '/'.join(['..'] * self.pathname.strip('/').count('/'))
+        """
+        When in a server context and the pathname is overridden dynamically
+        we need to keep the state.rel_path in sync to ensure that resources
+        are resolved relative to the new URL.
+        """
+        session_context = state.curdoc.session_context
+        if not (state._servers and session_context and session_context.server_context):
+            return
+        for server, _, _ in state._servers.values():
+            if server.port == self.port:
+                break
+        else:
+            return
+        state.rel_path = '/'.join(['..'] * self.pathname.replace(server.prefix, '').strip('/').count('/'))
 
     def get_root(
         self, doc: Document | None = None, comm: Comm | None = None,

--- a/panel/io/location.py
+++ b/panel/io/location.py
@@ -136,6 +136,10 @@ class Location(Syncable):
         self._link_props(model, self._linked_properties, doc, root, comm)
         return model
 
+    @param.depends("pathname", watch=True)
+    def _sync_pathname(self):
+        state.rel_path = '/'.join(['..'] * self.pathname.strip('/').count('/'))
+
     def get_root(
         self, doc: Document | None = None, comm: Comm | None = None,
         preprocess: bool = True

--- a/panel/io/location.py
+++ b/panel/io/location.py
@@ -147,11 +147,14 @@ class Location(Syncable):
         if not (state._servers and session_context and session_context.server_context):
             return
         for server, _, _ in state._servers.values():
-            if server.port == self.port:
+            server_port = server.port if hasattr(server, 'port') else server.config.port
+            breakpoint()
+            if self.port == server_port:
                 break
         else:
             return
-        state.rel_path = '/'.join(['..'] * self.pathname.replace(server.prefix, '').strip('/').count('/'))
+        prefix = getattr(server, 'prefix', '')
+        state.rel_path = '/'.join(['..'] * self.pathname.replace(prefix, '').strip('/').count('/'))
 
     def get_root(
         self, doc: Document | None = None, comm: Comm | None = None,

--- a/panel/models/location.ts
+++ b/panel/models/location.ts
@@ -6,6 +6,9 @@ export class LocationView extends View {
   declare model: Location
 
   _hash_listener: any
+  private _idle_ready = false
+  private _pending_url: string | null = null
+  private _idle_connected = false
 
   override initialize(): void {
     super.initialize()
@@ -44,28 +47,60 @@ export class LocationView extends View {
     window.removeEventListener("hashchange", this._hash_listener)
   }
 
-  update(change: string): void {
-    if (!this.model.reload || (change === "reload")) {
-      window.history.pushState(
-        {},
-        "",
-        `${this.model.pathname}${this.model.search}${this.model.hash}`,
-      )
-      this.model.href = window.location.href
-      if (change === "reload") {
-        window.location.reload()
-      }
-    } else {
-      if (change == "pathname") {
-        window.location.pathname = (this.model.pathname)
-      }
-      if (change == "search") {
-        window.location.search = (this.model.search)
-      }
-      if (change == "hash") {
-        window.location.hash = (this.model.hash)
-      }
+  private _ensure_idle_gate(): void {
+    if (this._idle_connected) {
+      return
     }
+    this._idle_connected = true
+
+    const doc = this.model.document as any
+    if (!doc || !doc.idle) {
+      this._idle_ready = true
+      return
+    }
+
+    doc.idle.connect(() => {
+      this._idle_ready = true
+      if (this._pending_url != null) {
+        const url = this._pending_url
+        this._pending_url = null
+        window.history.pushState({}, "", url)
+        this.model.href = window.location.href
+      }
+    })
+  }
+
+  private _set_url_gated(url: string): void {
+    this._ensure_idle_gate()
+    if (this._idle_ready) {
+      window.history.pushState({}, "", url)
+      this.model.href = window.location.href
+    } else {
+      this._pending_url = url
+    }
+  }
+
+  update(change: string): void {
+    const url = `${this.model.pathname}${this.model.search}${this.model.hash}`
+
+    if (change === "reload") {
+      window.history.pushState({}, "", url)
+      this.model.href = window.location.href
+      window.location.reload()
+      return
+    }
+
+    if (!this.model.reload) {
+      this._set_url_gated(url)
+      return
+    }
+
+    if (change === "hash") {
+      window.location.hash = this.model.hash
+      return
+    }
+
+    window.location.href = url
   }
 }
 

--- a/panel/models/location.ts
+++ b/panel/models/location.ts
@@ -54,7 +54,7 @@ export class LocationView extends View {
     this._idle_connected = true
 
     const doc = this.model.document as any
-    if (!doc || !doc.idle) {
+    if (doc.is_idle) {
       this._idle_ready = true
       return
     }


### PR DESCRIPTION
**Summary**
Changing the browser pathname early in the lifecycle can cause resources created just before the update to resolve against the wrong base URL. This PR ensures that resources generated prior to a pathname change continue to resolve relative to the original path, and keeps Panel’s internal relative path in sync for future resources.

**Changes**

* Gate URL updates on the Bokeh document idle signal so the initial batch of resources resolves against the original pathname.
* Update `pn.state.rel_path` when `pn.state.location.pathname` changes to ensure subsequently generated relative URLs resolve correctly.
* Use the History API for non-reload URL updates.

**Why**

Without this change:

* Early pathname updates can shift the document base too soon.
* Dynamically injected resources (JS/CSS/static) may resolve relative to the new path instead of the original one.
* Future resource generation can become inconsistent with the displayed URL.

**Result**

* Resources created before a pathname change resolve correctly.
* Resources created after the change use the updated relative base.
* URL updates remain SPA-friendly without unintended navigation side effects.

**Notes**

* The idle gating only affects the initial render window; subsequent updates proceed immediately.
* Backward compatible for existing Panel apps.
