### PR TITLE
Ensure ready parameter and next button are in sync after previous button

### DIFF
--- a/panel/pipeline.py
+++ b/panel/pipeline.py
@@ -180,7 +180,6 @@ class Pipeline(Viewer):
         self._states = {}
         self._state = None
         self._linear = True
-        self._block = False
         self._error = None
         self._graph = {}
         self._route = []
@@ -248,18 +247,12 @@ class Pipeline(Viewer):
         return self._stages[index][0]
 
     def _unblock(self, event):
-        if self._state is not event.obj or self._block:
-            self._block = False
+        self.next_button.disabled = not event.new
+        if not event.new:
             return
 
-        button = self.next_button
-        if button.disabled and event.new:
-            button.disabled = False
-        elif not button.disabled and not event.new:
-            button.disabled = True
-
         stage_kwargs = self._stages[self._stage][-1]
-        if event.new and stage_kwargs.get('auto_advance', self.auto_advance):
+        if stage_kwargs.get('auto_advance', self.auto_advance):
             self._next()
 
     def _select_next(self, event):
@@ -444,7 +437,6 @@ class Pipeline(Viewer):
                 self.stage[0] = self._state.panel()
             else:
                 self.stage[0] = self._init_stage()
-            self._block = True
         except Exception as e:
             self.error[:] = [self._get_error_button(e)]
             self._error = self._stage

--- a/panel/tests/test_pipeline.py
+++ b/panel/tests/test_pipeline.py
@@ -66,6 +66,23 @@ class DummyStage(param.Parameterized):
         return 'foo'
 
 
+class DummyReadyParameterStage(param.Parameterized):
+
+    ready = param.Boolean(default=False)
+
+    def panel(self):
+        return 'foo'
+
+
+class DummyResetReadyParameterStage(param.Parameterized):
+
+    ready = param.Boolean(default=False)
+
+    def panel(self):
+        self.ready = False
+        return 'foo'
+
+
 def test_find_route():
     graph = {'A': ('B', 'C'), 'C': ('D',), 'D': ('E', 'F', 'G'), 'F': ('H',), 'G': ('I',)}
 
@@ -413,35 +430,29 @@ def test_pipeline_repr():
     assert repr(pipeline) == 'Pipeline:\n    [0] Stage 1: Stage1()\n    [1] Stage 2: Stage2()'
 
 
-def test_pipeline_ready_parameter_preserved_on_back_navigation():
+@pytest.mark.parametrize("stage1", [DummyReadyParameterStage(), DummyResetReadyParameterStage()])
+@pytest.mark.parametrize("auto_advance", [True, False])
+def test_pipeline_ready_parameter_preserved_on_back_navigation(stage1, auto_advance):
     """
-    Regression test for https://github.com/holoviz/panel/issues/8378.
+    Regression test for https://github.com/holoviz/panel/issues/8378 and https://github.com/holoviz/panel/issues/8631
 
-    When navigating back to a stage whose ready_parameter is already True,
-    the 'next' button should remain enabled (not disabled).
-    Previously, _update_button read from the stage class (always default=False)
-    instead of the live instance (self._state), causing the button to be
-    incorrectly disabled until the parameter was set to True a second time.
+    On back navigation, ensure the ready parameter is preserved and the next button is
+    enabled when ready parameter is True.
     """
     pipeline = Pipeline(ready_parameter='ready')
-    pipeline.add_stage('Stage 1', Stage1)
-    pipeline.add_stage('Stage 2', Stage2)
+    pipeline.add_stage('Stage 1', stage1, auto_advance=auto_advance)
+    pipeline.add_stage('Stage 2', DummyStage)
 
-    # Initially disabled because ready=False
-    assert pipeline.next_button.disabled
-
-    # Set ready=True → button enables
     pipeline._state.ready = True
-    assert not pipeline.next_button.disabled
-
-    # Advance to Stage 2
-    pipeline._next()
-    assert isinstance(pipeline._state, Stage2)
-
-    # Go back to Stage 1 — ready is still True on the instance
+    if not auto_advance:
+        pipeline._next()
+    assert pipeline._stage == 'Stage 2'
     pipeline._previous()
-    assert isinstance(pipeline._state, Stage1)
-    assert pipeline._state.ready is True
-
-    # The next button must be enabled immediately (not disabled)
-    assert not pipeline.next_button.disabled
+    assert pipeline._stage == 'Stage 1'
+    assert pipeline._state.ready == isinstance(stage1, DummyReadyParameterStage)
+    assert not pipeline.next_button.disabled == pipeline._state.ready
+    pipeline._state.ready = True
+    if not auto_advance:
+        assert not pipeline.next_button.disabled
+        pipeline._next()
+    assert pipeline._stage == 'Stage 2'


### PR DESCRIPTION
## Description
Fixes #8631

When coming back to a stage, the `_block` attribute set to `True` meant that on the first time the `ready` parameter was set to `True`, the _next_ button stayed disabled and, for stages with `auto_advance`, the pipeline did not proceed.

In this minimal example, you can try various combinations of `auto_advance` and automatic reset of the `ready` parameter in the `panel` method. All are included in the now expanded test introduced by #8443.
```python
import panel as pn
import param

pipeline = pn.pipeline.Pipeline()


class Stage1(param.Parameterized):
    ready = param.Boolean(default=False)

    def __init__(self):
        super().__init__()
        self.ready_button = pn.widgets.Button(name="Ready", on_click=self._ready)

    def _ready(self, _):
        self.ready = True

    def panel(self):
        # self.ready = False
        return pn.Column(self.ready_button)


class Stage2(param.Parameterized):

    def panel(self):
        return "Stage 2"


auto_advance = True
pipeline.add_stage("Stage 1", Stage1, ready_parameter="ready", auto_advance=auto_advance)
pipeline.add_stage("Stage 2", Stage2)

pipeline.servable()
```

NB: there are small but significant changes in this new implementation, including that there is no need for a `_block` attribute anymore.

## Checklist
- [x] Tests added and are passing