### PR TITLE
Improve state.busy logic to avoid state mismatch

### DIFF
--- a/panel/io/callbacks.py
+++ b/panel/io/callbacks.py
@@ -6,12 +6,13 @@ import asyncio
 import inspect
 import logging
 import time
+import uuid
 
 from functools import partial
 
 import param
 
-from ..util import edit_readonly, function_name
+from ..util import function_name
 from .logging import LOG_PERIODIC_END, LOG_PERIODIC_START
 from .state import curdoc_locked, set_curdoc, state
 
@@ -78,7 +79,7 @@ class PeriodicCallback(param.Parameterized):
             self.stop()
             self.start()
 
-    def _exec_callback(self, post=False):
+    def _exec_callback(self, post=False, busy_event_id=None):
         try:
             with set_curdoc(self._doc):
                 if self.running:
@@ -88,18 +89,17 @@ class PeriodicCallback(param.Parameterized):
                 cb = self.callback() if self.running else None
         finally:
             if post:
-                self._post_callback()
+                self._post_callback(busy_event_id)
         return cb
 
-    def _post_callback(self):
+    def _post_callback(self, busy_event_id=None):
         cbname = function_name(self.callback)
         if self._doc and self.log:
             _periodic_logger.info(
                 LOG_PERIODIC_END, id(self._doc), cbname, self.counter
             )
-        if not self._background:
-            with edit_readonly(state):
-                state._busy_counter -= 1
+        if not self._background and busy_event_id is not None:
+            state._remove_busy_event(busy_event_id)
         if self.timeout is not None:
             dt = (time.time() - self._start_time) * 1000
             if dt > self.timeout:
@@ -108,9 +108,10 @@ class PeriodicCallback(param.Parameterized):
             self.stop()
 
     async def _periodic_callback(self):
+        busy_event_id = None
         if not self._background:
-            with edit_readonly(state):
-                state._busy_counter += 1
+            busy_event_id = f'periodic-{uuid.uuid4().hex}'
+            state._add_busy_event(busy_event_id)
         cbname = function_name(self.callback)
         if self._doc and self.log:
             _periodic_logger.info(
@@ -121,7 +122,7 @@ class PeriodicCallback(param.Parameterized):
             inspect.iscoroutinefunction(self.callback)
         )
         if state._thread_pool and not is_async:
-            future = state._thread_pool.submit(self._exec_callback, True)
+            future = state._thread_pool.submit(self._exec_callback, True, busy_event_id)
             future.add_done_callback(partial(state._handle_future_exception, doc=self._doc))
             return
         try:
@@ -133,7 +134,7 @@ class PeriodicCallback(param.Parameterized):
                 else:
                     await cb
         finally:
-            self._post_callback()
+            self._post_callback(busy_event_id)
 
     async def _async_repeat(self, func):
         """

--- a/panel/io/callbacks.py
+++ b/panel/io/callbacks.py
@@ -46,12 +46,16 @@ class PeriodicCallback(param.Parameterized):
     period = param.Integer(default=500, doc="""
         Period in milliseconds at which the callback is executed.""")
 
+    running = param.Boolean(default=False, doc="""
+        Toggles whether the periodic callback is currently running.""")
+
+    session_scoped = param.Boolean(default=True, doc="""
+        If scheduled from inside a user session scopes the callback
+        to that session.""")
+
     timeout = param.Integer(default=None, doc="""
         Timeout in milliseconds from the start time at which the callback
         expires.""")
-
-    running = param.Boolean(default=False, doc="""
-        Toggles whether the periodic callback is currently running.""")
 
     def __init__(self, **params):
         self._background = params.pop('background', False)
@@ -166,7 +170,7 @@ class PeriodicCallback(param.Parameterized):
             finally:
                 self._updating = False
         self._start_time = time.time()
-        if state.curdoc and state.curdoc.session_context and not state._is_pyodide:
+        if state.curdoc and state.curdoc.session_context and not state._is_pyodide and self.session_scoped:
             self._doc = state.curdoc
             if state._unblocked(state.curdoc):
                 self._cb = self._doc.add_periodic_callback(self._periodic_callback, self.period)
@@ -199,7 +203,7 @@ class PeriodicCallback(param.Parameterized):
             self._cb.cancel()
         self._cb = None
         doc = self._doc or curdoc_locked()
-        if doc:
+        if doc and self.session_scoped:
             doc.callbacks.session_destroyed_callbacks = {
                 cb for cb in doc.callbacks.session_destroyed_callbacks
                 if cb is not self._cleanup

--- a/panel/io/callbacks.py
+++ b/panel/io/callbacks.py
@@ -176,7 +176,7 @@ class PeriodicCallback(param.Parameterized):
                 self._cb = self._doc.add_periodic_callback(self._periodic_callback, self.period)
             else:
                 self._doc.add_next_tick_callback(self.start)
-        elif state._thread_id != state._current_thread:
+        elif state._thread_id and state._thread_id != state._current_thread:
             state.execute(self.start, schedule=True)
         else:
             try:

--- a/panel/io/callbacks.py
+++ b/panel/io/callbacks.py
@@ -176,10 +176,17 @@ class PeriodicCallback(param.Parameterized):
                 self._cb = self._doc.add_periodic_callback(self._periodic_callback, self.period)
             else:
                 self._doc.add_next_tick_callback(self.start)
+        elif state._thread_id != state._current_thread:
+            state.execute(self.start, schedule=True)
         else:
-            self._cb = asyncio.create_task(
-                self._async_repeat(self._periodic_callback)
-            )
+            try:
+                loop = asyncio.get_running_loop()
+            except RuntimeError:
+                loop = None
+            if loop and loop.is_running():
+                self._cb = asyncio.create_task(
+                    self._async_repeat(self._periodic_callback)
+                )
 
     def stop(self):
         """

--- a/panel/io/state.py
+++ b/panel/io/state.py
@@ -323,32 +323,28 @@ class _state(param.Parameterized):
         self._schedule_busy_cleanup()
 
     def _remove_busy_event(self, event_id: str) -> None:
-        with edit_readonly(self):
-            self._busy_counter = [
-                (eid, started) for eid, started in self._busy_counter if eid != event_id
-            ]
-        self._cleanup_busy_counter()
+        self._cleanup_busy_counter(event_id)
 
-    def _cleanup_busy_counter(self, timeout: float = 30.0) -> None:
+    def _cleanup_busy_counter(self, event_id: str | None = None, timeout: float = 30.0) -> None:
         now = time.monotonic()
         with edit_readonly(self):
             self._busy_counter = [
-                (event_id, started_at)
-                for event_id, started_at in self._busy_counter
-                if now - started_at <= timeout
+                (eid, started_at)
+                for eid, started_at in self._busy_counter
+                if now - started_at <= timeout and eid != event_id
             ]
 
     def _schedule_busy_cleanup(self) -> None:
-        if self._busy_cleanup_scheduled:
+        if state._busy_cleanup_scheduled:
             return
         from .callbacks import PeriodicCallback
-        self._busy_cleanup_scheduled = PeriodicCallback(
+        state._busy_cleanup_scheduled = PeriodicCallback(
             background=True,
             callback=self._cleanup_busy_counter,
             session_scoped=False,
             period=10000
         )
-        self._busy_cleanup_scheduled.start()
+        state._busy_cleanup_scheduled.start()
 
     @param.depends('busy', watch=True)
     def _update_busy(self) -> None:

--- a/panel/io/state.py
+++ b/panel/io/state.py
@@ -119,8 +119,8 @@ class _state(param.Parameterized):
     _base_url = param.String(default='/', readonly=True, doc="""
        Base URL for all server paths.""")
 
-    _busy_counter = param.Integer(default=0, doc="""
-       Count of active callbacks current being processed.""")
+    _busy_counter = param.List(default=[], doc="""
+       Active callbacks currently being processed as (event_id, started_at).""")
 
     _memoize_cache = param.Dict(default={}, doc="""
        A dictionary used by the cache decorator.""")
@@ -236,6 +236,7 @@ class _state(param.Parameterized):
 
     # Watchers
     _watch_events: ClassVar[list[asyncio.Event]] = []
+    _busy_cleanup_scheduled: bool = False
 
     # Types
     _notification_type: ClassVar[type[NotificationAreaBase] | None] = None
@@ -311,8 +312,48 @@ class _state(param.Parameterized):
 
     @param.depends('_busy_counter', watch=True)
     def _update_busy_counter(self):
+        self._cleanup_busy_counter()
         with edit_readonly(self):
-            self.busy = self._busy_counter >= 1
+            self.busy = bool(self._busy_counter)
+
+    def _add_busy_event(self, event_id: str) -> None:
+        self._cleanup_busy_counter()
+        with edit_readonly(self):
+            self._busy_counter = [*self._busy_counter, (event_id, time.monotonic())]
+        self._schedule_busy_cleanup()
+
+    def _remove_busy_event(self, event_id: str) -> None:
+        with edit_readonly(self):
+            self._busy_counter = [
+                (eid, started) for eid, started in self._busy_counter if eid != event_id
+            ]
+        self._cleanup_busy_counter()
+
+    def _cleanup_busy_counter(self, timeout: float = 30.0) -> None:
+        now = time.monotonic()
+        with edit_readonly(self):
+            self._busy_counter = [
+                (event_id, started_at)
+                for event_id, started_at in self._busy_counter
+                if now - started_at <= timeout
+            ]
+
+    def _schedule_busy_cleanup(self) -> None:
+        if self._busy_cleanup_scheduled or not self._busy_counter:
+            return
+
+        self._busy_cleanup_scheduled = True
+
+        def cleanup_busy_events():
+            self._busy_cleanup_scheduled = False
+            self._cleanup_busy_counter()
+            if self._busy_counter:
+                self._schedule_busy_cleanup()
+
+        if self._is_pyodide:
+            self._ioloop.call_later(1, cleanup_busy_events)
+        else:
+            self._ioloop.call_later(delay=1, callback=cleanup_busy_events)
 
     @param.depends('busy', watch=True)
     def _update_busy(self) -> None:
@@ -854,6 +895,9 @@ class _state(param.Parameterized):
         self._connected.clear()
         self._loaded.clear()
         self.cache.clear()
+        self._busy_cleanup_scheduled = False
+        with edit_readonly(self):
+            self._busy_counter = []
         self._scheduled.clear()
         if self._thread_pool is not None:
             self._thread_pool.shutdown(wait=False)

--- a/panel/io/state.py
+++ b/panel/io/state.py
@@ -343,7 +343,9 @@ class _state(param.Parameterized):
             return
         from .callbacks import PeriodicCallback
         self._busy_cleanup_scheduled = PeriodicCallback(
-            callback=self._cleanup_busy_counter, session_scoped=False,
+            background=True,
+            callback=self._cleanup_busy_counter,
+            session_scoped=False,
             period=10000
         )
         self._busy_cleanup_scheduled.start()

--- a/panel/io/state.py
+++ b/panel/io/state.py
@@ -335,16 +335,16 @@ class _state(param.Parameterized):
             ]
 
     def _schedule_busy_cleanup(self) -> None:
-        if state._busy_cleanup_scheduled:
+        if _state._busy_cleanup_scheduled:
             return
         from .callbacks import PeriodicCallback
-        state._busy_cleanup_scheduled = PeriodicCallback(
+        _state._busy_cleanup_scheduled = PeriodicCallback(
             background=True,
             callback=self._cleanup_busy_counter,
             session_scoped=False,
             period=10000
         )
-        state._busy_cleanup_scheduled.start()
+        _state._busy_cleanup_scheduled.start()
 
     @param.depends('busy', watch=True)
     def _update_busy(self) -> None:

--- a/panel/io/state.py
+++ b/panel/io/state.py
@@ -236,7 +236,7 @@ class _state(param.Parameterized):
 
     # Watchers
     _watch_events: ClassVar[list[asyncio.Event]] = []
-    _busy_cleanup_scheduled: bool = False
+    _busy_cleanup_scheduled: ClassVar[PeriodicCallback | None] = None
 
     # Types
     _notification_type: ClassVar[type[NotificationAreaBase] | None] = None
@@ -339,21 +339,14 @@ class _state(param.Parameterized):
             ]
 
     def _schedule_busy_cleanup(self) -> None:
-        if self._busy_cleanup_scheduled or not self._busy_counter:
+        if self._busy_cleanup_scheduled:
             return
-
-        self._busy_cleanup_scheduled = True
-
-        def cleanup_busy_events():
-            self._busy_cleanup_scheduled = False
-            self._cleanup_busy_counter()
-            if self._busy_counter:
-                self._schedule_busy_cleanup()
-
-        if self._is_pyodide:
-            self._ioloop.call_later(1, cleanup_busy_events)
-        else:
-            self._ioloop.call_later(delay=1, callback=cleanup_busy_events)
+        from .callbacks import PeriodicCallback
+        self._busy_cleanup_scheduled = PeriodicCallback(
+            callback=self._cleanup_busy_counter, session_scoped=False,
+            period=10000
+        )
+        self._busy_cleanup_scheduled.start()
 
     @param.depends('busy', watch=True)
     def _update_busy(self) -> None:
@@ -895,7 +888,7 @@ class _state(param.Parameterized):
         self._connected.clear()
         self._loaded.clear()
         self.cache.clear()
-        self._busy_cleanup_scheduled = False
+        self._busy_cleanup_scheduled = None
         with edit_readonly(self):
             self._busy_counter = []
         self._scheduled.clear()

--- a/panel/reactive.py
+++ b/panel/reactive.py
@@ -464,9 +464,10 @@ class Syncable(Renderable):
 
     def _process_events(self, events: dict[str, Any]) -> None:
         self._log('received events %s', events)
+        busy_event_id = None
         if any(e for e in events if e not in self._busy__ignore):
-            with edit_readonly(state):
-                state._busy_counter += 1
+            busy_event_id = f'events-{uuid.uuid4().hex}'
+            state._add_busy_event(busy_event_id)
         try:
             params = {}
             if events and state.curdoc:
@@ -499,21 +500,19 @@ class Syncable(Renderable):
             if state.curdoc and state.curdoc in self._in_process__events:
                 del self._in_process__events[state.curdoc]
             self._log('finished processing events %s', events)
-            if any(e for e in events if e not in self._busy__ignore):
-                with edit_readonly(state):
-                    state._busy_counter -= 1
+            if busy_event_id is not None:
+                state._remove_busy_event(busy_event_id)
 
     def _process_bokeh_event(self, doc: Document, event: Event) -> None:
         self._log('received bokeh event %s', event)
-        with edit_readonly(state):
-            state._busy_counter += 1
+        busy_event_id = f'bokeh-events-{uuid.uuid4().hex}'
+        state._add_busy_event(busy_event_id)
         try:
             with set_curdoc(doc):
                 self._process_event(event)
         finally:
             self._log('finished processing bokeh event %s', event)
-            with edit_readonly(state):
-                state._busy_counter -= 1
+            state._remove_busy_event(busy_event_id)
 
     async def _change_coroutine(self, doc: Document, event_id: str | None = None) -> None:
         if event_id is not None:

--- a/panel/tests/test_server.py
+++ b/panel/tests/test_server.py
@@ -967,7 +967,7 @@ def test_server_thread_pool_busy(server_implementation, threads):
 
     serve_and_request(app, suffix="/")
 
-    wait_until(lambda: len(clicks) == 3 and state._busy_counter == 0 and not state.busy)
+    wait_until(lambda: len(clicks) == 3 and not state._busy_counter and not state.busy)
 
 
 def test_server_async_onload(threads):

--- a/panel/widgets/file_selector.py
+++ b/panel/widgets/file_selector.py
@@ -191,7 +191,9 @@ class BaseFileSelector(param.Parameterized):
         super().__init__(**params)
 
         # Set up periodic callback
-        self._periodic = PeriodicCallback(callback=self._refresh, period=self.refresh_period or 0)
+        self._periodic = PeriodicCallback(
+            background=True, callback=self._refresh, period=self.refresh_period or 0
+        )
         self.param.watch(self._update_periodic, 'refresh_period')
         if self.refresh_period:
             self._periodic.start()

--- a/panel/widgets/terminal.py
+++ b/panel/widgets/terminal.py
@@ -122,6 +122,7 @@ class TerminalSubprocess(param.Parameterized):
             self._set_winsize()
 
             self._periodic_callback = PeriodicCallback(
+                background=True,
                 callback=self._forward_subprocess_output_to_terminal,
                 period=self._period
             )


### PR DESCRIPTION
The existing logic to track whether the application was busy was error prone because it relied on a simple counter. We now track actual event ids and clean them up should some event never get processed.

Fixes https://github.com/panel-extensions/panel-material-ui/issues/582