### PR TITLE
fix: prevent ValueError when EditableFloatSlider input is cleared

### DIFF
--- a/panel/tests/widgets/test_slider.py
+++ b/panel/tests/widgets/test_slider.py
@@ -683,6 +683,20 @@ def test_editable_slider_disabled():
     assert not slider._value_edit.disabled
 
 @pytest.mark.parametrize(
+    'editableslider',
+    [EditableFloatSlider, EditableIntSlider],
+    ids=["EditableFloatSlider", "EditableIntSlider"]
+)
+def test_editable_slider_none_value_no_error(editableslider):
+    slider = editableslider(value=5, start=0, end=10)
+    previous_slider_value = slider._slider.value
+
+    slider._value_edit.value = None  # simulate clearing the input field
+
+    assert slider._slider.value == previous_slider_value
+    assert slider._value_edit.value is None
+
+@pytest.mark.parametrize(
     'editableslider,start,end,step,val1,val2,val3,diff1',
     [
         (EditableRangeSlider, 0.1, 0.5, 0.1, (0.2, 0.4), (0.2, 0.3), (0.1, 0.5), 0.1),

--- a/panel/widgets/slider.py
+++ b/panel/widgets/slider.py
@@ -968,7 +968,8 @@ class _EditableContinuousSlider(CompositeWidget):
 
     @param.depends('value', watch=True)
     def _update_value(self):
-        self._slider.value = self.value
+        if self.value is not None:
+            self._slider.value = self.value
         self._value_edit.value = self.value
 
     def _sync_value(self, event):


### PR DESCRIPTION
## Description

While working on issue #8123, I noticed that `EditableFloatSlider` crashes with a `ValueError` the moment you clear out the input field. So I started digging into why that happens.

After tracing through the code, I found that when the text input is emptied, the underlying `FloatInput` widget fires a `value=None` event. That `None` gets picked up by `_sync_value`, which propagates it to `self.value`, which in turn triggers `_update_value`. Inside `_update_value`, the code does `self._slider.value = self.value` — and Bokeh's `Slider` model simply doesn't accept `None` as a value. It expects a `Real` number, so it blows up with:

```
ValueError: failed to validate Slider(id='...').value: expected a value of type Real, got None of type NoneType
```

## Before the fix:

https://github.com/user-attachments/assets/d3d58391-2d1b-4530-977e-34f3809944aa

## After the fix:

https://github.com/user-attachments/assets/0c1065b1-fd3e-47f0-b4c8-c868e3423ada


The fix is straightforward. In `_update_value`, we just skip updating the Bokeh slider when `self.value is None`. The input widget can still hold and display the empty state, but the slider quietly keeps its last valid value until the user types something again.

```python
@param.depends('value', watch=True)
def _update_value(self):
    if self.value is not None:
        self._slider.value = self.value
    self._value_edit.value = self.value
```

Fixes #8123

## How Has This Been Tested?

After applying the fix, I tested it by running the exact reproduction case from the issue report, cleared the input field on an `EditableFloatSlider` and confirmed no `ValueError` is raised. The slider holds its last value while the input shows empty, which feels like the right behavior.

I also added a parametrized unit test `test_editable_slider_none_value_no_error` covering both `EditableFloatSlider` and `EditableIntSlider`:

```python
def test_editable_slider_none_value_no_error(editableslider):
    slider = editableslider(value=5, start=0, end=10)
    previous_slider_value = slider._slider.value

    slider._value_edit.value = None  # simulate clearing the input field

    assert slider._slider.value == previous_slider_value
    assert slider._value_edit.value is None
```

Both pass. Ran the full editable slider test suite (31 tests) — all green.

## AI Disclosure

- [x] This PR contains AI-generated content.
  - [x] I have tested all AI-generated content in my PR.
  - [x] I take responsibility for all AI-generated content in my PR.
    Tools: Claude Sonnet 4.6 (Claude Code)

## Checklist

- [x] Tests added and is passing
- [ ] Added documentation
