### PR TITLE
Fix rendering of HTML in error template

### DIFF
--- a/panel/_templates/error.html
+++ b/panel/_templates/error.html
@@ -83,7 +83,7 @@
     <div class="content">
       <section class="error-message">
       {% block content %}
-      <h3>{{ error_msg|escape }}</h3>
+      <h3>{{ error_msg }}</h3>
       {% if oauth_logout_link %}
       <a href="{{ oauth_logout_link }}">Logout</a>
       {% endif %}

--- a/panel/auth.py
+++ b/panel/auth.py
@@ -29,7 +29,7 @@ from .io.resources import (
     BASIC_LOGIN_TEMPLATE, CDN_DIST, ERROR_TEMPLATE, LOGOUT_TEMPLATE, _env,
 )
 from .io.state import state
-from .util import base64url_encode, decode_token
+from .util import HTML_SANITIZER, base64url_encode, decode_token
 
 log = logging.getLogger(__name__)
 
@@ -505,7 +505,7 @@ class OAuthLoginHandler(tornado.web.RequestHandler, OAuth2Mixin):
             title='Panel: Authentication Error',
             error_type='Authentication Error',
             error=error,
-            error_msg=error_msg,
+            error_msg=HTML_SANITIZER.clean(error_msg),
             oauth_logout_link=self._OAUTH_LOGOUT_URL,
         ))
 

--- a/panel/io/jupyter_server_extension.py
+++ b/panel/io/jupyter_server_extension.py
@@ -55,6 +55,7 @@ from tornado.ioloop import PeriodicCallback
 from tornado.web import StaticFileHandler
 
 from ..config import config
+from ..util import HTML_SANITIZER
 from .resources import DIST_DIR, ERROR_TEMPLATE, _env
 from .server import COMPONENT_PATH, ComponentResourceHandler
 from .state import state
@@ -304,7 +305,7 @@ class PanelJupyterHandler(PanelBaseHandler):
                 base_url=f'{root_url}/',
                 error_type="Kernel Error",
                 error="Failed to start application",
-                error_msg=str(e),
+                error_msg=HTML_SANITIZER.clean(str(e)),
                 title="Panel: Kernel Error"
             )
             self.finish(html)

--- a/panel/io/server.py
+++ b/panel/io/server.py
@@ -54,7 +54,7 @@ from tornado.wsgi import WSGIContainer
 
 # Internal imports
 from ..config import config
-from ..util import edit_readonly, fullpath
+from ..util import HTML_SANITIZER, edit_readonly, fullpath
 from ..util.warnings import warn
 from .application import build_applications
 from .document import (  # noqa
@@ -474,7 +474,7 @@ class DocHandler(LoginUrlMixin, BkDocHandler):
             title='Panel: Authorization Error',
             error_type='Authorization Error',
             error='User is not authorized.',
-            error_msg=auth_error
+            error_msg=HTML_SANITIZER.clean(auth_error)
         )
 
     @authenticated


### PR DESCRIPTION
The rendering of HTML in error templates was broken due to the escaping. Instead of escaping we now apply the `nh3` HTML sanitizer to avoid security issues via injection.