### PR TITLE
Ensure that property changes do not boomerang on ReactiveESM

### DIFF
--- a/panel/custom.py
+++ b/panel/custom.py
@@ -602,15 +602,26 @@ class ReactiveESM(ReactiveCustomBase, metaclass=ReactiveESMMetaclass):
         root: Model, model: Model, doc: Document, comm: Comm | None
     ) -> None:
         model_msg, data_msg, data_resets  = {}, {}, {}
-        for prop, v in list(msg.items()):
+        curdoc_events = self._in_process__events.get(doc, {})
+        for prop, value in list(msg.items()):
             if prop in list(Reactive.param)+['esm', 'importmap']:
-                model_msg[prop] = v
+                model_msg[prop] = value
+                continue
             elif prop in model.children:
                 continue
-            else:
-                data_msg[prop] = v
-                if prop in self.param and isinstance(self.param[prop], param.Event) and v:
-                    data_resets[prop] = False
+
+            if prop in curdoc_events:
+                try:
+                    is_boomerang = bool(value == curdoc_events[prop])
+                except Exception:
+                    is_boomerang = value is curdoc_events[prop]
+                if is_boomerang:
+                    continue
+
+            data_msg[prop] = value
+            if prop in self.param and isinstance(self.param[prop], param.Event) and value:
+                data_resets[prop] = False
+
         for name, event in events.items():
             if name not in model.children:
                 continue

--- a/panel/tests/test_custom.py
+++ b/panel/tests/test_custom.py
@@ -5,7 +5,7 @@ import param
 from bokeh.plotting import figure
 
 from panel.custom import PyComponent, ReactiveESM
-from panel.io.state import state
+from panel.io.state import set_curdoc, state
 from panel.layout import Row
 from panel.pane import Bokeh, Markdown
 from panel.util import edit_readonly
@@ -225,3 +225,56 @@ def test_esm_parameter_override(document, comm):
     esm.width = 84
 
     assert model.width == 84
+
+
+class ESMWithValue(ReactiveESM):
+
+    value = param.String(default='A')
+
+
+def test_esm_python_update_not_suppressed_by_stale_frontend_event(document, comm):
+    esm = ESMWithValue(value='A')
+
+    model = esm.get_root(document, comm)
+
+    # Simulate a frontend event setting value to 'B'
+    with set_curdoc(document):
+        esm._process_events({'value': 'B'})
+
+    assert esm.value == 'B'
+
+    # Now a Python-side update sets a different value
+    esm.value = 'C'
+
+    # The model must reflect the Python update
+    assert model.data.value == 'C'
+
+
+def test_esm_boomerang_suppresses_model_update(document, comm):
+    esm = ESMWithValue(value='A')
+
+    model = esm.get_root(document, comm)
+
+    with set_curdoc(document):
+        esm._process_events({'value': 'B'})
+
+    assert esm.value == 'B'
+    assert model.data.value == 'A'
+
+
+def test_esm_python_update_different_from_frontend_is_applied(document, comm):
+    esm = ESMWithValue(value='A')
+
+    model = esm.get_root(document, comm)
+
+    # Frontend sends 'B'
+    with set_curdoc(document):
+        esm._process_events({'value': 'B'})
+
+    assert esm.value == 'B'
+
+    # Python sets a different value from what the frontend sent
+    esm.value = 'C'
+
+    # The model must reflect the Python update since 'C' != 'B'
+    assert model.data.value == 'C'

--- a/panel/tests/test_custom.py
+++ b/panel/tests/test_custom.py
@@ -229,7 +229,7 @@ def test_esm_parameter_override(document, comm):
 
 class ESMWithValue(ReactiveESM):
 
-    value = param.String(default='A')
+    value = param.String(default='A', doc="Test value")
 
 
 def test_esm_python_update_not_suppressed_by_stale_frontend_event(document, comm):


### PR DESCRIPTION
Regular components implement a check that prevents model updates arriving from the frontend from boomeranging, which is implemented in `Reactive._update_model`. `ReactiveESM._update_model` overrides this implementation because it has to dispatch events to both the ESM model and the data model that represents the parameters specific to that ESM component. This overridden implementation did not preserve the boomerang checks however, which means that in certain scenarios events could boomerang back and forth between server and client, causing issues as described in https://github.com/panel-extensions/panel-material-ui/issues/647 and https://github.com/holoviz/panel/pull/8522.

Supersedes https://github.com/holoviz/panel/pull/8522