### PR TITLE
ci: Fix jupyterlite workflow - round 2

### DIFF
--- a/.github/workflows/jupyterlite.yaml
+++ b/.github/workflows/jupyterlite.yaml
@@ -62,7 +62,7 @@ jobs:
       - name: Upload dev
         if: |
           (github.event_name == 'workflow_dispatch' && github.event.inputs.target == 'dev') ||
-          (github.event_name == 'workflow_run' && (contains(steps.vars.outputs.tag, 'a') || contains(steps.vars.outputs.tag, 'b') || contains(steps.vars.outputs.tag, 'rc')))
+          (github.event_name == 'push' && (contains(steps.vars.outputs.tag, 'a') || contains(steps.vars.outputs.tag, 'b') || contains(steps.vars.outputs.tag, 'rc')))
         uses: peaceiris/actions-gh-pages@v4
         with:
           personal_token: ${{ secrets.ACCESS_TOKEN }}


### PR DESCRIPTION
## Description

<!--
- Summarize the change and which issue is fixed.
- Include relevant motivation and context.
- Add visuals when possible, e.g. before/after screenshots with full code snippets.
-->

Continue working on the #8494, now it no longer publish to main, but the `github.event_name` was not set correctly. Causing no upload to happen.

<img width="733" height="518" alt="image" src="https://github.com/user-attachments/assets/246c7c24-1ec6-4e76-aae1-3ae8f74048d7" />

## How Has This Been Tested?

None, will check again on next dev release.

