### PR TITLE
Enrich displayed python error message occuring while serving app

### DIFF
--- a/panel/io/handlers.py
+++ b/panel/io/handlers.py
@@ -365,8 +365,10 @@ def run_app(handler, module, doc: Document, post_run=None, allow_empty: bool = F
                 try:
                     handler._func(doc)
                 except Exception as e:
+                    error_message = ''.join(traceback.format_exception(None, e, e.__traceback__))
+                    print(error_message)
                     Alert(
-                        f'<b>{type(e).__name__}</b>\n<pre style="overflow-y: auto">{str(e)}</pre>',
+                        f'<b>{type(e).__name__}</b>\n<pre style="overflow-y: auto">{str(error_message)}</pre>',
                         alert_type='danger', margin=5, sizing_mode='stretch_width'
                     ).servable()
             elif runner is None or runner.error:

--- a/panel/io/handlers.py
+++ b/panel/io/handlers.py
@@ -366,7 +366,7 @@ def run_app(handler, module, doc: Document, post_run=None, allow_empty: bool = F
                     handler._func(doc)
                 except Exception as e:
                     error_message = ''.join(traceback.format_exception(None, e, e.__traceback__))
-                    print(error_message)
+                    print(error_message)  # noqa
                     Alert(
                         f'<b>{type(e).__name__}</b>\n<pre style="overflow-y: auto">{str(error_message)}</pre>',
                         alert_type='danger', margin=5, sizing_mode='stretch_width'


### PR DESCRIPTION
Hello,

Between the versions 1.8.2 and 1.8.3, a behavior was changed in the error handler. If we serve a function that runs into a python error, the behavior goes from

1.8.2 : Error 505 appearing in the browser, full traceback in the console
to

1.8.3 : Simple error message in the browser, nothing in the console
The loss of traceback turns debugging into a nightmare.

The simple error message seem to come from this, whose code actually changed between the two versions:
https://github.com/holoviz/panel/blob/v1.8.3/panel/io/handlers.py#L369

I propose to replace the simple e put in the string by its traceback, and print it to have it in the console to benefit from IDE console features.

I propose a pull request with the associated changes.

Thanks,
Thibault