### PR TITLE
Add on_click Parameter to Button widgets

### DIFF
--- a/panel/tests/widgets/test_button.py
+++ b/panel/tests/widgets/test_button.py
@@ -1,6 +1,7 @@
 from bokeh.events import ButtonClick, MenuItemClick
 
 from panel.widgets import Button, MenuButton, Toggle
+from panel.widgets.icon import ButtonIcon
 
 
 def test_button(document, comm):
@@ -47,6 +48,33 @@ def test_menu_button(document, comm):
     menu_button._process_event(MenuItemClick(widget, 'b'))
 
     assert events == ['b']
+
+
+def test_button_on_click_kwarg(document, comm):
+    events = []
+    button = Button(name='Button', on_click=lambda e: events.append(e))
+    button.get_root(document, comm=comm)
+    button._process_event(None)
+    assert len(events) == 1
+
+
+def test_menu_button_on_click_kwarg(document, comm):
+    events = []
+    menu_button = MenuButton(
+        items=[('Option A', 'a')],
+        on_click=lambda e: events.append(e)
+    )
+    widget = menu_button.get_root(document, comm=comm)
+    menu_button._process_event(MenuItemClick(widget, 'a'))
+    assert len(events) == 1
+
+
+def test_button_icon_on_click_kwarg(document, comm):
+    events = []
+    button_icon = ButtonIcon(icon='heart', on_click=lambda e: events.append(e))
+    button_icon.get_root(document, comm=comm)
+    button_icon._process_event(None)
+    assert len(events) == 1
 
 
 def test_button_jscallback_clicks(document, comm):


### PR DESCRIPTION
## Summary

The `on_click` parameter was already implemented in Button widgets (`panel/widgets/button.py` and `panel/widgets/icon.py`), allowing callbacks to be defined during widget instantiation. However, this functionality lacked unit test coverage. This PR adds tests to verify that the `on_click` parameter works correctly for all button widgets.

## Changes

- Added `test_button_on_click_kwarg` to verify `Button(on_click=...)` works
- Added `test_menu_button_on_click_kwarg` to verify `MenuButton(on_click=...)` works  
- Added `test_button_icon_on_click_kwarg` to verify `ButtonIcon(on_click=...)` works

## Testing

All tests pass and verify that callbacks can be registered during widget instantiation:

```python
button = pn.widgets.Button(name="Click me", on_click=lambda _: print("Clicked!"))
```

Fixes #8430
