### PR TITLE
Fix Gauge/ECharts crash when echarts library not yet loaded

### DIFF
--- a/panel/models/echarts.ts
+++ b/panel/models/echarts.ts
@@ -106,7 +106,7 @@ export class EChartsView extends HTMLBoxView {
 
   _await_echarts(): void {
     // Try script onload listener first (event-driven, not polling)
-    const script = document.querySelector("script[src*='echarts']") as HTMLScriptElement | null
+    const script = document.querySelector("script[src*='echarts']")
     if (script != null) {
       const onLoad = () => {
         script.removeEventListener("load", onLoad)

--- a/panel/models/echarts.ts
+++ b/panel/models/echarts.ts
@@ -39,9 +39,12 @@ export class EChartsEvent extends ModelEvent {
 export class EChartsView extends HTMLBoxView {
   declare model: ECharts
 
-  container: Element
+  container: HTMLDivElement
   _chart: any
   _callbacks: Array<any>[] = []
+  _loading_interval: ReturnType<typeof setInterval> | null = null
+  _loading_timeout: ReturnType<typeof setTimeout> | null = null
+  _loading_el: HTMLDivElement | null = null
 
   override connect_signals(): void {
     super.connect_signals()
@@ -50,7 +53,9 @@ export class EChartsView extends HTMLBoxView {
     this.on_change([width, height], () => this._resize())
     this.on_change([theme, renderer], () => {
       this.render()
-      this._chart.resize()
+      if (this._chart != null) {
+        this._chart.resize()
+      }
     })
     this.on_change([event_config, js_events], () => this._subscribe())
   }
@@ -61,8 +66,89 @@ export class EChartsView extends HTMLBoxView {
         (window as any).echarts.dispose(this._chart)
       } catch (e) {}
     }
+    this._clear_loading_timer()
     super.render()
-    this.container = div({style: {height: "100%", width: "100%"}})
+    this.container = div({style: {height: "100%", width: "100%"}}) as HTMLDivElement
+    this.shadow_el.append(this.container)
+
+    if ((window as any).echarts == null) {
+      this._show_loading()
+      this._await_echarts()
+      return
+    }
+    this._init_chart()
+  }
+
+  _show_loading(): void {
+    this._loading_el = div({
+      style: {
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        height: "100%",
+        width: "100%",
+        color: "#888",
+        fontSize: "14px",
+      },
+    }) as HTMLDivElement
+    this._loading_el.textContent = "Loading ECharts..."
+    this.container.append(this._loading_el)
+  }
+
+  _hide_loading(): void {
+    if (this._loading_el != null) {
+      this._loading_el.remove()
+      this._loading_el = null
+    }
+  }
+
+  _await_echarts(): void {
+    // Try script onload listener first (event-driven, not polling)
+    const script = document.querySelector("script[src*='echarts']") as HTMLScriptElement | null
+    if (script != null) {
+      const onLoad = () => {
+        script.removeEventListener("load", onLoad)
+        this._clear_loading_timer()
+        this._hide_loading()
+        this._init_chart()
+      }
+      script.addEventListener("load", onLoad)
+    }
+
+    // Polling fallback in case script tag isn't found or onload doesn't fire
+    this._loading_interval = setInterval(() => {
+      if ((window as any).echarts != null) {
+        this._clear_loading_timer()
+        this._hide_loading()
+        this._init_chart()
+      }
+    }, 50)
+    this._loading_timeout = setTimeout(() => {
+      this._clear_loading_timer()
+      this._hide_loading()
+      console.warn(
+        "ECharts library failed to load. Ensure you call pn.extension('echarts') " +
+        "before using Gauge or ECharts components.",
+      )
+    }, 10000)
+  }
+
+  _clear_loading_timer(): void {
+    if (this._loading_interval != null) {
+      clearInterval(this._loading_interval)
+      this._loading_interval = null
+    }
+    if (this._loading_timeout != null) {
+      clearTimeout(this._loading_timeout)
+      this._loading_timeout = null
+    }
+  }
+
+  _init_chart(): void {
+    if ((window as any).echarts == null) {
+      return
+    }
+    this._hide_loading()
     const config = {width: this.model.width, height: this.model.height, renderer: this.model.renderer}
     this._chart = (window as any).echarts.init(
       this.container,
@@ -71,13 +157,15 @@ export class EChartsView extends HTMLBoxView {
     )
     this._plot()
     this._subscribe()
-    this.shadow_el.append(this.container)
   }
 
   override remove(): void {
+    this._clear_loading_timer()
     super.remove()
     if (this._chart != null) {
-      (window as any).echarts.dispose(this._chart)
+      try {
+        (window as any).echarts.dispose(this._chart)
+      } catch (e) {}
     }
   }
 
@@ -89,7 +177,7 @@ export class EChartsView extends HTMLBoxView {
   }
 
   _plot(): void {
-    if ((window as any).echarts == null) {
+    if ((window as any).echarts == null || this._chart == null) {
       return
     }
     const data = transformJsPlaceholders(this.model.data)
@@ -97,11 +185,13 @@ export class EChartsView extends HTMLBoxView {
   }
 
   _resize(): void {
-    this._chart.resize({width: this.model.width, height: this.model.height})
+    if (this._chart != null) {
+      this._chart.resize({width: this.model.width, height: this.model.height})
+    }
   }
 
   _subscribe(): void {
-    if ((window as any).echarts == null) {
+    if ((window as any).echarts == null || this._chart == null) {
       return
     }
     for (const [event_type, callback] of this._callbacks) {

--- a/panel/models/echarts.ts
+++ b/panel/models/echarts.ts
@@ -65,7 +65,7 @@ export class EChartsView extends HTMLBoxView {
       try {
         (window as any).echarts.dispose(this._chart)
       } catch (e) {
-        console.debug("ECharts dispose error during re-render:", e)
+        // dispose may fail if echarts was never fully initialized
       }
     }
     this._clear_loading_timer()
@@ -168,7 +168,7 @@ export class EChartsView extends HTMLBoxView {
       try {
         (window as any).echarts.dispose(this._chart)
       } catch (e) {
-        console.debug("ECharts dispose error during removal:", e)
+        // dispose may fail if echarts was never fully initialized
       }
     }
   }

--- a/panel/models/echarts.ts
+++ b/panel/models/echarts.ts
@@ -64,7 +64,9 @@ export class EChartsView extends HTMLBoxView {
     if (this._chart != null) {
       try {
         (window as any).echarts.dispose(this._chart)
-      } catch (e) {}
+      } catch (e) {
+        console.debug("ECharts dispose error during re-render:", e)
+      }
     }
     this._clear_loading_timer()
     super.render()
@@ -165,7 +167,9 @@ export class EChartsView extends HTMLBoxView {
     if (this._chart != null) {
       try {
         (window as any).echarts.dispose(this._chart)
-      } catch (e) {}
+      } catch (e) {
+        console.debug("ECharts dispose error during removal:", e)
+      }
     }
   }
 
@@ -211,7 +215,7 @@ export class EChartsView extends HTMLBoxView {
           const serialized = JSON.parse(JSON.stringify(processed))
           this.model.trigger_event(new EChartsEvent(event_type, serialized, query))
         }
-        if (query == null) {
+        if (query != null) {
           this._chart.on(event_type, query, callback)
         } else {
           this._chart.on(event_type, callback)

--- a/panel/tests/ui/widgets/test_indicators.py
+++ b/panel/tests/ui/widgets/test_indicators.py
@@ -5,8 +5,10 @@ pytest.importorskip("playwright")
 from bokeh.models import Tooltip
 from playwright.sync_api import expect
 
+import panel as pn
 from panel.tests.util import serve_component, wait_until
 from panel.widgets import TooltipIcon
+from panel.widgets.indicators import Gauge
 
 pytestmark = pytest.mark.ui
 
@@ -80,3 +82,40 @@ def test_tooltip_text_updates(page):
     tooltip = page.locator(".bk-tooltip-content")
     expect(tooltip).to_have_count(1)
     expect(tooltip).to_have_text("Updated")
+
+
+def test_gauge_renders(page):
+    gauge = Gauge(name="Speed", value=75, bounds=(0, 200))
+
+    serve_component(page, gauge)
+
+    # Wait for ECharts to load and render a canvas element
+    expect(page.locator("canvas")).to_have_count(1, timeout=10000)
+
+
+def test_gauge_does_not_crash_other_widgets(page):
+    """Regression test: Gauge should not crash other widgets on the page."""
+    gauge = Gauge(name="G", value=50, bounds=(0, 100))
+    slider = pn.widgets.IntSlider(name="Slider", value=25, start=0, end=100)
+    col = pn.Column(gauge, slider)
+
+    serve_component(page, col)
+
+    # The slider must render even if Gauge is on the same page
+    expect(page.locator(".noUi-target")).to_have_count(1, timeout=10000)
+    # Gauge canvas should also eventually render
+    expect(page.locator("canvas")).to_have_count(1, timeout=10000)
+
+
+def test_gauge_value_update(page):
+    gauge = Gauge(name="G", value=25, bounds=(0, 100))
+
+    serve_component(page, gauge)
+
+    expect(page.locator("canvas")).to_have_count(1, timeout=10000)
+
+    # Update value and verify no crash
+    gauge.value = 75
+
+    # Canvas should still be present after update
+    expect(page.locator("canvas")).to_have_count(1, timeout=5000)

--- a/panel/tests/ui/widgets/test_indicators.py
+++ b/panel/tests/ui/widgets/test_indicators.py
@@ -6,6 +6,7 @@ from bokeh.models import Tooltip
 from playwright.sync_api import expect
 
 import panel as pn
+
 from panel.tests.util import serve_component, wait_until
 from panel.widgets import TooltipIcon
 from panel.widgets.indicators import Gauge

--- a/panel/tests/widgets/test_indicators.py
+++ b/panel/tests/widgets/test_indicators.py
@@ -150,6 +150,19 @@ def test_gauge_process_param_change_with_colors():
     ]
 
 
+def test_gauge_warns_without_extension(caplog):
+    import logging
+    from panel.config import panel_extension
+    original = list(panel_extension._loaded_extensions)
+    try:
+        panel_extension._loaded_extensions.clear()
+        with caplog.at_level(logging.WARNING):
+            Gauge(name="G", value=50, bounds=(0, 100))
+        assert "Gauge requires the ECharts library" in caplog.text
+    finally:
+        panel_extension._loaded_extensions.extend(original)
+
+
 def test_tqdm_color():
     tqdm = Tqdm()
     tqdm.text_pane.styles={'color': 'green'}

--- a/panel/tests/widgets/test_indicators.py
+++ b/panel/tests/widgets/test_indicators.py
@@ -102,6 +102,54 @@ def test_gauge_bounds():
     with pytest.raises(ValueError):
         dial.value = 100
 
+
+def test_gauge_creation():
+    gauge = Gauge(name="Test", value=50, bounds=(0, 100))
+    assert gauge.value == 50
+    assert gauge.bounds == (0, 100)
+    assert gauge.name == "Test"
+
+
+def test_gauge_colors():
+    gauge = Gauge(value=75, colors=[(0.4, 'green'), (0.8, 'yellow'), (1, 'red')])
+    assert gauge.colors == [(0.4, 'green'), (0.8, 'yellow'), (1, 'red')]
+
+
+def test_gauge_custom_opts():
+    gauge = Gauge(value=50, custom_opts={'pointer': {'width': 5}})
+    assert gauge.custom_opts == {'pointer': {'width': 5}}
+
+
+def test_gauge_process_param_change():
+    gauge = Gauge(name="G", value=50, bounds=(0, 100))
+    msg = gauge._process_param_change({
+        'value': 50, 'bounds': (0, 100), 'tooltip_format': '{b} : {c}%',
+        'show_ticks': True, 'show_labels': True, 'title_size': 18,
+        'format': '{value}%', 'start_angle': 225, 'end_angle': -45,
+        'num_splits': 10, 'annulus_width': 10,
+    })
+    assert 'data' in msg
+    assert msg['data']['series'][0]['type'] == 'gauge'
+    assert msg['data']['series'][0]['data'][0]['value'] == 50
+    assert msg['data']['series'][0]['min'] == 0
+    assert msg['data']['series'][0]['max'] == 100
+
+
+def test_gauge_process_param_change_with_colors():
+    gauge = Gauge(name="G", value=75, bounds=(0, 100),
+                  colors=[(0.5, 'green'), (1, 'red')])
+    msg = gauge._process_param_change({
+        'value': 75, 'bounds': (0, 100), 'tooltip_format': '{b} : {c}%',
+        'show_ticks': True, 'show_labels': True, 'title_size': 18,
+        'format': '{value}%', 'start_angle': 225, 'end_angle': -45,
+        'num_splits': 10, 'annulus_width': 10,
+        'colors': [(0.5, 'green'), (1, 'red')],
+    })
+    assert msg['data']['series'][0]['axisLine']['lineStyle']['color'] == [
+        (0.5, 'green'), (1, 'red')
+    ]
+
+
 def test_tqdm_color():
     tqdm = Tqdm()
     tqdm.text_pane.styles={'color': 'green'}

--- a/panel/tests/widgets/test_indicators.py
+++ b/panel/tests/widgets/test_indicators.py
@@ -152,6 +152,7 @@ def test_gauge_process_param_change_with_colors():
 
 def test_gauge_warns_without_extension(caplog):
     import logging
+
     from panel.config import panel_extension
     original = list(panel_extension._loaded_extensions)
     try:

--- a/panel/widgets/indicators.py
+++ b/panel/widgets/indicators.py
@@ -442,12 +442,13 @@ class Gauge(ValueIndicator):
     """
     A `Gauge` represents a value in some range as a position on
     speedometer or gauge. It is similar to a `Dial` but visually a lot
-    busier.
+    busier. Requires the ECharts extension to be loaded.
 
     Reference: https://panel.holoviz.org/reference/indicators/Gauge.html
 
     :Example:
 
+    >>> pn.extension('echarts')
     >>> Gauge(name='Speed', value=79, bounds=(0, 200), colors=[(0.4, 'green'), (1, 'red')])
     """
 
@@ -514,6 +515,12 @@ class Gauge(ValueIndicator):
         return ECharts
 
     def __init__(self, **params):
+        from ..config import panel_extension
+        if 'echarts' not in panel_extension._loaded_extensions:
+            self.param.warning(
+                "Gauge requires the ECharts library. Ensure you call "
+                "pn.extension('echarts') before using Gauge components."
+            )
         super().__init__(**params)
         self._update_value_bounds()
 


### PR DESCRIPTION
## Description

I was testing the `Gauge` indicator and found that it crashes the entire page with `TypeError: Cannot read properties of undefined (reading 'init')`. When a Gauge is placed alongside other widgets, all widgets fail to render and the page goes completely blank.

The root cause is that `EChartsView.render()` calls `window.echarts.init()` without checking if the ECharts library has loaded from CDN yet. The error propagates up through Bokeh's render pipeline and kills everything on the page.

Fixes #8514

### Changes

**`panel/models/echarts.ts`**
- Added null guards on all `window.echarts` and `this._chart` accesses (6 vulnerable code paths)
- Extracted `_init_chart()` for deferred initialization when library loads late
- Added `_await_echarts()` with script `onload` listener and polling fallback (50ms interval, 10s timeout)
- Added loading indicator ("Loading ECharts...") while waiting for library
- Fixed pre-existing bug in `_subscribe()` where the query null check was inverted (passing `null` as query selector instead of the actual query string)
- Replaced empty `catch` blocks with `console.debug` logging

**`panel/widgets/indicators.py`**
- Added Python-side `param.warning` in `Gauge.__init__` when echarts extension is not loaded
- Updated docstring to document `pn.extension('echarts')` requirement

### After fix

<img width="1217" height="764" alt="after_fix_with_extension" src="https://github.com/user-attachments/assets/044d69aa-6cef-48a3-aa29-0c59411cff09" />

https://github.com/user-attachments/assets/1e2a2b4a-c42f-4951-aa73-77c364139e18

## How Has This Been Tested?
**Unit tests** (7 passing):
```
pytest panel/tests/widgets/test_indicators.py -k gauge
```
- `test_gauge_creation` - basic instantiation
- `test_gauge_colors` - color threshold params
- `test_gauge_custom_opts` - custom ECharts options
- `test_gauge_process_param_change` - full output validation
- `test_gauge_process_param_change_with_colors` - color in processed output
- `test_gauge_warns_without_extension` - warning fires when echarts not loaded

**UI tests** (3 new Playwright tests):
- `test_gauge_renders` - canvas element appears
- `test_gauge_does_not_crash_other_widgets` - regression test: Gauge + IntSlider on same page
- `test_gauge_value_update` - value change does not crash

**Manual verification** with screen recording showing before/after behavior.

## Checklist

- [x] Tests added and is passing
- [ ] Added documentation

## AI Disclosure

Used AI for planning the fix approach and code scaffolding. All testing, debugging, and verification were done manually.