### PR TITLE
Fix feed rendering all objects at once

### DIFF
--- a/panel/layout/feed.py
+++ b/panel/layout/feed.py
@@ -39,7 +39,9 @@ class Feed(Column):
     load_buffer = param.Integer(default=50, bounds=(0, None), doc="""
         The number of objects loaded on each side of the visible objects.
         When scrolled halfway into the buffer, the feed will automatically
-        load additional objects while unloading objects on the opposite side.""")
+        load additional objects while unloading objects on the opposite side.
+        Has no effect when scroll=False, in which case all objects are
+        rendered and visibility is tracked against the page viewport.""")
 
     scroll: t.Literal[
         False, True, "both-auto", "y-auto", "x-auto", "both", "x", "y"
@@ -70,12 +72,15 @@ class Feed(Column):
     }
 
     def __init__(self, *objects, **params):
-        for height_param in ["height", "min_height", "max_height"]:
-            if height_param in params:
-                break
-        else:
+        # A scrolling Feed virtualizes by only rendering objects near the visible
+        # range, so it needs a bounding height (height or max_height) to clip its
+        # viewport; min_height only sets a floor and lets it grow, so everything
+        # ends up loaded (#8661). A non-scrolling Feed renders all of its objects
+        # (see _synced_range) and needs no default height.
+        scroll = params.get('scroll', type(self).param.scroll.default)
+        if scroll and 'height' not in params and 'max_height' not in params:
             # sets a default height to prevent infinite load
-            params["height"] = 300
+            params['height'] = 300
 
         super().__init__(*objects, **params)
         self._last_synced = None
@@ -83,7 +88,9 @@ class Feed(Column):
 
     @param.depends("visible_range", "load_buffer", watch=True)
     def _trigger_get_objects(self):
-        if self.visible_range is None:
+        # A non-scrolling Feed renders every object up front (see _synced_range),
+        # so there is nothing further to load as visible_range changes.
+        if self.visible_range is None or not self.scroll:
             return
 
         # visible start, end / synced start, end
@@ -110,6 +117,11 @@ class Feed(Column):
     @property
     def _synced_range(self):
         n = len(self.objects)
+        if not self.scroll:
+            # A non-scrolling Feed cannot clip a viewport to virtualize against,
+            # so it renders every object; the frontend measures visible_range
+            # against the page viewport instead (#8661).
+            return (0, n)
         if self.visible_range:
             return (
                 max(self.visible_range[0] - self.load_buffer, 0),

--- a/panel/layout/feed.py
+++ b/panel/layout/feed.py
@@ -39,9 +39,7 @@ class Feed(Column):
     load_buffer = param.Integer(default=50, bounds=(0, None), doc="""
         The number of objects loaded on each side of the visible objects.
         When scrolled halfway into the buffer, the feed will automatically
-        load additional objects while unloading objects on the opposite side.
-        Has no effect when scroll=False, in which case all objects are
-        rendered and visibility is tracked against the page viewport.""")
+        load additional objects while unloading objects on the opposite side.""")
 
     scroll: t.Literal[
         False, True, "both-auto", "y-auto", "x-auto", "both", "x", "y"
@@ -72,15 +70,17 @@ class Feed(Column):
     }
 
     def __init__(self, *objects, **params):
-        # A scrolling Feed virtualizes by only rendering objects near the visible
-        # range, so it needs a bounding height (height or max_height) to clip its
-        # viewport; min_height only sets a floor and lets it grow, so everything
-        # ends up loaded (#8661). A non-scrolling Feed renders all of its objects
-        # (see _synced_range) and needs no default height.
-        scroll = params.get('scroll', type(self).param.scroll.default)
-        if scroll and 'height' not in params and 'max_height' not in params:
-            # sets a default height to prevent infinite load
-            params['height'] = 300
+        # Only a scrolling Feed clips a viewport to virtualize against, so it
+        # needs a bounding height to avoid loading everything (#8661). A
+        # non-scrolling Feed renders all its objects (see _synced_range) and must
+        # not get a height, which would clip it rather than let the page scroll.
+        if params.get('scroll', type(self).param.scroll.default):
+            for height_param in ["height", "min_height", "max_height"]:
+                if height_param in params:
+                    break
+            else:
+                # sets a default height to prevent infinite load
+                params["height"] = 300
 
         super().__init__(*objects, **params)
         self._last_synced = None

--- a/panel/models/feed.ts
+++ b/panel/models/feed.ts
@@ -37,6 +37,14 @@ export class FeedView extends ColumnView {
   override initialize(): void {
     super.initialize()
     this._sync = true
+    // The Feed only clips its children when it is a scroll container, whose css
+    // classes (see _SCROLL_MAPPING) all start with "scroll". Otherwise it grows
+    // to fit its content and an ancestor (e.g. the page) scrolls, so visibility
+    // must be measured against the viewport; rooting on this.el would treat
+    // every rendered child - including the load_buffer - as visible and expand
+    // visible_range until all objects load (#8661).
+    const is_scroll_container = this.model.css_classes.some((cls) => cls.startsWith("scroll"))
+    const root = is_scroll_container ? this.el : null
     this._intersection_observer = new IntersectionObserver((entries) => {
       const visible = [...this.model.visible_children]
       const nodes = this.node_map
@@ -64,7 +72,7 @@ export class FeedView extends ColumnView {
         this._last_visible = null
       }
     }, {
-      root: this.el,
+      root,
       threshold: 0.01,
     })
   }

--- a/panel/tests/layout/test_feed.py
+++ b/panel/tests/layout/test_feed.py
@@ -1,3 +1,5 @@
+import pytest
+
 from panel import Feed
 
 
@@ -5,6 +7,34 @@ def test_feed_init():
     feed = Feed()
     assert feed.height == 300
     assert feed.scroll
+
+
+@pytest.mark.parametrize(
+    ("params", "expected_height"),
+    [
+        ({}, 300),
+        ({"height": 250}, 250),
+        ({"max_height": 400}, None),
+        ({"min_height": 500}, 300),
+        ({"scroll": False}, None),
+    ],
+    ids=["no_bounds", "explicit_height", "max_height", "min_height_only", "scroll_false"],
+)
+def test_feed_default_height_guard(params, expected_height):
+    # A scrolling Feed needs a bounding height (height/max_height) to clip its
+    # viewport; min_height only sets a floor, so a min_height-only Feed must
+    # still receive the default height to prevent runaway loading (#8661). A
+    # non-scrolling Feed renders all objects and needs no default height.
+    feed = Feed(**params)
+    assert feed.height == expected_height
+
+
+def test_feed_scroll_false_renders_all():
+    # A non-scrolling Feed cannot clip a viewport, so it renders every object
+    # instead of virtualizing; visible_range is measured against the page
+    # viewport on the frontend (#8661).
+    feed = Feed(*list(range(100)), scroll=False)
+    assert feed._synced_range == (0, 100)
 
 
 def test_feed_set_objects():

--- a/panel/tests/layout/test_feed.py
+++ b/panel/tests/layout/test_feed.py
@@ -1,5 +1,3 @@
-import pytest
-
 from panel import Feed
 
 
@@ -9,32 +7,18 @@ def test_feed_init():
     assert feed.scroll
 
 
-@pytest.mark.parametrize(
-    ("params", "expected_height"),
-    [
-        ({}, 300),
-        ({"height": 250}, 250),
-        ({"max_height": 400}, None),
-        ({"min_height": 500}, 300),
-        ({"scroll": False}, None),
-    ],
-    ids=["no_bounds", "explicit_height", "max_height", "min_height_only", "scroll_false"],
-)
-def test_feed_default_height_guard(params, expected_height):
-    # A scrolling Feed needs a bounding height (height/max_height) to clip its
-    # viewport; min_height only sets a floor, so a min_height-only Feed must
-    # still receive the default height to prevent runaway loading (#8661). A
-    # non-scrolling Feed renders all objects and needs no default height.
-    feed = Feed(**params)
-    assert feed.height == expected_height
-
-
 def test_feed_scroll_false_renders_all():
     # A non-scrolling Feed cannot clip a viewport, so it renders every object
     # instead of virtualizing; visible_range is measured against the page
     # viewport on the frontend (#8661).
     feed = Feed(*list(range(100)), scroll=False)
     assert feed._synced_range == (0, 100)
+
+
+def test_feed_scroll_false_no_default_height():
+    # A non-scrolling Feed must not receive the default height, which would clip
+    # it to a fixed viewport rather than letting the page scroll (#8661).
+    assert Feed(scroll=False).height is None
 
 
 def test_feed_set_objects():

--- a/panel/tests/layout/test_feed.py
+++ b/panel/tests/layout/test_feed.py
@@ -8,16 +8,16 @@ def test_feed_init():
 
 
 def test_feed_scroll_false_renders_all():
-    # A non-scrolling Feed cannot clip a viewport, so it renders every object
-    # instead of virtualizing; visible_range is measured against the page
-    # viewport on the frontend (#8661).
+    """A non-scrolling Feed cannot clip a viewport, so it renders every object
+    instead of virtualizing; visible_range is measured against the page viewport
+    on the frontend (#8661)."""
     feed = Feed(*list(range(100)), scroll=False)
     assert feed._synced_range == (0, 100)
 
 
 def test_feed_scroll_false_no_default_height():
-    # A non-scrolling Feed must not receive the default height, which would clip
-    # it to a fixed viewport rather than letting the page scroll (#8661).
+    """A non-scrolling Feed must not receive the default height, which would clip
+    it to a fixed viewport rather than letting the page scroll (#8661)."""
     assert Feed(scroll=False).height is None
 
 

--- a/panel/tests/ui/layout/test_feed.py
+++ b/panel/tests/ui/layout/test_feed.py
@@ -35,6 +35,22 @@ def test_feed_load_entries(page):
     feed_el.evaluate('(el) => el.scrollTo({top: 0})')
     wait_until(lambda: feed_el.locator('.bk-panel-models-markup-HTML').count() >= 50, page)
 
+def test_feed_scroll_false_reports_visible_subset(page):
+    # Regression test for #8661: a Feed embedded in a scrolling page
+    # (scroll=False) renders all of its objects but must report only the
+    # on-screen objects in visible_range, instead of expanding it to cover
+    # every rendered object.
+    feed = Feed(*list(range(ITEMS)), scroll=False)
+    serve_component(page, feed)
+
+    feed_el = page.locator(".bk-panel-models-feed-Feed")
+    expect(feed_el).to_be_attached()
+
+    wait_until(lambda: feed.visible_range is not None, page)
+    page.wait_for_timeout(500)
+    lo, hi = feed.visible_range
+    assert hi - lo < ITEMS - 1
+
 def test_feed_view_latest(page):
     feed = Feed(*list(range(ITEMS)), height=250, view_latest=True)
     serve_component(page, feed)

--- a/panel/tests/ui/layout/test_feed.py
+++ b/panel/tests/ui/layout/test_feed.py
@@ -36,10 +36,10 @@ def test_feed_load_entries(page):
     wait_until(lambda: feed_el.locator('.bk-panel-models-markup-HTML').count() >= 50, page)
 
 def test_feed_scroll_false_reports_visible_subset(page):
-    # Regression test for #8661: a Feed embedded in a scrolling page
-    # (scroll=False) renders all of its objects but must report only the
-    # on-screen objects in visible_range, instead of expanding it to cover
-    # every rendered object.
+    """Regression test for #8661: a Feed embedded in a scrolling page
+    (scroll=False) renders all of its objects but must report only the on-screen
+    objects in visible_range, instead of expanding it to cover every rendered
+    object."""
     feed = Feed(*list(range(ITEMS)), scroll=False)
     serve_component(page, feed)
 


### PR DESCRIPTION
<!-- Using AI? READ FIRST: https://holoviz.org/contribute.html#ai-readme -->

## Description
<!-- Summarize the change and which issue is fixed. Be sure to include relevant motivation and context. Describe the tests run to verify these changes and how to reproduce them (copy-pastable minimal, reproducible example). Include visuals when possible (e.g. before/after screenshots). -->

Fixes #8661

When a `Feed` scrolls with the page instead of itself (`scroll=False`, or no
bounding height), `visible_range` kept growing until every object was reported
visible. The `IntersectionObserver` was rooted on the Feed's own element, which
grows to fit its content, so every rendered child — including the `load_buffer`
— intersected it and fed back into `visible_range`.

- **`feed.ts`**: root the observer on the viewport (not `this.el`) when the Feed
  is not a scroll container, so `visible_range` reflects what's actually on screen.
- **`feed.py`**: when not scrolling, render all objects (`_synced_range → (0, n)`)
  and skip load-triggers, so the page keeps full height and nothing collapses.
  The default-height guard now applies only to scrolling feeds.

https://github.com/user-attachments/assets/794e8105-9a41-47c0-b5b2-d27a725b1e1e


## AI Disclosure
<!-- Delete this section if AI was not used, else specify the tool/model (e.g. Cursor + Sonnet 4.6, Claude Code + Opus 4.6, ChatGPT) and briefly describe how it was used. Failure to disclose AI usage may result in a ban. -->

Tool & Model: Opus 4.8
Usage: Identify and fix bug, and write this PR description

- [x] I have tested all AI-generated content in my PR.
- [x] I take responsibility for all AI-generated content in my PR.


## Checklist
<!-- Remove the non relevant items. -->

- [ ] Tests added and are passing
