### PR TITLE
Fix Video pane rejecting URLs with query parameters

### DIFF
--- a/panel/tests/pane/test_media.py
+++ b/panel/tests/pane/test_media.py
@@ -78,6 +78,10 @@ def test_video_applies_url_without_format():
     url = 'https://www.videoserver.com/watch?v=12345'
     assert not Video.applies(url)
 
+def test_video_applies_url_with_format_prefix_in_query():
+    url = 'https://www.videoserver.com/watch?v=file.mp4extra'
+    assert not Video.applies(url)
+
 def test_local_audio(document, comm):
     audio = Audio(str(ASSETS / 'mp3.mp3'))
     model = audio.get_root(document, comm=comm)

--- a/panel/tests/pane/test_media.py
+++ b/panel/tests/pane/test_media.py
@@ -63,6 +63,21 @@ def test_video_muted(document, comm):
 
     assert model.muted
 
+def test_video_url_with_query_params(document, comm):
+    url = 'https://www.videoserver.com/watch?v=/path/to/video.mp4'
+    video = Video(url)
+    model = video.get_root(document, comm=comm)
+
+    assert model.value == url
+
+def test_video_applies_url_with_query_params():
+    url = 'https://www.videoserver.com/watch?v=/path/to/video.mp4'
+    assert Video.applies(url)
+
+def test_video_applies_url_without_format():
+    url = 'https://www.videoserver.com/watch?v=12345'
+    assert not Video.applies(url)
+
 def test_local_audio(document, comm):
     audio = Audio(str(ASSETS / 'mp3.mp3'))
     model = audio.get_root(document, comm=comm)

--- a/panel/util/checks.py
+++ b/panel/util/checks.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import datetime as dt
 import importlib.util
 import os
+import re
 import sys
 
 from collections.abc import Iterable
@@ -40,17 +41,17 @@ def isurl(obj: Any, formats: Iterable[str] | None = None) -> bool:
     if not isinstance(obj, str):
         return False
     lower = obj.lower()
-    path = lower.split('?')[0].split('#')[0]
+    parts = lower.split('?', 1)
+    path = parts[0].split('#')[0]
     if not path.startswith(("http://", "https://")):
         return False
     if formats is None:
         return True
-    # Check path for format extension
     if any(path.endswith('.'+fmt) for fmt in formats):
         return True
     # Check query string for format extension (e.g. ?v=/path/to/video.mp4)
-    query = lower.split('?', 1)[1] if '?' in lower else ''
-    return any('.'+fmt in query for fmt in formats)
+    query = parts[1] if len(parts) > 1 else ''
+    return any(re.search(r'\.' + fmt + r'(?![a-z0-9])', query) for fmt in formats)
 
 
 def is_dataframe(obj) -> bool:

--- a/panel/util/checks.py
+++ b/panel/util/checks.py
@@ -39,10 +39,18 @@ def isfile(path: str | os.PathLike) -> bool:
 def isurl(obj: Any, formats: Iterable[str] | None = None) -> bool:
     if not isinstance(obj, str):
         return False
-    lower_string = obj.lower().split('?')[0].split('#')[0]
-    return (
-        lower_string.startswith(("http://", "https://"))
-    ) and (formats is None or any(lower_string.endswith('.'+fmt) for fmt in formats))
+    lower = obj.lower()
+    path = lower.split('?')[0].split('#')[0]
+    if not path.startswith(("http://", "https://")):
+        return False
+    if formats is None:
+        return True
+    # Check path for format extension
+    if any(path.endswith('.'+fmt) for fmt in formats):
+        return True
+    # Check query string for format extension (e.g. ?v=/path/to/video.mp4)
+    query = lower.split('?', 1)[1] if '?' in lower else ''
+    return any('.'+fmt in query for fmt in formats)
 
 
 def is_dataframe(obj) -> bool:


### PR DESCRIPTION
## Summary

Fixes the Video pane rejecting URLs that contain media format extensions in query parameters rather than the URL path.

Closes #3203

## Key Changes

**`panel/util/checks.py`**
- Updated `isurl()` to check the query string for format extensions when the URL path does not contain one
- URLs like `https://server.com/watch?v=/path/to/video.mp4` are now correctly recognized as media URLs

**`panel/tests/pane/test_media.py`**
- `test_video_url_with_query_params` - verifies Video pane accepts and renders a URL with format in query string
- `test_video_applies_url_with_query_params` - verifies `Video.applies()` returns True for query param URLs
- `test_video_applies_url_without_format` - verifies URLs without any format extension are still rejected

## Tests

All 25 existing media tests pass, plus 3 new tests added. No regressions.
