### PR TITLE
Fix missing validation in _imgshape for image panes

### DIFF
--- a/panel/pane/image.py
+++ b/panel/pane/image.py
@@ -301,6 +301,8 @@ class PNG(ImageBase):
     @classmethod
     def _imgshape(cls, data):
         import struct
+        if len(data) < 24:
+            raise ValueError("Could not determine dimensions of PNG image: insufficient data")
         w, h = struct.unpack('>LL', data[16:24])
         return int(w), int(h)
 
@@ -327,6 +329,8 @@ class GIF(ImageBase):
     @classmethod
     def _imgshape(cls, data):
         import struct
+        if len(data) < 10:
+            raise ValueError("Could not determine dimensions of GIF image: insufficient data")
         w, h = struct.unpack("<HH", data[6:10])
         return int(w), int(h)
 
@@ -359,6 +363,8 @@ class ICO(ImageBase):
     @classmethod
     def _imgshape(cls, data):
         import struct
+        if len(data) < 8:
+            raise ValueError("Could not determine dimensions of ICO image: insufficient data")
         w, h = struct.unpack("<BB" , data[6:8])
         return int(w or 256), int(h or 256)
 
@@ -392,16 +398,18 @@ class JPG(ImageBase):
         b.read(2)
         c = b.read(1)
         while (c and ord(c) != 0xDA):
-            while (ord(c) != 0xFF): c = b.read(1)
-            while (ord(c) == 0xFF): c = b.read(1)
+            while (c and ord(c) != 0xFF): c = b.read(1)
+            while (c and ord(c) == 0xFF): c = b.read(1)
+            if not c:
+                break
             if (ord(c) >= 0xC0 and ord(c) <= 0xC3):
                 b.read(3)
                 h, w = struct.unpack(">HH", b.read(4))
-                break
+                return int(w), int(h)
             else:
                 b.read(int(struct.unpack(">H", b.read(2))[0])-2)
             c = b.read(1)
-        return int(w), int(h)
+        raise ValueError("Could not determine dimensions of JPEG image: no SOF marker found")
 
 
 class SVG(ImageBase):
@@ -593,10 +601,12 @@ class AVIF(ImageBase):
 
     @classmethod
     def _imgshape(cls, data: bytes) -> tuple[int, int]:
-        # The width and height position are stored withyin the ispe box, its format is :
+        # The width and height position are stored within the ispe box, its format is:
         # ispe + 4 bytes + 4 bytes for width + 4 bytes for height
 
         ispe = data.find(b"ispe")
+        if ispe == -1 or len(data) < ispe + 16:
+            raise ValueError("Could not determine dimensions of AVIF image: no 'ispe' box found")
         w = int.from_bytes(data[ispe + 8 : ispe + 12], byteorder="big", signed=False)
         h = int.from_bytes(data[ispe + 12 : ispe + 16], byteorder="big", signed=False)
 

--- a/panel/pane/image.py
+++ b/panel/pane/image.py
@@ -605,8 +605,10 @@ class AVIF(ImageBase):
         # ispe + 4 bytes + 4 bytes for width + 4 bytes for height
 
         ispe = data.find(b"ispe")
-        if ispe == -1 or len(data) < ispe + 16:
+        if ispe == -1:
             raise ValueError("Could not determine dimensions of AVIF image: no 'ispe' box found")
+        if len(data) < ispe + 16:
+            raise ValueError("Could not determine dimensions of AVIF image: 'ispe' box is truncated or incomplete")
         w = int.from_bytes(data[ispe + 8 : ispe + 12], byteorder="big", signed=False)
         h = int.from_bytes(data[ispe + 12 : ispe + 16], byteorder="big", signed=False)
 

--- a/panel/tests/pane/test_image.py
+++ b/panel/tests/pane/test_image.py
@@ -337,3 +337,27 @@ def test_image_caption(document, comm):
     model = png.get_root(document, comm)
     assert 'Some Caption' in model.text
     assert 'figcaption' in model.text
+
+
+@pytest.mark.parametrize('cls,data', [
+    (PNG, b'\x89PNG\r\n\x1a\n'),        # Valid PNG header but truncated before IHDR dimensions
+    (GIF, b'GIF89a'),                     # Valid GIF header but truncated before dimensions
+    (ICO, b'\x00\x00\x01\x00\x01'),      # Valid ICO header but truncated before entry
+], ids=['png', 'gif', 'ico'])
+def test_imgshape_truncated_data(cls, data):
+    with pytest.raises(ValueError, match="insufficient data"):
+        cls._imgshape(data)
+
+
+def test_imgshape_jpg_no_sof_marker():
+    # JPEG with valid SOI marker but no SOF marker (just SOI + SOS)
+    data = b'\xff\xd8\xff\xda' + b'\x00' * 10
+    with pytest.raises(ValueError, match="no SOF marker found"):
+        JPG._imgshape(data)
+
+
+def test_imgshape_avif_no_ispe_box():
+    # AVIF data without an ispe box
+    data = b'\x00\x00\x00\x1cftypavifall' + b'\x00' * 50
+    with pytest.raises(ValueError, match="no 'ispe' box found"):
+        AVIF._imgshape(data)


### PR DESCRIPTION
## Description

Fixes #8484

Several `_imgshape` methods in image panes lack input validation, leading to confusing errors or silently wrong dimensions on malformed/truncated image data. I noticed this while reading through the image pane code -- only `WebP._imgshape` had proper validation.

**Before:**
| Pane | Error on malformed data |
|------|------------------------|
| JPG | `UnboundLocalError` (SOF marker not found, `w`, `h` never assigned) |
| AVIF | **Silently returns garbage dimensions** (`find()` returns `-1`, reads wrong bytes) |
| PNG | `struct.error: unpack requires a buffer of 8 bytes` |
| GIF | `struct.error: unpack requires a buffer of 4 bytes` |
| ICO | `struct.error: unpack requires a buffer of 2 bytes` |

**After:** All raise clear `ValueError` with a descriptive message, e.g.:
```
ValueError: Could not determine dimensions of JPEG image: no SOF marker found
ValueError: Could not determine dimensions of AVIF image: no 'ispe' box found
ValueError: Could not determine dimensions of PNG image: insufficient data
```

### Changes

- **JPG**: Return inside the SOF branch, raise `ValueError` after the loop if no SOF found. Also added EOF guards in inner `while` loops to prevent `TypeError` on truncated data.
- **AVIF**: Check `data.find(b"ispe") == -1` before reading offsets
- **PNG/GIF/ICO**: Check `len(data)` before `struct.unpack`

## How Has This Been Tested?

I added 5 new tests in `panel/tests/pane/test_image.py`:
- `test_imgshape_truncated_data` (parametrized for PNG, GIF, ICO)
- `test_imgshape_jpg_no_sof_marker`
- `test_imgshape_avif_no_ispe_box`

All existing `test_imgshape` tests still pass (valid images unaffected).

```
$ pytest panel/tests/pane/test_image.py::test_imgshape -v
PASSED panel/tests/pane/test_image.py::test_imgshape[avif]
PASSED panel/tests/pane/test_image.py::test_imgshape[png]
PASSED panel/tests/pane/test_image.py::test_imgshape[jpg]
PASSED panel/tests/pane/test_image.py::test_imgshape[gif]
PASSED panel/tests/pane/test_image.py::test_imgshape[ico]
PASSED panel/tests/pane/test_image.py::test_imgshape[webp]
```

## Checklist

- [x] Tests added and is passing
- [ ] Added documentation

## AI Disclosure

I used Claude Code to help identify the pattern across the different `_imgshape` methods and scaffold the validation checks and test cases. I reviewed all changes myself, understood the JPEG SOF marker parsing, AVIF ispe box format, and struct.unpack requirements, and ran the full test suite locally to verify correctness.