### PR TITLE
Fix flaky Gauge and Tabulator UI tests

### DIFF
--- a/panel/tests/ui/widgets/test_indicators.py
+++ b/panel/tests/ui/widgets/test_indicators.py
@@ -85,12 +85,23 @@ def test_tooltip_text_updates(page):
     expect(tooltip).to_have_text("Updated")
 
 
+def _wait_for_echarts(page, timeout=30000):
+    """Wait for the ECharts JS module to be loaded on the page.
+
+    Gauge renders via ECharts. serve_component only waits for the Panel
+    websocket and networkidle, not for the ECharts module fetch. On slow
+    CI runners the canvas can appear well after networkidle, so polling
+    for `window.echarts` is the reliable readiness signal.
+    """
+    page.wait_for_function("typeof window.echarts !== 'undefined'", timeout=timeout)
+
+
 def test_gauge_renders(page):
     gauge = Gauge(name="Speed", value=75, bounds=(0, 200))
 
     serve_component(page, gauge)
 
-    # Wait for ECharts to load and render a canvas element
+    _wait_for_echarts(page)
     expect(page.locator("canvas")).to_have_count(1, timeout=10000)
 
 
@@ -105,6 +116,7 @@ def test_gauge_does_not_crash_other_widgets(page):
     # The slider must render even if Gauge is on the same page
     expect(page.locator(".noUi-target")).to_have_count(1, timeout=10000)
     # Gauge canvas should also eventually render
+    _wait_for_echarts(page)
     expect(page.locator("canvas")).to_have_count(1, timeout=10000)
 
 
@@ -113,6 +125,7 @@ def test_gauge_value_update(page):
 
     serve_component(page, gauge)
 
+    _wait_for_echarts(page)
     expect(page.locator("canvas")).to_have_count(1, timeout=10000)
 
     # Update value and verify no crash

--- a/panel/tests/ui/widgets/test_tabulator.py
+++ b/panel/tests/ui/widgets/test_tabulator.py
@@ -1169,6 +1169,7 @@ def test_tabulator_frozen_columns(page, df_mixed):
     assert int_bb == page.locator('text="int"').bounding_box()
 
 
+@pytest.mark.flaky(reruns=3, reruns_delays=2)
 def test_tabulator_frozen_columns_with_positions(page, df_mixed):
     widths = 100
     width = int(((df_mixed.shape[1] + 1) * widths) / 2)
@@ -1233,7 +1234,9 @@ def test_tabulator_frozen_columns_with_positions(page, df_mixed):
     assert str_bb['x'] < int_bb['x']
 
     # Scroll to the right, and give it a little extra time
-    page.locator('text="2019-01-01 10:00:00"').scroll_into_view_if_needed()
+    cell = page.locator('text="2019-01-01 10:00:00"')
+    expect(cell).to_be_attached()
+    cell.scroll_into_view_if_needed()
 
     # Check that the position of one of the non-frozen columns has indeed moved
     wait_until(lambda: page.locator('text="str"').bounding_box()['x'] < str_bb['x'], page)


### PR DESCRIPTION
## Description

Two intermittent UI test failures on `ui:test-ui:macos-latest` and `ui:test-ui:ubuntu-latest` propagate failures to every open PR. Fixing both with the established readiness-wait patterns from this codebase.

### 1. Gauge tests (#8515)

`test_gauge_renders`, `test_gauge_does_not_crash_other_widgets`, and `test_gauge_value_update` flake intermittently with:

```
AssertionError: Locator expected to have count '1'
```

`serve_component` only waits for the Panel WebSocket and `networkidle`, neither guarantees the ECharts JS module has finished loading. Gauge renders through ECharts, so the canvas only appears after the module fetch + parse + setOption. On slow CI runners this chain can take longer than 10 seconds.

**Fix:** added a small `_wait_for_echarts(page)` helper that polls for `window.echarts` to be defined (timeout 30s), called before each canvas-count assertion.

### 2. Tabulator test (#7945-class flake)

`test_tabulator_frozen_columns_with_positions` flakes with:

```
playwright._impl._errors.Error: Locator.scroll_into_view_if_needed:
Element is not attached to the DOM
```

The dict-based `frozen_columns={"float": "left", "int": "right"}` path re-orders columns and re-renders rows. Between Playwright matching `text=\"2019-01-01 10:00:00\"` and the scroll firing, the row can detach.

**Fix:** same pattern as commit `7411f182` (which fixed `test_tabulator_patch_no_horizontal_rescroll` for the same flake class):
- `expect(cell).to_be_attached()` before `scroll_into_view_if_needed()` to eliminate the match-then-detach race
- `@pytest.mark.flaky(reruns=3, reruns_delays=2)` as defense in depth

## How Has This Been Tested?

Both changes are test-only and follow established readiness-wait patterns already used in this codebase. CI on this PR is the authoritative verifier. Latest run on the previous push showed only the tabulator test still failing, which this commit addresses; the gauge tests now pass.
