### PR TITLE
Fix from_param to respect user-provided name as label override

### DIFF
--- a/panel/param.py
+++ b/panel/param.py
@@ -534,6 +534,8 @@ class Param(Pane):
         # Update kwargs
         onkeyup = kw_widget.pop('onkeyup', False)
         throttled = kw_widget.pop('throttled', False)
+        if 'name' in kw_widget and 'label' not in kw_widget:
+            kw_widget['label'] = kw_widget.pop('name')
         kw.update(kw_widget)
         kwargs = {k: v for k, v in kw.items() if k in widget_class.param}
         non_param_kwargs = {k: v for k, v in kw_widget.items() if k not in widget_class.param}

--- a/panel/tests/widgets/test_base.py
+++ b/panel/tests/widgets/test_base.py
@@ -200,6 +200,26 @@ def test_widget_from_param_instance_with_kwargs():
     assert test.a == 4.3
 
 
+def test_widget_from_param_name_overrides_label():
+    class Test(param.Parameterized):
+
+        a = param.Number(default=3.14)
+
+    test = Test()
+    widget = FloatSlider.from_param(test.param.a, name='Custom Name')
+    assert widget.label == 'Custom Name'
+
+
+def test_widget_from_param_label_overrides_name():
+    class Test(param.Parameterized):
+
+        a = param.Number(default=3.14)
+
+    test = Test()
+    widget = FloatSlider.from_param(test.param.a, label='Custom Label')
+    assert widget.label == 'Custom Label'
+
+
 def test_infer_params_attribute_error():
     class MyComponent(param.Parameterized):
         name = param.String(default='World', doc="Name to greet")


### PR DESCRIPTION
When using `Widget.from_param` with `name` kwarg, the user-provided name was being ignored because the auto-detected label from the parameter took precedence. Now name is converted to label in `Param.widget` before merging kwargs, ensuring user overrides work correctly.


### AI Disclosure

- [x] Used Claude Code
- [x] Tested everything manually