### PR TITLE
Ensure ESM components mark view as finished

### DIFF
--- a/panel/models/react_component.ts
+++ b/panel/models/react_component.ts
@@ -117,7 +117,7 @@ export class ReactComponentView extends ReactiveESMView {
     if (this.model.compiled === null || this.model.render_module === null) {
       return
     }
-    this._changing = true
+    this._rendered = false
     if (this.model.usesMui) {
       if (this.model.root_node) {
         this.style_cache = document.head
@@ -290,13 +290,7 @@ export class ReactComponentView extends ReactiveESMView {
   }
 
   override has_finished(): boolean {
-    if (!super.has_finished()) {
-      return false
-    }
-    if (this._changing) {
-      return false
-    }
-    return true
+    return super.has_finished() && this._rendered
   }
 
   patch_container(container: HTMLDivElement): void {
@@ -317,7 +311,6 @@ export class ReactComponentView extends ReactiveESMView {
       }
     }
     this._rendered = true
-    this._changing = false
     if (this._mounted_resolve) {
       const resolve = this._mounted_resolve
       this._mounted_resolve = null
@@ -331,6 +324,7 @@ export class ReactComponentView extends ReactiveESMView {
         resolve()
       }
     }
+    this.finish()
   }
 }
 
@@ -606,27 +600,27 @@ async function render(id) {
   })
 
   class ErrorBoundary extends React.Component {
-  constructor(props) {
-    super(props)
-    // initialize the error state
-    this.state = { hasError: false }
-  }
-
-  // if an error happened, set the state to true
-  static getDerivedStateFromError(error) {
-    return { hasError: true }
-  }
-
-  componentDidCatch(error) {
-    this.props.view.render_error(error)
-  }
-
-  render() {
-    if (this.state.hasError) {
-      return React.createElement('div')
+    constructor(props) {
+      super(props)
+      // initialize the error state
+      this.state = { hasError: false }
     }
-    return React.createElement('div', {className: "error-wrapper"}, this.props.children)
-  }
+
+    // if an error happened, set the state to true
+    static getDerivedStateFromError(error) {
+      return { hasError: true }
+    }
+
+    componentDidCatch(error) {
+      this.props.view.render_error(error)
+    }
+
+    render() {
+      if (this.state.hasError) {
+        return React.createElement('div')
+      }
+      return React.createElement('div', {className: "error-wrapper"}, this.props.children)
+    }
   }
 
   class Component extends React.Component {

--- a/panel/models/reactive_esm.ts
+++ b/panel/models/reactive_esm.ts
@@ -172,7 +172,6 @@ export class ReactiveESMView extends HTMLBoxView {
   accessed_children: string[] = []
   compiled_module: any = null
   model_proxy: any
-  _changing: boolean = false
   _child_callbacks: Map<string, ((new_views: UIElementView[]) => void)[]>
   _child_rendered: Map<UIElementView, boolean> = new Map()
   _event_handlers: ((data: unknown) => void)[] = []
@@ -473,7 +472,7 @@ export class ReactiveESMView extends HTMLBoxView {
   }
 
   override after_resize(): void {
-    if (this._rendered && !this._changing) {
+    if (this._rendered) {
       super.after_resize()
       for (const cb of (this._lifecycle_handlers.get("resize") || [])) {
         cb()
@@ -483,7 +482,7 @@ export class ReactiveESMView extends HTMLBoxView {
 
   override after_layout(): void {
     super.after_layout()
-    if (this._rendered && !this._changing) {
+    if (this._rendered) {
       for (const cb of (this._lifecycle_handlers.get("after_layout") || [])) {
         cb()
       }


### PR DESCRIPTION
The logic around handling `has_finished` handling was confusing and `_rendered` and `_changing` properties were redundant. This simplifies things and ensures that ReactComponent calls `finished()` on mount, ensuring that the `Document` is correctly marked as `is_idle`.