### PR TITLE
Fix Param widget not reflecting value changes made in own callback

### DIFF
--- a/panel/param.py
+++ b/panel/param.py
@@ -571,6 +571,11 @@ class Param(Pane):
                 updating.remove(p_key)
                 if reset:
                     widget.value = new
+                current_val = getattr(parameterized, p_name)
+                if not reset and current_val != new:
+                    is_w = isinstance(widget, Row) and len(widget) == 2
+                    target = widget[0] if is_w else widget
+                    target.param.update(value=current_val)
 
         if hasattr(param, 'Event') and isinstance(p_obj, param.Event):
             def event(change):

--- a/panel/tests/test_param.py
+++ b/panel/tests/test_param.py
@@ -2053,38 +2053,23 @@ async def test_async_skip_param(document, comm):
     assert div.text == '&lt;pre&gt; &lt;/pre&gt;'
 
 
-def test_param_widget_updates_from_own_callback(document, comm):
-    class ParameterizedCheckbox(param.Parameterized):
-        value = param.Boolean(label='Parameterized checkbox', default=False)
+@pytest.mark.parametrize('param_type,initial_value,user_input,expected_value', [
+    (param.Boolean, False, True, False),
+    (param.Number, 0, 7, 5),
+])
+def test_param_widget_updates_from_own_callback(document, comm, param_type, initial_value, user_input, expected_value):
+    class TestClass(param.Parameterized):
+        value = param_type(default=initial_value)
 
         @param.depends('value', watch=True)
         def update(self):
-            self.value = False
+            self.value = expected_value
 
-    pc = ParameterizedCheckbox()
-    param_pane = Param(pc, parameters=['value'])
+    instance = TestClass()
+    param_pane = Param(instance, parameters=['value'])
     widget = param_pane._widgets['value']
 
-    widget.value = True
+    widget.value = user_input
 
-    assert pc.value is False
-    assert widget.value is False
-
-
-def test_param_widget_updates_from_own_callback_number(document, comm):
-    class ParameterizedNumber(param.Parameterized):
-        value = param.Number(default=0, bounds=(0, 10))
-
-        @param.depends('value', watch=True)
-        def update(self):
-            if self.value != 5:
-                self.value = 5
-
-    pn = ParameterizedNumber()
-    param_pane = Param(pn, parameters=['value'])
-    widget = param_pane._widgets['value']
-
-    widget.value = 7
-
-    assert pn.value == 5
-    assert widget.value == 5
+    assert instance.value == expected_value
+    assert widget.value == expected_value

--- a/panel/tests/test_param.py
+++ b/panel/tests/test_param.py
@@ -2051,3 +2051,40 @@ async def test_async_skip_param(document, comm):
     button.param.trigger('value')
     await asyncio.sleep(0.01)
     assert div.text == '&lt;pre&gt; &lt;/pre&gt;'
+
+
+def test_param_widget_updates_from_own_callback(document, comm):
+    class ParameterizedCheckbox(param.Parameterized):
+        value = param.Boolean(label='Parameterized checkbox', default=False)
+
+        @param.depends('value', watch=True)
+        def update(self):
+            self.value = False
+
+    pc = ParameterizedCheckbox()
+    param_pane = Param(pc, parameters=['value'])
+    widget = param_pane._widgets['value']
+
+    widget.value = True
+
+    assert pc.value is False
+    assert widget.value is False
+
+
+def test_param_widget_updates_from_own_callback_number(document, comm):
+    class ParameterizedNumber(param.Parameterized):
+        value = param.Number(default=0, bounds=(0, 10))
+
+        @param.depends('value', watch=True)
+        def update(self):
+            if self.value != 5:
+                self.value = 5
+
+    pn = ParameterizedNumber()
+    param_pane = Param(pn, parameters=['value'])
+    widget = param_pane._widgets['value']
+
+    widget.value = 7
+
+    assert pn.value == 5
+    assert widget.value == 5


### PR DESCRIPTION
## Description

This PR fixes an issue where `pn.widgets` built from a `param.Parameterized` model do not update in the UI when their value is changed inside their own `@param.depends` callback. The param model updates correctly, but the change is never reflected in the frontend.

**Problem:** 
When a `@param.depends` callback modifies its own parameter, the widget doesn't reflect the new value even though the param model is correct.

While investigating, I found that `link_widget()` holds a re-entrancy lock (`updating`) while syncing the param model. If a watcher fires and changes the parameter during that window, the param→widget sync (`link()`) sees the lock and silently returns early, leaving the widget out of sync.

**Solution:** 
After releasing the lock, compare the current parameter value to what we originally set. If they differ, sync the widget immediately. This avoids infinite loops since it only fires when there's an actual mismatch.

## Before/After UI:

> 📹 *See attached video — before the fix, clicking the checkbox leaves it checked; after the fix, it correctly resets itself to unchecked.*

**Before:**

https://github.com/user-attachments/assets/f0b5bf8c-4f1c-4c40-a85d-b088f9e41bea


**After:**

https://github.com/user-attachments/assets/f4badc95-6c1d-43ed-adec-4a6d3a490842

Fixes #8159

## How Has This Been Tested?

Two cases were tested to verify the fix and ensure no regressions:

- **Case 1 — Regression check:** A classic `pn.widgets.Checkbox` with a bound function that resets itself to `False`. This was already working before the fix and should continue to work.
- **Case 2 — Bug fix check:** A `param.Parameterized` model with a `@param.depends` callback that resets its own value. Before the fix, the param model would update correctly but the widget would stay stale in the UI. After the fix, both the param model and the widget correctly reflect `False`.

To reproduce, run the following code:

```python
import panel as pn
import param

pn.extension()

# Works as expected:
# Classic panel widget checkbox with bound function that sets itself to False

widget_checkbox = pn.widgets.Checkbox(name='Widget checkbox')

@pn.depends(widget_checkbox, watch=True)
def update_checkbox(event):
    widget_checkbox.value = False
    print(f'Widget checkbox value set to {widget_checkbox.value}')


# Does not work as expected:
# Parameterized model with boolean value parameter

class ParameterizedCheckbox(param.Parameterized):
    
    value = param.Boolean(label='Parameterized checkbox')

    @param.depends('value', watch=True)
    def update(self):
        self.value = False
        print(f'ParameterizedCheckbox value set to {self.value}')


pn.Column(
    'Both of these checkboxes should uncheck themselves after being clicked.',
    widget_checkbox,
    ParameterizedCheckbox().param.value
).servable()
```

## AI Disclosure

- [x] This PR contains AI-generated content.
  - [x] I have tested all AI-generated content in my PR.
  - [x] I take responsibility for all AI-generated content in my PR.
    Tools: Gemini 3 Flash - Used to analyze the bug and identify the root cause and the implementation.

## Checklist

- [x] Tests added and is passing
- [ ] Added documentation
