### PR TITLE
fix(tabulator): Scroll reset when filtering on patch 

### DIFF
--- a/panel/models/tabulator.ts
+++ b/panel/models/tabulator.ts
@@ -471,13 +471,14 @@ export class DataTabulatorView extends HTMLBoxView {
       if (this.tabulator === undefined) {
         return
       }
-      this._restore_scroll = "horizontal"
       this._selection_updating = true
-      this._updating_scroll = true
-      this.setData()
-      this._updating_scroll = false
-      this._selection_updating = false
-      this.postUpdate()
+      const scroll_left = this._lastHorizontalScrollbarLeftPosition
+      void this.setData().then(() => {
+        this._selection_updating = false
+        this._lastHorizontalScrollbarLeftPosition = scroll_left
+        this.postUpdate()
+        this.restore_scroll(true, false)
+      })
     })
     this.connect(this.model.source.streaming, () => this.addData())
     this.connect(this.model.source.patching, () => {
@@ -1215,20 +1216,17 @@ export class DataTabulatorView extends HTMLBoxView {
     const last_row = rows[rows.length-1]
     const start = ((last_row?.data._index) || 0)
     this._updating_page = true
-    const promise = this.setData()
-    if (this.model.follow) {
-      promise.then(() => {
+    void this.setData().then(() => {
+      if (this.model.follow) {
         if (this.model.pagination) {
           this.tabulator.setPage(Math.ceil(this.tabulator.rowManager.getDataCount() / (this.model.page_size || 20)))
         }
         if (last_row) {
           this.tabulator.scrollToRow(start, "top", false)
         }
-        this._updating_page = false
-      })
-    } else {
-      this._updating_page = true
-    }
+      }
+      this._updating_page = false
+    })
   }
 
   postUpdate(): void {

--- a/panel/models/tabulator.ts
+++ b/panel/models/tabulator.ts
@@ -472,12 +472,13 @@ export class DataTabulatorView extends HTMLBoxView {
         return
       }
       this._selection_updating = true
+      this._updating_scroll = true
       const scroll_left = this._lastHorizontalScrollbarLeftPosition
       void this.setData().then(() => {
         this._selection_updating = false
         this._lastHorizontalScrollbarLeftPosition = scroll_left
         this.postUpdate()
-        this.restore_scroll(true, false)
+        this.restore_scroll()
       })
     })
     this.connect(this.model.source.streaming, () => this.addData())

--- a/panel/models/tabulator.ts
+++ b/panel/models/tabulator.ts
@@ -1395,11 +1395,11 @@ export class DataTabulatorView extends HTMLBoxView {
     if (horizontal) {
       opts.left = this._lastHorizontalScrollbarLeftPosition
     }
-    setTimeout(() => {
+    requestAnimationFrame(() => {
       this._updating_scroll = true
       this.tabulator.rowManager.element.scrollTo(opts)
       this._updating_scroll = false
-    }, 0)
+    })
   }
 
   // Update model

--- a/panel/models/tabulator.ts
+++ b/panel/models/tabulator.ts
@@ -471,12 +471,11 @@ export class DataTabulatorView extends HTMLBoxView {
       if (this.tabulator === undefined) {
         return
       }
+      this._restore_scroll = "horizontal"
       this._selection_updating = true
       this._updating_scroll = true
-      const scroll_left = this._lastHorizontalScrollbarLeftPosition
       void this.setData().then(() => {
         this._selection_updating = false
-        this._lastHorizontalScrollbarLeftPosition = scroll_left
         this.postUpdate()
         this.restore_scroll()
       })

--- a/panel/tests/ui/widgets/test_tabulator.py
+++ b/panel/tests/ui/widgets/test_tabulator.py
@@ -3104,7 +3104,6 @@ def test_tabulator_edit_event_and_header_filters_same_column(page, show_index, i
     assert len(widget.current_view) == 2
 
 
-@pytest.mark.flaky(max_runs=3)
 @pytest.mark.parametrize('pagination', ['remote', 'local'])
 def test_tabulator_edit_event_and_header_filters_same_column_pagination(page, pagination):
     df = pd.DataFrame({
@@ -3128,7 +3127,7 @@ def test_tabulator_edit_event_and_header_filters_same_column_pagination(page, pa
     header.fill('B')
     header.press('Enter')
 
-    wait_until(lambda: widget.current_view.equals(df[df['values'] == 'B']))
+    wait_until(lambda: widget.current_view is not None and widget.current_view.equals(df[df['values'] == 'B']))
 
     cell = page.locator('text="B"').first
     cell.click()

--- a/panel/tests/ui/widgets/test_tabulator.py
+++ b/panel/tests/ui/widgets/test_tabulator.py
@@ -1326,7 +1326,7 @@ def test_tabulator_patch_with_filter_no_vertical_rescroll(page):
     page.wait_for_timeout(400)
 
     scroll_top_before = tableholder.evaluate("el => el.scrollTop")
-    assert scroll_top_before > 0, "Table did not scroll"
+    assert scroll_top_before > 0
 
     # Patch a visible (non-filtered) row
     widget.patch({"value": [(0, 999.0)]})
@@ -1335,9 +1335,7 @@ def test_tabulator_patch_with_filter_no_vertical_rescroll(page):
     page.wait_for_timeout(400)
 
     scroll_top_after = tableholder.evaluate("el => el.scrollTop")
-    assert scroll_top_before == scroll_top_after, (
-        f"Scroll reset after patch: was {scroll_top_before}, now {scroll_top_after}"
-    )
+    assert scroll_top_before == scroll_top_after
 
 
 def test_tabulator_patch_no_height_resize(page):

--- a/panel/tests/ui/widgets/test_tabulator.py
+++ b/panel/tests/ui/widgets/test_tabulator.py
@@ -1308,6 +1308,38 @@ def test_tabulator_patch_no_vertical_rescroll(page):
     assert bb == page.locator(f'text="{new_val}"').bounding_box()
 
 
+def test_tabulator_patch_with_filter_no_vertical_rescroll(page):
+    df = pd.DataFrame({
+        "value": [0.0] * 30,
+        "state": ["Present" if i % 2 == 0 else "Hidden" for i in range(30)],
+    })
+    widget = Tabulator(df, height=300)
+    widget.add_filter("Present", "state")
+
+    serve_component(page, widget)
+
+    tableholder = page.locator(".tabulator-tableholder")
+    expect(tableholder).to_be_attached()
+
+    # Scroll down inside the tableholder
+    tableholder.evaluate("el => el.scrollTop = 10000")
+    page.wait_for_timeout(400)
+
+    scroll_top_before = tableholder.evaluate("el => el.scrollTop")
+    assert scroll_top_before > 0, "Table did not scroll"
+
+    # Patch a visible (non-filtered) row
+    widget.patch({"value": [(0, 999.0)]})
+
+    # Wait to catch a potential scroll reset
+    page.wait_for_timeout(400)
+
+    scroll_top_after = tableholder.evaluate("el => el.scrollTop")
+    assert scroll_top_before == scroll_top_after, (
+        f"Scroll reset after patch: was {scroll_top_before}, now {scroll_top_after}"
+    )
+
+
 def test_tabulator_patch_no_height_resize(page):
     header = Column('Text', height=1000)
     df = pd.DataFrame(np.random.random((150, 1)), columns=['a'])


### PR DESCRIPTION
## Description

<!--
Using AI? READ FIRST: https://holoviz.org/contribute.html#ai-readme

- Summarize the change and which issue is fixed.
- Include relevant motivation and context.
- Add visuals when possible, e.g. before/after screenshots with full code snippets.
-->


Started out with improving flaky UI test. But found a bug where scroll would reset if patch was used with filtering.

## How Has This Been Tested?

<!-- Describe the tests that you ran to verify your changes. Provide instructions so it can be reproduced while reviewing your changes. -->

## AI Disclosure

<!-- Remove this section if your PR does not contain AI-generated content. -->
<!-- Failure in disclosing the use of AI will result in a ban. -->

- [x] This PR contains AI-generated content.
  - [x] I have tested all AI-generated content in my PR.
  - [x] I take responsibility for all AI-generated content in my PR.

<!-- If you used AI to generate code, please specify the tool and model used, and briefly describe how they were used. -->

Tools and Models: Cursor + Sonnet 4.6, used to try to fix the flaky tabulator test.

## Checklist

<!-- Remove the non relevant items. -->

- [x] Tests added and are passing
