### PR TITLE
Fix ESM component ready and has_finished compliance

### DIFF
--- a/panel/models/react_component.ts
+++ b/panel/models/react_component.ts
@@ -94,6 +94,7 @@ export class ReactComponentView extends ReactiveESMView {
   model_getter = model_getter
   model_setter = model_setter
   react_root: any = null
+  mounted: boolean = false
 
   _force_update_callbacks: (() => void)[] = []
   _scheduled_removals: DOMView[] = []
@@ -115,6 +116,7 @@ export class ReactComponentView extends ReactiveESMView {
     if (this.model.compiled === null || this.model.render_module === null) {
       return
     }
+    this._changing = true
     if (this.model.usesMui) {
       if (this.model.root_node) {
         this.style_cache = document.head
@@ -128,9 +130,10 @@ export class ReactComponentView extends ReactiveESMView {
       (this._lifecycle_handlers.get(lf) || []).splice(0)
     }
     this.model.disconnect_watchers(this)
-    this.model.render_module.then((mod: any) => {
+    const render_promise = this.model.render_module.then((mod: any) => {
       this.react_root = mod.default.render(this.model.id)
     })
+    this._await_ready(render_promise)
   }
 
   on_force_update(cb: () => void): void {
@@ -145,6 +148,7 @@ export class ReactComponentView extends ReactiveESMView {
 
   override remove(): void {
     this._force_update_callbacks = []
+    this.mounted = false
     if (this.react_root && this.use_shadow_dom) {
       super.remove()
       this.react_root.then((root: any) => root && root.unmount())
@@ -197,6 +201,7 @@ export class ReactComponentView extends ReactiveESMView {
       this.react_root.then((root: any) => root.unmount())
     }
     this._force_update_callbacks = []
+    this.mounted = false
     super.render()
   }
 
@@ -277,6 +282,17 @@ export class ReactComponentView extends ReactiveESMView {
 
   override _on_mounted(): void {
     this.invalidate_layout()
+    this.mounted = true
+  }
+
+  override has_finished(): boolean {
+    if (!super.has_finished()) {
+      return false
+    }
+    if (this._changing) {
+      return false
+    }
+    return true
   }
 
   patch_container(container: HTMLDivElement): void {
@@ -630,7 +646,6 @@ async function render(id) {
     return rendered
   }
   if (rendered) {
-    view._changing = true
     let container
     if (view.model.root_node) {
       container = document.querySelector(view.model.root_node)

--- a/panel/models/reactive_esm.ts
+++ b/panel/models/reactive_esm.ts
@@ -411,7 +411,8 @@ export class ReactiveESMView extends HTMLBoxView {
       (this._lifecycle_handlers.get(lf) || []).splice(0)
     }
     this.model.disconnect_watchers(this)
-    this.model.render_module.then((mod: any) => mod.default.render(this.model.id))
+    const render_promise = this.model.render_module.then((mod: any) => mod.default.render(this.model.id))
+    this._await_ready(render_promise)
   }
 
   render_children() {

--- a/panel/tests/ui/test_custom.py
+++ b/panel/tests/ui/test_custom.py
@@ -1325,3 +1325,245 @@ def test_esm_compile_shared(page, components):
 
     expect(page.locator(f'#{example[0].name}')).to_have_text('Rendered')
     expect(page.locator(f'#{example[1].name}')).to_have_text('Rendered')
+
+
+class JSReady(JSComponent):
+
+    _esm = """
+    export function render({ model, view }) {
+      const div = document.createElement('div')
+      div.id = 'ready-status'
+      div.textContent = 'waiting'
+      view.ready.then(() => { div.textContent = 'ready' })
+      return div
+    }
+    """
+
+class JSRootReady(JSComponent):
+
+    child = Child()
+
+    _esm = """
+    export function render({ model, view }) {
+      const div = document.createElement('div')
+      const status = document.createElement('div')
+      status.id = 'root-ready-status'
+      status.textContent = 'waiting'
+      view.root.ready.then(() => { status.textContent = 'ready' })
+      const child = model.get_child('child')
+      div.append(status, child)
+      return div
+    }
+    """
+
+
+class ReactReady(ReactComponent):
+
+    _esm = """
+    import {useEffect, useState} from "react"
+
+    export function render({ model, view }) {
+      const [status, setStatus] = useState("waiting")
+      useEffect(() => { view.ready.then(() => setStatus("ready")) }, [])
+      return <div id="ready-status">{status}</div>
+    }
+    """
+
+class ReactRootReady(ReactComponent):
+
+    child = Child()
+
+    _esm = """
+    import {useEffect, useState} from "react"
+
+    export function render({ model, view }) {
+      const [status, setStatus] = useState("waiting")
+      useEffect(() => { view.root.ready.then(() => setStatus("ready")) }, [])
+      return <div><div id="root-ready-status">{status}</div>{model.get_child('child')}</div>
+    }
+    """
+
+
+@pytest.mark.parametrize('component', [JSReady, ReactReady])
+def test_view_ready(page, component):
+    example = component()
+
+    serve_component(page, example)
+
+    expect(page.locator('#ready-status')).to_have_text('ready')
+
+
+@pytest.mark.parametrize('component', [JSRootReady, ReactRootReady])
+def test_view_root_ready_with_child(page, component):
+    example = component(child=Markdown('Hello'))
+
+    serve_component(page, example)
+
+    expect(page.locator('#root-ready-status')).to_have_text('ready')
+    expect(page.locator('.markdown')).to_have_count(1)
+
+
+class ReactReadyPartialChildren(ReactComponent):
+
+    items = Children()
+    active = param.Integer(default=0)
+
+    _esm = """
+    import {useEffect, useState} from "react"
+
+    export function render({ model, view }) {
+      const [status, setStatus] = useState("waiting")
+      const [active] = model.useState("active")
+      const children = model.get_child("items")
+      useEffect(() => { view.ready.then(() => setStatus("ready")) }, [])
+      return (
+        <div>
+          <div id="ready-status">{status}</div>
+          <div id="container">{children[active]}</div>
+        </div>
+      )
+    }
+    """
+
+
+class JSReadyPartialChildren(JSComponent):
+
+    items = Children()
+    active = param.Integer(default=0)
+
+    _esm = """
+    export function render({ model, view }) {
+      const div = document.createElement('div')
+      const status = document.createElement('div')
+      status.id = 'ready-status'
+      status.textContent = 'waiting'
+      view.ready.then(() => { status.textContent = 'ready' })
+      const container = document.createElement('div')
+      container.id = 'container'
+      const children = model.get_child('items')
+      if (children[model.active]) container.appendChild(children[model.active])
+      div.append(status, container)
+      return div
+    }
+    """
+
+
+@pytest.mark.parametrize('component', [JSReadyPartialChildren, ReactReadyPartialChildren])
+def test_view_ready_partial_children(page, component):
+    example = component(items=[Markdown('Tab 0'), Markdown('Tab 1'), Markdown('Tab 2')])
+
+    serve_component(page, example)
+
+    expect(page.locator('#ready-status')).to_have_text('ready')
+    expect(page.locator('#container')).to_have_text('Tab 0\n')
+
+
+class ReactReadyChildUpdate(ReactComponent):
+
+    child = Child()
+
+    _esm = """
+    import {useEffect, useState} from "react"
+
+    export function render({ model, view }) {
+      const [count, setCount] = useState(0)
+      useEffect(() => {
+        view.root.ready.then(() => setCount(c => c + 1))
+      }, [])
+      return (
+        <div>
+          <div id="ready-count">{count}</div>
+          {model.get_child('child')}
+        </div>
+      )
+    }
+    """
+
+
+class ReactChildInner(ReactComponent):
+
+    text = param.String(default="")
+
+    _esm = """
+    export function render({ model }) {
+      const [text] = model.useState("text")
+      return <div className="inner">{text}</div>
+    }
+    """
+
+
+def test_react_root_ready_after_child_update(page):
+    inner = ReactChildInner(text="first")
+    example = ReactReadyChildUpdate(child=inner)
+
+    serve_component(page, example)
+
+    expect(page.locator('#ready-count')).to_have_text('1')
+    expect(page.locator('.inner')).to_have_text('first')
+
+    example.child = ReactChildInner(text="second")
+
+    expect(page.locator('.inner')).to_have_text('second')
+
+    # After the child swap, re-check root.ready resolves
+    page.wait_for_function("""
+        () => {
+            const views = Object.values(Bokeh.index)
+            if (views.length === 0) return false
+            const root = views[0].root
+            let resolved = false
+            root.ready.then(() => { resolved = true })
+            return new Promise(r => setTimeout(() => r(resolved), 100))
+        }
+    """, timeout=10000)
+
+
+class ReactReadyChildrenAppend(ListLike, ReactComponent):
+
+    objects = Children()
+
+    _esm = """
+    import {useEffect, useState} from "react"
+
+    export function render({ model, view }) {
+      const [count, setCount] = useState(0)
+      useEffect(() => {
+        view.root.ready.then(() => setCount(c => c + 1))
+      }, [])
+      return (
+        <div>
+          <div id="ready-count">{count}</div>
+          <div id="container">{model.get_child("objects")}</div>
+        </div>
+      )
+    }
+    """
+
+
+def test_react_root_ready_after_children_append(page):
+    example = ReactReadyChildrenAppend(
+        objects=[ReactChildInner(text="child-0")]
+    )
+
+    serve_component(page, example)
+
+    expect(page.locator('#ready-count')).to_have_text('1')
+    expect(page.locator('.inner')).to_have_count(1)
+    expect(page.locator('.inner').first).to_have_text('child-0')
+
+    example.append(ReactChildInner(text="child-1"))
+
+    expect(page.locator('.inner')).to_have_count(2)
+    expect(page.locator('.inner').nth(1)).to_have_text('child-1')
+
+    # After appending, root.ready should resolve once the new child is mounted
+    page.wait_for_function("""
+        () => {
+            const views = Object.values(Bokeh.index)
+            if (views.length === 0) return false
+            const root = views[0].root
+            let resolved = false
+            root.ready.then(() => { resolved = true })
+            return new Promise(r => setTimeout(() => r(resolved), 100))
+        }
+    """, timeout=10000)


### PR DESCRIPTION
- `ReactiveESMView` and `ReactComponentView` now properly chain their async render work into Bokeh's `_await_ready()` mechanism, ensuring `view.ready` and `root.ready` don't resolve until rendering is actually complete
- `ReactComponentView` sets `_changing = true` synchronously at the start of `render_esm()` (not inside the async callback), closing a race window where `after_resize` could trigger `finish()` before React had started rendering
- `ReactComponentView.has_finished()` now gates on `_changing`, preventing the view from reporting "finished" until React's `componentDidMount` fires

###  Problem

Neither view was feeding its render promise into _await_ready(), so view.ready and root.ready could resolve before the component had actually mounted. For ReactComponentView specifically, there was also a race window between render_esm() being called and the async render code executing where after_resize could fire and prematurely mark the view as finished.

### AI Disclosure

- [x] Used AI via Claude Code with Opus 4.6
- [x] I take responsibility and have tested the changes 

### Test plan

  - test_view_ready — verifies view.ready resolves after render for both JS and React components
  - test_view_root_ready_with_child — verifies root.ready resolves when a child is present
  - test_view_ready_partial_children — verifies view.ready resolves even when only one of multiple children is rendered (Tabs-like scenario), confirming we don't deadlock
  - test_react_root_ready_after_child_update — verifies root.ready re-resolves after swapping a React child