### PR TITLE
Add documentation explaining pn.panel with examples

### DIFF
--- a/doc/how_to/components/construct_panes.md
+++ b/doc/how_to/components/construct_panes.md
@@ -26,7 +26,78 @@ png = pn.panel('https://upload.wikimedia.org/wikipedia/commons/4/47/PNG_transpar
 
 png
 ```
+## Using `pn.panel`
 
+The `pn.panel` function is one of the most important entry points in Panel. It converts many different Python objects into Panel components that can be displayed in layouts or served in applications.
+
+### Basic usage
+
+`pn.panel` automatically converts Python objects into appropriate Panel panes.
+
+```python
+import panel as pn
+pn.extension()
+
+pn.panel("Hello Panel!")
+```
+
+### Converting different objects
+
+#### Strings
+
+```python
+pn.panel("Hello world")
+```
+
+#### Functions
+
+Functions can be wrapped and displayed dynamically.
+
+```python
+import panel as pn
+pn.extension()
+
+def greet(name):
+    return f"Hello {name}"
+
+pn.panel(greet)
+```
+
+#### DataFrames
+
+```python
+import pandas as pd
+import panel as pn
+
+pn.extension()
+
+df = pd.DataFrame({
+    "A": [1,2,3],
+    "B": [4,5,6]
+})
+
+pn.panel(df)
+```
+
+#### Plots
+
+Many plotting libraries can be passed directly.
+
+```python
+import matplotlib.pyplot as plt
+import panel as pn
+
+pn.extension()
+
+fig, ax = plt.subplots()
+ax.plot([1,2,3], [4,5,6])
+
+pn.panel(fig)
+```
+
+### Why `pn.panel` is powerful
+
+`pn.panel` automatically selects the correct Pane type depending on the object you provide. This makes it easy to build dashboards quickly without manually selecting Pane classes.
 ---
 
 ## Related Resources


### PR DESCRIPTION
## Description

Fixes #3422

This PR adds documentation explaining how to use `pn.panel`. The guide demonstrates how different Python objects (strings, DataFrames, plots) can be converted automatically into Panel components.

## How Has This Been Tested?

The examples were run locally to verify that `pn.panel` correctly renders the provided objects.

## AI Disclosure

- [ ] This PR contains AI-generated content.

## Checklist

- [ ] Tests added and is passing
- [x] Added documentation