### PR TITLE
Set `Cache-Control: no-store` on the Bokeh document page

### DIFF
--- a/panel/io/server.py
+++ b/panel/io/server.py
@@ -635,6 +635,11 @@ class DocHandler(LoginUrlMixin, BkDocHandler):
 
     @authenticated
     async def get(self, *args, **kwargs):
+        # Prevent the browser from caching the document page. The page embeds
+        # a short-lived Bokeh session token; a cached page served after a
+        # logout/login cycle would carry a stale token and the subsequent
+        # WebSocket connection would fail (see e.g. holoviz/panel#8634).
+        self.set_header("Cache-Control", "no-store")
         prefix = self.application.prefix
         if prefix and self.request.path == prefix and not prefix.endswith('/'):
             query_string = self.request.query if self.request.query else ''

--- a/panel/tests/test_server.py
+++ b/panel/tests/test_server.py
@@ -157,6 +157,16 @@ def test_server_prefix_root_redirect():
     assert response.status_code == 200
     assert response.url.endswith('/foo/')
 
+def test_server_doc_page_is_not_cached():
+    # The document page embeds a short-lived Bokeh session token, so it must
+    # not be cached by the browser (a stale token breaks the WebSocket).
+    html = Markdown('# Title')
+
+    r = serve_and_request(html)
+
+    assert r.status_code == 200
+    assert r.headers.get('Cache-Control') == 'no-store'
+
 def test_server_static_dirs_index():
     html = Markdown('# Title')
 


### PR DESCRIPTION
## Summary

The served document page embeds a short-lived Bokeh **session token**. Because Panel's `DocHandler` sends no cache headers, browsers may cache the HTML page. After an oauth logout/login cycle (or when returning to an app later), the browser can serve the **stale cached page carrying an expired token**, so the subsequent WebSocket upgrade fails with *"Could not open websocket"* and the user is stuck in a disconnect loop.

## Change

Send `Cache-Control: no-store` from `DocHandler.get`, so the document page (and the token embedded in it) is always re-fetched.

This mirrors what Panel already does for the Jupyter server extension handler (`panel/io/jupyter_server_extension.py`), which sets `Cache-Control: no-cache, no-store, must-revalidate`.

## Tests

Adds `test_server_doc_page_is_not_cached`, which serves an app and asserts the response carries `Cache-Control: no-store`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)