### PR TITLE
Fix model.useState boomerang causing character loss during fast typing

### DIFF
--- a/panel/custom.py
+++ b/panel/custom.py
@@ -600,10 +600,16 @@ class ReactiveESM(ReactiveCustomBase, metaclass=ReactiveESMMetaclass):
         root: Model, model: Model, doc: Document, comm: Comm | None
     ) -> None:
         model_msg, data_msg, data_resets  = {}, {}, {}
+        curdoc_events = self._in_process__events.get(doc, {})
         for prop, v in list(msg.items()):
             if prop in list(Reactive.param)+['esm', 'importmap']:
                 model_msg[prop] = v
             elif prop in model.children:
+                continue
+            elif prop in curdoc_events and v is curdoc_events[prop]:
+                # Do not apply change that originated directly from
+                # the frontend since this may cause boomerang if a
+                # new property value is already in-flight
                 continue
             else:
                 data_msg[prop] = v

--- a/panel/models/react_component.ts
+++ b/panel/models/react_component.ts
@@ -515,13 +515,24 @@ async function render(id) {
         }
         if (resolvedProp && targetModel) {
           const [value, setValue] = React.useState(targetModel.attributes[resolvedProp])
+          // Track values sent to Python to detect echoed-back changes
+          const sentRef = React.useRef([])
 
           React.useEffect(() => {
             const cb = () => {
               if (target.model.events.includes(resolvedProp)) {
                 targetModel.attributes[resolvedProp] && (setValue((v) => v+1) || targetModel.setv({[resolvedProp]: false}))
               } else {
-                setValue(targetModel.attributes[resolvedProp])
+                const incoming = targetModel.attributes[resolvedProp]
+                const idx = sentRef.current.indexOf(incoming)
+                if (idx !== -1) {
+                  // Value is an echo of what we sent — discard it
+                  sentRef.current.splice(0, idx + 1)
+                } else {
+                  // Genuine server-initiated update — apply it
+                  sentRef.current.length = 0
+                  setValue(incoming)
+                }
               }
             }
             react_proxy.on(prop, cb, true)
@@ -530,6 +541,7 @@ async function render(id) {
 
           React.useEffect(() => {
             if (!target.model.events.includes(resolvedProp)) {
+              sentRef.current.push(value)
               targetModel.setv({ [resolvedProp]: value })
             }
           }, [value])

--- a/panel/tests/test_custom.py
+++ b/panel/tests/test_custom.py
@@ -1,11 +1,12 @@
 import numpy as np
 import pandas as pd
 import param
+import pytest
 
 from bokeh.plotting import figure
 
-from panel.custom import PyComponent, ReactiveESM
-from panel.io.state import state
+from panel.custom import PyComponent, ReactComponent, ReactiveESM
+from panel.io.state import set_curdoc, state
 from panel.layout import Row
 from panel.pane import Bokeh, Markdown
 from panel.util import edit_readonly
@@ -225,3 +226,46 @@ def test_esm_parameter_override(document, comm):
     esm.width = 84
 
     assert model.width == 84
+
+
+class ESMInput(ReactiveESM):
+
+    value_input = param.String(default='')
+
+    _esm = """
+    export function render({model}) {}
+    """
+
+
+class ReactInput(ReactComponent):
+
+    value_input = param.String(default='')
+
+    _esm = """
+    export function render({model}) {
+      const [value_input, setValueInput] = model.useState("value_input")
+      return <input value={value_input} onChange={(e) => setValueInput(e.target.value)} />
+    }
+    """
+
+
+@pytest.mark.parametrize('component', [ESMInput, ReactInput])
+def test_esm_property_change_does_not_boomerang(document, comm, component):
+    widget = component(value_input='A')
+
+    model = widget.get_root(document, comm)
+
+    assert model.data.value_input == 'A'
+
+    # Simulate: frontend updates the property to 'B' (user typed)
+    model.data.value_input = 'B'
+
+    # Simulate: a different frontend event arrives for processing
+    with set_curdoc(document):
+        widget._process_events({'value_input': 'C'})
+
+    # The Bokeh model should retain 'B' (the latest frontend value),
+    # NOT be overwritten to 'C' (which would be a boomerang).
+    assert model.data.value_input == 'B'
+    # The Python param should still be updated to 'C'.
+    assert widget.value_input == 'C'

--- a/panel/tests/test_custom.py
+++ b/panel/tests/test_custom.py
@@ -230,7 +230,7 @@ def test_esm_parameter_override(document, comm):
 
 class ESMInput(ReactiveESM):
 
-    value_input = param.String(default='')
+    value_input = param.String(default='', doc="Text value updated on every key press.")
 
     _esm = """
     export function render({model}) {}
@@ -239,7 +239,7 @@ class ESMInput(ReactiveESM):
 
 class ReactInput(ReactComponent):
 
-    value_input = param.String(default='')
+    value_input = param.String(default='', doc="Text value updated on every key press.")
 
     _esm = """
     export function render({model}) {

--- a/panel/tests/ui/test_custom.py
+++ b/panel/tests/ui/test_custom.py
@@ -1325,3 +1325,34 @@ def test_esm_compile_shared(page, components):
 
     expect(page.locator(f'#{example[0].name}')).to_have_text('Rendered')
     expect(page.locator(f'#{example[1].name}')).to_have_text('Rendered')
+
+
+def test_usestate_no_character_loss(page):
+    """Fast typing into a controlled input using model.useState should not lose characters."""
+
+    class TypingTest(ReactComponent):
+        value_input = param.String(default="")
+        _esm = """
+        export function render({model}) {
+          const [value_input, setValueInput] = model.useState("value_input")
+          return (
+            <textarea
+              id="typing-test"
+              value={value_input}
+              onChange={(e) => setValueInput(e.target.value)}
+            />
+          )
+        }
+        """
+
+    test_string = "The quick brown fox jumps"
+    widget = TypingTest()
+    serve_component(page, widget)
+
+    textarea = page.locator("#typing-test")
+    expect(textarea).to_be_visible(timeout=10000)
+    textarea.click()
+    textarea.press_sequentially(test_string, delay=30)
+
+    wait_until(lambda: widget.value_input == test_string, page, timeout=10000)
+    assert widget.value_input == test_string


### PR DESCRIPTION
## AI Disclaimer

Below is AI Generated. I will start reviewing and update.

## Summary

- Fixes character loss when typing fast in React ESM components that use `model.useState()` with controlled inputs
- Adds echo detection to `model.useState` in `react_component.ts` — tracks values sent to Python via a ref array and discards stale echoes from the Python → React callback
- This is the React ESM equivalent of the boomerang fix in PR #7093 (which fixed Bokeh components)

## Root Cause

`model.useState` creates two React effects:
1. **Python → React**: calls `setValue(targetModel.attributes[prop])` on any property change
2. **React → Python**: calls `targetModel.setv({prop: value})` when React state changes

When typing fast, the round-trip creates a race condition:
1. User types "a" → `setValue("a")` → syncs "a" to Python
2. User types "b" → `setValue("ab")` → syncs "ab" to Python  
3. Python echoes stale "a" back → `setValue("a")` → **overwrites "ab"** → character "b" lost

## Fix

A `sentRef` (React ref array) tracks values sent to Python. When the Python → React callback fires:
- If the incoming value is in `sentRef` → it's an echo → skip `setValue()`
- If not → it's a genuine server update → apply `setValue()`

## Real-world Impact

This fixes character loss in [panel-material-ui](https://github.com/panel-extensions/panel-material-ui) ChatInterface and all text input widgets (TextInput, TextAreaInput, PasswordInput, AutocompleteInput), as well as any custom `ReactComponent` using the `model.useState` + controlled input pattern.

## MRE

```python
import param
import panel as pn
from panel.custom import ReactComponent

pn.extension()

class TypingTest(ReactComponent):
    value_input = param.String(default="")
    _esm = """
    export function render({model}) {
      const [value_input, setValueInput] = model.useState("value_input")
      return (
        <div>
          <textarea
            value={value_input}
            onChange={(e) => setValueInput(e.target.value)}
          />
          <p>value_input: {value_input}</p>
        </div>
      )
    }
    """

TypingTest().servable()
```

Run with `panel serve script.py` and type fast — characters are dropped without this fix.

## Test plan

- [x] Playwright test: type "The quick brown fox jumps" at 30ms delay into custom ReactComponent — all characters present
- [x] Playwright test: same test with panel-material-ui ChatInterface — all characters present
- [ ] Verify no regressions in existing React ESM component tests
- [ ] Verify event-type properties (`param.Event`) still work correctly (code path unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)