### PR TITLE
test(ui): Fix failing Jupyter test on Windows

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -201,14 +201,10 @@ jobs:
         run: |
           jupyter server extension enable panel.io.jupyter_server_extension --sys-prefix
           (jupyter lab --config panel/tests/ui/jupyter_server_test_config.py --port 8887 > /tmp/jupyterlab_server.log 2>&1) &
+          curl -fsS --retry 180 --retry-delay 1 --retry-connrefused http://localhost:8887/lab >/dev/null
       - name: Build JupyterLite
         shell: pixi run -e test-ui bash -e {0}
         run: pixi run -e lite lite-build
-      - name: Wait for JupyterLab
-        uses: ifaxity/wait-on-action@v1.2.1
-        with:
-          resource: http-get://localhost:8887/lab
-          timeout: 180000
       - name: Check if auth should run
         if: '!github.event.pull_request.head.repo.fork'
         run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -158,7 +158,7 @@ jobs:
       - name: Test Examples
         run: |
           pixi run -e ${{ matrix.environment }} test-example
-      - uses: codecov/codecov-action@v5
+      - uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 
@@ -231,7 +231,7 @@ jobs:
         shell: pixi run -e test-ui bash -e {0}
         run: |
           jupyter lab stop 8887 || true
-      - uses: codecov/codecov-action@v5
+      - uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 

--- a/panel/tests/conftest.py
+++ b/panel/tests/conftest.py
@@ -175,13 +175,14 @@ def pytest_generate_tests(metafunc):
 def pytest_collection_modifyitems(config, items):
     skipped, selected = [], []
     markers = [m for m in optional_markers if config.getoption(f"--{m}")]
+    not_markers = [m for m in optional_markers if not config.getoption(f"--{m}")]
     empty = not markers
     for item in items:
         if empty and any(m in item.keywords for m in optional_markers):
             skipped.append(item)
         elif empty:
             selected.append(item)
-        elif not empty and any(m in item.keywords for m in markers):
+        elif any(m in item.keywords for m in markers) and not any(m in item.keywords for m in not_markers):
             selected.append(item)
         else:
             skipped.append(item)

--- a/panel/tests/ui/io/test_jupyter_server_extension.py
+++ b/panel/tests/ui/io/test_jupyter_server_extension.py
@@ -36,6 +36,7 @@ def test_jupyter_server_custom_resources(page, jupyter_preview):
         window.getComputedStyle(element).getPropertyValue('background-color')""") == 'rgb(128, 0, 128)'
 
 
+@pytest.mark.flaky(reruns=3, reruns_delay=5)
 def test_jupyter_server_kernel_error(page, jupyter_preview):
     page.goto(f"{jupyter_preview}/app.py?kernel=blah")
     page.wait_for_load_state('networkidle')

--- a/panel/tests/ui/io/test_jupyter_server_extension.py
+++ b/panel/tests/ui/io/test_jupyter_server_extension.py
@@ -10,11 +10,12 @@ from playwright.sync_api import expect
 
 from panel.tests.util import wait_until
 
-pytestmark = [pytest.mark.jupyter, pytest.mark.flaky(max_runs=3)]
+pytestmark = pytest.mark.jupyter
 
 
 def test_jupyter_server(page, jupyter_preview):
-    page.goto(f"{jupyter_preview}/app.py", timeout=30000)
+    page.goto(f"{jupyter_preview}/app.py")
+    page.wait_for_load_state('networkidle')
 
     assert page.text_content('pre') == '0'
 
@@ -28,14 +29,16 @@ def test_jupyter_server(page, jupyter_preview):
 
 
 def test_jupyter_server_custom_resources(page, jupyter_preview):
-    page.goto(f"{jupyter_preview}/app.py", timeout=30000)
+    page.goto(f"{jupyter_preview}/app.py")
+    page.wait_for_load_state('networkidle')
 
     assert page.locator('.bk-Row').evaluate("""(element) =>
         window.getComputedStyle(element).getPropertyValue('background-color')""") == 'rgb(128, 0, 128)'
 
 
 def test_jupyter_server_kernel_error(page, jupyter_preview):
-    page.goto(f"{jupyter_preview}/app.py?kernel=blah", timeout=30000)
+    page.goto(f"{jupyter_preview}/app.py?kernel=blah")
+    page.wait_for_load_state('networkidle')
 
     expect(page.locator('#error-type')).to_have_text("Kernel Error")
     expect(page.locator('#error')).to_have_text("No such kernel 'blah'")
@@ -50,7 +53,8 @@ def test_jupyter_server_kernel_error(page, jupyter_preview):
 
 
 def test_jupyter_server_session_arg_theme(page, jupyter_preview):
-    page.goto(f"{jupyter_preview}/app.py?theme=dark", timeout=30000)
+    page.goto(f"{jupyter_preview}/app.py?theme=dark")
+    page.wait_for_load_state('networkidle')
 
     expect(page.locator('body')).to_have_css('color', 'rgb(0, 0, 0)')
 

--- a/panel/tests/ui/io/test_jupyterlite.py
+++ b/panel/tests/ui/io/test_jupyterlite.py
@@ -42,6 +42,7 @@ def launch_jupyterlite():
         process.wait()
 
 
+@pytest.mark.flaky(reruns=3, reruns_delay=5)
 @pytest.mark.filterwarnings("ignore::ResourceWarning")
 def test_jupyterlite_execution(launch_jupyterlite, page):
     # INFO: Needs TS changes uploaded to CDN. Relevant when

--- a/panel/tests/ui/io/test_jupyterlite.py
+++ b/panel/tests/ui/io/test_jupyterlite.py
@@ -43,11 +43,11 @@ def launch_jupyterlite():
 
 
 @pytest.mark.filterwarnings("ignore::ResourceWarning")
-@pytest.mark.flaky(reruns=3, reruns_delay=5)
 def test_jupyterlite_execution(launch_jupyterlite, page):
     # INFO: Needs TS changes uploaded to CDN. Relevant when
     # testing a new version of Bokeh.
     page.goto("http://localhost:8123/index.html")
+    page.wait_for_load_state('networkidle')
 
     page.locator('text="Getting_Started.ipynb"').first.dblclick()
 

--- a/panel/tests/ui/io/test_jupyterlite.py
+++ b/panel/tests/ui/io/test_jupyterlite.py
@@ -43,6 +43,7 @@ def launch_jupyterlite():
 
 
 @pytest.mark.filterwarnings("ignore::ResourceWarning")
+@pytest.mark.flaky(reruns=3, reruns_delay=5)
 def test_jupyterlite_execution(launch_jupyterlite, page):
     # INFO: Needs TS changes uploaded to CDN. Relevant when
     # testing a new version of Bokeh.

--- a/panel/tests/ui/io/test_jupyterlite.py
+++ b/panel/tests/ui/io/test_jupyterlite.py
@@ -55,6 +55,8 @@ def test_jupyterlite_execution(launch_jupyterlite, page):
         page.locator('.jp-select-wrapper > select').select_option('Python (Pyodide)')
         page.locator('.jp-Dialog-footer > button').nth(1).click()
 
+    page.locator('.jp-Cell').first.wait_for()  # Wait for first cell to load
+
     for _ in range(6):
         page.locator('jp-button[data-command="notebook:run-cell-and-select-next"]').click()
         page.wait_for_timeout(500)

--- a/panel/tests/ui/io/test_jupyterlite.py
+++ b/panel/tests/ui/io/test_jupyterlite.py
@@ -52,14 +52,11 @@ def test_jupyterlite_execution(launch_jupyterlite, page):
     page.locator('text="Getting_Started.ipynb"').first.dblclick()
     page.wait_for_load_state('networkidle')
 
-    # Select the kernel
-    if page.locator('.jp-Dialog').count() == 1:
-        page.locator('.jp-select-wrapper > select').select_option('Python (Pyodide)')
-        page.locator('.jp-Dialog-footer > button').nth(1).click()
-        page.wait_for_load_state('networkidle')
-
     for _ in range(6):
         page.locator('jp-button[data-command="notebook:run-cell-and-select-next"]').click()
+        if page.locator('.jp-Dialog').count() == 1: # Select the kernel if pop-up
+            page.locator('.jp-select-wrapper > select').select_option('Python (Pyodide)')
+            page.locator('.jp-Dialog-footer > button').nth(1).click()
         page.wait_for_load_state('networkidle')
         expect(page.locator('.jp-Notebook-ExecutionIndicator')).to_have_attribute('data-status', 'idle', timeout=60_000)
 

--- a/panel/tests/ui/io/test_jupyterlite.py
+++ b/panel/tests/ui/io/test_jupyterlite.py
@@ -59,6 +59,7 @@ def test_jupyterlite_execution(launch_jupyterlite, page):
         page.wait_for_load_state('networkidle')
 
     indicator = page.locator('.jp-Notebook-ExecutionIndicator')
+    expect(indicator).to_have_attribute('data-status', 'idle', timeout=60_000)
     for _ in range(6):
         page.locator('jp-button[data-command="notebook:run-cell-and-select-next"]').click()
         page.wait_for_timeout(200)

--- a/panel/tests/ui/io/test_jupyterlite.py
+++ b/panel/tests/ui/io/test_jupyterlite.py
@@ -50,19 +50,19 @@ def test_jupyterlite_execution(launch_jupyterlite, page):
     page.wait_for_load_state('networkidle')
 
     page.locator('text="Getting_Started.ipynb"').first.dblclick()
+    page.wait_for_load_state('networkidle')
 
     # Select the kernel
     if page.locator('.jp-Dialog').count() == 1:
         page.locator('.jp-select-wrapper > select').select_option('Python (Pyodide)')
         page.locator('.jp-Dialog-footer > button').nth(1).click()
-
-    page.locator('.jp-Cell').first.wait_for()  # Wait for first cell to load
+        page.wait_for_load_state('networkidle')
 
     for _ in range(6):
         page.locator('jp-button[data-command="notebook:run-cell-and-select-next"]').click()
-        page.wait_for_timeout(500)
+        page.wait_for_load_state('networkidle')
 
-    page.locator('.noUi-handle').click(timeout=120 * 1000)
+    page.locator('.noUi-handle').click()
 
     page.keyboard.press('ArrowRight')
 

--- a/panel/tests/ui/io/test_jupyterlite.py
+++ b/panel/tests/ui/io/test_jupyterlite.py
@@ -58,12 +58,10 @@ def test_jupyterlite_execution(launch_jupyterlite, page):
         page.locator('.jp-Dialog-footer > button').nth(1).click()
         page.wait_for_load_state('networkidle')
 
-    indicator = page.locator('.jp-Notebook-ExecutionIndicator')
-    expect(indicator).to_have_attribute('data-status', 'idle', timeout=60_000)
     for _ in range(6):
         page.locator('jp-button[data-command="notebook:run-cell-and-select-next"]').click()
-        page.wait_for_timeout(200)
-        expect(indicator).to_have_attribute('data-status', 'idle', timeout=60_000)
+        page.wait_for_load_state('networkidle')
+        expect(page.locator('.jp-Notebook-ExecutionIndicator')).to_have_attribute('data-status', 'idle', timeout=60_000)
 
     page.locator('.noUi-handle').click()
 

--- a/panel/tests/ui/io/test_jupyterlite.py
+++ b/panel/tests/ui/io/test_jupyterlite.py
@@ -58,9 +58,11 @@ def test_jupyterlite_execution(launch_jupyterlite, page):
         page.locator('.jp-Dialog-footer > button').nth(1).click()
         page.wait_for_load_state('networkidle')
 
+    indicator = page.locator('.jp-Notebook-ExecutionIndicator')
     for _ in range(6):
         page.locator('jp-button[data-command="notebook:run-cell-and-select-next"]').click()
-        page.wait_for_load_state('networkidle')
+        page.wait_for_timeout(200)
+        expect(indicator).to_have_attribute('data-status', 'idle', timeout=60_000)
 
     page.locator('.noUi-handle').click()
 

--- a/pixi.toml
+++ b/pixi.toml
@@ -355,6 +355,7 @@ jupyterlab-myst = "*"
 jupyterlite-core = "<0.7.0"
 jupyterlite-pyodide-kernel = "*"
 python-build = "*"
+python-libarchive-c = "*"
 
 [feature.lite.tasks]
 lite-build = "bash scripts/jupyterlite/build.sh"


### PR DESCRIPTION
## Description

<!--
Using AI? READ FIRST: https://holoviz.org/contribute.html#ai-readme

- Summarize the change and which issue is fixed.
- Include relevant motivation and context.
- Add visuals when possible, e.g. before/after screenshots with full code snippets.
-->

One consistent failing UI test on Windows: `panel/tests/ui/io/test_jupyterlite.py::test_jupyterlite_execution`

Looking at the trace it seems we are to eager to click on a button:

<img width="1345" height="854" alt="image" src="https://github.com/user-attachments/assets/24653fe8-4e6e-4543-b983-86eec6581d7d" />

From `playwright show-trace ~/Downloads/fail/trace.zip`

## How Has This Been Tested?

CI

## AI Disclosure

<!-- Remove this section if your PR does not contain AI-generated content. -->
<!-- Failure in disclosing the use of AI will result in a ban. -->

- [x] This PR contains AI-generated content.
  - [x] I have tested all AI-generated content in my PR.
  - [x] I take responsibility for all AI-generated content in my PR.

<!-- If you used AI to generate code, please specify the tool and model used, and briefly describe how they were used. -->

Tools and Models: Claude Code + Sonnet 4.6. Trying to find the right thing to wait for. 

## Checklist

<!-- Remove the non relevant items. -->

- [x] Tests added and are passing
