### PR TITLE
Warn when the Bokeh session token may exceed proxy request-header limits

### DIFF
--- a/panel/io/server.py
+++ b/panel/io/server.py
@@ -125,6 +125,43 @@ _MAX_ROUTE_PARAM_KEY_CHARS = 128
 _MAX_ROUTE_PARAM_VALUE_CHARS = 1024
 _MAX_APP_PATH_CHARS = 2048
 
+# The browser echoes the Bokeh session token back in the `Sec-WebSocket-Protocol`
+# request header when opening the WebSocket connection. Many proxies reject
+# request headers larger than 8 kB (e.g. nginx `large_client_header_buffers`),
+# which surfaces as a cryptic "Could not open websocket". Warn once per app when
+# the token approaches that size so the cause is discoverable. See
+# https://panel.holoviz.org/how_to/authentication/trouble_shooting.html
+WS_TOKEN_SIZE_WARNING_THRESHOLD = 7600
+_ws_token_size_warned: set[str] = set()
+
+
+def _warn_if_ws_token_too_large(path: str, token: str) -> None:
+    """
+    Warn (once per app path) when the session token is large enough to risk
+    rejection by a proxy's request-header size limit.
+
+    The browser sends this token in the ``Sec-WebSocket-Protocol`` header when
+    opening the WebSocket connection; proxies such as nginx reject request
+    headers larger than 8 kB by default, which surfaces as a cryptic
+    "Could not open websocket".
+    """
+    if len(token) <= WS_TOKEN_SIZE_WARNING_THRESHOLD or path in _ws_token_size_warned:
+        return
+    _ws_token_size_warned.add(path)
+    logger.warning(
+        "The Bokeh session token for %r is %d bytes. The browser sends this "
+        "token in the 'Sec-WebSocket-Protocol' header when opening the "
+        "WebSocket connection. Some proxies reject request headers larger than "
+        "8 kB (e.g. nginx 'large_client_header_buffers'); if yours does, the "
+        "connection will fail with 'Could not open websocket'. This is only a "
+        "problem if you actually see that error - if the app connects fine you "
+        "can ignore this message. Otherwise, raise the proxy's request-header "
+        "buffer or reduce the token size (e.g. `panel serve --exclude-cookies "
+        "...`). See "
+        "https://panel.holoviz.org/how_to/authentication/trouble_shooting.html",
+        path, len(token),
+    )
+
 
 def _has_prefix_boundary(path: str, prefix: str) -> bool:
     if path == prefix:
@@ -695,6 +732,7 @@ class DocHandler(LoginUrlMixin, BkDocHandler):
                 )
         else:
             token = session.token
+        _warn_if_ws_token_too_large(self.request.path, token)
         logger.info(LOG_SESSION_CREATED, id(session.document))
         with set_curdoc(session.document):
             resources = Resources.from_bokeh(self.application.resources())

--- a/panel/tests/test_server.py
+++ b/panel/tests/test_server.py
@@ -167,6 +167,32 @@ def test_server_doc_page_is_not_cached():
     assert r.status_code == 200
     assert r.headers.get('Cache-Control') == 'no-store'
 
+def test_warn_if_ws_token_too_large():
+    from unittest.mock import patch
+
+    from panel.io import server as _server
+
+    _server._ws_token_size_warned.clear()
+    path = "/big-token-app"
+    small = "x" * 100
+    big = "x" * (_server.WS_TOKEN_SIZE_WARNING_THRESHOLD + 1)
+
+    try:
+        with patch.object(_server, "logger") as mock_logger:
+            # A small token does not warn.
+            _server._warn_if_ws_token_too_large(path, small)
+            assert mock_logger.warning.call_count == 0
+
+            # A large token warns once.
+            _server._warn_if_ws_token_too_large(path, big)
+            assert mock_logger.warning.call_count == 1
+
+            # The same app path does not warn again.
+            _server._warn_if_ws_token_too_large(path, big)
+            assert mock_logger.warning.call_count == 1
+    finally:
+        _server._ws_token_size_warned.clear()
+
 def test_server_static_dirs_index():
     html = Markdown('# Title')
 


### PR DESCRIPTION
## Summary

Approved in #8634 ([comment](https://github.com/holoviz/panel/issues/8634#issuecomment-4630656272)).

When OAuth is enabled, Bokeh embeds the request's cookies/headers into the **session token**, which the browser echoes back in the **`Sec-WebSocket-Protocol`** header when opening the WebSocket. If that header exceeds the proxy's per-request-header limit (nginx `large_client_header_buffers`, **default 8&nbsp;KB**), the proxy rejects the upgrade with `HTTP 400` and the user sees only a cryptic **`Could not open websocket`** — with nothing in the Panel server logs, because the request never reaches Panel. This was the root cause in #8634 (and #7909) and took the reporter ~2 years to diagnose.

## Change

`DocHandler.get` now logs a **one-time, informational warning per app** when the generated session token approaches the common 8&nbsp;KB proxy limit. The message is deliberately conditional — a large token is only a problem if a proxy actually rejects it, so it tells the operator to ignore the message if the app connects fine, and only points at remedies (`--exclude-cookies`, raising the proxy header buffer, the troubleshooting docs) for the case where they *do* hit `Could not open websocket`. Non-fatal; purely diagnostic.

```
The Bokeh session token for '/app' is 8123 bytes. The browser sends this token in the
'Sec-WebSocket-Protocol' header when opening the WebSocket connection. Some proxies reject
request headers larger than 8 kB (e.g. nginx 'large_client_header_buffers'); if yours does,
the connection will fail with 'Could not open websocket'. This is only a problem if you
actually see that error - if the app connects fine you can ignore this message. Otherwise,
raise the proxy's request-header buffer or reduce the token size (e.g. `panel serve
--exclude-cookies ...`). See https://panel.holoviz.org/how_to/authentication/trouble_shooting.html
```

The threshold (`WS_TOKEN_SIZE_WARNING_THRESHOLD = 7600`) leaves headroom under the 8&nbsp;KB default for the `"bokeh, "` subprotocol prefix.

## Tests

`test_warn_if_ws_token_too_large` verifies a small token does not warn, a large token warns, and the warning fires at most once per app path.

Refs #8634, #7909.

🤖 Generated with [Claude Code](https://claude.com/claude-code)