### PR TITLE
Docs: Recommend using bound function reference instead of watch=True in bind_component guide

### DIFF
--- a/doc/how_to/interactivity/bind_component.md
+++ b/doc/how_to/interactivity/bind_component.md
@@ -76,6 +76,7 @@ pn.Row(slider, size, select, pn.pane.Markdown(refs=irefs))
 ```
 
 In this way we can update both the current `object` and the `styles` **Parameter** of the `Markdown` pane simultaneously.
+
 ### Using the bound function as a reference
 
 In some cases it may be tempting to use `watch=True` when calling `pn.bind` to update a component:

--- a/doc/how_to/interactivity/bind_component.md
+++ b/doc/how_to/interactivity/bind_component.md
@@ -76,7 +76,26 @@ pn.Row(slider, size, select, pn.pane.Markdown(refs=irefs))
 ```
 
 In this way we can update both the current `object` and the `styles` **Parameter** of the `Markdown` pane simultaneously.
+### Using the bound function as a reference
 
+In some cases it may be tempting to use `watch=True` when calling `pn.bind` to update a component:
+
+```python
+pn.bind(update_value, select, slider, watch=True)
+```
+
+However, this pattern recreates the object whenever the inputs change and is generally considered an anti-pattern.
+
+A better approach is to assign the bound function directly to the component parameter that should update:
+
+```python
+def update_value(select_value, slider_value):
+    return select_value * slider_value
+
+text = pn.widgets.StaticText(value=pn.bind(update_value, select, slider))
+```
+
+This keeps the component reactive while avoiding unnecessary object recreation and ensures that only the relevant parameter is updated.
 ## Related Resources
 
 - Learn [how to use generators with `bind`](bind_generators)

--- a/doc/how_to/interactivity/bind_component.md
+++ b/doc/how_to/interactivity/bind_component.md
@@ -97,6 +97,7 @@ text = pn.widgets.StaticText(value=pn.bind(update_value, select, slider))
 ```
 
 This keeps the component reactive while avoiding unnecessary object recreation and ensures that only the relevant parameter is updated.
+
 ## Related Resources
 
 - Learn [how to use generators with `bind`](bind_generators)


### PR DESCRIPTION
## Description

Fixes #6271

This PR updates the documentation in `doc/how_to/interactivity/bind_component.md` to clarify the recommended pattern for using `pn.bind` when updating component parameters.

Users coming from `param.watch()` patterns may attempt to use `watch=True` with `pn.bind`. However, this pattern recreates the object whenever the inputs change and is generally considered an anti-pattern.

This PR adds a section explaining that a better approach is to assign the bound function directly to the relevant component parameter. For example:

```python
def update_value(select_value, slider_value):
    return select_value * slider_value

text = pn.widgets.StaticText(value=pn.bind(update_value, select, slider))
```

This approach keeps the component reactive while avoiding unnecessary object recreation and ensures that only the relevant parameter is updated.

The documentation change clarifies the intended usage of `pn.bind` and improves guidance for users working with reactive components.

---

## How Has This Been Tested?

This change only modifies documentation.

The updated section was reviewed locally to ensure:

* Correct Markdown formatting
* Proper placement within the existing guide
* Consistency with surrounding documentation examples

Since this is a documentation-only change, no runtime functionality or tests were affected.

---

## AI Disclosure

* [x] This PR contains AI-generated content.
* [x] I have tested all AI-generated content in my PR.
* [x] I take responsibility for all AI-generated content in my PR.

Tools: ChatGPT

---

## Checklist

* [ ] Tests added and is passing
* [x] Added documentation