### PR TITLE
Feat: Add `__shadow_root__` class variable to `JSComponent` for Light DOM rendering

### DIFF
--- a/panel/custom.py
+++ b/panel/custom.py
@@ -774,7 +774,14 @@ class JSComponent(ReactiveESM):
         CounterButton().servable()
     '''
 
+    __shadow_root__: ClassVar[bool] = True
+
     __abstract = True
+
+    def _get_properties(self, doc: Document | None) -> dict[str, Any]:
+        props = super()._get_properties(doc)
+        props['use_shadow_dom'] = type(self).__shadow_root__
+        return props
 
 
 class ReactComponent(ReactiveESM):

--- a/panel/models/esm.py
+++ b/panel/models/esm.py
@@ -52,6 +52,8 @@ class ReactiveESM(HTMLBox):
 
     render_policy = bp.Enum('manual', 'children', default="children")
 
+    use_shadow_dom = bp.Bool(True)
+
     __javascript_raw__ = [
         f"{config.npm_cdn}/es-module-shims@^1.10.0/dist/es-module-shims.min.js"
     ]
@@ -69,8 +71,6 @@ class ReactComponent(ReactiveESM):
     render_policy = bp.Override(default="manual") # type: ignore
 
     root_node = bp.Nullable(bp.String)
-
-    use_shadow_dom = bp.Bool(True)
 
 
 class AnyWidgetComponent(ReactComponent):

--- a/panel/models/react_component.ts
+++ b/panel/models/react_component.ts
@@ -107,7 +107,7 @@ export class ReactComponentView extends ReactiveESMView {
     }
   }
 
-  get use_shadow_dom(): boolean {
+  override get use_shadow_dom(): boolean {
     return this.model.use_shadow_dom || !(this.parent instanceof ReactComponentView)
   }
 
@@ -304,7 +304,6 @@ export namespace ReactComponent {
 
   export type Props = ReactiveESM.Props & {
     root_node: p.Property<string | null>
-    use_shadow_dom: p.Property<boolean>
   }
 }
 
@@ -675,9 +674,8 @@ ${compiled}`
 
   static {
     this.prototype.default_view = ReactComponentView
-    this.define<ReactComponent.Props>(({Bool, Nullable, Str}) => ({
+    this.define<ReactComponent.Props>(({Nullable, Str}) => ({
       root_node:  [ Nullable(Str), null ],
-      use_shadow_dom:   [ Bool,    true ],
     }))
 
     this.override<ReactComponent.Props>({

--- a/panel/models/reactive_esm.ts
+++ b/panel/models/reactive_esm.ts
@@ -319,6 +319,10 @@ export class ReactiveESMView extends HTMLBoxView {
     this.container.appendChild(error_div)
   }
 
+  get use_shadow_dom(): boolean {
+    return this.model.use_shadow_dom
+  }
+
   override render(): void {
     this.empty()
     this._update_stylesheets()
@@ -335,7 +339,19 @@ export class ReactiveESMView extends HTMLBoxView {
     this.container = div()
     this.container.className = this.model.class_name.replace(/([a-z])([A-Z])/g, "$1-$2").toLowerCase()
     set_size(this.container, this.model, false)
-    this.shadow_el.append(this.container)
+    let render_root: Element | ShadowRoot
+    if (this.use_shadow_dom) {
+      render_root = this.shadow_el
+    } else {
+      // Light DOM rendering: clear any previous Light DOM children of the
+      // shadow host (the shadow root itself is unaffected by replaceChildren),
+      // then add a <slot> to shadow_el so the Light DOM children are projected
+      // and visible in the rendered output.
+      this.el.replaceChildren()
+      this.shadow_el.appendChild(document.createElement("slot"))
+      render_root = this.el
+    }
+    render_root.append(this.container)
     if (this.model.compile_error) {
       this.render_error(this.model.compile_error)
     } else {
@@ -345,7 +361,7 @@ export class ReactiveESMView extends HTMLBoxView {
       // this.shadow_el is needed for Bokeh < 3.7.0 as this.self_target is not defined
       // can be removed when our minimum version is Bokeh 3.7.0
       // https://github.com/holoviz/panel/pull/7948
-      const target = element_view.rendering_target() ?? this.self_target ?? this.shadow_el
+      const target = element_view.rendering_target() ?? this.self_target ?? render_root
       element_view.render_to(target)
     }
   }
@@ -592,6 +608,7 @@ export namespace ReactiveESM {
     events: p.Property<string[]>
     importmap: p.Property<any>
     render_policy: p.Property<typeof RenderPolicy["__type__"]>
+    use_shadow_dom: p.Property<boolean>
   }
 }
 
@@ -941,6 +958,7 @@ export default {render}`
       events:      [ Array(Str),          [] ],
       importmap:   [ Any,                 {} ],
       render_policy: [ RenderPolicy, "children"],
+      use_shadow_dom: [ Bool,            true ],
     }))
   }
 }

--- a/panel/models/reactive_esm.ts
+++ b/panel/models/reactive_esm.ts
@@ -343,10 +343,6 @@ export class ReactiveESMView extends HTMLBoxView {
     if (this.use_shadow_dom) {
       render_root = this.shadow_el
     } else {
-      // Light DOM rendering: clear any previous Light DOM children of the
-      // shadow host (the shadow root itself is unaffected by replaceChildren),
-      // then add a <slot> to shadow_el so the Light DOM children are projected
-      // and visible in the rendered output.
       this.el.replaceChildren()
       this.shadow_el.appendChild(document.createElement("slot"))
       render_root = this.el

--- a/panel/tests/test_custom.py
+++ b/panel/tests/test_custom.py
@@ -4,7 +4,7 @@ import param
 
 from bokeh.plotting import figure
 
-from panel.custom import PyComponent, ReactiveESM
+from panel.custom import JSComponent, PyComponent, ReactiveESM
 from panel.io.state import state
 from panel.layout import Row
 from panel.pane import Bokeh, Markdown
@@ -225,3 +225,24 @@ def test_esm_parameter_override(document, comm):
     esm.width = 84
 
     assert model.width == 84
+
+
+class JSComponentWithShadowRoot(JSComponent):
+    _esm = "export function render() {}"
+
+
+class JSComponentNoShadowRoot(JSComponent):
+    __shadow_root__ = False
+    _esm = "export function render() {}"
+
+
+def test_jscomponent_shadow_root_default(document, comm):
+    component = JSComponentWithShadowRoot()
+    model = component.get_root(document, comm)
+    assert model.use_shadow_dom is True
+
+
+def test_jscomponent_shadow_root_disabled(document, comm):
+    component = JSComponentNoShadowRoot()
+    model = component.get_root(document, comm)
+    assert model.use_shadow_dom is False


### PR DESCRIPTION
Adds an opt-in `__shadow_root__` class variable to `JSComponent` that allows rendering into the Light DOM instead of Shadow DOM. Default is `True` — fully backward compatible, all existing components are unchanged. When `False`, external CSS from `<head>` applies naturally and global DOM APIs like `document.getElementById()` work without any patching.


### Problem

`JSComponent` always renders into a Shadow DOM. This breaks several common web component patterns:

- ***Dynamic CSS injection*** — Libraries like CodeMirror 6 dynamically insert `<link>` and `<style>` elements into `<head>`. These styles don't penetrate the shadow boundary, leaving components unstyled or broken.
- ***Third-party library compatibility*** — AnyWidget, ipywidgets, and other widget libraries that use global DOM APIs fail inside Shadow DOM without manual workarounds.

The `panel-live` project currently maintains **~80 lines of Shadow DOM workarounds** in its ESM module just to make its `JSComponent` work correctly. This change reduces that to one line:

```python
class PanelLive(JSComponent):
    __shadow_root__ = False  # render into Light DOM instead of Shadow DOM
    _esm = "panel_live_esm.js"
```


### Implementation

#### `panel/models/esm.py`
Added `use_shadow_dom = bp.Bool(True)` to the `ReactiveESM` Bokeh model so the value is serialized and synced from Python to the browser.

#### `panel/custom.py`
- Added `__shadow_root__: ClassVar[bool] = True` to `JSComponent`.
- Overrode `_get_properties()` to pass `type(self).__shadow_root__` to the model as `use_shadow_dom`.

#### `panel/models/reactive_esm.ts`
- Registered `use_shadow_dom` in `ReactiveESM`'s `static` define block (required for Bokeh to serialize the property).
- Added `get use_shadow_dom()` getter to `ReactiveESMView`.
- Modified `render()` to conditionally choose the render target:
  - `true` → existing behaviour, container appended to `this.shadow_el`.
  - `false` → container appended to `this.el` (Light DOM); a `<slot>` is added to `shadow_el` so the Light DOM child is projected through and rendered correctly.

#### `panel/models/react_component.ts`
- Added `override` to the `use_shadow_dom` getter in `ReactComponentView` (required since the base class now declares it).
- Removed duplicate `use_shadow_dom` from `ReactComponent.Props` and its `static` define block — it is now inherited from `ReactiveESM`.


### Tests

Added to `panel/tests/test_custom.py`:

| Test | Asserts |
|---|---|
| `test_jscomponent_shadow_root_default` | `model.use_shadow_dom is True` by default |
| `test_jscomponent_shadow_root_disabled` | `model.use_shadow_dom is False` when `__shadow_root__ = False` |


Closes #8429


Disclosure: Claude Haiku 4.5 was used as a coding assistant during the development of this PR.