### PR TITLE
fix: Add missing unwatch() method to Callback class

### DIFF
--- a/panel/links.py
+++ b/panel/links.py
@@ -184,6 +184,20 @@ class Callback(param.Parameterized):
         else:
             self.registry[source] = [self]
 
+    def unwatch(self) -> None:
+        """
+        Unregisters the Callback, preventing it from being applied
+        to future renders. Note that if the callback has already been
+        applied to a rendered model, it will not be removed from that
+        model automatically.
+        """
+        source = self.source
+        if source is None:
+            return
+        callbacks = self.registry.get(source, [])
+        if self in callbacks:
+            callbacks.remove(self)
+
     @classmethod
     def register_callback(cls, callback: type[CallbackGenerator]) -> None:
         """

--- a/panel/tests/test_links.py
+++ b/panel/tests/test_links.py
@@ -10,11 +10,11 @@ from bokeh.plotting import figure
 
 from panel.custom import JSComponent
 from panel.layout import Row
-from panel.links import Link
+from panel.links import Callback, Link
 from panel.pane import Bokeh, HoloViews
 from panel.tests.util import hv_available
 from panel.widgets import (
-    ColorPicker, DatetimeInput, FloatInput, FloatSlider, RangeSlider,
+    Button, ColorPicker, DatetimeInput, FloatInput, FloatSlider, RangeSlider,
     TextInput,
 )
 
@@ -398,3 +398,33 @@ def test_link_with_customcode(document, comm):
     assert link_customjs.args['source'] is range_slider
     assert link_customjs.args['x_range'] is x_range
     assert link_customjs.code == f"try {{ {code} }} catch(err) {{ console.log(err) }}"
+
+
+def test_callback_unwatch():
+    button = Button(name="Test")
+    cb = button.js_on_click(args=dict(url="google.com"), code="window.open(url, '_blank');")
+
+    assert len(Callback.registry.get(button, [])) == 1
+    assert cb in Callback.registry[button]
+
+    cb.unwatch()
+
+    assert len(Callback.registry.get(button, [])) == 0
+
+
+def test_callback_unwatch_multiple_callbacks():
+    button = Button(name="Test")
+    cb1 = button.js_on_click(args=dict(url1="url1"), code="console.log('1');")
+    cb2 = button.js_on_click(args=dict(url2="url2"), code="console.log('2');")
+
+    assert len(Callback.registry.get(button, [])) == 2
+
+    cb1.unwatch()
+
+    assert len(Callback.registry.get(button, [])) == 1
+    assert cb1 not in Callback.registry[button]
+    assert cb2 in Callback.registry[button]
+
+    cb2.unwatch()
+
+    assert len(Callback.registry.get(button, [])) == 0


### PR DESCRIPTION
## What's the issue?

While I picked up the issue [#7440](https://github.com/holoviz/panel/issues/7440),  the docs for `js_on_click` say the returned `Callback` *"can be used to disable the callback"*, so I went ahead and verified that in the docs, then tested it myself:

```python
import panel as pn

button = pn.widgets.Button(name="Open")
cb = button.js_on_click(args=dict(url="google.com"), code="window.open(url, '_blank');")
cb.unwatch()  # AttributeError: 'Callback' object has no attribute 'unwatch'
```

Confirmed, so the issue persists. The docs doesn't match with the code's output itself.


## Root Cause

I went into `panel/links.py` where the `Callback` class lives. Here's what I found:

- When a `Callback` is created via `js_on_click`, it registers itself into a `WeakKeyDictionary` called `registry` — keyed by the source widget.
- `_process_callbacks` later walks through this registry to attach the JS callbacks to the Bokeh model on render.
- The subclass `Link` (which extends `Callback`) already had an `unlink()` method that simply removes itself from the registry.
- But the base `Callback` class? **Nothing.** No `unwatch()`, no `unregister()`, no way to undo it at all.


## Fix

Added `unwatch()` to the `Callback` class, mirroring `Link.unlink()`:

```python
def unwatch(self) -> None:
    source = self.source
    if source is None:
        return
    callbacks = self.registry.get(source, [])
    if self in callbacks:
        callbacks.remove(self)
```


## Notes
- Only prevents the callback from being applied to **future** renders, consistent with `Link.unlink()` behaviour.

Closes #7440.

**AI Disclosure:** I used Gemini 3 Flash to explore and understand the codebase while working on this fix.