### PR TITLE
ci: Align build and docs actions with other repos

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -6,19 +6,14 @@ on:
       - "v[0-9]+.[0-9]+.[0-9]+a[0-9]+"
       - "v[0-9]+.[0-9]+.[0-9]+b[0-9]+"
       - "v[0-9]+.[0-9]+.[0-9]+rc[0-9]+"
-  # Dry-run only
   workflow_dispatch:
   schedule:
     - cron: "0 19 * * SUN"
 
-defaults:
-  run:
-    shell: bash -e {0}
-
 env:
-  PACKAGE: "panel"
-  PYTHON_VERSION: "3.11"
   NODE_VERSION: "24"
+  PACKAGE: "panel"
+  PYTHON_VERSION: "3.10"
 
 jobs:
   waiting_room:
@@ -52,8 +47,8 @@ jobs:
       - uses: actions/upload-artifact@v7
         if: always()
         with:
-          name: conda
-          path: dist/*tar.bz2
+          name: artifacts-conda
+          path: dist/*.conda
           if-no-files-found: error
       - name: Verify size
         run: python scripts/verify_build_size.py conda
@@ -63,33 +58,23 @@ jobs:
     runs-on: ubuntu-latest
     needs: [conda_build, waiting_room]
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
-    defaults:
-      run:
-        shell: bash -el {0}
     steps:
       - uses: actions/download-artifact@v8
         with:
-          name: conda
+          name: artifacts-conda
           path: dist/
-      - name: Set environment variables
+      - name: anaconda setup
         run: |
-          echo "TAG=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
-          echo "CONDA_FILE=$(ls dist/*.tar.bz2)" >> $GITHUB_ENV
-      - uses: conda-incubator/setup-miniconda@v3
-        with:
-          miniconda-version: "latest"
-          channels: "conda-forge"
-      - name: conda setup
+          pipx install anaconda-client
+          binstar --version
+      - name: anaconda dev upload
+        if: contains(github.ref_name, 'a') || contains(github.ref_name, 'b') || contains(github.ref_name, 'rc')
         run: |
-          conda install -y anaconda-client
-      - name: conda dev upload
-        if: contains(env.TAG, 'a') || contains(env.TAG, 'b') || contains(env.TAG, 'rc')
+          binstar --token ${{ secrets.CONDA_UPLOAD_TOKEN }} upload --user pyviz --label=dev dist/*.conda
+      - name: anaconda upload
+        if: (!(contains(github.ref_name, 'a') || contains(github.ref_name, 'b') || contains(github.ref_name, 'rc')))
         run: |
-          anaconda --token ${{ secrets.CONDA_UPLOAD_TOKEN }} upload --user pyviz --label=dev $CONDA_FILE
-      - name: conda main upload
-        if: (!(contains(env.TAG, 'a') || contains(env.TAG, 'b') || contains(env.TAG, 'rc')))
-        run: |
-          anaconda --token ${{ secrets.CONDA_UPLOAD_TOKEN }} upload --user pyviz --label=dev --label=main $CONDA_FILE
+          binstar --token ${{ secrets.CONDA_UPLOAD_TOKEN }} upload --user pyviz --label=dev --label=main dist/*.conda
 
   pip_build:
     name: Build PyPI
@@ -106,7 +91,7 @@ jobs:
       - uses: actions/upload-artifact@v7
         if: always()
         with:
-          name: pip
+          name: artifacts-pip
           path: dist/
           if-no-files-found: error
       - name: Verify sizes
@@ -124,7 +109,7 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
       - uses: actions/download-artifact@v8
         with:
-          name: pip
+          name: artifacts-pip
           path: dist/
       - name: Install package
         run: python -m pip install dist/*.whl
@@ -136,17 +121,15 @@ jobs:
     runs-on: ubuntu-latest
     needs: [pip_build, waiting_room]
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+    permissions:
+      id-token: write
     steps:
       - uses: actions/download-artifact@v8
         with:
-          name: pip
+          name: artifacts-pip
           path: dist/
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          user: ${{ secrets.PPU }}
-          password: ${{ secrets.PPP }}
-          repository-url: "https://upload.pypi.org/legacy/"
 
   npm_build:
     name: Build NPM
@@ -169,9 +152,9 @@ jobs:
       - uses: actions/upload-artifact@v7
         if: always()
         with:
-          name: npm
+          name: artifacts-npm
           if-no-files-found: error
-          path: ./${{ env.PACKAGE }}/${{ env.TARBALL }}
+          path: ${{ env.PACKAGE }}/${{ env.TARBALL }}
       - name: Verify size
         run: python scripts/verify_build_size.py npm
 
@@ -186,23 +169,19 @@ jobs:
     steps:
       - uses: actions/download-artifact@v8
         with:
-          name: npm
+          name: artifacts-npm
       - uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
-          registry-url: 'https://registry.npmjs.org'
-      - name: Set environment variables
-        run: |
-          echo "TAG=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
-          echo "TARBALL=$(ls *.tgz)" >> $GITHUB_ENV
+          registry-url: "https://registry.npmjs.org"
       - name: npm dev deploy
-        if: contains(env.TAG, 'a') || contains(env.TAG, 'b') || contains(env.TAG, 'rc')
+        if: contains(github.ref_name, 'a') || contains(github.ref_name, 'b') || contains(github.ref_name, 'rc')
         run: |
-          npm publish --tag dev $TARBALL
+          npm publish --tag dev *.tgz
       - name: npm main deploy
-        if: (!(contains(env.TAG, 'a') || contains(env.TAG, 'b') || contains(env.TAG, 'rc')))
+        if: (!(contains(github.ref_name, 'a') || contains(github.ref_name, 'b') || contains(github.ref_name, 'rc')))
         run: |
-          npm publish --tag latest $TARBALL
+          npm publish --tag latest *.tgz
 
   cdn_build:
     name: Build CDN

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -248,7 +248,7 @@ jobs:
         run: |
           awk -v ver="## Version ${TAG#v}" '
             $0 == ver {flag=1; next}
-            /^#{2} Version / && flag {exit}
+            /^## Version / && flag {exit}
             flag && !/^(\*\*.*\*\*)$/
           ' CHANGELOG.md | tee RELEASE_BODY.md
       - name: Create draft GitHub release with dist artifacts

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -227,3 +227,37 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_DEFAULT_REGION: "us-east-1"
         run: python scripts/cdn_upload.py
+
+  announce:
+    name: Announce GitHub
+    runs-on: ubuntu-latest
+    needs: [waiting_room]
+    permissions:
+      contents: write
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+    env:
+      TAG: ${{ github.ref_name }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/download-artifact@v8
+        with:
+          pattern: artifacts-*
+          path: artifacts/
+          merge-multiple: true
+      - name: Extract changelog section
+        run: |
+          awk -v ver="## Version ${TAG#v}" '
+            $0 == ver {flag=1; next}
+            /^#{2} Version / && flag {exit}
+            flag && !/^(\*\*.*\*\*)$/
+          ' CHANGELOG.md | tee RELEASE_BODY.md
+      - name: Create draft GitHub release with dist artifacts
+        if: (!(contains(env.TAG, 'a') || contains(env.TAG, 'b') || contains(env.TAG, 'rc')))
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "$TAG" \
+            --title "Version ${TAG#v}" \
+            --notes-file RELEASE_BODY.md \
+            --draft \
+            artifacts/*

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -40,8 +40,6 @@ jobs:
     needs: [pixi_lock]
     runs-on: "macos-latest"
     timeout-minutes: 180
-    outputs:
-      tag: ${{ steps.vars.outputs.tag }}
     steps:
       - uses: holoviz-dev/holoviz_tasks/pixi_install@v0
         with:
@@ -55,9 +53,6 @@ jobs:
           name: docs
           if-no-files-found: error
           path: builtdocs
-      - name: Set output
-        id: vars
-        run: echo "tag=${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT
 
   docs_publish:
     name: Publish Documentation
@@ -68,24 +63,21 @@ jobs:
         with:
           name: docs
           path: builtdocs/
-      - name: Set output
-        id: vars
-        run: echo "tag=${{ needs.docs_build.outputs.tag }}" >> $GITHUB_OUTPUT
       - name: Deploy dev
         uses: peaceiris/actions-gh-pages@v4
         if: |
           (github.event_name == 'workflow_dispatch' && github.event.inputs.target == 'dev') ||
-          (github.event_name == 'push' && (contains(steps.vars.outputs.tag, 'a') || contains(steps.vars.outputs.tag, 'b') || contains(steps.vars.outputs.tag, 'rc')))
+          (github.event_name == 'push' && (contains(github.ref_name, 'a') || contains(github.ref_name, 'b') || contains(github.ref_name, 'rc')))
         with:
           personal_token: ${{ secrets.ACCESS_TOKEN }}
           external_repository: holoviz-dev/panel
           publish_dir: ./builtdocs
           force_orphan: true
       - name: Deploy main
+        uses: peaceiris/actions-gh-pages@v4
         if: |
           (github.event_name == 'workflow_dispatch' && github.event.inputs.target == 'main') ||
-          (github.event_name == 'push' && !(contains(steps.vars.outputs.tag, 'a') || contains(steps.vars.outputs.tag, 'b') || contains(steps.vars.outputs.tag, 'rc')))
-        uses: peaceiris/actions-gh-pages@v4
+          (github.event_name == 'push' && !(contains(github.ref_name, 'a') || contains(github.ref_name, 'b') || contains(github.ref_name, 'rc')))
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./builtdocs

--- a/scripts/conda/build.sh
+++ b/scripts/conda/build.sh
@@ -19,6 +19,6 @@ else:
     print('bokeh')
 ")
 
-conda build scripts/conda/recipe --no-anaconda-upload --no-verify -c "$BK_CHANNEL" -c conda-forge --package-format 1
+conda build scripts/conda/recipe --no-anaconda-upload --no-verify -c "$BK_CHANNEL" -c conda-forge --package-format 2
 
-mv "$CONDA_PREFIX/conda-bld/noarch/$PACKAGE-$VERSION-py_0.tar.bz2" dist
+mv "$CONDA_PREFIX/conda-bld/noarch/$PACKAGE-$VERSION-py_0.conda" dist

--- a/scripts/verify_build_size.py
+++ b/scripts/verify_build_size.py
@@ -10,7 +10,7 @@ EXPECTED_SIZES_MB = {
 }
 
 GLOB_PATH = {
-    "conda": "dist/*.tar.bz2",
+    "conda": "dist/*.conda",
     "npm": "panel/*.tgz",
     "sdist": "dist/*.tar.gz",
     "whl": "dist/*.whl",


### PR DESCRIPTION
## Description

Updates CI workflow to match with work I have done in our other projects.

- Make conda package version 2
- Use PyPI for anaconda-client install 
- Use trusted publisher for PyPI
- Use `github.ref_name` instead of extracting that manually to figure out tag
- Add an announce step to release which will draft a Github release with artifacts.

## How Has This Been Tested?

CI
<img width="1379" height="669" alt="image" src="https://github.com/user-attachments/assets/716254a1-08d6-4f72-84b5-d1d791db3cb9" />

