### PR TITLE
Drop support for bokeh 3.7

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -251,7 +251,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest"]
-        environment: ["test-core", "test-bokeh37", "test-bokeh38"]
+        environment: ["test-core", "test-bokeh38"]
     timeout-minutes: 30
     steps:
       - uses: holoviz-dev/holoviz_tasks/pixi-install@ffddda04b2894fea39b407f64d3622d2f19e5a9f # v1

--- a/panel/io/handlers.py
+++ b/panel/io/handlers.py
@@ -26,7 +26,6 @@ from bokeh.io.doc import curdoc, patch_curdoc, set_curdoc as bk_set_curdoc
 from bokeh.util.dependencies import import_required
 
 from ..config import config
-from ..util import BOKEH_GE_3_8
 from .mime_render import MIME_RENDERERS
 from .profile import profile_ctx
 from .reload import record_modules
@@ -394,12 +393,11 @@ def run_app(handler, module, doc: Document, post_run=None, allow_empty: bool = F
                      'the bokeh document manually.'),
                     alert_type='danger', margin=5, sizing_mode='stretch_width'
                 ).servable()
-            if BOKEH_GE_3_8:
-                doc.config.update(
-                    reconnect_session=config.reconnect == True,
-                    notifications=None,
-                    notify_connection_status=False
-                )
+            doc.config.update(
+                reconnect_session=config.reconnect == True,
+                notifications=None,
+                notify_connection_status=False
+            )
     finally:
         if config.profiler and doc.session_context is not None:
             try:

--- a/panel/io/notifications.py
+++ b/panel/io/notifications.py
@@ -8,7 +8,7 @@ from bokeh.models import CustomJS
 
 from ..config import config
 from ..reactive import ReactiveHTML
-from ..util import BOKEH_GE_3_8, classproperty
+from ..util import classproperty
 from .datamodel import _DATA_MODELS, construct_data_model
 from .document import create_doc_if_none_exists
 from .resources import CDN_DIST, CSS_URLS, bundled_files
@@ -179,7 +179,7 @@ class NotificationArea(NotificationAreaBase, ReactiveHTML):
           dismissible: true,
           position: {x: x, y: y},
           types: data.types
-        })""" + ("""
+        })
         const clear_timeout = () => {
           if (state.reconnect_timeout != null) {
              clearTimeout(state.reconnect_timeout)
@@ -237,7 +237,7 @@ class NotificationArea(NotificationAreaBase, ReactiveHTML):
               reconnectSpan.addEventListener('click', () => { clear_timeout(); event.reconnect() })
             }
           }
-        })""" if BOKEH_GE_3_8 else ""),
+        })""",
       "notifications": """
       for (notification of [...data.notifications]) {
           if (notification._destroyed || notification._rendered) {
@@ -299,7 +299,7 @@ class NotificationArea(NotificationAreaBase, ReactiveHTML):
         root = super().get_root(doc, comm, preprocess)
         root.tags = ['prompt'] if config.reconnect else []
         for event, notification in self.js_events.items():
-            if event == 'connection_lost' and BOKEH_GE_3_8:
+            if event == 'connection_lost':
                 continue
             doc.js_on_event(event, CustomJS(code=f"""
             const config = {{

--- a/panel/tests/ui/widgets/test_tabulator.py
+++ b/panel/tests/ui/widgets/test_tabulator.py
@@ -27,7 +27,6 @@ from panel.layout.base import Column
 from panel.models.tabulator import _TABULATOR_THEMES_MAPPING
 from panel.pane import Markdown
 from panel.tests.util import get_ctrl_modifier, serve_component, wait_until
-from panel.util import BOKEH_GE_3_6
 from panel.widgets import (
     Select, Switch, Tabulator, TextInput,
 )
@@ -387,11 +386,7 @@ def test_tabulator_formatters_bokeh_string(page, df_mixed):
 
     serve_component(page, widget)
 
-    if BOKEH_GE_3_6:
-        style = "font-weight: bold; text-align: center; color: red;"
-    else:
-        style = "font-weight: bold; text-align: center; color: rgb(255, 0, 0);"
-
+    style = "font-weight: bold; text-align: center; color: red;"
     expect(page.locator('text="A"')).to_have_attribute("style", style)
 
 

--- a/panel/util/__init__.py
+++ b/panel/util/__init__.py
@@ -47,7 +47,6 @@ from .parameters import (  # noqa
 log = logging.getLogger('panel.util')
 
 bokeh_version = Version(Version(bokeh.__version__).base_version)
-BOKEH_GE_3_6 = bokeh_version >= Version('3.6')
 BOKEH_GE_3_8 = bokeh_version >= Version('3.8')
 
 PARAM_NAME_PATTERN = re.compile(r'^.*\d{5}$')

--- a/panel/util/__init__.py
+++ b/panel/util/__init__.py
@@ -47,7 +47,6 @@ from .parameters import (  # noqa
 log = logging.getLogger('panel.util')
 
 bokeh_version = Version(Version(bokeh.__version__).base_version)
-BOKEH_GE_3_8 = bokeh_version >= Version('3.8')
 
 PARAM_NAME_PATTERN = re.compile(r'^.*\d{5}$')
 

--- a/pixi.toml
+++ b/pixi.toml
@@ -51,10 +51,6 @@ no-default-feature = true
 features = ["py314", "required", "test-core", "test-unit-task"]
 no-default-feature = true
 
-[environments.test-bokeh37]
-features = ["py310", "required", "test-core", "test-unit-task", "bokeh37"]
-no-default-feature = true
-
 [environments.test-bokeh38]
 features = ["py310", "required", "test-core", "test-unit-task", "bokeh38"]
 no-default-feature = true
@@ -86,7 +82,7 @@ nomkl = "*"
 pip = "*"
 # Required
 nh3 = "*"
-bokeh = ">=3.7.0,<3.10.0a0"
+bokeh = ">=3.8.0,<3.10.0a0"
 linkify-it-py = "*"
 markdown = "*"
 markdown-it-py = "*"
@@ -195,9 +191,6 @@ pytest-cov = "*"
 pytest-github-actions-annotate-failures = "*"
 pytest-rerunfailures = "*"
 pytest-xdist = "*"
-
-[feature.bokeh37.dependencies]
-bokeh = "3.7.*"
 
 [feature.bokeh38.dependencies]
 bokeh = "3.8.*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = [
     "hatchling",
     "hatch-vcs",
     "param >=2.1.0",
-    "bokeh >=3.7.0,<3.10.0",
+    "bokeh >=3.8.0,<3.10.0",
     "pyviz_comms >=0.7.4",
     "requests",
     "packaging",


### PR DESCRIPTION
The last bokeh 3.7.x release was over a year ago and we should generally keep users within a 2 minor release window.