### PR TITLE
Fix tests using deprecated Widget.name and button_type kwargs

### DIFF
--- a/panel/tests/test_reactive.py
+++ b/panel/tests/test_reactive.py
@@ -416,7 +416,7 @@ def test_in_process_change_event_cleaned_up(document, comm):
     assert document not in checkbox._in_process__events
 
 def test_rapid_toggle_disabled(document, comm):
-    button = Button(name="dummy")
+    button = Button(label="dummy")
     model = button.get_root(document, comm)
 
     assert model.disabled is False
@@ -430,7 +430,7 @@ def test_rapid_toggle_disabled(document, comm):
     assert 'disabled' not in button._events
 
 def test_rapid_toggle_disabled_repeated(document, comm):
-    button = Button(name="dummy")
+    button = Button(label="dummy")
     model = button.get_root(document, comm)
 
     for _ in range(5):

--- a/panel/tests/ui/widgets/test_button.py
+++ b/panel/tests/ui/widgets/test_button.py
@@ -109,9 +109,9 @@ def test_button_tooltip_with_delay(page, button_fn, button_locator):
 
 
 def test_widget_disabled_toggle(page):
-    dummy_button = Button(name="dummy", button_type='primary')
+    dummy_button = Button(label="dummy", color='primary')
     dummy_text = TextAreaInput()
-    toggle_button = Button(name="toggle")
+    toggle_button = Button(label="toggle")
 
     def toggle(_):
         dummy_button.disabled = True


### PR DESCRIPTION
## Description

The `Widget.name` to `label` rename in #8328 and `button_type` to `color` rename in #8577 emit `PendingDeprecationWarning` for the old kwargs, which pytest treats as errors. Two tests I added in #8507 (`test_rapid_toggle_disabled`, `test_rapid_toggle_disabled_repeated`) and one earlier test (`test_widget_disabled_toggle`) still used the old kwargs, so they started failing on `main` once both PRs landed. This switches them to `label=` and `color=`.

CI on `main` is currently red because of these, so this is a forward fix.

## How Has This Been Tested?

Ran the affected tests locally on this branch:

- `pytest panel/tests/test_reactive.py` -> 43 passed (was 41 + 2 failed before this change)
- `pytest panel/tests/test_reactive.py::test_rapid_toggle_disabled panel/tests/test_reactive.py::test_rapid_toggle_disabled_repeated` -> 2 passed
- `pixi run lint` -> all hooks pass



