### PR TITLE
[codex] Fix repeated location sync mappings

### DIFF
--- a/panel/io/location.py
+++ b/panel/io/location.py
@@ -224,7 +224,10 @@ class Location(Syncable):
             return
         serialized = query or {}
         for e in events:
-            matches = [ps for o, ps, _, _ in self._synced if o in (e.cls, e.obj)]
+            matches = [
+                ps for o, ps, _, _ in self._synced
+                if o in (e.cls, e.obj) and e.name in ps
+            ]
             if not matches:
                 continue
             owner = e.cls if e.obj is None else e.obj

--- a/panel/tests/io/test_location.py
+++ b/panel/tests/io/test_location.py
@@ -94,6 +94,20 @@ def test_location_sync_query(location):
     assert location._synced == []
     assert location.search == ""
 
+def test_location_sync_same_object_multiple_calls(location):
+    p = SyncParameterized(integer=1, string='abc')
+    location.sync(p, ['integer'])
+    location.sync(p, ['string'])
+
+    p.string = 'def'
+    assert location.search == "?integer=1&string=def"
+    p.integer = 2
+    assert location.search == "?integer=2&string=def"
+
+    location.unsync(p)
+    assert location._synced == []
+    assert location.search == ""
+
 def test_location_sync_param_init(location):
     p = SyncParameterized()
     location.search = "?integer=1&string=abc"


### PR DESCRIPTION
Fixes #8654.

## What changed
- Updated `Location._update_query` to choose only sync mappings that contain the changed parameter.
- Added a regression test covering repeated `Location.sync` calls for the same `Parameterized` object.

## Why
Calling `Location.sync` multiple times for one object stores multiple parameter mappings. Parameter updates from later sync calls previously indexed the first mapping and raised `KeyError` for parameters that only existed in a later mapping.

## Validation
- `.venv/bin/python -m pytest panel/tests/io/test_location.py -k same_object_multiple_calls -q`
- `.venv/bin/python -m pytest panel/tests/io/test_location.py -q`
- `git diff --check`
- Manual reproduction snippet for issue #8654 now updates `language` without raising.

## Limitations
Full test suite and browser UI tests were not run locally.

## AI disclosure
This draft PR was prepared with assistance from OpenAI Codex/ChatGPT. The code change, regression test, PR body, and local validation workflow were AI-assisted and reviewed in the local checkout before submission.
