### PR TITLE
Fix issue where OAuth user data was overwritten while updating

### DIFF
--- a/panel/auth.py
+++ b/panel/auth.py
@@ -1178,9 +1178,9 @@ class OAuthProvider(BasicAuthProvider):
         state._active_users[user] -= 1
         if not state._active_users[user]:
             del state._active_users[user]
-            # Don't remove the user override when it is set to None or
-            # is missing, as this means it is being refreshed.
-            if state._oauth_user_overrides.get(user) is not None:
+            # Don't remove the user override when it is empty
+            # as this means it is being refreshed.
+            if state._oauth_user_overrides.get(user, False):
                 del state._oauth_user_overrides[user]
 
     def _schedule_refresh(self, expiry_ts, user, refresh_token, application, request):


### PR DESCRIPTION
Fix for new issue raised in https://github.com/holoviz/panel/issues/8374

The code incorrectly assumed that the condition that indicated whether the OAuth data was being refreshed required the oauth_user_override to be `None` when in reality it is meant to be an empty dict.