### PR TITLE
Add links to related API docs and include pn.rx in Functions vs. Classes doc

### DIFF
--- a/doc/explanation/api/functions_vs_classes.md
+++ b/doc/explanation/api/functions_vs_classes.md
@@ -1,6 +1,6 @@
 ## Classes vs functions in Panel: understanding the tradeoff
 
-In Panel, there are two main ways to structure reactive code: binding functions with `pn.bind` (the reactive API), or building classes that extend `param.Parameterized` or `pn.viewable.Viewer` (the declarative API). Both are valid, and the right choice depends on what you're building.
+In Panel, there are two main ways to structure reactive code: binding functions with `pn.bind` and `pn.rx`(the [reactive API](../../explanation/api/reactive.md)), or building classes that extend `param.Parameterized` or `pn.viewable.Viewer` (the [declarative API](../../explanation/api/parameterized.md)). Both approacheas are valid, and the right choice depends on what you're building.
 
 ### Why functions feel natural at first
 
@@ -16,7 +16,7 @@ Consider a dashboard that filters a dataset by year range and manufacturer. With
 
 ### What classes give you: a single source of truth
 
-The class-based approach solves this by giving state a home. Instead of free-floating widget variables, you create a dedicated object whose job is to hold the current selection as `param.Parameter` attributes. Any part of the app that needs to know what the user has selected asks that object directly.
+The class-based approach solves this by utlizing the declarative API (of Panel/param(?)), giving state a home. Instead of free-floating widget variables, you create a dedicated object whose job is to hold the current selection as `param.Parameter` attributes. Any part of the app that needs to know what the user has selected asks that object directly.
 
 Other objects can declare, using `@param.depends`, that they should recompute when those parameters change. The logic for what to do when state changes lives in one place, not spread across multiple `pn.bind` calls. Any number of views can all reference the same state-holding object, and when something changes they update automatically — without any view needing to know anything about the widgets that caused the change.
 

--- a/doc/explanation/api/functions_vs_classes.md
+++ b/doc/explanation/api/functions_vs_classes.md
@@ -16,7 +16,7 @@ Consider a dashboard that filters a dataset by year range and manufacturer. With
 
 ### What classes give you: a single source of truth
 
-The class-based approach solves this by utilizing the declarative API (of Panel/param(?)), giving state a home. Instead of free-floating widget variables, you create a dedicated object whose job is to hold the current selection as `param.Parameter` attributes. Any part of the app that needs to know what the user has selected asks that object directly.
+The class-based approach solves this by declaratively expressing state as parameters, giving state a home. Instead of free-floating widget variables, you create a dedicated object whose job is to hold the current selection as `param.Parameter` attributes. Any part of the app that needs to know what the user has selected asks that object directly.
 
 Other objects can declare, using `@param.depends`, that they should recompute when those parameters change. The logic for what to do when state changes lives in one place, not spread across multiple `pn.bind` calls. Any number of views can all reference the same state-holding object, and when something changes they update automatically — without any view needing to know anything about the widgets that caused the change.
 

--- a/doc/explanation/api/functions_vs_classes.md
+++ b/doc/explanation/api/functions_vs_classes.md
@@ -16,7 +16,7 @@ Consider a dashboard that filters a dataset by year range and manufacturer. With
 
 ### What classes give you: a single source of truth
 
-The class-based approach solves this by utlizing the declarative API (of Panel/param(?)), giving state a home. Instead of free-floating widget variables, you create a dedicated object whose job is to hold the current selection as `param.Parameter` attributes. Any part of the app that needs to know what the user has selected asks that object directly.
+The class-based approach solves this by utilizing the declarative API (of Panel/param(?)), giving state a home. Instead of free-floating widget variables, you create a dedicated object whose job is to hold the current selection as `param.Parameter` attributes. Any part of the app that needs to know what the user has selected asks that object directly.
 
 Other objects can declare, using `@param.depends`, that they should recompute when those parameters change. The logic for what to do when state changes lives in one place, not spread across multiple `pn.bind` calls. Any number of views can all reference the same state-holding object, and when something changes they update automatically — without any view needing to know anything about the widgets that caused the change.
 


### PR DESCRIPTION
First of all, great document @philippjfr ! Ties a lot of high level concepts together.

Updated the doc to include links to related API documents and added mention of pn.rx .

Not sure if pn.rx is mentioned in the right place in the updated doc, but it should definitely be included, for completeness, and to clarify where it sits in / relative to functions and classes.

Also, there seems to be some inconsistency / lack of clarity across (API explanation) documents.

It feels like concepts and terms like API, approach, reactive and declarative are sometimes used with different scope / intent / meaning across docs.

Makes it easy for new users to get things muddled, which contributes to the "beginner's hump" that users often experience.

Will try to raise a separate issue for this.