### PR TITLE
Fix Number and String indicators defaulting to black in dark theme

### DIFF
--- a/panel/tests/widgets/test_indicators.py
+++ b/panel/tests/widgets/test_indicators.py
@@ -10,11 +10,11 @@ def test_number_none(document, comm):
 
     model = number.get_root(document, comm)
 
-    assert model.text.endswith("&lt;div style=&quot;font-size: 54pt; color: black&quot;&gt;-&lt;/div&gt;")
+    assert model.text.endswith("&lt;div style=&quot;font-size: 54pt; color: currentcolor&quot;&gt;-&lt;/div&gt;")
 
     number.nan_format = 'nan'
 
-    assert model.text.endswith("&lt;div style=&quot;font-size: 54pt; color: black&quot;&gt;nan&lt;/div&gt;")
+    assert model.text.endswith("&lt;div style=&quot;font-size: 54pt; color: currentcolor&quot;&gt;nan&lt;/div&gt;")
 
 
 def test_number_thresholds(document, comm):

--- a/panel/widgets/indicators.py
+++ b/panel/widgets/indicators.py
@@ -331,7 +331,7 @@ class Number(ValueIndicator):
     >>> Number(name='Rate', value=72, format='{value}%', colors=[(80, 'green'), (100, 'red')]
     """
 
-    default_color = param.String(default='black', doc="""
+    default_color = param.String(default='currentcolor', doc="""
         The color of the Number indicator if no colors are provided""")
 
     colors = param.List(default=None, doc="""
@@ -396,8 +396,8 @@ class String(ValueIndicator):
     The String indicator renders a string with a title.
     """
 
-    default_color = param.String(default='black', doc="""
-        The color of the Number indicator if no colors are provided""")
+    default_color = param.String(default='currentcolor', doc="""
+        The color of the indicator if no colors are provided""")
 
     font_size = param.String(default='54pt', doc="""
         The size of number itself.""")


### PR DESCRIPTION
## Summary

Fixes Number and String indicators rendering black text in dark theme, making the value unreadable after updates.

Closes #8373

## Key Changes

**`panel/widgets/indicators.py`**
- Changed `default_color` from `'black'` to `'currentcolor'` on `Number` indicator
- Changed `default_color` from `'black'` to `'currentcolor'` on `String` indicator
- `currentcolor` is a CSS value that inherits the text color from the parent element, so it automatically adapts to both light and dark themes

**`panel/tests/widgets/test_indicators.py`**
- Updated `test_number_none` assertions to match new default color

## Tests

All 8 existing indicator tests pass. No regressions.
