### PR TITLE
compat: VTK 9.6.0

### DIFF
--- a/panel/pane/vtk/synchronizable_serializer.py
+++ b/panel/pane/vtk/synchronizable_serializer.py
@@ -7,6 +7,9 @@ import zipfile
 
 from typing import Any
 
+import vtk
+
+from packaging.version import Version
 from vtk.vtkCommonCore import vtkTypeInt32Array, vtkTypeUInt32Array
 from vtk.vtkCommonDataModel import vtkDataObject
 from vtk.vtkFiltersGeometry import (
@@ -15,6 +18,26 @@ from vtk.vtkFiltersGeometry import (
 from vtk.vtkRenderingCore import vtkColorTransferFunction
 
 from .enums import TextPosition
+
+_vtk_version = Version(vtk.__version__).release
+
+if _vtk_version >= (9, 6, 0):
+
+    def _get_cell_array_data(cell_array):
+        from vtk.vtkCommonCore import vtkIdTypeArray
+
+        legacy = vtkIdTypeArray()
+        cell_array.ExportLegacyFormat(legacy)
+        return legacy
+
+    def _cell_array_nonempty(cell_array):
+        return cell_array and cell_array.GetNumberOfCells() > 0
+else:
+    def _get_cell_array_data(cell_array):
+        return cell_array.GetData()
+
+    def _cell_array_nonempty(cell_array):
+        return cell_array and cell_array.GetData().GetNumberOfTuples() > 0
 
 
 def iteritems(d, **kwargs):
@@ -1100,27 +1123,26 @@ def polydataSerializer(parent, dataset, datasetId, context, depth):
         properties['points'] = points
 
         # Verts
-        if dataset.GetVerts() and dataset.GetVerts().GetData().GetNumberOfTuples() > 0:
-            _verts = getArrayDescription(dataset.GetVerts().GetData(), context)
+        if _cell_array_nonempty(dataset.GetVerts()):
+            _verts = getArrayDescription(_get_cell_array_data(dataset.GetVerts()), context)
             properties['verts'] = _verts
             properties['verts']['vtkClass'] = 'vtkCellArray'
 
         # Lines
-        if dataset.GetLines() and dataset.GetLines().GetData().GetNumberOfTuples() > 0:
-            _lines = getArrayDescription(dataset.GetLines().GetData(), context)
+        if _cell_array_nonempty(dataset.GetLines()):
+            _lines = getArrayDescription(_get_cell_array_data(dataset.GetLines()), context)
             properties['lines'] = _lines
             properties['lines']['vtkClass'] = 'vtkCellArray'
 
         # Polys
-        if dataset.GetPolys() and dataset.GetPolys().GetData().GetNumberOfTuples() > 0:
-            _polys = getArrayDescription(dataset.GetPolys().GetData(), context)
+        if _cell_array_nonempty(dataset.GetPolys()):
+            _polys = getArrayDescription(_get_cell_array_data(dataset.GetPolys()), context)
             properties['polys'] = _polys
             properties['polys']['vtkClass'] = 'vtkCellArray'
 
         # Strips
-        if dataset.GetStrips() and dataset.GetStrips().GetData().GetNumberOfTuples() > 0:
-            _strips = getArrayDescription(
-                dataset.GetStrips().GetData(), context)
+        if _cell_array_nonempty(dataset.GetStrips()):
+            _strips = getArrayDescription(_get_cell_array_data(dataset.GetStrips()), context)
             properties['strips'] = _strips
             properties['strips']['vtkClass'] = 'vtkCellArray'
 


### PR DESCRIPTION
## Description

<!--
- Summarize the change and which issue is fixed.
- Include relevant motivation and context.
- Add visuals when possible, e.g. before/after screenshots with full code snippets.
-->

Fixes failing deprecation warning `cell_array.GetData()` seen in the test suite with:

 ```
DeprecationWarning: Call to deprecated method GetData. (Use ExportLegacyFormat, or GetOffsetsArray/GetConnectivityArray instead.) -- Deprecated since version 9.6.0.
```

## How Has This Been Tested?

<!-- Describe the tests that you ran to verify your changes. Provide instructions so it can be reproduced while reviewing your changes. -->

Ran the VTK tests locally + CI


## AI Disclosure

<!-- Remove this section if your PR does not contain AI-generated content. -->

- [x] This PR contains AI-generated content.
  - [x] I have tested all AI-generated content in my PR.
  - [x] I take responsibility for all AI-generated content in my PR.
    <!-- If you used AI to generate code, please specify the tool and model used, and how you have used it. -->
    Tools: Claude Code

Asked it to fix the deprecation warning. I refactored the code, but the new function is AI generated. 

## Checklist

<!-- Remove the non relevant items. -->

- [ ] Tests added and is passing
