### PR TITLE
Fix Fast progress indicator height

### DIFF
--- a/panel/models/progress.ts
+++ b/panel/models/progress.ts
@@ -25,6 +25,9 @@ export class ProgressView extends HTMLBoxView {
   override render(): void {
     super.render()
     const style: any = {...this.model.styles, display: "inline-block"}
+    if (this.model.height != null) {
+      style.height = `${this.model.height}px`
+    }
     this.progressEl = document.createElement("progress")
     this.setValue()
     this.setMax()

--- a/panel/tests/ui/widgets/test_indicators.py
+++ b/panel/tests/ui/widgets/test_indicators.py
@@ -8,8 +8,9 @@ from playwright.sync_api import expect
 import panel as pn
 
 from panel.tests.util import serve_component, wait_until
+from panel.theme import Fast
 from panel.widgets import TooltipIcon
-from panel.widgets.indicators import Gauge
+from panel.widgets.indicators import Gauge, Progress
 
 pytestmark = pytest.mark.ui
 
@@ -133,3 +134,23 @@ def test_gauge_value_update(page):
 
     # Canvas should still be present after update
     expect(page.locator("canvas")).to_have_count(1, timeout=5000)
+
+
+def test_fast_progress_indicator_height(page):
+    progress = Progress(value=20, design=Fast)
+
+    serve_component(page, progress)
+
+    progress_el = page.locator("progress")
+    expect(progress_el).to_have_count(1)
+    expect(progress_el).to_have_css("height", "20px")
+
+
+def test_fast_progress_indicator_explicit_height(page):
+    progress = Progress(value=20, height=32, design=Fast)
+
+    serve_component(page, progress)
+
+    progress_el = page.locator("progress")
+    expect(progress_el).to_have_count(1)
+    expect(progress_el).to_have_css("height", "32px")

--- a/panel/theme/css/fast.css
+++ b/panel/theme/css/fast.css
@@ -805,7 +805,6 @@ select:not([size]).bk-input {
 
 progress {
   border-radius: calc(var(--corner-radius) * 1px);
-  height: 5px;
   margin: 0 0 0.5em;
 }
 
@@ -831,7 +830,6 @@ progress:not([value])::-webkit-progress-bar {
 
 progress:not([value])::before {
   border-radius: calc(var(--corner-radius) * 1px);
-  height: 5px;
 }
 
 /* Panes */


### PR DESCRIPTION
## Summary
- stop the Fast theme from overriding the Progress indicator height to 5px
- apply the explicit `height` parameter to the inner `<progress>` element
- add UI regression coverage for Fast Progress default and explicit heights

Fixes #8640.

## Validation
- `PYTHONPATH=. .venv/bin/python -m pytest panel/tests/ui/widgets/test_indicators.py::test_fast_progress_indicator_height panel/tests/ui/widgets/test_indicators.py::test_fast_progress_indicator_explicit_height --ui --browser chromium -q`
- `PYTHONPATH=. .venv/bin/python -m pytest panel/tests/widgets/test_misc.py::test_progress_bounds -q`
- `PYTHONPATH=. .venv/bin/python - <<'PY' ... panel.command main build panel ... PY`
- `git diff --check`

Note: I also ran the full `panel/tests/ui/widgets/test_indicators.py` file locally; the new Progress tests passed, while the existing Gauge tests timed out in this lightweight environment because ECharts was not loaded (`pn.extension('echarts')` warning).
