### PR TITLE
Fix Duplicate FastListTemplate in template registry intead of FastGridTemplate

### DIFF
--- a/panel/template/__init__.py
+++ b/panel/template/__init__.py
@@ -13,7 +13,7 @@ from .vanilla import VanillaTemplate  # noqa
 templates = {
     'bootstrap' : BootstrapTemplate,
     'editable'  : EditableTemplate,
-    'fast'      : FastListTemplate,
+    'fast'      : FastGridTemplate,
     'fast-list' : FastListTemplate,
     'material'  : MaterialTemplate,
     'golden'    : GoldenTemplate,


### PR DESCRIPTION
## Description

I was looking at the source code while developing and when going to the package definition of `pn.templates`, and  i found a duplicate entry for `FastListTemplate` .There seems to be a very minor bug on the templates package where `FastGridTemplate` is imported and re-exported in `__all__ ` but is missing from the templates dictionary and therefore it cannot be correctly selected by name via `pn.config.template`.

Example:
`pn.config.template = "fast"` would result in the same `FastListTemplate` as `pn.config.template = "fast-list" `would.

This seems to also affect when serving with :
```bash

panel serve app.py --template fast 
# Same as
panel serve app.py --template fast-list
```

For the changed i simply added the (pressumably) correct class FastGridTemplate.


Just one line of code changed:

```python

templates = {
    'bootstrap' : BootstrapTemplate,
    'editable'  : EditableTemplate,
    'fast'      : FastListTemplate, -> 'fast' : FastGridTemplate,
    'fast-list' : FastListTemplate,
    'material'  : MaterialTemplate,
    'golden'    : GoldenTemplate,
```
    
<!--
Using AI? READ FIRST: https://holoviz.org/contribute.html#ai-readme

- Summarize the change and which issue is fixed.

There seems to be a very minor bug on the templates package where FastGridTemplate is imported and re-exported in __all__ but is missing from the templates dictionary and therefore it cannot be correctly selected by name via pn.config.template.

Example:
pn.config.template = "fast" would result in the same FastListTemplate as pn.config.template = "fast-list" would.

This seems to also affect when serving with :
panel serve app.py --template fast being the same as panel serve app.py --template fast-list

For the changed i simply added the (pressumably) correct class FastGridTemplate.

- Include relevant motivation and context.
I was looking at the source code while developing and when going to the package definition of `pn.templates` i found the duplicate entry.

- Add visuals when possible, e.g. before/after screenshots with full code snippets.
Just one line of code changed:
`templates = {
    'bootstrap' : BootstrapTemplate,
    'editable'  : EditableTemplate,
    'fast'      : FastListTemplate,
    'fast-list' : FastListTemplate,
    'material'  : MaterialTemplate,
    'golden'    : GoldenTemplate,`
-->

Fixes #8549 

## How Has This Been Tested?

The issue is very small, and it was manually tests. Unit tests still pass.  

<!-- Describe the tests that you ran to verify your changes. Provide instructions so it can be reproduced while reviewing your changes. -->

## AI Disclosure

NAN

## Checklist

<!-- Remove the non relevant items. -->

- [ ] Tests added and are passing
- [ ] Added documentation
