### PR TITLE
docs: fix Tabs ParamFunction links

### DIFF
--- a/examples/reference/layouts/Tabs.ipynb
+++ b/examples/reference/layouts/Tabs.ipynb
@@ -144,7 +144,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If you want the `Tabs` to be completely lazy when rendering some output you can leverage a [ParamFunction or ParamMethod](../../user_guide/Param.ipynb) to ensure that the output is not computed until you navigate to the tab:"
+    "If you want the `Tabs` to be completely lazy when rendering some output you can leverage a [ParamFunction](https://panel.holoviz.org/api/panel.param.html#panel.param.ParamFunction) or [ParamMethod](https://panel.holoviz.org/api/panel.param.html#panel.param.ParamMethod) to ensure that the output is not computed until you navigate to the tab:"
    ]
   },
   {


### PR DESCRIPTION
## Summary

- replace the stale `../../user_guide/Param.ipynb` link in the Tabs reference notebook
- link `ParamFunction` and `ParamMethod` directly to their current API documentation anchors

Closes #8542

## Verification

- `python3 -m json.tool examples/reference/layouts/Tabs.ipynb >/dev/null`
- `git diff --check`
- `curl -L -I -s https://panel.holoviz.org/api/panel.param.html` returned HTTP 200
- verified the page contains `panel.param.ParamFunction` and `panel.param.ParamMethod`
