### PR TITLE
Allow providing global context to pyrender function

### DIFF
--- a/panel/io/mime_render.py
+++ b/panel/io/mime_render.py
@@ -135,7 +135,7 @@ def exec_with_return(
     ----------
     code: str
         The code to execute
-    global_context: Dict[str, Any]
+    global_context: dict[str, Any] | None
         The globals to inject into the execution context.
     stdout: io.StringIO
         The stream to redirect stdout to.
@@ -147,7 +147,7 @@ def exec_with_return(
 
     The return value of the executed code.
     """
-    global_context = global_context if global_context else globals()
+    global_context = global_context if global_context else {}
     global_context['display'] = _display
     code_ast = ast.parse(code)
 

--- a/panel/io/mime_render.py
+++ b/panel/io/mime_render.py
@@ -29,10 +29,7 @@ from textwrap import dedent
 # Import API
 #---------------------------------------------------------------------
 
-# Global context for backward compatibility where all exec calls shared
-# the global context of this module (causing issues when overwriting
-# global variables.
-_GLOBAL_CONTEXT = {}
+_GLOBAL_CONTEXT_EXEC: dict[str, t.Any] = {}
 _STDLIBS = sys.stdlib_module_names
 _PACKAGE_MAP = {
     'sklearn': 'scikit-learn',
@@ -151,7 +148,7 @@ def exec_with_return(
 
     The return value of the executed code.
     """
-    global_context = global_context if global_context else _GLOBAL_CONTEXT
+    global_context = global_context if global_context else _GLOBAL_CONTEXT_EXEC
     global_context['display'] = _display
     code_ast = ast.parse(code)
 

--- a/panel/io/mime_render.py
+++ b/panel/io/mime_render.py
@@ -29,6 +29,10 @@ from textwrap import dedent
 # Import API
 #---------------------------------------------------------------------
 
+# Global context for backward compatibility where all exec calls shared
+# the global context of this module (causing issues when overwriting
+# global variables.
+_GLOBAL_CONTEXT = {}
 _STDLIBS = sys.stdlib_module_names
 _PACKAGE_MAP = {
     'sklearn': 'scikit-learn',
@@ -147,7 +151,7 @@ def exec_with_return(
 
     The return value of the executed code.
     """
-    global_context = global_context if global_context else {}
+    global_context = global_context if global_context else _GLOBAL_CONTEXT
     global_context['display'] = _display
     code_ast = ast.parse(code)
 

--- a/panel/io/pyodide.py
+++ b/panel/io/pyodide.py
@@ -627,7 +627,8 @@ def pyrender(
     code: str,
     stdout_callback: Callable[[str], None] | None,
     stderr_callback: Callable[[str], None] | None,
-    target: str
+    target: str,
+    global_context: dict[str, t.Any] | None = None
 ):
     """
     Executes Python code and returns a MIME representation of the
@@ -643,6 +644,8 @@ def pyrender(
         Callback executed with output written to stderr.
     target: str
         The ID of the DOM node to write the output into.
+    global_context: dict[str, Any] | None
+        The globals to inject into the execution context.
 
     Returns
     -------
@@ -654,7 +657,7 @@ def pyrender(
     PANES = (HoloViews, Interactive, ReactiveExpr)
     stdout = WriteCallbackStream(stdout_callback) if stdout_callback else None
     stderr = WriteCallbackStream(stderr_callback) if stderr_callback else None
-    out = exec_with_return(code, stdout=stdout, stderr=stderr)
+    out = exec_with_return(code, global_context=global_context, stdout=stdout, stderr=stderr)
     ret = {}
     if isinstance(out, (Model, Viewable, Viewer)) or any(pane.applies(out) for pane in PANES):
         doc, model_json = _model_json(as_panel(out), target)


### PR DESCRIPTION
Without providing the context it defaulted to `globals` which caused issues when overwriting global variables in the module. 

Fixes https://github.com/holoviz/panel/issues/7506