### PR TITLE
fix: markdown docs render

### DIFF
--- a/examples/reference/panes/Markdown.ipynb
+++ b/examples/reference/panes/Markdown.ipynb
@@ -10,7 +10,7 @@
    "source": [
     "import panel as pn\n",
     "\n",
-    "pn.extension('mathjax')"
+    "pn.extension()"
    ]
   },
   {
@@ -311,6 +311,8 @@
    },
    "outputs": [],
    "source": [
+    "pn.extension('mathjax')\n",
+    "\n",
     "pn.pane.Markdown(r\"\"\"\n",
     "The Markdown pane supports math rendering for string encapsulated with double $ delimiters: $$\\sum_{j}{\\sum_{i}{a*w_{j, i}}}$$\n",
     "\"\"\", width=800)"


### PR DESCRIPTION
Closes #8422 
The page was initializing `MathJax` for every example at the top, even though only LaTeX needs it.
That made normal Markdown examples wait on `MathJax` and sometimes appear blank until manual Run.
I moved pn.extension('mathjax') to the LaTeX section only, where it is actually required.
Now regular Markdown renders immediately, and LaTeX rendering still works as expected.
<img width="1919" height="962" alt="image" src="https://github.com/user-attachments/assets/11a52b93-b51e-4253-9e4c-353c4ffae5f5" />

however, some lower cells in this page still require clicking Run to render.
<img width="1918" height="974" alt="image" src="https://github.com/user-attachments/assets/d40a2fdc-38cb-47f2-b9d8-26b5818ea2c8" />
i think what we can do is move the LaTeX block to the bottom (move New Lines section above) (but LaTeX section still need manual click :( )