### PR TITLE
Fix FileDownload color styling

### DIFF
--- a/panel/models/file_download.ts
+++ b/panel/models/file_download.ts
@@ -212,7 +212,7 @@ export class FileDownloadView extends InputWidgetView {
       this.button_el.classList.add(buttons.btn)
       this.button_el.classList.add(btn_type)
     } else {  // When the button type is changed.
-      const prev_button_type = this.anchor_el.classList.item(1)
+      const prev_button_type = this.button_el.classList.item(1)
       if (prev_button_type) {
         this.button_el.classList.replace(prev_button_type, btn_type)
       }

--- a/panel/tests/widgets/test_misc.py
+++ b/panel/tests/widgets/test_misc.py
@@ -155,3 +155,19 @@ def test_file_path_download():
     file_download._clicks += 1
     assert file_download.data
     assert file_download._transfers == 1
+
+
+def test_file_download_color_renders_to_bokeh_model(document, comm):
+    file_download = FileDownload(color="primary", filename="x.txt", callback=lambda: "")
+    widget = file_download.get_root(document, comm=comm)
+    assert widget.button_type == "primary"
+    file_download.color = "danger"
+    assert widget.button_type == "danger"
+
+
+def test_file_download_variant_renders_to_css_class(document, comm):
+    file_download = FileDownload(variant="outline", filename="x.txt", callback=lambda: "")
+    widget = file_download.get_root(document, comm=comm)
+    assert "outline" in widget.css_classes
+    file_download.variant = "solid"
+    assert "solid" in widget.css_classes

--- a/panel/widgets/misc.py
+++ b/panel/widgets/misc.py
@@ -174,7 +174,7 @@ class FileDownload(IconMixin):
         '_clicks': 'clicks',
         'button_style': None,
         'callback': None,
-        'color': None,
+        'color': 'button_type',
         'file': None,
         'label': 'label',
         'variant': None,
@@ -201,9 +201,9 @@ class FileDownload(IconMixin):
     def _process_param_change(self, params):
         params = dict(params)
         _merge_button_appearance_aliases_in_param_change(params)
-        if 'button_style' in params or 'css_classes' in params:
+        if 'variant' in params or 'css_classes' in params:
             params['css_classes'] = [
-                params.pop('button_style', self.button_style)
+                params.pop('variant', self.variant)
             ] + params.get('css_classes', self.css_classes)
         return super()._process_param_change(params)
 


### PR DESCRIPTION
Fixes #8653.

## What changed
- Map `FileDownload.color` through to the Bokeh `button_type` model property so semantic colors render on the download button.
- Use the normalized `variant` alias when updating `FileDownload` CSS classes, matching the other button-like widgets.
- Replace the previous button type CSS class on the actual button element in the TypeScript view.
- Added regression tests for initial and dynamic `FileDownload` color/variant updates.

## Why
`FileDownload` accepted the same `color` API as other button-like widgets, but its `_rename` mapping dropped `color` before it reached the Bokeh model. As a result, every rendered download button kept the default button type regardless of the requested color.

## Validation
- `.venv/bin/python -m pytest panel/tests/widgets/test_misc.py -q`
- `.venv/bin/python -m pytest panel/tests/widgets/test_button.py panel/tests/widgets/test_misc.py -q`
- `npm run lint -- --quiet`
- `git diff --check`

## Limitations
- I did not run the full test suite.

## AI disclosure
This draft PR was prepared with assistance from OpenAI Codex/ChatGPT. The code changes, tests, validation commands, and PR text were AI-assisted and reviewed in the local checkout before submission.