### PR TITLE
Avoid hacky IconMixin rename override

### DIFF
--- a/panel/widgets/button.py
+++ b/panel/widgets/button.py
@@ -225,10 +225,6 @@ class IconMixin(Widget):
 
     __abstract = True
 
-    def __init__(self, **params) -> None:
-        type(self)._rename = dict(self._rename, **IconMixin._rename)
-        super().__init__(**params)
-
     def _process_param_change(self, params):
         icon_size = params.pop('icon_size', self.icon_size)
         if params.get('icon') is not None:
@@ -329,8 +325,11 @@ class Button(_ButtonBase, _ClickButton, IconMixin, TooltipMixin):
         Toggles from False to True while the event is being processed.""")
 
     _rename: t.ClassVar[Mapping[str, str | None]] = {
-        **TooltipMixin._rename, 'clicks': None, 'value': None,
         **_ButtonBase._rename,
+        **IconMixin._rename,
+        **TooltipMixin._rename,
+        'clicks': None,
+        'value': None,
     }
 
     _source_transforms: t.ClassVar[Mapping[str, str | None]] = {
@@ -441,6 +440,8 @@ class Toggle(_ButtonBase, IconMixin):
         Whether the button is currently toggled.""")
 
     _rename: t.ClassVar[Mapping[str, str | None]] = {
+        **TooltipMixin._rename,
+        **IconMixin._rename,
         **_ButtonBase._rename,
         'value': 'active',
     }
@@ -487,8 +488,11 @@ class MenuButton(_ButtonBase, _ClickButton, IconMixin):
     _event: t.ClassVar[str] = 'menu_item_click'
 
     _rename: t.ClassVar[Mapping[str, str | None]] = {
+        **IconMixin._rename,
         **_ButtonBase._rename,
-        'items': 'menu', 'clicked': None, 'value': None
+        'clicked': None,
+        'items': 'menu',
+        'value': None
     }
 
     _widget_type: t.ClassVar[type[Model]] = _BkDropdown

--- a/panel/widgets/misc.py
+++ b/panel/widgets/misc.py
@@ -170,8 +170,15 @@ class FileDownload(IconMixin):
     }
 
     _rename: t.ClassVar[Mapping[str, str | None]] = {
-        'callback': None, 'button_style': None, 'color': None, 'variant': None,
-        'file': None, '_clicks': 'clicks', 'value': None, 'label': 'label'
+        **IconMixin._rename,
+        '_clicks': 'clicks',
+        'button_style': None,
+        'callback': None,
+        'color': None,
+        'file': None,
+        'label': 'label',
+        'variant': None,
+        'value': None
     }
 
     _stylesheets: t.ClassVar[list[str]] = [f'{CDN_DIST}css/button.css']


### PR DESCRIPTION
`IconMixin` was overriding the `_rename` dictionary at runtime, which is super hacky and messed with some sub-classes that override the Icon handling. This ensures that the `_rename` is applied manually for relevant subclasses.