### PR TITLE
Return a clean 403 for unauthenticated WebSocket connections

### DIFF
--- a/panel/io/server.py
+++ b/panel/io/server.py
@@ -751,6 +751,21 @@ class AutoloadJsHandler(BkAutoloadJsHandler):
 
 class WSHandler(BkWSHandler):
 
+    async def prepare(self):
+        await super().prepare()
+        # A WebSocket upgrade cannot be redirected to a login page, so the
+        # @authenticated check on Bokeh's open() (which runs after the
+        # handshake) raises an uncaught RuntimeError ("Method not supported for
+        # Web Sockets") for unauthenticated connections. Reject the handshake
+        # cleanly with a 403 here instead, before it is performed.
+        if self.current_user is None:
+            logger.debug(
+                "Rejecting unauthenticated WebSocket connection to %r with 403.",
+                self.request.path
+            )
+            self.set_status(403)
+            self.finish()
+
     def open(self, *args, **kwargs):
         _set_request_route_context(self, *args, suffix='/ws', **kwargs)
         return super().open()

--- a/panel/tests/test_server.py
+++ b/panel/tests/test_server.py
@@ -167,6 +167,29 @@ def test_server_doc_page_is_not_cached():
     assert r.status_code == 200
     assert r.headers.get('Cache-Control') == 'no-store'
 
+def test_unauthenticated_websocket_returns_403(port):
+    # An unauthenticated WebSocket upgrade cannot be redirected to a login page,
+    # so it must be rejected with a clean 403 rather than raising server-side.
+    import asyncio
+
+    from tornado.httpclient import HTTPClientError
+    from tornado.websocket import websocket_connect
+
+    html = Markdown('# Title')
+    serve_and_wait(
+        html, port=port, basic_auth="secret-password", cookie_secret="cookie-secret"
+    )
+
+    async def _connect():
+        url = f"ws://localhost:{port}/ws"
+        try:
+            await websocket_connect(url, connect_timeout=10)
+            return None  # handshake unexpectedly succeeded
+        except HTTPClientError as e:
+            return e.code
+
+    assert asyncio.run(_connect()) == 403
+
 def test_server_static_dirs_index():
     html = Markdown('# Title')
 


### PR DESCRIPTION
## Summary

Approved in #8634 ([comment](https://github.com/holoviz/panel/issues/8634#issuecomment-4630656272)).

Bokeh's `WSHandler.open` is wrapped with `@web.authenticated`. For an unauthenticated request that decorator calls `self.redirect(login_url)` — but a WebSocket upgrade cannot be redirected, so Tornado raises `RuntimeError: Method not supported for Web Sockets`. Because `open()` runs *after* the handshake, this also happens only after a `101` has been sent, producing a confusing server-side traceback instead of a clean rejection.

Observed during the #8634 investigation:

```
File ".../panel/io/server.py", line 751, in open
    return super().open()
File ".../tornado/web.py", line 3406, in wrapper
    self.redirect(url)
File ".../tornado/websocket.py", line 638, in _raise_not_supported_for_websockets
    raise RuntimeError("Method not supported for Web Sockets")
```

## Change

Override `prepare()` on Panel's `WSHandler` (it runs *before* the handshake): after the auth provider has resolved `current_user`, if it is `None`, reject the upgrade with a clean **403** instead of letting the post-handshake `@authenticated` redirect raise. Authenticated users, guest endpoints, and the no-auth case (`current_user == "default_user"`) are unaffected.

## Tests

`test_unauthenticated_websocket_returns_403` serves a `basic_auth`-protected app and asserts that a WebSocket connection without credentials fails the handshake with HTTP 403 (rather than completing the handshake and erroring server-side).

Refs #8634.

🤖 Generated with [Claude Code](https://claude.com/claude-code)