### PR TITLE
fix: `widget.link()` to support HoloViews streams

### DIFF
--- a/panel/reactive.py
+++ b/panel/reactive.py
@@ -800,7 +800,14 @@ class Reactive(Syncable, Viewable):
                     if callbacks:
                         callbacks[event.name](target, event)
                     else:
-                        setattr(target, links[event.name], event.new)
+                        _is_hv_stream = (
+                            'holoviews' in sys.modules and
+                            isinstance(target, sys.modules['holoviews'].streams.Stream)
+                        )
+                        if _is_hv_stream:
+                            target.event(**{links[event.name]: event.new})
+                        else:
+                            setattr(target, links[event.name], event.new)
                 finally:
                     _updating.pop(_updating.index(event.name))
         params = list(callbacks) if callbacks else list(links)

--- a/panel/tests/test_reactive.py
+++ b/panel/tests/test_reactive.py
@@ -59,6 +59,23 @@ def test_link():
     assert obj2.a == 1
 
 
+def test_link_holoviews_stream():
+    "Link a Reactive object to a HoloViews stream"
+    try:
+        import holoviews as hv
+    except ImportError:
+        pytest.skip("holoviews not available")
+
+    class ReactiveLink(Reactive):
+        selection = param.List(default=[])
+
+    obj = ReactiveLink()
+    stream = hv.streams.Selection1D()
+    obj.link(stream, selection='index')
+    obj.selection = [0, 1]
+    assert stream.index == [0, 1]
+
+
 def test_param_rename():
     "Test that Reactive renames params and properties"
 


### PR DESCRIPTION
## Problem

Panel's `widget.link()` method is designed to create bidirectional connections between widgets and other parameterized objects. When we try to link a widget to a HoloViews stream (used for interactive plots), the connection appears to be made, but it doesn't actually work.

For example, when we write:
```python
tabulator.link(selection_1d, selection="index", bidirectional=True)
```

We expect that clicking a row in the table will update the plot selection, and clicking a point in the plot will update the table selection. However, while the table selection changes correctly, the plot never updates because the stream's subscribers aren't notified.

## The video demonstrates:
**Before fix**: Using a single tabulator.link() call doesn't work 

https://github.com/user-attachments/assets/22019bb2-24b7-4754-adad-478854c010c3

**After fix**: Using a single `tabulator.link()` call that works correctly

https://github.com/user-attachments/assets/fe584896-79df-4417-89df-117d5d41a01d

**What's happening:** The `link()` method uses `setattr()` to update the stream parameter. This sets the value correctly, but HoloViews streams need their `.event()` method to be called to notify all subscribers (like `DynamicMap` objects) that something changed. Without calling `.event()`, the stream value changes silently but nothing listening to the stream gets notified, so plots don't refresh.

The workaround required two separate `pn.bind()` calls:

```python
def selection1d_to_tabulator(index):
    tabulator.selection = index

def tabulator_to_selection1d(selection):
    selection_1d.event(index=selection)

pn.bind(selection1d_to_tabulator, selection_1d.param.index, watch=True)
pn.bind(tabulator_to_selection1d, tabulator.param.selection, watch=True)
```

## Solution

Modified `Reactive.link()` in `panel/reactive.py` to detect when the link target is a HoloViews `Stream` object. When detected, it calls `.event()` instead of `setattr()`, which properly triggers all stream subscribers and enables `DynamicMap` updates.

The fix is **fully backward compatible** — it only changes behavior for HoloViews stream targets. All other `.link()` calls work exactly as before.

## Example

**Before** — required two `pn.bind()` calls:
```python
pn.bind(selection1d_to_tabulator, selection_1d.param.index, watch=True)
pn.bind(tabulator_to_selection1d, tabulator.param.selection, watch=True)
```

**After** — one simple `.link()` call:
```python
tabulator.link(selection_1d, selection="index", bidirectional=True)
```

## Files Changed

- `panel/reactive.py` — Updated `Reactive.link()` to call `.event()` on HoloViews stream targets

## Related Issue

Closes #7801

> **AI Disclosure:** I used Gemini 3 Flash to explore and understand the codebase while working on this fix.
