### PR TITLE
Fix DataFrame comparison in Tabulator.from_param

### DIFF
--- a/panel/param.py
+++ b/panel/param.py
@@ -21,7 +21,6 @@ from functools import partial
 from types import FunctionType
 from typing import TYPE_CHECKING, Any, ClassVar
 
-import numpy as np
 import param
 
 try:
@@ -38,6 +37,8 @@ from param.parameterized import (
 )
 from param.reactive import rx
 
+from panel.io.cache import is_equal
+
 from .config import config
 from .io import state
 from .layout import (
@@ -50,9 +51,7 @@ from .util import (
     abbreviated_repr, flatten, full_groupby, fullpath, is_parameterized,
     param_name, recursive_parameterized, to_async_gen,
 )
-from .util.checks import (
-    is_array, is_dataframe, is_mpl_axes, is_series,
-)
+from .util.checks import is_dataframe, is_mpl_axes, is_series
 from .viewable import Layoutable, Viewable
 from .widgets import (
     ArrayInput, Button, Checkbox, ColorPicker, DataFrame, DatePicker,
@@ -549,18 +548,6 @@ class Param(Pane):
             watchers, updating = [], []
             widgets = {p_name: widget}
 
-        def _equal(current, new):
-            if (is_dataframe(current) and is_dataframe(new)) or (
-                is_series(current) and is_series(new)
-            ):
-                return current.equals(new)
-            if is_array(current) and is_array(new):
-                return np.array_equal(current, new)
-            try:
-                return bool(current == new)
-            except Exception:
-                return True
-
         def link_widget(change):
             p_key = p_name if config.nthreads is None else (threading.get_ident(), p_name)
             if p_key in updating:
@@ -587,7 +574,7 @@ class Param(Pane):
                 if reset:
                     widget.value = new
                 current_val = getattr(parameterized, p_name)
-                if not reset and not _equal(current_val, new):
+                if not reset and not is_equal(current_val, new):
                     is_w = isinstance(widget, Row) and len(widget) == 2
                     target = widget[0] if is_w else widget
                     target.param.update(value=current_val)

--- a/panel/param.py
+++ b/panel/param.py
@@ -21,6 +21,7 @@ from functools import partial
 from types import FunctionType
 from typing import TYPE_CHECKING, Any, ClassVar
 
+import numpy as np
 import param
 
 try:
@@ -49,7 +50,9 @@ from .util import (
     abbreviated_repr, flatten, full_groupby, fullpath, is_parameterized,
     param_name, recursive_parameterized, to_async_gen,
 )
-from .util.checks import is_dataframe, is_mpl_axes, is_series
+from .util.checks import (
+    is_array, is_dataframe, is_mpl_axes, is_series,
+)
 from .viewable import Layoutable, Viewable
 from .widgets import (
     ArrayInput, Button, Checkbox, ColorPicker, DataFrame, DatePicker,
@@ -551,10 +554,12 @@ class Param(Pane):
                 is_series(current) and is_series(new)
             ):
                 return current.equals(new)
+            if is_array(current) and is_array(new):
+                return np.array_equal(current, new)
             try:
-                return current == new
+                return bool(current == new)
             except Exception:
-                return False
+                return True
 
         def link_widget(change):
             p_key = p_name if config.nthreads is None else (threading.get_ident(), p_name)

--- a/panel/param.py
+++ b/panel/param.py
@@ -37,10 +37,9 @@ from param.parameterized import (
 )
 from param.reactive import rx
 
-from panel.io.cache import is_equal
-
 from .config import config
 from .io import state
+from .io.cache import is_equal
 from .layout import (
     Column, HSpacer, ListLike, Panel, Row, Spacer, Tabs, WidgetBox,
 )

--- a/panel/param.py
+++ b/panel/param.py
@@ -546,6 +546,16 @@ class Param(Pane):
             watchers, updating = [], []
             widgets = {p_name: widget}
 
+        def _equal(current, new):
+            if (is_dataframe(current) and is_dataframe(new)) or (
+                is_series(current) and is_series(new)
+            ):
+                return current.equals(new)
+            try:
+                return current == new
+            except Exception:
+                return False
+
         def link_widget(change):
             p_key = p_name if config.nthreads is None else (threading.get_ident(), p_name)
             if p_key in updating:
@@ -572,7 +582,7 @@ class Param(Pane):
                 if reset:
                     widget.value = new
                 current_val = getattr(parameterized, p_name)
-                if not reset and current_val != new:
+                if not reset and not _equal(current_val, new):
                     is_w = isinstance(widget, Row) and len(widget) == 2
                     target = widget[0] if is_w else widget
                     target.param.update(value=current_val)

--- a/panel/tests/widgets/test_tabulator.py
+++ b/panel/tests/widgets/test_tabulator.py
@@ -1,0 +1,17 @@
+import pandas as pd
+import param
+
+import panel as pn
+
+
+def test_tabulator_from_param_dataframe_update():
+    class MyObject(param.Parameterized):
+        data = param.DataFrame()
+
+    obj = MyObject(data=pd.DataFrame({"a": [1, 2, 3]}))
+
+    widget = pn.widgets.Tabulator.from_param(obj.param.data)
+
+    widget.value = pd.DataFrame({"a": [1, 2, 5]})
+
+    assert obj.data.equals(pd.DataFrame({"a": [1, 2, 5]}))

--- a/panel/tests/widgets/test_tabulator.py
+++ b/panel/tests/widgets/test_tabulator.py
@@ -1,7 +1,8 @@
+"""Tests for Param widget DataFrame synchronization"""
 import pandas as pd
 import param
 
-import panel as pn
+from panel.widgets import Tabulator
 
 
 def test_tabulator_from_param_dataframe_update():
@@ -9,10 +10,31 @@ def test_tabulator_from_param_dataframe_update():
         data = param.DataFrame()
 
     obj = MyObject(data=pd.DataFrame({"a": [1, 2, 3]}))
-
-    widget = pn.widgets.Tabulator.from_param(obj.param.data)
-
+    widget = Tabulator.from_param(obj.param.data)
     widget.value = pd.DataFrame({"a": [1, 2, 5]})
-
     assert obj.data.equals(pd.DataFrame({"a": [1, 2, 5]}))
     assert widget.value.equals(pd.DataFrame({"a": [1, 2, 5]}))
+
+
+def test_tabulator_from_param_no_spurious_updates():
+    class MyObject(param.Parameterized):
+        data = param.DataFrame()
+
+    obj = MyObject(data=pd.DataFrame({"a": [1, 2, 3]}))
+    widget = Tabulator.from_param(obj.param.data)
+    update_count = [0]
+    def on_change(event):
+        update_count[0] += 1
+    obj.param.watch(on_change, "data")
+    widget.value = pd.DataFrame({"a": [1, 2, 5]})
+    assert update_count[0] == 1, f"Expected 1 update, got {update_count[0]}"
+
+
+def test_tabulator_from_param_param_update_reflects_in_widget():
+    class MyObject(param.Parameterized):
+        data = param.DataFrame()
+
+    obj = MyObject(data=pd.DataFrame({"a": [1, 2, 3]}))
+    widget = Tabulator.from_param(obj.param.data)
+    obj.data = pd.DataFrame({"a": [4, 5, 6]})
+    assert widget.value.equals(pd.DataFrame({"a": [4, 5, 6]}))

--- a/panel/tests/widgets/test_tabulator.py
+++ b/panel/tests/widgets/test_tabulator.py
@@ -15,3 +15,4 @@ def test_tabulator_from_param_dataframe_update():
     widget.value = pd.DataFrame({"a": [1, 2, 5]})
 
     assert obj.data.equals(pd.DataFrame({"a": [1, 2, 5]}))
+    assert widget.value.equals(pd.DataFrame({"a": [1, 2, 5]}))

--- a/panel/util/checks.py
+++ b/panel/util/checks.py
@@ -74,6 +74,8 @@ def is_mpl_axes(obj) -> bool:
     from matplotlib.axes import Axes
     return isinstance(obj, Axes)
 
+def is_array(obj) -> bool:
+    return isinstance(obj, np.ndarray)
 
 def isIn(obj, objs):
     """

--- a/panel/util/checks.py
+++ b/panel/util/checks.py
@@ -74,9 +74,6 @@ def is_mpl_axes(obj) -> bool:
     from matplotlib.axes import Axes
     return isinstance(obj, Axes)
 
-def is_array(obj) -> bool:
-    return isinstance(obj, np.ndarray)
-
 def isIn(obj, objs):
     """
     Checks if the object is in the list of objects safely.


### PR DESCRIPTION
## Description

This PR fixes a bug in Tabulator.from_param where updating the widget value would incorrectly trigger updates back to the parameter due to DataFrame comparison issues.

Fixes #8538 
 
## How Has This Been Tested?

Created unit test `panel/tests/widgets/test_tabulator.py`
## AI Disclosure

<!-- Remove this section if your PR does not contain AI-generated content. -->
<!-- Failure in disclosing the use of AI will result in a ban. -->

- [x] This PR contains AI-generated content.
  - [x] I have tested all AI-generated content in my PR.
  - [x] I take responsibility for all AI-generated content in my PR.

<!-- If you used AI to generate code, please specify the tool and model used, and briefly describe how they were used. -->

Tools and Models: Claude Sonnet 4.5

## Checklist

<!-- Remove the non relevant items. -->

- [x] Tests added and are passing
