### PR TITLE
docs: fix Tabs ParamFunction link

### DIFF
--- a/examples/reference/layouts/Tabs.ipynb
+++ b/examples/reference/layouts/Tabs.ipynb
@@ -144,7 +144,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If you want the `Tabs` to be completely lazy when rendering some output you can leverage a [ParamFunction or ParamMethod](../../user_guide/Param.ipynb) to ensure that the output is not computed until you navigate to the tab:"
+    "If you want the `Tabs` to be completely lazy when rendering some output you can leverage a [ParamFunction or ParamMethod](../../explanation/api/reactivity.md) to ensure that the output is not computed until you navigate to the tab:"
    ]
   },
   {


### PR DESCRIPTION
## Summary

- replace the stale `../../user_guide/Param.ipynb` reference in the `Tabs` reference notebook with the current reactivity docs page

## Testing

- verified the notebook no longer points at the removed `user_guide/Param.ipynb` path

Closes #8542
