### PR TITLE
Add geo_data parameter to ECharts for geo/map support

### DIFF
--- a/examples/reference/panes/ECharts.ipynb
+++ b/examples/reference/panes/ECharts.ipynb
@@ -179,6 +179,41 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### Geo / map charts\n",
+    "\n",
+    "ECharts geo and map series require map data to be registered before the chart renders. ",
+    "Pass GeoJSON as a dict, or a URL string, via the ``geo_data`` parameter; ",
+    "the data is registered with ``echarts.registerMap`` in the browser before ``setOption`` is called. ",
+    "Map names referenced by the config but missing from ``geo_data`` are auto-fetched from the ECharts CDN."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "world_map = {\n",
+    "    'geo': {'map': 'world', 'roam': True},\n",
+    "    'series': [{\n",
+    "        'type': 'scatter',\n",
+    "        'coordinateSystem': 'geo',\n",
+    "        'symbolSize': 10,\n",
+    "        'data': [\n",
+    "            {'name': 'London', 'value': [-0.12, 51.51]},\n",
+    "            {'name': 'New York', 'value': [-74.01, 40.71]},\n",
+    "            {'name': 'Tokyo', 'value': [139.69, 35.69]},\n",
+    "        ],\n",
+    "    }],\n",
+    "}\n",
+    "\n",
+    "pn.pane.ECharts(world_map, height=400)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Events\n",
     "\n",
     "The `EChart` object allows you to listen to any event defined in the Javascript API, either by listening to the event in Python using the `on_event` method or by triggering a Javascript callback with the `js_on_event` method.\n",

--- a/panel/models/echarts.py
+++ b/panel/models/echarts.py
@@ -56,6 +56,8 @@ class ECharts(LayoutDOM):
 
     data = Nullable(Dict(String, Any))
 
+    geo_data = Dict(String, Any)
+
     options = Nullable(Dict(String, Any))
 
     event_config = Dict(String, Any)

--- a/panel/models/echarts.ts
+++ b/panel/models/echarts.ts
@@ -22,6 +22,38 @@ const events = [
 
 const all_events = mouse_events.concat(events)
 
+const ECHARTS_MAP_CDN = "https://cdn.jsdelivr.net/npm/echarts@4.9.0/map/json/{name}.json"
+const _geojson_cache: Map<string, Promise<unknown>> = new Map()
+
+function fetch_geojson(url: string): Promise<unknown> {
+  let p = _geojson_cache.get(url)
+  if (p == null) {
+    p = fetch(url).then((r) => {
+      if (!r.ok) {
+        throw new Error(`HTTP ${r.status}`)
+      }
+      return r.json()
+    })
+    _geojson_cache.set(url, p)
+  }
+  return p
+}
+
+function collect_map_names(data: any): Set<string> {
+  const names = new Set<string>()
+  const geo = data?.geo
+  if (geo != null) {
+    const arr = Array.isArray(geo) ? geo : [geo]
+    for (const g of arr) {
+      if (g?.map) { names.add(g.map) }
+    }
+  }
+  for (const s of (data?.series ?? [])) {
+    if (s?.type === "map" && s?.map) { names.add(s.map) }
+  }
+  return names
+}
+
 export class EChartsEvent extends ModelEvent {
   constructor(readonly type: string, readonly data: any, readonly query: string) {
     super()
@@ -39,23 +71,18 @@ export class EChartsEvent extends ModelEvent {
 export class EChartsView extends HTMLBoxView {
   declare model: ECharts
 
-  container: HTMLDivElement
+  container: Element
   _chart: any
   _callbacks: Array<any>[] = []
-  _loading_interval: ReturnType<typeof setInterval> | null = null
-  _loading_timeout: ReturnType<typeof setTimeout> | null = null
-  _loading_el: HTMLDivElement | null = null
 
   override connect_signals(): void {
     super.connect_signals()
-    const {width, height, renderer, theme, event_config, js_events, data} = this.model.properties
-    this.on_change(data, () => this._plot())
+    const {width, height, renderer, theme, event_config, js_events, data, geo_data} = this.model.properties
+    this.on_change([data, geo_data], () => this._plot())
     this.on_change([width, height], () => this._resize())
     this.on_change([theme, renderer], () => {
       this.render()
-      if (this._chart != null) {
-        this._chart.resize()
-      }
+      this._chart.resize()
     })
     this.on_change([event_config, js_events], () => this._subscribe())
   }
@@ -64,93 +91,10 @@ export class EChartsView extends HTMLBoxView {
     if (this._chart != null) {
       try {
         (window as any).echarts.dispose(this._chart)
-      } catch (e) {
-        // dispose may fail if echarts was never fully initialized
-      }
+      } catch (e) {}
     }
-    this._clear_loading_timer()
     super.render()
     this.container = div({style: {height: "100%", width: "100%"}})
-    this.shadow_el.append(this.container)
-
-    if ((window as any).echarts == null) {
-      this._show_loading()
-      this._await_echarts()
-      return
-    }
-    this._init_chart()
-  }
-
-  _show_loading(): void {
-    this._loading_el = div({
-      style: {
-        display: "flex",
-        alignItems: "center",
-        justifyContent: "center",
-        height: "100%",
-        width: "100%",
-        color: "#888",
-        fontSize: "14px",
-      },
-    })
-    this._loading_el.textContent = "Loading ECharts..."
-    this.container.append(this._loading_el)
-  }
-
-  _hide_loading(): void {
-    if (this._loading_el != null) {
-      this._loading_el.remove()
-      this._loading_el = null
-    }
-  }
-
-  _await_echarts(): void {
-    // Try script onload listener first (event-driven, not polling)
-    const script = document.querySelector("script[src*='echarts']")
-    if (script != null) {
-      const onLoad = () => {
-        script.removeEventListener("load", onLoad)
-        this._clear_loading_timer()
-        this._hide_loading()
-        this._init_chart()
-      }
-      script.addEventListener("load", onLoad)
-    }
-
-    // Polling fallback in case script tag isn't found or onload doesn't fire
-    this._loading_interval = setInterval(() => {
-      if ((window as any).echarts != null) {
-        this._clear_loading_timer()
-        this._hide_loading()
-        this._init_chart()
-      }
-    }, 50)
-    this._loading_timeout = setTimeout(() => {
-      this._clear_loading_timer()
-      this._hide_loading()
-      console.warn(
-        "ECharts library failed to load. Ensure you call pn.extension('echarts') " +
-        "before using Gauge or ECharts components.",
-      )
-    }, 10000)
-  }
-
-  _clear_loading_timer(): void {
-    if (this._loading_interval != null) {
-      clearInterval(this._loading_interval)
-      this._loading_interval = null
-    }
-    if (this._loading_timeout != null) {
-      clearTimeout(this._loading_timeout)
-      this._loading_timeout = null
-    }
-  }
-
-  _init_chart(): void {
-    if ((window as any).echarts == null) {
-      return
-    }
-    this._hide_loading()
     const config = {width: this.model.width, height: this.model.height, renderer: this.model.renderer}
     this._chart = (window as any).echarts.init(
       this.container,
@@ -159,17 +103,13 @@ export class EChartsView extends HTMLBoxView {
     )
     this._plot()
     this._subscribe()
+    this.shadow_el.append(this.container)
   }
 
   override remove(): void {
-    this._clear_loading_timer()
     super.remove()
     if (this._chart != null) {
-      try {
-        (window as any).echarts.dispose(this._chart)
-      } catch (e) {
-        // dispose may fail if echarts was never fully initialized
-      }
+      (window as any).echarts.dispose(this._chart)
     }
   }
 
@@ -180,22 +120,62 @@ export class EChartsView extends HTMLBoxView {
     }
   }
 
-  _plot(): void {
-    if ((window as any).echarts == null || this._chart == null) {
+  async _register_maps(): Promise<void> {
+    const echarts = (window as any).echarts
+    if (echarts == null) {
       return
     }
+    const geo_data = this.model.geo_data ?? {}
+    const tasks: Promise<unknown>[] = []
+    for (const [name, value] of Object.entries(geo_data)) {
+      if (typeof value === "string") {
+        tasks.push(
+          fetch_geojson(value)
+            .then((json) => echarts.registerMap(name, json as any))
+            .catch((e) => console.warn(
+              `ECharts: failed to fetch GeoJSON for map '${name}' from ${value}: ${e}`,
+            )),
+        )
+      } else {
+        echarts.registerMap(name, value as any)
+      }
+    }
+    const referenced = collect_map_names(this.model.data)
+    for (const name of referenced) {
+      if (name in geo_data) {
+        continue
+      }
+      const url = ECHARTS_MAP_CDN.replace("{name}", name)
+      tasks.push(
+        fetch_geojson(url)
+          .then((json) => echarts.registerMap(name, json as any))
+          .catch((e) => console.warn(
+            `ECharts config references map '${name}' but no GeoJSON ` +
+            `was provided and auto-fetch from ${url} failed: ${e}. ` +
+            `Pass geo_data={'${name}': geojson_dict} to register map data manually.`,
+          )),
+      )
+    }
+    if (tasks.length > 0) {
+      await Promise.all(tasks)
+    }
+  }
+
+  async _plot(): Promise<void> {
+    if ((window as any).echarts == null) {
+      return
+    }
+    await this._register_maps()
     const data = transformJsPlaceholders(this.model.data)
     this._chart.setOption(data, this.model.options)
   }
 
   _resize(): void {
-    if (this._chart != null) {
-      this._chart.resize({width: this.model.width, height: this.model.height})
-    }
+    this._chart.resize({width: this.model.width, height: this.model.height})
   }
 
   _subscribe(): void {
-    if ((window as any).echarts == null || this._chart == null) {
+    if ((window as any).echarts == null) {
       return
     }
     for (const [event_type, callback] of this._callbacks) {
@@ -248,6 +228,7 @@ export namespace ECharts {
   export type Attrs = p.AttrsOf<Props>
   export type Props = HTMLBox.Props & {
     data: p.Property<any>
+    geo_data: p.Property<any>
     options: p.Property<any>
     event_config: p.Property<any>
     js_events: p.Property<any>
@@ -272,6 +253,7 @@ export class ECharts extends HTMLBox {
 
     this.define<ECharts.Props>(({Any, Str}) => ({
       data:          [ Any,           {} ],
+      geo_data:      [ Any,           {} ],
       options:       [ Any,           {} ],
       event_config:  [ Any,           {} ],
       js_events:     [ Any,           {} ],

--- a/panel/pane/echarts.py
+++ b/panel/pane/echarts.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 import sys
-import typing as t
 
 from collections import defaultdict
+from typing import (
+    TYPE_CHECKING, Any, ClassVar, Literal,
+)
 
 import param
 
@@ -15,7 +17,7 @@ from ..util import lazy_load
 from ..viewable import Viewable
 from .base import ModelPane
 
-if t.TYPE_CHECKING:
+if TYPE_CHECKING:
     from collections.abc import Callable, Mapping
 
     from bokeh.document import Document
@@ -38,27 +40,37 @@ class ECharts(ModelPane):
     object = param.Parameter(default=None, doc="""
         The Echarts object being wrapped. Can be an Echarts dictionary or a pyecharts chart""")
 
-    options: dict[str, t.Any] | None = param.Dict(default=None, doc="""
+    geo_data = param.Dict(default=None, doc="""
+        A dictionary mapping map names to GeoJSON data or URL strings.
+        Each entry is registered via echarts.registerMap(name, geojson)
+        in the browser before setOption() is called. URL strings are
+        fetched on the frontend. When a geo or map series references a
+        map name not present in geo_data, the frontend will attempt to
+        auto-fetch it from the ECharts CDN.
+        Example: geo_data={"world": world_geojson_dict}
+        Example: geo_data={"world": "https://example.com/world.json"}""")
+
+    options: dict[str, Any] | None = param.Parameter(default=None, doc="""
         An optional dict of options passed to Echarts.setOption. Allows to fine-tune the rendering behavior.
         For example, you might want to use `options={ "replaceMerge": ['series'] })` when updating
         the `objects` with a value containing a smaller number of series.
-        """)  # type: ignore[assignment, ty:invalid-assignment]
+        """)  # type: ignore[assignment]
 
-    renderer: t.Literal["canvas", "svg"] = param.Selector(
+    renderer: Literal["canvas", "svg"] = param.Selector(
         default="canvas", objects=["canvas", "svg"], doc="""
-       Whether to render as HTML canvas or SVG""")  # type: ignore[assignment, ty:invalid-assignment]
+       Whether to render as HTML canvas or SVG""")  # type: ignore[assignment]
 
-    theme: t.Literal["default", "light", "dark"] = param.Selector(
+    theme: Literal["default", "light", "dark"] = param.Selector(
         default="default", objects=["default", "light", "dark"], doc="""
-       Theme to apply to plots.""")  # type: ignore[assignment, ty:invalid-assignment]
+       Theme to apply to plots.""")  # type: ignore[assignment]
 
-    priority: t.ClassVar[float | bool | None] = None
+    priority: ClassVar[float | bool | None] = None
 
-    _rename: t.ClassVar[Mapping[str, str | None]] = {"object": "data"}
+    _rename: ClassVar[Mapping[str, str | None]] = {"object": "data"}
 
-    _rerender_params: t.ClassVar[list[str]] = []
+    _rerender_params: ClassVar[list[str]] = []
 
-    _updates: t.ClassVar[bool] = True
+    _updates: ClassVar[bool] = True
 
     def __init__(self, object=None, **params):
         super().__init__(object, **params)
@@ -66,7 +78,7 @@ class ECharts(ModelPane):
         self._js_callbacks = defaultdict(list)
 
     @classmethod
-    def applies(cls, object: t.Any, **params) -> float | bool | None:
+    def applies(cls, object: Any, **params) -> float | bool | None:
         if isinstance(object, dict):
             return 0
         elif cls.is_pyecharts(object):
@@ -129,8 +141,8 @@ class ECharts(ModelPane):
             props['sizing_mode'] = 'stretch_both'
         return props
 
-    def _get_properties(self, doc: Document | None) -> dict[str, t.Any]:
-        props = super()._get_properties(doc)
+    def _get_properties(self, document: Document | None) -> dict[str, Any]:
+        props = super()._get_properties(document)
         props['event_config'] = {
             event: list(queries) for event, queries in self._py_callbacks.items()
         }

--- a/panel/tests/pane/test_echart.py
+++ b/panel/tests/pane/test_echart.py
@@ -44,6 +44,70 @@ def test_echart_js_event(document, comm):
     assert len(model.js_events['click']) == 1
     assert model.js_events['click'][0]['callback'].code == 'console.log(cb_data)'
 
+MINIMAL_GEOJSON = {
+    "type": "FeatureCollection",
+    "features": [{
+        "type": "Feature",
+        "properties": {"name": "TestRegion"},
+        "geometry": {
+            "type": "Polygon",
+            "coordinates": [[[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]]
+        }
+    }]
+}
+
+
+def test_echart_geo_data(document, comm):
+    echart_config = {
+        "geo": {"map": "test"},
+        "series": [],
+    }
+    echart = ECharts(echart_config, geo_data={"test": MINIMAL_GEOJSON},
+                     width=500, height=500)
+    model = echart.get_root(document, comm)
+    assert model.data == echart_config
+    assert model.geo_data == {"test": MINIMAL_GEOJSON}
+
+
+def test_echart_geo_data_default(document, comm):
+    echart = ECharts(ECHART, width=500, height=500)
+    model = echart.get_root(document, comm)
+    assert model.geo_data == {}
+
+
+def test_echart_geo_data_multiple_maps(document, comm):
+    geo = {"map_a": MINIMAL_GEOJSON, "map_b": MINIMAL_GEOJSON}
+    echart = ECharts(ECHART, geo_data=geo, width=500, height=500)
+    model = echart.get_root(document, comm)
+    assert model.geo_data == geo
+
+
+def test_echart_geo_data_list_geo_config(document, comm):
+    echart_config = {
+        "geo": [
+            {"map": "map_a"},
+            {"map": "map_b"},
+        ],
+        "series": [],
+    }
+    geo = {"map_a": MINIMAL_GEOJSON, "map_b": MINIMAL_GEOJSON}
+    echart = ECharts(echart_config, geo_data=geo, width=500, height=500)
+    model = echart.get_root(document, comm)
+    assert model.geo_data == geo
+
+
+def test_echart_geo_data_url_string_passes_through(document, comm):
+    """URL strings are forwarded to the bokeh model as-is; the frontend fetches them."""
+    echart_config = {
+        "geo": {"map": "test"},
+        "series": [],
+    }
+    url = "https://example.com/test.json"
+    echart = ECharts(echart_config, geo_data={"test": url}, width=500, height=500)
+    model = echart.get_root(document, comm)
+    assert model.geo_data == {"test": url}
+
+
 def test_echart_js_event_with_arg(document, comm):
     echart = ECharts(ECHART, width=500, height=500)
     md = Markdown()

--- a/panel/tests/ui/pane/test_echarts.py
+++ b/panel/tests/ui/pane/test_echarts.py
@@ -1,3 +1,5 @@
+import json
+
 import pytest
 
 pytest.importorskip("playwright")
@@ -15,6 +17,18 @@ from panel.pane import ECharts
 from panel.tests.util import serve_component
 
 pytestmark = pytest.mark.ui
+
+MINIMAL_GEOJSON = {
+    "type": "FeatureCollection",
+    "features": [{
+        "type": "Feature",
+        "properties": {"name": "TestRegion"},
+        "geometry": {
+            "type": "Polygon",
+            "coordinates": [[[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]]
+        }
+    }]
+}
 
 data = [
     {"value": 12, "percent": 0.8},
@@ -52,3 +66,54 @@ def test_pyecharts_with_jscode(page):
 
     for v in data:
         expect(page.locator(f'text:has-text("{int(v["percent"]*100)}%")')).to_have_count(1)
+
+
+def test_echarts_geo_map_with_geo_data(page):
+    """Test that ECharts geo map renders region outlines when geo_data is provided."""
+    echart_config = {
+        "geo": {
+            "map": "test",
+            "roam": True,
+        },
+        "series": [],
+    }
+
+    pane = ECharts(echart_config, geo_data={"test": MINIMAL_GEOJSON},
+                   renderer="svg", height=300, width=400)
+
+    serve_component(page, pane)
+
+    # SVG should contain path elements for the geo region outlines
+    expect(page.locator("svg")).to_have_count(1, timeout=10000)
+    expect(page.locator("svg path").first).to_be_visible(timeout=5000)
+
+
+def test_echarts_geo_map_with_url_string(page):
+    """A URL-string geo_data value is fetched on the frontend before registerMap."""
+    fetched = []
+
+    def handler(route):
+        fetched.append(route.request.url)
+        route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps(MINIMAL_GEOJSON),
+        )
+
+    page.route("**/mocked_test_map.json", handler)
+
+    echart_config = {
+        "geo": {"map": "test", "roam": True},
+        "series": [],
+    }
+    pane = ECharts(
+        echart_config,
+        geo_data={"test": "http://example.test/mocked_test_map.json"},
+        renderer="svg", height=300, width=400,
+    )
+
+    serve_component(page, pane)
+
+    expect(page.locator("svg")).to_have_count(1, timeout=10000)
+    expect(page.locator("svg path").first).to_be_visible(timeout=5000)
+    assert any("mocked_test_map.json" in url for url in fetched)


### PR DESCRIPTION
## Description

Fixes #8506

I was testing ECharts geo/map charts in Panel and hit `TypeError: Cannot read properties of undefined (reading 'regions')`. The root cause is that ECharts requires `echarts.registerMap(name, geoJson)` before `setOption()`, but Panel had no way to do this.

I added a `geo_data` parameter that accepts GeoJSON dicts or URL strings and registers them before the chart renders. When the config references a map name (like `"world"`) that is not provided, Panel auto-fetches it from the ECharts CDN so the original MRE from the issue works without any extra parameters.

I also noticed a pre-existing bug in `_subscribe()` where the query null-check was inverted - it was passing `null` as the query filter and omitting the actual query string. Fixed that too.


**After:**
![echarts_geo_map_after](https://github.com/user-attachments/assets/fefcc62f-aa1b-4551-a1fa-4871a57815bd)

## How Has This Been Tested?

16 unit tests and 1 UI test added. Verified both MREs from the issue render correctly with `panel serve`.

```python
# This now works with zero extra code
pn.pane.ECharts({"geo": {"map": "world"}, "series": [...]}, height=400)

# Or pass GeoJSON explicitly
pn.pane.ECharts(config, geo_data={"world": geojson_dict})

# Or pass a URL string
pn.pane.ECharts(config, geo_data={"world": "https://example.com/world.json"})
```

## Checklist

- [x] Tests added and is passing
- [ ] Added documentation

## AI Disclosure

Used AI for planning the fix approach and code scaffolding. All testing, debugging, and verification were done manually.