### PR TITLE
Ensure we only de-duplicate param value events

### DIFF
--- a/panel/param.py
+++ b/panel/param.py
@@ -654,6 +654,8 @@ class Param(Pane):
             else:
                 updates['value'] = change.new
 
+            # Ensure we only de-duplicate value events since only
+            # the widget value can be controlled from the frontend 
             value_update = 'value' in updates or 'value_throttled' in updates
             try:
                 if value_update:

--- a/panel/param.py
+++ b/panel/param.py
@@ -654,8 +654,10 @@ class Param(Pane):
             else:
                 updates['value'] = change.new
 
+            value_update = 'value' in updates or 'value_throttled' in updates
             try:
-                updating.append(p_key)
+                if value_update:
+                    updating.append(p_key)
                 if change.type == 'triggered':
                     with discard_events(widget):
                         widget.param.update(**updates)
@@ -666,7 +668,8 @@ class Param(Pane):
                 else:
                     widget.param.update(**updates)
             finally:
-                updating.remove(p_key)
+                if value_update:
+                    updating.remove(p_key)
 
         # Set up links to parameterized object
         watchers.append(parameterized.param.watch(link, p_name, 'constant'))

--- a/panel/param.py
+++ b/panel/param.py
@@ -655,7 +655,7 @@ class Param(Pane):
                 updates['value'] = change.new
 
             # Ensure we only de-duplicate value events since only
-            # the widget value can be controlled from the frontend 
+            # the widget value can be controlled from the frontend
             value_update = 'value' in updates or 'value_throttled' in updates
             try:
                 if value_update:


### PR DESCRIPTION
Currently the `Param` pane tracks parameter events and blocks events from bouncing back and forth by tracking when a parameter value is changing. However we track this for all parameter attribute changes, including attributes like constant, label etc., and treat all of these the same. This means that when constant is toggled it can occur that we end up dropping events for another attribute or even the value. We now only apply this handling when the value changes.