### PR TITLE
Add support for wildcard route handling

### DIFF
--- a/doc/how_to/server/index.md
+++ b/doc/how_to/server/index.md
@@ -36,6 +36,13 @@ Discover how to launch and configure a Panel application programmatically.
 Discover how-to launch and configure multiple applications on the same server.
 :::
 
+:::{grid-item-card} {octicon}`git-branch;2.5em;sd-mr-1 sd-animate-grow50` Wildcard routes
+:link: wildcard_routes
+:link-type: doc
+
+Discover how to serve apps on dynamic URL patterns and access route parameters.
+:::
+
 :::{grid-item-card} {octicon}`stack;2.5em;sd-mr-1 sd-animate-grow50` Configure session re-connect
 :link: reconnect
 :link-type: doc
@@ -88,6 +95,7 @@ Discover how configure the web socket settings to enable larger data transfers
 commandline
 programmatic
 multiple
+wildcard_routes
 ssh
 reconnect
 proxy

--- a/doc/how_to/server/wildcard_routes.md
+++ b/doc/how_to/server/wildcard_routes.md
@@ -1,0 +1,115 @@
+# Serving applications on wildcard routes
+
+When serving multiple apps with `pn.serve`, the route keys are usually static paths (for example `"/app"`). You can also use wildcard-style route patterns to match dynamic URL segments.
+
+## Serve an app on a wildcard route
+
+Use a route pattern as the dictionary key:
+
+```python
+import panel as pn
+
+pn.extension()
+
+def app():
+    return pn.pane.JSON(
+        {
+            "route_params": pn.state.route_params,
+            "app_url": pn.state.app_url,
+        },
+        depth=2,
+    )
+
+pn.serve(
+    {
+        "/user/{name}": app,
+    },
+    show=False,
+)
+```
+
+Now:
+
+- `/user/alice` and `/user/bob` will both resolve to the same app
+- `pn.state.route_params` will contain the captured values for the current request
+
+For the two URLs above, `pn.state.route_params` will be:
+
+- `{"name": "alice"}`
+- `{"name": "bob"}`
+
+Path converters are supported as well:
+
+```python
+pn.serve(
+    {
+        "/files/{filepath:path}": app,
+    },
+    show=False,
+)
+```
+
+Then `pn.state.route_params` contains:
+
+- `{"filepath": "a/b/c.txt"}`
+
+Template converters currently supported are:
+
+- `str` (default) for single path segments
+- `path` for slash-containing paths
+- `int` for signed integers (for example `-2`, `0`, `+3`)
+- `float` for signed decimal/scientific formats (for example `-1.5`, `.5`, `1.`, `6.02e23`)
+- `uuid` for canonical UUID strings
+
+## Regex syntax (Tornado-style)
+
+On Tornado you can also use regular expression routes directly:
+
+```python
+pn.serve(
+    {
+        "/user/([^/]+)": app,
+    },
+    show=False,
+)
+```
+
+For this route, `pn.state.route_params` contains positional captures:
+
+- `{"0": "alice"}`
+
+Unlike path-template routes (which use parameter names), raw regex captures are exposed as positional string keys (`"0"`, `"1"`, ...).
+
+### Named parameters with regex syntax
+
+You can also use named groups:
+
+```python
+pn.serve(
+    {
+        "/org/(?P<org>[^/]+)/user/(?P<user>[^/]+)": app,
+    },
+    show=False,
+)
+```
+
+Then `pn.state.route_params` contains the named captures:
+
+- `{"org": "acme", "user": "alice"}`
+
+## Backend compatibility
+
+- **Tornado (`panel serve`, `panel.io.server.serve`)**
+  - Supports regex-style routes, e.g. `"/user/([^/]+)"` and named groups.
+  - Supports path-template syntax, which is normalized to Tornado-compatible patterns (for example `"/user/{name}"`).
+- **FastAPI (`panel.io.fastapi.serve`)**
+  - Supports path-template syntax, e.g. `"/user/{name}"`, `"/files/{filepath:path}"`.
+  - Route parameters are available on `pn.state.route_params`.
+  - Concrete matched paths are reflected in `pn.state.app_url`.
+
+## Best practices
+
+- Prefer path-template syntax (`{name}`, `{name:path}`) when writing apps intended to run on both Tornado and FastAPI.
+- If you use regex syntax, prefer non-greedy segment patterns such as `([^/]+)` for path segments.
+- Prefer explicit groups over very broad patterns like `(.*)` unless you specifically need to capture slashes.
+- Use `pn.state.app_url` when you need the concrete matched application URL for the current session.

--- a/doc/how_to/server/wildcard_routes.md
+++ b/doc/how_to/server/wildcard_routes.md
@@ -104,8 +104,6 @@ Then `pn.state.route_params` contains the named captures:
   - Supports path-template syntax, which is normalized to Tornado-compatible patterns (for example `"/user/{name}"`).
 - **FastAPI (`panel.io.fastapi.serve`)**
   - Supports path-template syntax, e.g. `"/user/{name}"`, `"/files/{filepath:path}"`.
-  - Route parameters are available on `pn.state.route_params`.
-  - Concrete matched paths are reflected in `pn.state.app_url`.
 
 ## Best practices
 
@@ -113,3 +111,4 @@ Then `pn.state.route_params` contains the named captures:
 - If you use regex syntax, prefer non-greedy segment patterns such as `([^/]+)` for path segments.
 - Prefer explicit groups over very broad patterns like `(.*)` unless you specifically need to capture slashes.
 - Use `pn.state.app_url` when you need the concrete matched application URL for the current session.
+- Use `pn.state.route_params` to access the route parameters.

--- a/panel/io/application.py
+++ b/panel/io/application.py
@@ -144,7 +144,7 @@ class Application(BkApplication):
 
         request_path = getattr(request, 'path', None) or app_path
         prefix = ''
-        if app_path != '/' and request_path.endswith(app_path):
+        if app_path != '/' and (request_path == app_path or request_path.endswith(app_path)):
             prefix = request_path[:-len(app_path)]
         elif app_path == '/' and request_path.endswith('/'):
             prefix = request_path[:-1]

--- a/panel/io/application.py
+++ b/panel/io/application.py
@@ -133,15 +133,16 @@ class Application(BkApplication):
         if request is None:
             return
         app_context = session_context.server_context.application_context
-        app_path = app_context._url
-        try:
-            app_path = session_context.token_payload.get('app_path', app_path)
-        except AssertionError:
-            pass
+        app_path = getattr(request, 'app_path', None) or app_context._url
+        if app_path == app_context._url:
+            try:
+                app_path = session_context.token_payload.get('app_path', app_path)
+            except AssertionError:
+                pass
         if not app_path.startswith('/'):
             app_path = f'/{app_path}'
 
-        request_path = request.path
+        request_path = getattr(request, 'path', None) or app_path
         prefix = ''
         if app_path != '/' and request_path.endswith(app_path):
             prefix = request_path[:-len(app_path)]
@@ -188,10 +189,10 @@ class Application(BkApplication):
             the session context.
         '''
         request_data = super().process_request(request)
-        route_params = getattr(request, 'pn_route_params', None)
+        route_params = getattr(request, 'route_params', {})
         if route_params:
             request_data['route_params'] = route_params
-        app_path = getattr(request, 'pn_app_path', None)
+        app_path = getattr(request, 'app_path', None)
         if app_path:
             request_data['app_path'] = app_path
         user = request.cookies.get('user')

--- a/panel/io/application.py
+++ b/panel/io/application.py
@@ -130,17 +130,33 @@ class Application(BkApplication):
         if not (session_context and session_context.server_context):
             return
         request = session_context.request
+        if request is None:
+            return
         app_context = session_context.server_context.application_context
-        prefix = request.uri.replace(app_context._url, '')
-        if not prefix.endswith('/'):
+        app_path = app_context._url
+        try:
+            app_path = session_context.token_payload.get('app_path', app_path)
+        except AssertionError:
+            pass
+        if not app_path.startswith('/'):
+            app_path = f'/{app_path}'
+
+        request_path = request.path
+        prefix = ''
+        if app_path != '/' and request_path.endswith(app_path):
+            prefix = request_path[:-len(app_path)]
+        elif app_path == '/' and request_path.endswith('/'):
+            prefix = request_path[:-1]
+
+        if prefix and not prefix.endswith('/'):
             prefix += '/'
-        base_url = urljoin('/', prefix)
-        rel_path = '/'.join(['..'] * app_context._url.strip('/').count('/'))
+        base_url = urljoin('/', prefix.lstrip('/'))
+        rel_path = '/'.join(['..'] * app_path.strip('/').count('/'))
 
         # Handle autoload.js absolute paths
         abs_url = request.arguments.get('bokeh-absolute-url')
         if abs_url:
-            rel_path = abs_url[0].decode('utf-8').replace(app_context._url, '')
+            rel_path = abs_url[0].decode('utf-8').replace(app_path, '')
 
         with set_curdoc(doc):
             state.base_url = base_url
@@ -172,6 +188,12 @@ class Application(BkApplication):
             the session context.
         '''
         request_data = super().process_request(request)
+        route_params = getattr(request, 'pn_route_params', None)
+        if route_params:
+            request_data['route_params'] = route_params
+        app_path = getattr(request, 'pn_app_path', None)
+        if app_path:
+            request_data['app_path'] = app_path
         user = request.cookies.get('user')
         if user and config.cookie_secret:
             from tornado.web import decode_signed_value

--- a/panel/io/fastapi.py
+++ b/panel/io/fastapi.py
@@ -57,7 +57,7 @@ DocHandler.render_session = server_html_page_for_session
 
 
 def _route_context(
-    request_or_scope: Request | dict[str, t.Any], suffix: str = ''
+    request_or_scope: Request | dict[str, t.Any], suffix: str = '', prefix: str = ''
 ) -> tuple[dict[str, str], str | None]:
     if isinstance(request_or_scope, dict):
         path_params = request_or_scope.get('path_params') or {}
@@ -65,10 +65,26 @@ def _route_context(
     else:
         path_params = request_or_scope.path_params
         path = request_or_scope.url.path
+    if path and prefix and path.startswith(prefix):
+        path = path[len(prefix):] or '/'
+        if not path.startswith('/'):
+            path = '/' + path
     if path and suffix and path.endswith(suffix):
         path = path[:-len(suffix)] or '/'
     route_params = {k: str(v) for k, v in path_params.items()}
     return route_params, path
+
+
+def _prefix_path(path: str, prefix: str) -> str:
+    if not prefix:
+        return path
+    if not path.startswith('/'):
+        path = '/' + path
+    if path == '/':
+        return prefix
+    if path.startswith(prefix + '/') or path == prefix:
+        return path
+    return f"{prefix}{path}"
 
 
 async def _get_fastapi_session(self, request: Request, session_id: t.Any):
@@ -78,7 +94,9 @@ async def _get_fastapi_session(self, request: Request, session_id: t.Any):
             secret_key=app.secret_key, signed=app.sign_sessions
         )
 
-    route_params, app_path = _route_context(request)
+    route_params, app_path = _route_context(
+        request, prefix=getattr(self.application, '_prefix', '')
+    )
     uri = f"{request.url.path}{f'?{request.url.query}' if request.url.query else ''}"
     if tornado.version_info < (6, 5, 0) and request.client is not None:
         # Compatibility with changes made in Tornado 6.5
@@ -153,7 +171,9 @@ _bk_fastapi_async_open = WSHandler._async_open
 
 async def _async_open_with_route_context(self, socket, token):
     payload = get_token_payload(token)
-    route_params, app_path = _route_context(socket.scope, suffix='/ws')
+    route_params, app_path = _route_context(
+        socket.scope, suffix='/ws', prefix=getattr(self.application, '_prefix', '')
+    )
     socket.scope['route_params'] = route_params
     socket.scope['app_path'] = app_path
     if route_params or app_path:
@@ -257,7 +277,15 @@ def add_applications(
     **kwargs:
         Additional keyword arguments to pass to the BokehFastAPI application
     """
+    prefix = kwargs.get('prefix', '') or ''
+    if prefix:
+        if not prefix.startswith('/'):
+            raise ValueError("prefix must start with '/'.")
+        prefix = prefix.rstrip('/') or '/'
+        kwargs['prefix'] = prefix
     apps = build_applications(panel, title=title, location=location, admin=admin)
+    if prefix:
+        apps = {_prefix_path(endpoint, prefix): app for endpoint, app in apps.items()}
     ws_origins = kwargs.pop('websocket_origin', None)
     if ws_origins and not isinstance(ws_origins, list):
         ws_origins = [ws_origins]
@@ -267,13 +295,16 @@ def add_applications(
     application = BokehFastAPI(apps, app=app, **kwargs)
     if session_history is not None:
         config.session_history = session_history
-        add_history_handler(application.app, endpoint='/session_info')
+        add_history_handler(application.app, endpoint=_prefix_path('/session_info', prefix))
     if liveness:
         liveness_endpoint = liveness if isinstance(liveness, str) else '/liveness'
-        add_liveness_handler(application.app, endpoint=liveness_endpoint, applications=apps)
+        add_liveness_handler(
+            application.app, endpoint=_prefix_path(liveness_endpoint, prefix), applications=apps
+        )
 
     @application.app.get(
-        f"/{COMPONENT_PATH.rstrip('/')}" + "/{path:path}", include_in_schema=False
+        _prefix_path(f"/{COMPONENT_PATH.rstrip('/')}" + "/{path:path}", prefix),
+        include_in_schema=False
     )
     def get_component_resource(path: str):
         # ComponentResourceHandler.parse_url_path only ever accesses

--- a/panel/io/fastapi.py
+++ b/panel/io/fastapi.py
@@ -1,9 +1,8 @@
 from __future__ import annotations
 
 import asyncio
-import calendar
-import datetime as dt
 import socket
+import time
 import typing as t
 import uuid
 
@@ -116,10 +115,10 @@ async def _get_fastapi_session(self, request: Request, session_id: t.Any):
         )
     tornado_request.route_params = route_params
     tornado_request.app_path = app_path
-    simple_cookies = SimpleCookie()
-    for name, cookie in request.cookies.items():
-        cookie_value = cookie.value if hasattr(cookie, "value") else str(cookie)
-        simple_cookies[name] = cookie_value
+    simple_cookies = SimpleCookie({
+        name: cookie.value if hasattr(cookie, "value") else str(cookie)
+        for name, cookie in request.cookies.items()
+    })
     tornado_request._cookies = simple_cookies
 
     headers = dict(tornado_request.headers)
@@ -192,10 +191,7 @@ async def _async_open_with_route_context(self, socket, token):
         if app_path:
             payload['app_path'] = app_path
         expiry = int(payload.pop('session_expiry', 0))
-        expires_in = max(
-            1,
-            expiry - calendar.timegm(dt.datetime.now(tz=dt.timezone.utc).timetuple())
-        ) if expiry else 300
+        expires_in = max(1, expiry - int(time.time())) if expiry else 300
         token = generate_jwt_token(
             get_session_id(token),
             secret_key=self.application.secret_key,

--- a/panel/io/fastapi.py
+++ b/panel/io/fastapi.py
@@ -8,6 +8,7 @@ import typing as t
 import uuid
 
 from functools import wraps
+from http.cookies import SimpleCookie
 
 import tornado
 
@@ -115,9 +116,17 @@ async def _get_fastapi_session(self, request: Request, session_id: t.Any):
         )
     tornado_request.route_params = route_params
     tornado_request.app_path = app_path
+    # Preserve a tornado-compatible cookie mapping for Application.process_request.
+    simple_cookies = SimpleCookie()
+    for name, value in request.cookies.items():
+        simple_cookies[name] = value
+    tornado_request._cookies = dict(simple_cookies.items())
 
     headers = dict(tornado_request.headers)
-    cookies = {name: cookie.value for name, cookie in request.cookies.items()}
+    cookies = {
+        name: cookie.value if hasattr(cookie, "value") else str(cookie)
+        for name, cookie in request.cookies.items()
+    }
 
     if app.include_headers is None:
         excluded_headers = app.exclude_headers or []

--- a/panel/io/fastapi.py
+++ b/panel/io/fastapi.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import asyncio
 import socket
-import time
 import typing as t
 import uuid
 
@@ -15,15 +14,15 @@ from ..config import config
 from .application import build_applications
 from .document import _cleanup_doc, extra_socket_handlers
 from .resources import COMPONENT_PATH
-from .server import ComponentResourceHandler, server_html_page_for_session
+from .server import (
+    ComponentResourceHandler, _sanitize_route_context, _strip_prefixed_path,
+    _validate_token_for_resign, server_html_page_for_session,
+)
 from .state import state
 from .threads import StoppableThread
 
 try:
-    from bokeh.util.token import (
-        generate_jwt_token, generate_session_id, get_session_id,
-        get_token_payload,
-    )
+    from bokeh.util.token import generate_jwt_token, generate_session_id
     from bokeh_fastapi import BokehFastAPI
     from bokeh_fastapi.handler import (
         DocHandler, SessionHandler as BkSessionHandler, WSHandler,
@@ -65,14 +64,13 @@ def _route_context(
     else:
         path_params = request_or_scope.path_params
         path = request_or_scope.url.path
-    if path and prefix and path.startswith(prefix):
-        path = path[len(prefix):] or '/'
+    if path and prefix:
+        path = _strip_prefixed_path(path, prefix)
         if not path.startswith('/'):
             path = '/' + path
     if path and suffix and path.endswith(suffix):
         path = path[:-len(suffix)] or '/'
-    route_params = {k: str(v) for k, v in path_params.items()}
-    return route_params, path
+    return _sanitize_route_context(path_params, path)
 
 
 def _prefix_path(path: str, prefix: str) -> str:
@@ -178,7 +176,9 @@ _bk_fastapi_async_open = WSHandler._async_open
 
 
 async def _async_open_with_route_context(self, socket, token):
-    payload = get_token_payload(token)
+    payload, session_id, expires_in = _validate_token_for_resign(
+        token, secret_key=self.application.secret_key, signed=self.application.sign_sessions
+    )
     route_params, app_path = _route_context(
         socket.scope, suffix='/ws', prefix=getattr(self.application, '_prefix', '')
     )
@@ -190,10 +190,9 @@ async def _async_open_with_route_context(self, socket, token):
             payload['route_params'] = route_params
         if app_path:
             payload['app_path'] = app_path
-        expiry = int(payload.pop('session_expiry', 0))
-        expires_in = max(1, expiry - int(time.time())) if expiry else 300
+        payload.pop('session_expiry', None)
         token = generate_jwt_token(
-            get_session_id(token),
+            session_id,
             secret_key=self.application.secret_key,
             signed=self.application.sign_sessions,
             expiration=expires_in,

--- a/panel/io/fastapi.py
+++ b/panel/io/fastapi.py
@@ -116,11 +116,11 @@ async def _get_fastapi_session(self, request: Request, session_id: t.Any):
         )
     tornado_request.route_params = route_params
     tornado_request.app_path = app_path
-    # Preserve a tornado-compatible cookie mapping for Application.process_request.
     simple_cookies = SimpleCookie()
-    for name, value in request.cookies.items():
-        simple_cookies[name] = value
-    tornado_request._cookies = dict(simple_cookies.items())
+    for name, cookie in request.cookies.items():
+        cookie_value = cookie.value if hasattr(cookie, "value") else str(cookie)
+        simple_cookies[name] = cookie_value
+    tornado_request._cookies = simple_cookies
 
     headers = dict(tornado_request.headers)
     cookies = {

--- a/panel/io/fastapi.py
+++ b/panel/io/fastapi.py
@@ -95,8 +95,8 @@ async def _get_fastapi_session(self, request: Request, session_id: t.Any):
             uri=uri,
             headers=HTTPHeaders(request.headers),
         )
-    tornado_request.pn_route_params = route_params
-    tornado_request.pn_app_path = app_path
+    tornado_request.route_params = route_params
+    tornado_request.app_path = app_path
 
     headers = dict(tornado_request.headers)
     cookies = {name: cookie.value for name, cookie in request.cookies.items()}
@@ -154,6 +154,8 @@ _bk_fastapi_async_open = WSHandler._async_open
 async def _async_open_with_route_context(self, socket, token):
     payload = get_token_payload(token)
     route_params, app_path = _route_context(socket.scope, suffix='/ws')
+    socket.scope['route_params'] = route_params
+    socket.scope['app_path'] = app_path
     if route_params or app_path:
         payload = dict(payload)
         if route_params:

--- a/panel/io/fastapi.py
+++ b/panel/io/fastapi.py
@@ -550,11 +550,12 @@ def serve(
     if threaded:
         # To ensure that we have correspondence between state._threads and state._servers
         # we must provide a server_id here
-        kwargs['loop'] = loop = asyncio.new_event_loop() if loop is None else loop
+        owns_loop = loop is None
+        kwargs['loop'] = loop = asyncio.new_event_loop() if owns_loop else loop
         if 'server_id' not in kwargs:
             kwargs['server_id'] = uuid.uuid4().hex
         server = StoppableThread(
-            target=get_server, io_loop=loop, args=(panels,), kwargs=kwargs
+            target=get_server, io_loop=loop, args=(panels,), kwargs=kwargs, owns_loop=owns_loop
         )
         server_id = kwargs['server_id']
         state._threads[server_id] = server

--- a/panel/io/fastapi.py
+++ b/panel/io/fastapi.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 
 import asyncio
+import calendar
+import datetime as dt
 import socket
 import typing as t
 import uuid
 
 from functools import wraps
+
+import tornado
 
 from ..config import config
 from .application import build_applications
@@ -16,12 +20,20 @@ from .state import state
 from .threads import StoppableThread
 
 try:
+    from bokeh.util.token import (
+        generate_jwt_token, generate_session_id, get_session_id,
+        get_token_payload,
+    )
     from bokeh_fastapi import BokehFastAPI
-    from bokeh_fastapi.handler import DocHandler, WSHandler
+    from bokeh_fastapi.handler import (
+        DocHandler, SessionHandler as BkSessionHandler, WSHandler,
+    )
     from fastapi import (
         FastAPI, HTTPException, Query, Request,
     )
     from fastapi.responses import FileResponse
+    from tornado.httputil import HTTPHeaders, HTTPServerRequest
+    from tornado.ioloop import IOLoop
 except ImportError as e:
     if e.name == "bokeh_fastapi":
         msg = "bokeh_fastapi must be installed to use the panel.io.fastapi module."
@@ -42,6 +54,125 @@ if t.TYPE_CHECKING:
 #---------------------------------------------------------------------
 
 DocHandler.render_session = server_html_page_for_session
+
+
+def _route_context(
+    request_or_scope: Request | dict[str, t.Any], suffix: str = ''
+) -> tuple[dict[str, str], str | None]:
+    if isinstance(request_or_scope, dict):
+        path_params = request_or_scope.get('path_params') or {}
+        path = request_or_scope.get('path')
+    else:
+        path_params = request_or_scope.path_params
+        path = request_or_scope.url.path
+    if path and suffix and path.endswith(suffix):
+        path = path[:-len(suffix)] or '/'
+    route_params = {k: str(v) for k, v in path_params.items()}
+    return route_params, path
+
+
+async def _get_fastapi_session(self, request: Request, session_id: t.Any):
+    app = self.application
+    if session_id is None:
+        session_id = generate_session_id(
+            secret_key=app.secret_key, signed=app.sign_sessions
+        )
+
+    request_kwargs = {}
+    route_params, app_path = _route_context(request)
+    if tornado.version_info < (6, 5, 0):
+        # Compatibility with changes made in Tornado 6.5
+        # https://github.com/tornadoweb/tornado/pull/3487
+        request_kwargs["host"] = request.client.host
+
+    tornado_request = HTTPServerRequest(
+        method=request.method,
+        uri=f"{request.url.path}{f'?{request.url.query}' if request.url.query else ''}",
+        headers=HTTPHeaders(request.headers),
+        **request_kwargs,
+    )
+    tornado_request.pn_route_params = route_params
+    tornado_request.pn_app_path = app_path
+
+    headers = dict(tornado_request.headers)
+    cookies = {name: cookie.value for name, cookie in request.cookies.items()}
+
+    if app.include_headers is None:
+        excluded_headers = app.exclude_headers or []
+        allowed_headers = [
+            header for header in headers if header not in excluded_headers
+        ]
+    else:
+        allowed_headers = app.include_headers
+    headers = {k: v for k, v in headers.items() if k in allowed_headers}
+
+    if app.include_cookies is None:
+        excluded_cookies = app.exclude_cookies or []
+        allowed_cookies = [
+            cookie for cookie in cookies if cookie not in excluded_cookies
+        ]
+    else:
+        allowed_cookies = app.include_cookies
+    cookies = {k: v for k, v in cookies.items() if k in allowed_cookies}
+
+    if (
+        cookies
+        and "Cookie" in headers
+        and "Cookie" not in (app.include_headers or [])
+    ):
+        # Do not include Cookie header since cookies can be restored from cookies dict
+        del headers["Cookie"]
+
+    payload = {
+        "headers": headers,
+        "cookies": cookies,
+        "arguments": tornado_request.arguments,
+    }
+    payload.update(self.application_context.application.process_request(tornado_request))
+    token = generate_jwt_token(
+        session_id,
+        secret_key=app.secret_key,
+        signed=app.sign_sessions,
+        expiration=300,
+        extra_payload=payload,
+    )
+    if self.application_context.io_loop is None:
+        self.application_context._loop = IOLoop.current()
+    session = await self.application_context.create_session_if_needed(
+        session_id, tornado_request, token
+    )
+    return session
+
+
+_bk_fastapi_async_open = WSHandler._async_open
+
+
+async def _async_open_with_route_context(self, socket, token):
+    payload = get_token_payload(token)
+    route_params, app_path = _route_context(socket.scope, suffix='/ws')
+    if route_params or app_path:
+        payload = dict(payload)
+        if route_params:
+            payload['route_params'] = route_params
+        if app_path:
+            payload['app_path'] = app_path
+        expiry = int(payload.pop('session_expiry', 0))
+        expires_in = max(
+            1,
+            expiry - calendar.timegm(dt.datetime.now(tz=dt.timezone.utc).timetuple())
+        ) if expiry else 300
+        token = generate_jwt_token(
+            get_session_id(token),
+            secret_key=self.application.secret_key,
+            signed=self.application.sign_sessions,
+            expiration=expires_in,
+            extra_payload=payload,
+        )
+    return await _bk_fastapi_async_open(self, socket, token)
+
+
+BkSessionHandler.get_session = _get_fastapi_session
+WSHandler._async_open = _async_open_with_route_context
 
 
 def dispatch_fastapi(conn, events: list[DocumentPatchedEvent] | None = None, msg: Message | None = None):

--- a/panel/io/fastapi.py
+++ b/panel/io/fastapi.py
@@ -78,19 +78,23 @@ async def _get_fastapi_session(self, request: Request, session_id: t.Any):
             secret_key=app.secret_key, signed=app.sign_sessions
         )
 
-    request_kwargs = {}
     route_params, app_path = _route_context(request)
-    if tornado.version_info < (6, 5, 0):
+    uri = f"{request.url.path}{f'?{request.url.query}' if request.url.query else ''}"
+    if tornado.version_info < (6, 5, 0) and request.client is not None:
         # Compatibility with changes made in Tornado 6.5
         # https://github.com/tornadoweb/tornado/pull/3487
-        request_kwargs["host"] = request.client.host
-
-    tornado_request = HTTPServerRequest(
-        method=request.method,
-        uri=f"{request.url.path}{f'?{request.url.query}' if request.url.query else ''}",
-        headers=HTTPHeaders(request.headers),
-        **request_kwargs,
-    )
+        tornado_request = HTTPServerRequest(
+            method=request.method,
+            uri=uri,
+            headers=HTTPHeaders(request.headers),
+            host=request.client.host,
+        )
+    else:
+        tornado_request = HTTPServerRequest(
+            method=request.method,
+            uri=uri,
+            headers=HTTPHeaders(request.headers),
+        )
     tornado_request.pn_route_params = route_params
     tornado_request.pn_app_path = app_path
 

--- a/panel/io/server.py
+++ b/panel/io/server.py
@@ -14,6 +14,7 @@ import re
 import signal
 import sys
 import threading
+import time
 import typing as t
 import uuid
 
@@ -49,7 +50,8 @@ from bokeh.server.views.static_handler import StaticHandler
 from bokeh.server.views.ws import WSHandler as BkWSHandler
 from bokeh.util.serialization import make_id
 from bokeh.util.token import (
-    generate_jwt_token, generate_session_id, get_session_id, get_token_payload,
+    check_token_signature, generate_jwt_token, generate_session_id,
+    get_session_id, get_token_payload,
 )
 # Tornado imports
 from tornado.ioloop import IOLoop
@@ -118,6 +120,53 @@ _PATH_TEMPLATE_CONVERTERS = {
     'float': r'[+-]?(?:[0-9]+(?:\.[0-9]*)?|\.[0-9]+)(?:[eE][+-]?[0-9]+)?',
     'uuid': r'[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}',
 }
+_MAX_ROUTE_PARAMS = 32
+_MAX_ROUTE_PARAM_KEY_CHARS = 128
+_MAX_ROUTE_PARAM_VALUE_CHARS = 1024
+_MAX_APP_PATH_CHARS = 2048
+
+
+def _has_prefix_boundary(path: str, prefix: str) -> bool:
+    if path == prefix:
+        return True
+    if prefix == '/':
+        return path.startswith('/')
+    return path.startswith(prefix + '/')
+
+
+def _strip_prefixed_path(path: str, prefix: str) -> str:
+    if not prefix:
+        return path
+    if _has_prefix_boundary(path, prefix):
+        stripped = path[len(prefix):]
+        return stripped or '/'
+    return path
+
+
+def _sanitize_route_context(
+    route_params: dict[str, t.Any], app_path: str | None
+) -> tuple[dict[str, str], str | None]:
+    sanitized_params: dict[str, str] = {}
+    for i, (key, value) in enumerate(route_params.items()):
+        if i >= _MAX_ROUTE_PARAMS:
+            break
+        sanitized_key = str(key)[:_MAX_ROUTE_PARAM_KEY_CHARS]
+        sanitized_value = str(value)[:_MAX_ROUTE_PARAM_VALUE_CHARS]
+        sanitized_params[sanitized_key] = sanitized_value
+    sanitized_app_path = None if app_path is None else str(app_path)[:_MAX_APP_PATH_CHARS]
+    return sanitized_params, sanitized_app_path
+
+
+def _validate_token_for_resign(token: str, secret_key: bytes | None, signed: bool) -> tuple[dict[str, t.Any], str, int]:
+    if not check_token_signature(token, secret_key=secret_key, signed=signed):
+        raise RuntimeError("Token signature validation failed before websocket re-sign.")
+    payload = dict(get_token_payload(token))
+    expiry = int(payload.get('session_expiry', 0) or 0)
+    now = int(time.time())
+    if expiry and expiry <= now:
+        raise RuntimeError("Token expired before websocket re-sign.")
+    expires_in = max(1, expiry - now) if expiry else 300
+    return payload, get_session_id(token), expires_in
 
 def _origin_url(url: str) -> str:
     if url.startswith("http"):
@@ -432,10 +481,11 @@ class RequestProxy(BkRequestProxy):
             app_path = getattr(request, 'app_path', None)
             if app_path is None and isinstance(request, dict):
                 app_path = request.get('app_path')
-        self._route_params = {} if not isinstance(route_params, dict) else {
-            str(k): str(v) for k, v in route_params.items()
-        }
-        self._app_path = None if app_path is None else str(app_path)
+        sanitized_params, sanitized_app_path = _sanitize_route_context(
+            route_params if isinstance(route_params, dict) else {}, app_path
+        )
+        self._route_params = sanitized_params
+        self._app_path = sanitized_app_path
 
     @property
     def route_params(self) -> dict[str, str]:
@@ -449,7 +499,6 @@ class RequestProxy(BkRequestProxy):
         if not name.startswith("_") and isinstance(self._request, dict):
             if name in self._request:
                 return self._request[name]
-            raise AttributeError(name)
         return super().__getattr__(name)
 
 
@@ -457,9 +506,7 @@ bokeh.server.contexts._RequestProxy = RequestProxy
 
 
 def _normalize_app_path(path: str, prefix: str, suffix: str = '') -> str:
-    app_path = path
-    if prefix and app_path.startswith(prefix):
-        app_path = app_path[len(prefix):]
+    app_path = _strip_prefixed_path(path, prefix)
     if suffix and app_path.endswith(suffix):
         app_path = app_path[:-len(suffix)]
     if not app_path:
@@ -470,15 +517,17 @@ def _normalize_app_path(path: str, prefix: str, suffix: str = '') -> str:
 
 
 def _route_params(args: tuple[t.Any, ...], kwargs: dict[str, t.Any]) -> dict[str, str]:
-    route_params = {str(i): str(value) for i, value in enumerate(args)}
-    route_params.update({str(key): str(value) for key, value in kwargs.items()})
-    return route_params
+    route_params = {str(i): value for i, value in enumerate(args)}
+    route_params.update({str(key): value for key, value in kwargs.items()})
+    sanitized_params, _ = _sanitize_route_context(route_params, app_path=None)
+    return sanitized_params
 
 
 def _set_request_route_context(handler: t.Any, *args, suffix: str = '', **kwargs) -> None:
     request = handler.request
-    request.route_params = _route_params(args, kwargs)
-    request.app_path = _normalize_app_path(request.path, handler.application.prefix, suffix=suffix)
+    raw_route_params = _route_params(args, kwargs)
+    raw_app_path = _normalize_app_path(request.path, handler.application.prefix, suffix=suffix)
+    request.route_params, request.app_path = _sanitize_route_context(raw_route_params, raw_app_path)
 
 
 class DocHandler(LoginUrlMixin, BkDocHandler):
@@ -702,15 +751,24 @@ class WSHandler(BkWSHandler):
         return super().open()
 
     async def _async_open(self, token: str) -> None:
-        payload = get_token_payload(token)
-        session_id = get_session_id(token)
-        payload.update(self.application_context.application.process_request(self.request))
+        payload, session_id, expires_in = _validate_token_for_resign(
+            token, secret_key=self.application.secret_key, signed=self.application.sign_sessions
+        )
+        request_data = self.application_context.application.process_request(self.request)
+        route_params, app_path = _sanitize_route_context(
+            request_data.get('route_params', {}), request_data.get('app_path')
+        )
+        if route_params:
+            request_data['route_params'] = route_params
+        if app_path:
+            request_data['app_path'] = app_path
+        payload.update(request_data)
         payload.pop('session_expiry', None)
         token = generate_jwt_token(
-            session_id,
+            t.cast("ID", session_id),
             secret_key=self.application.secret_key,
             signed=self.application.sign_sessions,
-            expiration=self.application.session_token_expiration,
+            expiration=min(self.application.session_token_expiration, expires_in),
             extra_payload=payload
         )
         return await super()._async_open(token)

--- a/panel/io/server.py
+++ b/panel/io/server.py
@@ -83,7 +83,9 @@ logger = logging.getLogger(__name__)
 if t.TYPE_CHECKING:
     from collections.abc import Callable, Mapping
 
-    from bokeh.application.application import SessionContext
+    from bokeh.application.application import (
+        Application as BkApplication, SessionContext,
+    )
     from bokeh.core.types import ID
     from bokeh.document.document import DocJson
     from bokeh.embed.bundle import Bundle
@@ -1189,8 +1191,8 @@ def get_server(
     apps = build_applications(
         panel, title=title, location=location, admin=admin, custom_handlers=(flask_handler,)
     )
-    normalized_apps = {}
-    normalized_sources = {}
+    normalized_apps: dict[str, BkApplication] = {}
+    normalized_sources: dict[str, str] = {}
     for endpoint, app in apps.items():
         normalized_endpoint = _path_template_to_tornado_route(endpoint)
         if normalized_endpoint in normalized_apps:

--- a/panel/io/server.py
+++ b/panel/io/server.py
@@ -134,7 +134,7 @@ def _path_template_to_tornado_route(route: str) -> str:
     """
     Convert FastAPI-style route templates into Tornado-compatible regex routes.
     """
-    if route == '/' or '{' not in route:
+    if route == '/' or ('{' not in route and '}' not in route):
         return route
     segments = route.lstrip('/').split('/')
     converted_segments = []

--- a/panel/io/server.py
+++ b/panel/io/server.py
@@ -34,6 +34,7 @@ from bokeh.embed.bundle import Script
 from bokeh.embed.elements import script_for_render_items
 from bokeh.embed.util import RenderItem
 from bokeh.embed.wrappers import wrap_in_script_tag
+from bokeh.server.contexts import _RequestProxy as BkRequestProxy
 from bokeh.server.server import Server as BokehServer
 from bokeh.server.urls import per_app_patterns, toplevel_patterns
 from bokeh.server.views.autoload_js_handler import (
@@ -419,6 +420,42 @@ class LoginUrlMixin:
         raise RuntimeError('login_url or get_login_url() must be supplied when authentication hooks are enabled')
 
 
+class RequestProxy(BkRequestProxy):
+
+    def __init__(self, request, *args, route_params=None, app_path=None, **kwargs):
+        super().__init__(request, *args, **kwargs)
+        if route_params is None:
+            route_params = getattr(request, 'route_params', None)
+            if route_params is None and isinstance(request, dict):
+                route_params = request.get('route_params')
+        if app_path is None:
+            app_path = getattr(request, 'app_path', None)
+            if app_path is None and isinstance(request, dict):
+                app_path = request.get('app_path')
+        self._route_params = {} if not isinstance(route_params, dict) else {
+            str(k): str(v) for k, v in route_params.items()
+        }
+        self._app_path = None if app_path is None else str(app_path)
+
+    @property
+    def route_params(self) -> dict[str, str]:
+        return self._route_params
+
+    @property
+    def app_path(self) -> str | None:
+        return self._app_path
+
+    def __getattr__(self, name: str) -> t.Any:
+        if not name.startswith("_") and isinstance(self._request, dict):
+            if name in self._request:
+                return self._request[name]
+            raise AttributeError(name)
+        return super().__getattr__(name)
+
+
+bokeh.server.contexts._RequestProxy = RequestProxy
+
+
 def _normalize_app_path(path: str, prefix: str, suffix: str = '') -> str:
     app_path = path
     if prefix and app_path.startswith(prefix):
@@ -440,8 +477,8 @@ def _route_params(args: tuple[t.Any, ...], kwargs: dict[str, t.Any]) -> dict[str
 
 def _set_request_route_context(handler: t.Any, *args, suffix: str = '', **kwargs) -> None:
     request = handler.request
-    request.pn_route_params = _route_params(args, kwargs)
-    request.pn_app_path = _normalize_app_path(request.path, handler.application.prefix, suffix=suffix)
+    request.route_params = _route_params(args, kwargs)
+    request.app_path = _normalize_app_path(request.path, handler.application.prefix, suffix=suffix)
 
 
 class DocHandler(LoginUrlMixin, BkDocHandler):

--- a/panel/io/server.py
+++ b/panel/io/server.py
@@ -815,8 +815,13 @@ def create_static_handler(prefix, key, app):
     key = '/__patchedroot' if is_root else key
 
     route = prefix
-    static_route = "/static/(?P<static_path>.*)" if "(?P<" in key else "/static/(.*)"
-    route += static_route if is_root else key + static_route
+    if is_root:
+        # Avoid matching /static/extensions/... here so Bokeh's top-level
+        # MultiRootStaticHandler route can serve extension assets.
+        route += "/static/(?!extensions/)(.*)"
+    else:
+        static_route = "/static/(?P<static_path>.*)" if "(?P<" in key else "/static/(.*)"
+        route += key + static_route
     if app.static_path is not None:
         return (route, StaticFileHandler, {"path" : app.static_path})
     return (route, StaticHandler, {})

--- a/panel/io/server.py
+++ b/panel/io/server.py
@@ -114,8 +114,8 @@ _PATH_TEMPLATE_PATTERN = re.compile(
 _PATH_TEMPLATE_CONVERTERS = {
     'str': r'[^/]+',
     'path': r'.*',
-    'int': r'[0-9]+',
-    'float': r'[0-9]+(?:\.[0-9]+)?',
+    'int': r'[+-]?[0-9]+',
+    'float': r'[+-]?(?:[0-9]+(?:\.[0-9]*)?|\.[0-9]+)(?:[eE][+-]?[0-9]+)?',
     'uuid': r'[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}',
 }
 
@@ -730,7 +730,7 @@ class RootHandler(LoginUrlMixin, BkRootHandler):
     template variable.
     """
 
-    _regex_tokens = ('(', ')', '[', ']', '?', '+', '*', '|', '\\', '^', '$')
+    _regex_tokens = ('(', ')', '[', ']', '{', '}', '?', '+', '*', '|', '\\', '^', '$')
 
     @classmethod
     def _is_concrete_route(cls, route: str) -> bool:
@@ -807,6 +807,9 @@ class AuthenticatedStaticFileHandler(StaticFileHandler):
     async def get(self, *args, **kwargs):
         return await super().get(*args, **kwargs)
 
+def _to_non_capturing_groups(route: str) -> str:
+    route = re.sub(r'\(\?P<[^>]+>', '(?:', route)
+    return re.sub(r'(?<!\\)\((?!\?)', '(?:', route)
 
 # Copied from bokeh 2.4.0, to fix directly in bokeh at some point.
 def create_static_handler(prefix, key, app):
@@ -820,8 +823,7 @@ def create_static_handler(prefix, key, app):
         # MultiRootStaticHandler route can serve extension assets.
         route += "/static/(?!extensions/)(.*)"
     else:
-        static_route = "/static/(?P<static_path>.*)" if "(?P<" in key else "/static/(.*)"
-        route += key + static_route
+        route += _to_non_capturing_groups(key) + "/static/(.*)"
     if app.static_path is not None:
         return (route, StaticFileHandler, {"path" : app.static_path})
     return (route, StaticHandler, {})

--- a/panel/io/server.py
+++ b/panel/io/server.py
@@ -774,11 +774,12 @@ class AuthenticatedStaticFileHandler(StaticFileHandler):
 # Copied from bokeh 2.4.0, to fix directly in bokeh at some point.
 def create_static_handler(prefix, key, app):
     # patch
-    key = '/__patchedroot' if key == '/' else key
+    is_root = key == '/'
+    key = '/__patchedroot' if is_root else key
 
     route = prefix
     static_route = "/static/(?P<static_path>.*)" if "(?P<" in key else "/static/(.*)"
-    route += static_route if key == "/" else key + static_route
+    route += static_route if is_root else key + static_route
     if app.static_path is not None:
         return (route, StaticFileHandler, {"path" : app.static_path})
     return (route, StaticHandler, {})

--- a/panel/io/server.py
+++ b/panel/io/server.py
@@ -10,6 +10,7 @@ import inspect
 import logging
 import os
 import pathlib
+import re
 import signal
 import sys
 import threading
@@ -39,11 +40,15 @@ from bokeh.server.views.autoload_js_handler import (
     AutoloadJsHandler as BkAutoloadJsHandler,
 )
 from bokeh.server.views.doc_handler import DocHandler as BkDocHandler
+from bokeh.server.views.metadata_handler import (
+    MetadataHandler as BkMetadataHandler,
+)
 from bokeh.server.views.root_handler import RootHandler as BkRootHandler
 from bokeh.server.views.static_handler import StaticHandler
+from bokeh.server.views.ws import WSHandler as BkWSHandler
 from bokeh.util.serialization import make_id
 from bokeh.util.token import (
-    generate_jwt_token, generate_session_id, get_token_payload,
+    generate_jwt_token, generate_session_id, get_session_id, get_token_payload,
 )
 # Tornado imports
 from tornado.ioloop import IOLoop
@@ -100,6 +105,16 @@ if t.TYPE_CHECKING:
 
 INDEX_HTML = os.path.join(os.path.dirname(__file__), '..', '_templates', "index.html")
 DEFAULT_TITLE = "Panel Application"
+_PATH_TEMPLATE_PATTERN = re.compile(
+    r'^\{(?P<name>[A-Za-z_][A-Za-z0-9_]*)(?::(?P<converter>str|path|int|float|uuid))?\}$'
+)
+_PATH_TEMPLATE_CONVERTERS = {
+    'str': r'[^/]+',
+    'path': r'.*',
+    'int': r'[0-9]+',
+    'float': r'[0-9]+(?:\.[0-9]+)?',
+    'uuid': r'[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}',
+}
 
 def _origin_url(url: str) -> str:
     if url.startswith("http"):
@@ -111,6 +126,34 @@ def _server_url(url: str, port: int) -> str:
         return f"{url.rsplit(':', 1)[0]}:{port}/"
     else:
         return f"http://{url.split(':')[0]}:{port}/"
+
+
+def _path_template_to_tornado_route(route: str) -> str:
+    """
+    Convert FastAPI-style route templates into Tornado-compatible regex routes.
+    """
+    if route == '/' or '{' not in route:
+        return route
+    segments = route.lstrip('/').split('/')
+    converted_segments = []
+    found_template = False
+    for segment in segments:
+        match = _PATH_TEMPLATE_PATTERN.fullmatch(segment)
+        if match:
+            found_template = True
+            converter = match.group('converter') or 'str'
+            converted_segments.append(
+                f"(?P<{match.group('name')}>{_PATH_TEMPLATE_CONVERTERS[converter]})"
+            )
+            continue
+        if '{' in segment or '}' in segment:
+            raise ValueError(
+                f"Invalid path template segment {segment!r} in route {route!r}."
+            )
+        converted_segments.append(re.escape(segment))
+    if not found_template:
+        return route
+    return '/' + '/'.join(converted_segments)
 
 _tasks = set()
 
@@ -374,6 +417,31 @@ class LoginUrlMixin:
         raise RuntimeError('login_url or get_login_url() must be supplied when authentication hooks are enabled')
 
 
+def _normalize_app_path(path: str, prefix: str, suffix: str = '') -> str:
+    app_path = path
+    if prefix and app_path.startswith(prefix):
+        app_path = app_path[len(prefix):]
+    if suffix and app_path.endswith(suffix):
+        app_path = app_path[:-len(suffix)]
+    if not app_path:
+        app_path = '/'
+    if not app_path.startswith('/'):
+        app_path = '/' + app_path
+    return app_path
+
+
+def _route_params(args: tuple[t.Any, ...], kwargs: dict[str, t.Any]) -> dict[str, str]:
+    route_params = {str(i): str(value) for i, value in enumerate(args)}
+    route_params.update({str(key): str(value) for key, value in kwargs.items()})
+    return route_params
+
+
+def _set_request_route_context(handler: t.Any, *args, suffix: str = '', **kwargs) -> None:
+    request = handler.request
+    request.pn_route_params = _route_params(args, kwargs)
+    request.pn_app_path = _normalize_app_path(request.path, handler.application.prefix, suffix=suffix)
+
+
 class DocHandler(LoginUrlMixin, BkDocHandler):
 
     @authenticated  # type: ignore
@@ -485,6 +553,7 @@ class DocHandler(LoginUrlMixin, BkDocHandler):
             redirect_url = f'{prefix}/' + (f'?{query_string}' if query_string else '')
             self.redirect(redirect_url)
             return
+        _set_request_route_context(self, *args, **kwargs)
 
         # Run global authorization callback
         payload = self._generate_token_payload()
@@ -552,8 +621,6 @@ class DocHandler(LoginUrlMixin, BkDocHandler):
         self.set_header("Content-Type", 'text/html')
         self.write(page)
 
-per_app_patterns[0] = (r'/?', DocHandler)
-
 # Patch Bokeh Autoload handler
 class AutoloadJsHandler(BkAutoloadJsHandler):
     ''' Implements a custom Tornado handler for the autoload JS chunk
@@ -561,6 +628,7 @@ class AutoloadJsHandler(BkAutoloadJsHandler):
     '''
 
     async def get(self, *args, **kwargs) -> None:
+        _set_request_route_context(self, *args, suffix='/autoload.js', **kwargs)
         element_id = self.get_argument("bokeh-autoload-element", default=None)
         if not element_id:
             self.send_error(status_code=400, reason='No bokeh-autoload-element query parameter')
@@ -587,7 +655,35 @@ class AutoloadJsHandler(BkAutoloadJsHandler):
         self.set_header("Content-Type", 'application/javascript')
         self.write(js)
 
-per_app_patterns[3] = (r'/autoload.js', AutoloadJsHandler)
+
+class WSHandler(BkWSHandler):
+
+    def open(self, *args, **kwargs):
+        _set_request_route_context(self, *args, suffix='/ws', **kwargs)
+        return super().open()
+
+    async def _async_open(self, token: str) -> None:
+        payload = get_token_payload(token)
+        session_id = get_session_id(token)
+        payload.update(self.application_context.application.process_request(self.request))
+        payload.pop('session_expiry', None)
+        token = generate_jwt_token(
+            session_id,
+            secret_key=self.application.secret_key,
+            signed=self.application.sign_sessions,
+            expiration=self.application.session_token_expiration,
+            extra_payload=payload
+        )
+        return await super()._async_open(token)
+
+
+_metadata_handler = per_app_patterns[2][1] if len(per_app_patterns) > 2 else BkMetadataHandler
+per_app_patterns[:] = [
+    (r'/ws', WSHandler),
+    (r'/metadata', _metadata_handler),
+    (r'/autoload.js', AutoloadJsHandler),
+    (r'/?', DocHandler),
+]
 
 class RootHandler(LoginUrlMixin, BkRootHandler):
     """
@@ -595,9 +691,18 @@ class RootHandler(LoginUrlMixin, BkRootHandler):
     template variable.
     """
 
+    _regex_tokens = ('(', ')', '[', ']', '?', '+', '*', '|', '\\', '^', '$')
+
+    @classmethod
+    def _is_concrete_route(cls, route: str) -> bool:
+        return not any(token in route for token in cls._regex_tokens)
+
     @authenticated
     async def get(self, *args, **kwargs):
-        if self.use_redirect and len(self.applications) == 1:
+        if (
+            self.use_redirect and len(self.applications) == 1 and
+            self._is_concrete_route(next(iter(self.applications)))
+        ):
             app_names = list(self.applications.keys())
             redirect_to = f".{app_names[0]}"
             self.redirect(redirect_to)
@@ -670,7 +775,8 @@ def create_static_handler(prefix, key, app):
     key = '/__patchedroot' if key == '/' else key
 
     route = prefix
-    route += "/static/(.*)" if key == "/" else key + "/static/(.*)"
+    static_route = "/static/(?P<static_path>.*)" if "(?P<" in key else "/static/(.*)"
+    route += static_route if key == "/" else key + static_route
     if app.static_path is not None:
         return (route, StaticFileHandler, {"path" : app.static_path})
     return (route, StaticHandler, {})
@@ -1083,6 +1189,18 @@ def get_server(
     apps = build_applications(
         panel, title=title, location=location, admin=admin, custom_handlers=(flask_handler,)
     )
+    normalized_apps = {}
+    normalized_sources = {}
+    for endpoint, app in apps.items():
+        normalized_endpoint = _path_template_to_tornado_route(endpoint)
+        if normalized_endpoint in normalized_apps:
+            raise ValueError(
+                f"Application routes {endpoint!r} and {normalized_sources[normalized_endpoint]!r} "
+                "normalize to the same Tornado route."
+            )
+        normalized_apps[normalized_endpoint] = app
+        normalized_sources[normalized_endpoint] = endpoint
+    apps = normalized_apps
 
     if warm or config.autoreload:
         for endpoint, app in apps.items():

--- a/panel/io/server.py
+++ b/panel/io/server.py
@@ -1014,14 +1014,15 @@ def serve(
         location=location, admin=admin
     ))
     if threaded:
-        kwargs['loop'] = loop = IOLoop(make_current=False) if loop is None else loop
+        owns_loop = loop is None
+        kwargs['loop'] = loop = IOLoop(make_current=False) if owns_loop else loop
         # To ensure that we have correspondence between state._threads and state._servers
         # we must provide a server_id here
         if 'server_id' not in kwargs:
             kwargs['server_id'] = uuid.uuid4().hex
 
         server = StoppableThread(
-            target=get_server, io_loop=loop, args=(panels,), kwargs=kwargs
+            target=get_server, io_loop=loop, args=(panels,), kwargs=kwargs, owns_loop=owns_loop
         )
         server_id = kwargs['server_id']
         state._threads[server_id] = server

--- a/panel/io/state.py
+++ b/panel/io/state.py
@@ -1077,7 +1077,12 @@ class _state(param.Parameterized):
         """
         if not (self.curdoc and self.curdoc.session_context):
             return None
-        app_url = self.curdoc.session_context.server_context.application_context.url
+        session_context = self.curdoc.session_context
+        app_url = session_context.server_context.application_context.url
+        try:
+            app_url = session_context.token_payload.get('app_path', app_url)
+        except AssertionError:
+            pass
         app_url = app_url[1:] if app_url.startswith('/') else app_url
         return urljoin(self.base_url, app_url)
 
@@ -1261,6 +1266,19 @@ class _state(param.Parameterized):
         Returns the request arguments associated with the request that started the session.
         """
         return self.curdoc.session_context.request.arguments if self.curdoc and self.curdoc.session_context else {}
+
+    @property
+    def route_params(self) -> dict[str, str]:
+        """
+        Returns route parameters captured from wildcard routes.
+        """
+        if not (self.curdoc and self.curdoc.session_context):
+            return {}
+        try:
+            route_params = self.curdoc.session_context.token_payload.get('route_params', {})
+        except AssertionError:
+            return {}
+        return dict(route_params) if isinstance(route_params, dict) else {}
 
     @property
     def template(self) -> BaseTemplate | None:

--- a/panel/io/state.py
+++ b/panel/io/state.py
@@ -1078,7 +1078,11 @@ class _state(param.Parameterized):
         if not (self.curdoc and self.curdoc.session_context):
             return None
         session_context = self.curdoc.session_context
-        app_url = session_context.server_context.application_context.url
+        request = session_context.request
+        app_url = (
+            getattr(request, 'app_path', None)
+            if request is not None else None
+        ) or session_context.server_context.application_context.url
         try:
             app_url = session_context.token_payload.get('app_path', app_url)
         except AssertionError:
@@ -1274,6 +1278,11 @@ class _state(param.Parameterized):
         """
         if not (self.curdoc and self.curdoc.session_context):
             return {}
+        request = self.curdoc.session_context.request
+        if request is not None:
+            route_params = getattr(request, 'route_params', None)
+            if isinstance(route_params, dict):
+                return {str(k): str(v) for k, v in route_params.items()}
         try:
             route_params = self.curdoc.session_context.token_payload.get('route_params', {})
         except AssertionError:

--- a/panel/io/threads.py
+++ b/panel/io/threads.py
@@ -1,5 +1,6 @@
 import asyncio
 import threading
+import typing as t
 
 from .state import state
 
@@ -7,14 +8,15 @@ from .state import state
 class StoppableThread(threading.Thread):
     """Thread class with a stop() method."""
 
-    def __init__(self, io_loop, **kwargs):
+    def __init__(self, io_loop, owns_loop: bool = False, **kwargs):
         super().__init__(**kwargs)
         # Backward compatibility to handle Tornado IOLoop
         if hasattr(io_loop, 'asyncio_loop'):
             io_loop = io_loop.asyncio_loop
         self.asyncio_loop = io_loop
+        self._owns_loop = owns_loop
         self.server_id = kwargs.get('kwargs', {}).get('server_id')
-        self._shutdown_task = None
+        self._shutdown_task: t.Any | None = None
 
     def run(self) -> None:
         if hasattr(self, '_target'):
@@ -31,6 +33,11 @@ class StoppableThread(threading.Thread):
                 # Handle tornado server
                 try:
                     bokeh_server.stop()
+                except Exception:
+                    pass
+            if self._owns_loop and self.asyncio_loop and not self.asyncio_loop.is_closed():
+                try:
+                    self.asyncio_loop.close()
                 except Exception:
                     pass
             if hasattr(self, '_target'):

--- a/panel/tests/test_server.py
+++ b/panel/tests/test_server.py
@@ -1123,6 +1123,28 @@ def test_server_ico_path_on_proxy(reverse_proxy):
     ico = requests.get(f"http://localhost:{proxy}/proxy/favicon.ico")
     assert ico.content == ico_path.read_bytes()
 
+
+def test_server_route_params_on_proxy(reverse_proxy, server_implementation):
+    route_params = []
+    app_urls = []
+
+    def app():
+        route_params.append(state.route_params)
+        app_urls.append(state.app_url)
+        return 'route'
+
+    port, proxy = reverse_proxy
+    serve_and_request(
+        {'/user/{name}': app},
+        port=port,
+        proxy=proxy,
+        suffix='/proxy/user/alice'
+    )
+
+    assert route_params == [{'name': 'alice'}]
+    assert app_urls == ['/user/alice']
+
+
 def test_server_template_custom_resources_with_prefix(port):
     template = CustomBootstrapTemplate()
 

--- a/panel/tests/test_server.py
+++ b/panel/tests/test_server.py
@@ -236,6 +236,13 @@ def test_server_extensions_on_root(server_implementation):
     assert serve_and_request(md).ok
 
 
+def test_server_extension_static_on_root(server_implementation):
+    md = Markdown('# Title')
+    r = serve_and_request(md, suffix='/static/extensions/panel/panel.min.js')
+    assert r.ok
+    assert 'Bokeh' in r.content.decode('utf-8')
+
+
 def test_autoload_js(port):
     html = Markdown('# Title')
     app_name = 'test'

--- a/panel/tests/test_server.py
+++ b/panel/tests/test_server.py
@@ -723,7 +723,6 @@ def test_server_dynamic_ws_endpoint_resolution(port, server_implementation):
         assert ws.status_code == 404
 
 
-@pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
 def test_server_dynamic_metadata_endpoint_resolution(port, server_implementation):
     if server_implementation == 'fastapi':
         pytest.skip("bokeh_fastapi does not expose a metadata endpoint.")
@@ -736,7 +735,6 @@ def test_server_dynamic_metadata_endpoint_resolution(port, server_implementation
     assert metadata.status_code == 200
 
 
-@pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
 def test_server_dynamic_static_file_route(port, server_implementation):
     if server_implementation == 'fastapi':
         pytest.skip("bokeh_fastapi does not expose per-app static endpoints.")
@@ -749,7 +747,6 @@ def test_server_dynamic_static_file_route(port, server_implementation):
     assert static.status_code == 404
 
 
-@pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
 def test_server_dynamic_routes_with_prefix_endpoint_access(port, server_implementation):
     def app():
         return 'route'

--- a/panel/tests/test_server.py
+++ b/panel/tests/test_server.py
@@ -16,6 +16,7 @@ from bokeh.events import ButtonClick
 
 from panel.config import config
 from panel.io import state
+from panel.io.application import Application
 from panel.io.resources import DIST_DIR, JS_VERSION
 from panel.io.server import (
     INDEX_HTML, _path_template_to_tornado_route, get_server, set_curdoc,
@@ -52,8 +53,11 @@ def test_get_server(html_server_session):
         ('/app', '/app'),
         ('/user/{name}', '/user/(?P<name>[^/]+)'),
         ('/files/{filepath:path}', '/files/(?P<filepath>.*)'),
-        ('/measure/{value:int}', '/measure/(?P<value>[0-9]+)'),
-        ('/measure/{value:float}', '/measure/(?P<value>[0-9]+(?:\\.[0-9]+)?)'),
+        ('/measure/{value:int}', '/measure/(?P<value>[+-]?[0-9]+)'),
+        (
+            '/measure/{value:float}',
+            '/measure/(?P<value>[+-]?(?:[0-9]+(?:\\.[0-9]*)?|\\.[0-9]+)(?:[eE][+-]?[0-9]+)?)'
+        ),
         (
             '/run/{uid:uuid}',
             '/run/(?P<uid>[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})'
@@ -681,6 +685,123 @@ def test_server_route_params_path_converter_path(port, server_implementation):
 
     assert route_params == [{'filepath': 'a/b/c.txt'}]
     assert app_urls == ['/files/a/b/c.txt']
+
+
+def test_server_route_params_autoload_js(port, server_implementation):
+    if server_implementation == 'fastapi':
+        pytest.skip("bokeh_fastapi does not expose an autoload.js endpoint.")
+    route_params = []
+    app_urls = []
+
+    def app():
+        route_params.append(state.route_params)
+        app_urls.append(state.app_url)
+        return 'route'
+
+    serve_and_wait({'/user/{name}': app}, port=port)
+    args = (
+        "bokeh-autoload-element=1002"
+        "&bokeh-app-path=/user/alice"
+        f"&bokeh-absolute-url=http://localhost:{port}/user/alice"
+    )
+    r = requests.get(f"http://localhost:{port}/user/alice/autoload.js?{args}")
+    assert r.status_code == 200
+    wait_until(lambda: route_params == [{'name': 'alice'}])
+    assert app_urls == ['/user/alice']
+
+
+def test_server_dynamic_ws_endpoint_resolution(port, server_implementation):
+    def app():
+        return 'route'
+
+    serve_and_wait({'/user/{name}': app}, port=port)
+    ws = requests.get(f"http://localhost:{port}/user/alice/ws")
+    if server_implementation == 'tornado':
+        assert ws.status_code == 400
+    else:
+        # FastAPI exposes websocket routes that are not accessible via HTTP GET.
+        assert ws.status_code == 404
+
+
+@pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
+def test_server_dynamic_metadata_endpoint_resolution(port, server_implementation):
+    if server_implementation == 'fastapi':
+        pytest.skip("bokeh_fastapi does not expose a metadata endpoint.")
+
+    def app():
+        return 'route'
+
+    serve_and_wait({'/user/{name}': app}, port=port)
+    metadata = requests.get(f"http://localhost:{port}/user/alice/metadata")
+    assert metadata.status_code == 200
+
+
+@pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
+def test_server_dynamic_static_file_route(port, server_implementation):
+    if server_implementation == 'fastapi':
+        pytest.skip("bokeh_fastapi does not expose per-app static endpoints.")
+
+    def app():
+        return 'route'
+
+    serve_and_wait({'/user/{name}': app}, port=port)
+    static = requests.get(f"http://localhost:{port}/user/alice/static/does-not-exist.css")
+    assert static.status_code == 404
+
+
+@pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
+def test_server_dynamic_routes_with_prefix_endpoint_access(port, server_implementation):
+    def app():
+        return 'route'
+
+    serve_and_wait({'/user/{name}': app}, port=port, prefix='/prefix')
+    app_page = requests.get(f"http://localhost:{port}/prefix/user/alice")
+    assert app_page.status_code == 200
+    duplicate_prefix = requests.get(f"http://localhost:{port}/prefix/prefix/user/alice")
+    assert duplicate_prefix.status_code == 404
+
+    if server_implementation == 'tornado':
+        metadata = requests.get(f"http://localhost:{port}/prefix/user/alice/metadata")
+        assert metadata.status_code == 200
+
+
+def test_fastapi_prefixed_route_registration_no_double_prefix():
+    fastapi = pytest.importorskip("fastapi")
+    from panel.io.fastapi import add_applications
+
+    app = fastapi.FastAPI()
+
+    def panel_app():
+        return 'route'
+
+    application = add_applications({'/user/{name}': panel_app}, app=app, prefix='/prefix')
+    paths = {route.path for route in application.app.router.routes if hasattr(route, "path")}
+    assert '/prefix/user/{name}' in paths
+    assert '/prefix/user/{name}/ws' in paths
+    assert '/prefix/prefix/user/{name}' not in paths
+    assert '/prefix/user/{name}/metadata' not in paths
+    assert '/prefix/user/{name}/autoload.js' not in paths
+
+
+def test_fastapi_synthetic_request_preserves_cookies(monkeypatch, port):
+    seen_cookie_values = []
+    original_process_request = Application.process_request
+
+    def wrapped_process_request(self, request):
+        user_cookie = request.cookies.get('user')
+        seen_cookie_values.append(None if user_cookie is None else user_cookie.value)
+        return original_process_request(self, request)
+
+    monkeypatch.setattr(Application, 'process_request', wrapped_process_request)
+
+    def app():
+        return 'route'
+
+    serve_and_wait({'/user/{name}': app}, port=port)
+    response = requests.get(f"http://localhost:{port}/user/alice", cookies={'user': 'alice'})
+    assert response.status_code == 200
+    wait_until(lambda: len(seen_cookie_values) > 0)
+    assert seen_cookie_values[-1] == 'alice'
 
 
 @pytest.mark.parametrize(

--- a/panel/tests/test_server.py
+++ b/panel/tests/test_server.py
@@ -171,8 +171,6 @@ def test_server_root_handler_does_not_redirect_wildcard(port, route):
 def test_root_handler_concrete_route_detection():
     assert RootHandler._is_concrete_route('/app')
     assert RootHandler._is_concrete_route('/a/b/c/app')
-    assert RootHandler._is_concrete_route(r'/literal/\(name\)')
-    assert RootHandler._is_concrete_route(r'/a/b/\(literal\)/c')
     assert not RootHandler._is_concrete_route('/user/([^/]+)')
     assert not RootHandler._is_concrete_route('/a/b/([^/]+)/c')
     assert not RootHandler._is_concrete_route('/user/{name}')

--- a/panel/tests/test_server.py
+++ b/panel/tests/test_server.py
@@ -19,7 +19,8 @@ from panel.io import state
 from panel.io.application import Application
 from panel.io.resources import DIST_DIR, JS_VERSION
 from panel.io.server import (
-    INDEX_HTML, RootHandler, _path_template_to_tornado_route, get_server,
+    _MAX_APP_PATH_CHARS, _MAX_ROUTE_PARAM_VALUE_CHARS, INDEX_HTML, RootHandler,
+    _normalize_app_path, _path_template_to_tornado_route, get_server,
     set_curdoc,
 )
 from panel.layout import Row
@@ -84,6 +85,33 @@ def test_path_template_to_tornado_route_mapping(route, expected):
 def test_path_template_to_tornado_route_invalid_templates(route):
     with pytest.raises(ValueError, match='Invalid path template segment'):
         _path_template_to_tornado_route(route)
+
+
+def test_normalize_app_path_prefix_boundary():
+    assert _normalize_app_path('/pre/user/alice', '/pre') == '/user/alice'
+    assert _normalize_app_path('/prefix/user/alice', '/pre') == '/prefix/user/alice'
+    assert _normalize_app_path('/pre/user/alice/ws', '/pre', suffix='/ws') == '/user/alice'
+
+
+def test_fastapi_route_context_prefix_boundary():
+    fastapi = pytest.importorskip("fastapi")
+    from panel.io.fastapi import _route_context
+
+    request = fastapi.Request({
+        'type': 'http',
+        'method': 'GET',
+        'scheme': 'http',
+        'path': '/prefix/user/alice',
+        'query_string': b'',
+        'headers': [],
+        'client': ('127.0.0.1', 5000),
+        'server': ('127.0.0.1', 8000),
+        'path_params': {'name': 'alice'},
+    })
+    route_params, app_path = _route_context(request, prefix='/pre')
+    assert route_params == {'name': 'alice'}
+    assert app_path == '/prefix/user/alice'
+
 
 @pytest.mark.xdist_group(name="server")
 def test_server_update(html_server_session):
@@ -736,6 +764,23 @@ def test_server_route_params_path_converter_path(port, server_implementation):
 
     assert route_params == [{'filepath': 'a/b/c.txt'}]
     assert app_urls == ['/files/a/b/c.txt']
+
+
+def test_server_route_context_size_is_capped(port, server_implementation):
+    route_params = []
+    app_urls = []
+
+    def app():
+        route_params.append(state.route_params)
+        app_urls.append(state.app_url)
+        return 'route'
+
+    overlong = 'a' * (_MAX_ROUTE_PARAM_VALUE_CHARS + 300)
+    serve_and_wait({'/files/{filepath:path}': app}, port=port)
+    requests.get(f"http://localhost:{port}/files/{overlong}")
+
+    assert route_params == [{'filepath': overlong[:_MAX_ROUTE_PARAM_VALUE_CHARS]}]
+    assert app_urls == [f"/files/{overlong}"[:_MAX_APP_PATH_CHARS]]
 
 
 def test_server_route_params_autoload_js(port, server_implementation):

--- a/panel/tests/test_server.py
+++ b/panel/tests/test_server.py
@@ -19,7 +19,8 @@ from panel.io import state
 from panel.io.application import Application
 from panel.io.resources import DIST_DIR, JS_VERSION
 from panel.io.server import (
-    INDEX_HTML, _path_template_to_tornado_route, get_server, set_curdoc,
+    INDEX_HTML, RootHandler, _path_template_to_tornado_route, get_server,
+    set_curdoc,
 )
 from panel.layout import Row
 from panel.models import HTML as BkHTML
@@ -147,16 +148,36 @@ def test_server_root_handler():
 
     assert 'href="./app"' in r.content.decode('utf-8')
 
-def test_server_root_handler_does_not_redirect_wildcard(port):
+@pytest.mark.parametrize(
+    'route',
+    [
+        '/user/([^/]+)',
+        '/org/([^/]+)/user/([^/]+)',
+        '/api/v1/projects/([^/]+)/runs/([^/]+)',
+    ],
+)
+def test_server_root_handler_does_not_redirect_wildcard(port, route):
     html = Markdown('# Title')
 
     r = serve_and_request(
-        {'/user/([^/]+)': html}, port=port, use_index=True, index=INDEX_HTML, suffix='/'
+        {route: html}, port=port, use_index=True, index=INDEX_HTML, suffix='/'
     )
 
     assert not r.history
     assert r.status_code == 200
-    assert 'href="./user/([^/]+)"' in r.content.decode('utf-8')
+    assert f'href=".{route}"' in r.content.decode('utf-8')
+
+
+def test_root_handler_concrete_route_detection():
+    assert RootHandler._is_concrete_route('/app')
+    assert RootHandler._is_concrete_route('/a/b/c/app')
+    assert RootHandler._is_concrete_route(r'/literal/\(name\)')
+    assert RootHandler._is_concrete_route(r'/a/b/\(literal\)/c')
+    assert not RootHandler._is_concrete_route('/user/([^/]+)')
+    assert not RootHandler._is_concrete_route('/a/b/([^/]+)/c')
+    assert not RootHandler._is_concrete_route('/user/{name}')
+    assert not RootHandler._is_concrete_route('/a/b/{name}/c')
+
 
 @pytest.mark.parametrize('path', ["/app", "/nested/app"])
 def test_server_ico_handling(path, port):
@@ -654,7 +675,39 @@ def test_server_route_params(port, server_implementation):
     assert app_urls == ['/user/alice', '/user/bob']
 
 
-def test_server_route_params_path_templates(port, server_implementation):
+@pytest.mark.parametrize(
+    ('route', 'requests_and_expected'),
+    [
+        (
+            '/user/{name}',
+            [
+                ('/user/alice', {'name': 'alice'}),
+                ('/user/bob', {'name': 'bob'}),
+            ],
+        ),
+        (
+            '/org/{org}/team/{team}/user/{name}',
+            [
+                ('/org/acme/team/eng/user/alice', {'org': 'acme', 'team': 'eng', 'name': 'alice'}),
+                ('/org/holoviz/team/viz/user/bob', {'org': 'holoviz', 'team': 'viz', 'name': 'bob'}),
+            ],
+        ),
+        (
+            '/v1/projects/{project}/runs/{run}/artifacts/{artifact}',
+            [
+                (
+                    '/v1/projects/panel/runs/123/artifacts/report',
+                    {'project': 'panel', 'run': '123', 'artifact': 'report'}
+                ),
+                (
+                    '/v1/projects/hvplot/runs/456/artifacts/metrics',
+                    {'project': 'hvplot', 'run': '456', 'artifact': 'metrics'}
+                ),
+            ],
+        ),
+    ],
+)
+def test_server_route_params_path_templates(port, server_implementation, route, requests_and_expected):
     route_params = []
     app_urls = []
 
@@ -663,12 +716,12 @@ def test_server_route_params_path_templates(port, server_implementation):
         app_urls.append(state.app_url)
         return 'route'
 
-    serve_and_wait({'/user/{name}': app}, port=port)
-    requests.get(f"http://localhost:{port}/user/alice")
-    requests.get(f"http://localhost:{port}/user/bob")
+    serve_and_wait({route: app}, port=port)
+    for suffix, _expected in requests_and_expected:
+        requests.get(f"http://localhost:{port}{suffix}")
 
-    assert route_params == [{'name': 'alice'}, {'name': 'bob'}]
-    assert app_urls == ['/user/alice', '/user/bob']
+    assert route_params == [expected for _, expected in requests_and_expected]
+    assert app_urls == [suffix for suffix, _ in requests_and_expected]
 
 
 def test_server_route_params_path_converter_path(port, server_implementation):
@@ -806,6 +859,16 @@ def test_fastapi_synthetic_request_preserves_cookies(monkeypatch, port):
     [
         ('/user/{name}', '/user/alice', '/user/alice'),
         ('/nested/app/{name}', '/nested/app/alice', '/nested/app/alice'),
+        (
+            '/org/{org}/team/{team}/user/{name}',
+            '/org/acme/team/eng/user/alice',
+            '/org/acme/team/eng/user/alice'
+        ),
+        (
+            '/v1/projects/{project}/runs/{run}/artifacts/{artifact}',
+            '/v1/projects/panel/runs/123/artifacts/report',
+            '/v1/projects/panel/runs/123/artifacts/report'
+        ),
     ]
 )
 def test_server_app_url_context(port, server_implementation, route, suffix, expected_app_url):
@@ -821,17 +884,33 @@ def test_server_app_url_context(port, server_implementation, route, suffix, expe
     assert app_urls == [expected_app_url]
 
 
-def test_server_app_url_context_with_prefix(port, server_implementation):
+@pytest.mark.parametrize(
+    ('route', 'suffix', 'expected_app_url'),
+    [
+        ('/nested/app/{name}', '/prefix/nested/app/alice', '/prefix/nested/app/alice'),
+        (
+            '/org/{org}/team/{team}/user/{name}',
+            '/prefix/org/acme/team/eng/user/alice',
+            '/prefix/org/acme/team/eng/user/alice'
+        ),
+        (
+            '/v1/projects/{project}/runs/{run}/artifacts/{artifact}',
+            '/prefix/v1/projects/panel/runs/123/artifacts/report',
+            '/prefix/v1/projects/panel/runs/123/artifacts/report'
+        ),
+    ],
+)
+def test_server_app_url_context_with_prefix(port, server_implementation, route, suffix, expected_app_url):
     app_urls = []
 
     def app():
         app_urls.append(state.app_url)
         return 'route'
 
-    serve_and_wait({'/nested/app/{name}': app}, port=port, prefix='/prefix')
-    requests.get(f"http://localhost:{port}/prefix/nested/app/alice")
+    serve_and_wait({route: app}, port=port, prefix='/prefix')
+    requests.get(f"http://localhost:{port}{suffix}")
 
-    assert app_urls == ['/prefix/nested/app/alice']
+    assert app_urls == [expected_app_url]
 
 
 @pytest.mark.parametrize(
@@ -839,6 +918,16 @@ def test_server_app_url_context_with_prefix(port, server_implementation):
     [
         ('/user/{name}', '/proxy/user/alice', '/user/alice'),
         ('/nested/app/{name}', '/proxy/nested/app/alice', '/nested/app/alice'),
+        (
+            '/org/{org}/team/{team}/user/{name}',
+            '/proxy/org/acme/team/eng/user/alice',
+            '/org/acme/team/eng/user/alice'
+        ),
+        (
+            '/v1/projects/{project}/runs/{run}/artifacts/{artifact}',
+            '/proxy/v1/projects/panel/runs/123/artifacts/report',
+            '/v1/projects/panel/runs/123/artifacts/report'
+        ),
     ]
 )
 def test_server_app_url_context_on_proxy(
@@ -857,7 +946,29 @@ def test_server_app_url_context_on_proxy(
     assert app_urls == [expected_app_url]
 
 
-def test_server_app_url_context_on_proxy_with_prefix(reverse_proxy, server_implementation):
+@pytest.mark.parametrize(
+    ('route', 'suffix', 'expected_app_url'),
+    [
+        (
+            '/nested/app/{name}',
+            '/proxy/prefix/nested/app/alice',
+            '/prefix/nested/app/alice'
+        ),
+        (
+            '/org/{org}/team/{team}/user/{name}',
+            '/proxy/prefix/org/acme/team/eng/user/alice',
+            '/prefix/org/acme/team/eng/user/alice'
+        ),
+        (
+            '/v1/projects/{project}/runs/{run}/artifacts/{artifact}',
+            '/proxy/prefix/v1/projects/panel/runs/123/artifacts/report',
+            '/prefix/v1/projects/panel/runs/123/artifacts/report'
+        ),
+    ],
+)
+def test_server_app_url_context_on_proxy_with_prefix(
+    reverse_proxy, server_implementation, route, suffix, expected_app_url
+):
     app_urls = []
 
     def app():
@@ -865,10 +976,10 @@ def test_server_app_url_context_on_proxy_with_prefix(reverse_proxy, server_imple
         return 'route'
 
     port, proxy = reverse_proxy
-    serve_and_wait({'/nested/app/{name}': app}, port=port, proxy=proxy, prefix='/prefix')
-    requests.get(f"http://localhost:{proxy}/proxy/prefix/nested/app/alice")
+    serve_and_wait({route: app}, port=port, proxy=proxy, prefix='/prefix')
+    requests.get(f"http://localhost:{proxy}{suffix}")
 
-    assert app_urls == ['/prefix/nested/app/alice']
+    assert app_urls == [expected_app_url]
 
 
 @pytest.mark.xdist_group(name="server")

--- a/panel/tests/test_server.py
+++ b/panel/tests/test_server.py
@@ -683,6 +683,76 @@ def test_server_route_params_path_converter_path(port, server_implementation):
     assert app_urls == ['/files/a/b/c.txt']
 
 
+@pytest.mark.parametrize(
+    ('route', 'suffix', 'expected_app_url'),
+    [
+        ('/user/{name}', '/user/alice', '/user/alice'),
+        ('/nested/app/{name}', '/nested/app/alice', '/nested/app/alice'),
+    ]
+)
+def test_server_app_url_context(port, server_implementation, route, suffix, expected_app_url):
+    app_urls = []
+
+    def app():
+        app_urls.append(state.app_url)
+        return 'route'
+
+    serve_and_wait({route: app}, port=port)
+    requests.get(f"http://localhost:{port}{suffix}")
+
+    assert app_urls == [expected_app_url]
+
+
+def test_server_app_url_context_with_prefix(port, server_implementation):
+    app_urls = []
+
+    def app():
+        app_urls.append(state.app_url)
+        return 'route'
+
+    serve_and_wait({'/nested/app/{name}': app}, port=port, prefix='/prefix')
+    requests.get(f"http://localhost:{port}/prefix/nested/app/alice")
+
+    assert app_urls == ['/prefix/nested/app/alice']
+
+
+@pytest.mark.parametrize(
+    ('route', 'suffix', 'expected_app_url'),
+    [
+        ('/user/{name}', '/proxy/user/alice', '/user/alice'),
+        ('/nested/app/{name}', '/proxy/nested/app/alice', '/nested/app/alice'),
+    ]
+)
+def test_server_app_url_context_on_proxy(
+    reverse_proxy, server_implementation, route, suffix, expected_app_url
+):
+    app_urls = []
+
+    def app():
+        app_urls.append(state.app_url)
+        return 'route'
+
+    port, proxy = reverse_proxy
+    serve_and_wait({route: app}, port=port, proxy=proxy)
+    requests.get(f"http://localhost:{proxy}{suffix}")
+
+    assert app_urls == [expected_app_url]
+
+
+def test_server_app_url_context_on_proxy_with_prefix(reverse_proxy, server_implementation):
+    app_urls = []
+
+    def app():
+        app_urls.append(state.app_url)
+        return 'route'
+
+    port, proxy = reverse_proxy
+    serve_and_wait({'/nested/app/{name}': app}, port=port, proxy=proxy, prefix='/prefix')
+    requests.get(f"http://localhost:{proxy}/proxy/prefix/nested/app/alice")
+
+    assert app_urls == ['/prefix/nested/app/alice']
+
+
 @pytest.mark.xdist_group(name="server")
 def test_server_reuse_sessions_with_session_key_func(port, reuse_sessions):
     config.session_key_func = lambda r: (r.path, r.arguments.get('arg', [''])[0])

--- a/panel/tests/test_server.py
+++ b/panel/tests/test_server.py
@@ -17,7 +17,9 @@ from bokeh.events import ButtonClick
 from panel.config import config
 from panel.io import state
 from panel.io.resources import DIST_DIR, JS_VERSION
-from panel.io.server import INDEX_HTML, get_server, set_curdoc
+from panel.io.server import (
+    INDEX_HTML, _path_template_to_tornado_route, get_server, set_curdoc,
+)
 from panel.layout import Row
 from panel.models import HTML as BkHTML
 from panel.models.tabulator import TableEditEvent
@@ -41,6 +43,42 @@ def test_get_server(html_server_session):
     root = session.document.roots[0]
     assert isinstance(root, BkHTML)
     assert root.text == '&lt;h1&gt;Title&lt;/h1&gt;'
+
+
+@pytest.mark.parametrize(
+    ('route', 'expected'),
+    [
+        ('/', '/'),
+        ('/app', '/app'),
+        ('/user/{name}', '/user/(?P<name>[^/]+)'),
+        ('/files/{filepath:path}', '/files/(?P<filepath>.*)'),
+        ('/measure/{value:int}', '/measure/(?P<value>[0-9]+)'),
+        ('/measure/{value:float}', '/measure/(?P<value>[0-9]+(?:\\.[0-9]+)?)'),
+        (
+            '/run/{uid:uuid}',
+            '/run/(?P<uid>[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})'
+        ),
+        ('/assets.v1/{name}', '/assets\\.v1/(?P<name>[^/]+)'),
+        ('/user/([^/]+)', '/user/([^/]+)'),
+    ]
+)
+def test_path_template_to_tornado_route_mapping(route, expected):
+    assert _path_template_to_tornado_route(route) == expected
+
+
+@pytest.mark.parametrize(
+    'route',
+    [
+        '/user/{name',
+        '/user/name}',
+        '/user/{name:bad}',
+        '/user/prefix-{name}',
+        '/user/{name}-suffix',
+    ]
+)
+def test_path_template_to_tornado_route_invalid_templates(route):
+    with pytest.raises(ValueError, match='Invalid path template segment'):
+        _path_template_to_tornado_route(route)
 
 @pytest.mark.xdist_group(name="server")
 def test_server_update(html_server_session):

--- a/panel/tests/test_server.py
+++ b/panel/tests/test_server.py
@@ -105,6 +105,17 @@ def test_server_root_handler():
 
     assert 'href="./app"' in r.content.decode('utf-8')
 
+def test_server_root_handler_does_not_redirect_wildcard(port):
+    html = Markdown('# Title')
+
+    r = serve_and_request(
+        {'/user/([^/]+)': html}, port=port, use_index=True, index=INDEX_HTML, suffix='/'
+    )
+
+    assert not r.history
+    assert r.status_code == 200
+    assert 'href="./user/([^/]+)"' in r.content.decode('utf-8')
+
 @pytest.mark.parametrize('path', ["/app", "/nested/app"])
 def test_server_ico_handling(path, port):
     md = Markdown('# Favicon test')
@@ -571,6 +582,61 @@ def test_server_session_args(port, server_implementation):
     requests.get(f"http://localhost:{port}/?arg=bar")
 
     assert session_args == ["foo", "bar"]
+
+
+def test_server_route_params(port, server_implementation):
+    route_params = []
+    app_urls = []
+
+    def app():
+        route_params.append(state.route_params)
+        app_urls.append(state.app_url)
+        return 'route'
+
+    route = '/user/{name}' if server_implementation == 'fastapi' else '/user/([^/]+)'
+    serve_and_wait({route: app}, port=port)
+    requests.get(f"http://localhost:{port}/user/alice")
+    requests.get(f"http://localhost:{port}/user/bob")
+
+    if server_implementation == 'fastapi':
+        assert route_params == [{'name': 'alice'}, {'name': 'bob'}]
+    else:
+        assert route_params == [{'0': 'alice'}, {'0': 'bob'}]
+    assert app_urls == ['/user/alice', '/user/bob']
+
+
+def test_server_route_params_path_templates(port, server_implementation):
+    route_params = []
+    app_urls = []
+
+    def app():
+        route_params.append(state.route_params)
+        app_urls.append(state.app_url)
+        return 'route'
+
+    serve_and_wait({'/user/{name}': app}, port=port)
+    requests.get(f"http://localhost:{port}/user/alice")
+    requests.get(f"http://localhost:{port}/user/bob")
+
+    assert route_params == [{'name': 'alice'}, {'name': 'bob'}]
+    assert app_urls == ['/user/alice', '/user/bob']
+
+
+def test_server_route_params_path_converter_path(port, server_implementation):
+    route_params = []
+    app_urls = []
+
+    def app():
+        route_params.append(state.route_params)
+        app_urls.append(state.app_url)
+        return 'route'
+
+    serve_and_wait({'/files/{filepath:path}': app}, port=port)
+    requests.get(f"http://localhost:{port}/files/a/b/c.txt")
+
+    assert route_params == [{'filepath': 'a/b/c.txt'}]
+    assert app_urls == ['/files/a/b/c.txt']
+
 
 @pytest.mark.xdist_group(name="server")
 def test_server_reuse_sessions_with_session_key_func(port, reuse_sessions):


### PR DESCRIPTION
## Description

This PR adds first-class dynamic route support across both server implementations and makes route context available inside apps in a backend-consistent way.

Users can now serve apps on dynamic routes and reliably read:

- `pn.state.route_params` for captured path variables
- `pn.state.app_url` as the concrete matched app path for the current session (not new)

It also improves route matching behavior for wildcard routes, ensures websocket/session flows preserve route context, and updates docs to present path-template syntax as the primary recommended style.

### Supported route syntax

- **Path-template syntax (recommended, cross-backend):**
  - `/user/{name}`
  - `/files/{filepath:path}`

- **Regex syntax (Tornado):**
  - `/user/([^/]+)`
  - `/org/(?P<org>[^/]+)/user/(?P<user>[^/]+)`

For Tornado, path templates are normalized to Tornado-compatible patterns.  
For FastAPI, path templates are passed through naturally and now preserve route metadata in session state.

### Behavior improvements included

- Wildcard/dynamic routes no longer interfere with core app endpoints (`/ws`, `/metadata`, `/autoload.js`).
- Root index no longer auto-redirects to an invalid wildcard-only route.
- Session creation and websocket-first flows both carry route metadata so app state is consistent regardless of connection path.
- Server docs now include a dedicated wildcard routes how-to and backend compatibility guidance.

### Examples

#### Tornado
```python
import panel as pn
pn.extension()

def app():
    return {
        "route_params": pn.state.route_params,
        "app_url": pn.state.app_url,
    }

pn.serve({"/user/{name}": app}, show=False)
# /user/alice -> {"route_params": {"name": "alice"}, "app_url": "/user/alice"}
```

#### FastAPI
```python
import panel as pn
from panel.io.fastapi import serve
pn.extension()

def app():
    return {
        "route_params": pn.state.route_params,
        "app_url": pn.state.app_url,
    }

serve({"/files/{filepath:path}": app}, show=False)
# /files/a/b/c.txt -> {"route_params": {"filepath": "a/b/c.txt"}, "app_url": "/files/a/b/c.txt"}
```

## AI Disclosure

- Tool & Model: Cursor + Codex 5.3 / GPT 5.5
- Usage: Used to investigate routing internals, implement dynamic route support across Tornado/FastAPI, add tests, and update documentation.

- [x] I have tested all AI-generated content in my PR.
- [x] I take responsibility for all AI-generated content in my PR.

## Checklist

- [x] Tests added and are passing
- [x] Added documentation