### PR TITLE
Feature/overlay layout

### DIFF
--- a/examples/reference/layouts/Overlay.ipynb
+++ b/examples/reference/layouts/Overlay.ipynb
@@ -1,0 +1,196 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import panel as pn\n",
+    "\n",
+    "pn.extension()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The `Overlay` layout floats one or more panels at anchored positions on top of a `base` component (e.g. a map, plot, image or video) *without* the panels consuming layout space or displacing the base. Unlike a full-size covering layer, each floating panel is only as large as its own footprint, so the base stays interactive (pan/zoom/click) everywhere else.\n",
+    "\n",
+    "Each panel is declared as a `(where, obj)` tuple where `where` is either one of the nine named anchors of a 3x3 grid (`\"top-left\"`, `\"top-center\"`, `\"top-right\"`, `\"center-left\"`, `\"center\"`, `\"center-right\"`, `\"bottom-left\"`, `\"bottom-center\"`, `\"bottom-right\"`) or an explicit `(x, y)` coordinate -- in pixels or as a percentage string -- measured from the top-left corner of `base`. To place more than one thing at a single anchor, compose them first with `Row`, `Column` or `FlexBox`.\n",
+    "\n",
+    "#### Parameters:\n",
+    "\n",
+    "* **``base``** (Viewable): The underlay component the panels float on top of. Determines the size of the `Overlay` unless overridden by `sizing_mode`, `width` and/or `height`.\n",
+    "* **``objects``** (list): The list of floating panels, each placed at the anchor or coordinate it was declared with. Should not generally be modified directly except when replaced in its entirety -- use the list-like methods below (`append`, `insert`, etc.) instead.\n",
+    "* **``anchors``** (list, read-only): Each panel's anchor or coordinate, aligned with `objects`.\n",
+    "\n",
+    "Styling related parameters:\n",
+    "\n",
+    "* **``margin``** (int or tuple): Space around the *whole* `Overlay` in its parent layout. This does not inset the panels -- that is controlled by each panel's own `margin` instead (see below). Defaults to `0` so a full-bleed base has no stray outer gap.\n",
+    "\n",
+    "For details on other options for customizing the component see the [layout](../../how_to/layout/index.md) and [styling](../../how_to/styling/index.md) how-to guides.\n",
+    "\n",
+    "___"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Anchors\n",
+    "\n",
+    "A classic use case -- inspired by tools like Breakthrough Energy's *Contrails Map* -- is pinning a legend, some controls, and a guide card around the corners of a full-bleed map or plot that stays interactive underneath. Here we stand in for the map with a plain colored box:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def panel_box(text, color):\n",
+    "    return pn.pane.HTML(\n",
+    "        f'<div style=\"width:100%;height:100%;color:white;'\n",
+    "        f'display:flex;align-items:center;justify-content:center;\">{text}</div>',\n",
+    "        styles={'background': color, 'border-radius': '4px'},\n",
+    "        width=120, height=40,\n",
+    "    )\n",
+    "\n",
+    "base_map = pn.pane.HTML(\n",
+    "    '<div style=\"width:100%;height:100%;\"></div>',\n",
+    "    styles={'background': '#2b2b2b'},\n",
+    ")\n",
+    "\n",
+    "overlay = pn.layout.Overlay(\n",
+    "    ('top-left', panel_box('Legend', '#3b82f6')),\n",
+    "    ('top-right', pn.Column(panel_box('Search', '#10b981'), panel_box('Layers', '#10b981'))),\n",
+    "    ('bottom-center', panel_box('\u25c0 \u25a0 \u25b6', '#f59e0b')),\n",
+    "    ('bottom-right', panel_box('Guide', '#ef4444')),\n",
+    "    base=base_map,\n",
+    "    sizing_mode='stretch_both',\n",
+    "    height=320,\n",
+    ")\n",
+    "overlay"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Since only `base` occupies layout space, the `Overlay` above is exactly as tall as the `height` we gave it, with the four panels floating on top and the dark background filling the rest -- try resizing the browser window and the panels stay pinned to their corners while the base keeps filling the available space.\n",
+    "\n",
+    "The read-only `anchors` property stays aligned with `objects`, in declaration order:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "overlay.anchors"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Coordinates\n",
+    "\n",
+    "Instead of a named anchor, `where` may also be an explicit `(x, y)` coordinate measured from the top-left of `base`. Values may be pixels (`int`) or percentages (`str`), and unlike named anchors, coordinates may repeat freely:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "chart = pn.pane.HTML(\n",
+    "    '<div style=\"width:100%;height:100%;\"></div>',\n",
+    "    styles={'background': '#1f2937'}, width=400, height=250,\n",
+    ")\n",
+    "\n",
+    "pn.layout.Overlay(\n",
+    "    ((24, 16), panel_box('Pixels: (24, 16)', '#8b5cf6')),\n",
+    "    ((\"60%\", \"70%\"), panel_box('Percent: (60%, 70%)', '#ec4899')),\n",
+    "    base=chart,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Sizing\n",
+    "\n",
+    "Only `base` is in normal flow -- panels are absolutely positioned and never affect the `Overlay`'s size. That leaves two ways to size it:\n",
+    "\n",
+    "* **Content-sized** (default, `sizing_mode=None`): the `Overlay` hugs `base`'s natural size, exactly like the fixed-size `chart` example above.\n",
+    "* **Responsive** (`sizing_mode=\"stretch_both\"`, `\"stretch_width\"`, or an explicit `width`/`height`): the `Overlay` takes that size and `base` is stretched to fill it -- this is the full-bleed map/plot case used at the top of this page.\n",
+    "\n",
+    "Mixing the two the wrong way round -- a responsively sized `Overlay` around a fixed-size `base` -- leaves the panels anchored to empty space beyond the smaller base, so pick whichever of the two matches how `base` itself is sized."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Updating\n",
+    "\n",
+    "Like `Row` and `Column`, `Overlay` has a list-like API -- `append`, `extend`, `clear`, `insert`, `pop`, `remove`, `reverse` and `__setitem__` -- for interactively updating the panels, keeping `anchors` aligned automatically:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "overlay.append(('center', panel_box('New!', '#06b6d4')))\n",
+    "overlay.anchors"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Re-assigning an existing panel's tuple moves it to a new anchor\n",
+    "overlay[0] = ('bottom-left', overlay[0])\n",
+    "overlay.anchors"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Validation\n",
+    "\n",
+    "Placement is always explicit: a bare object with no anchor, an unrecognized anchor name, or reusing the same named anchor twice all raise a `ValueError` rather than silently doing the wrong thing. Coordinates are exempt from the uniqueness check since they're free placement:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    pn.layout.Overlay(('top-left', 'A'), ('top-left', 'B'))\n",
+    "except ValueError as e:\n",
+    "    print(e)"
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/examples/reference/layouts/Overlay.ipynb
+++ b/examples/reference/layouts/Overlay.ipynb
@@ -65,11 +65,11 @@
     "overlay = pn.layout.Overlay(\n",
     "    ('top-left', panel_box('Legend', '#3b82f6')),\n",
     "    ('top-right', pn.Column(panel_box('Search', '#10b981'), panel_box('Layers', '#10b981'))),\n",
-    "    ('bottom-center', panel_box('\u25c0 \u25a0 \u25b6', '#f59e0b')),\n",
+    "    ('bottom-center', panel_box('◀ ■ ▶', '#f59e0b')),\n",
     "    ('bottom-right', panel_box('Guide', '#ef4444')),\n",
     "    base=base_map,\n",
     "    sizing_mode='stretch_both',\n",
-    "    height=320,\n",
+    "    min_height=320,\n",
     ")\n",
     "overlay"
    ]

--- a/examples/reference/layouts/Overlay.ipynb
+++ b/examples/reference/layouts/Overlay.ipynb
@@ -130,7 +130,39 @@
     "* **Content-sized** (default, `sizing_mode=None`): the `Overlay` hugs `base`'s natural size, exactly like the fixed-size `chart` example above.\n",
     "* **Responsive** (`sizing_mode=\"stretch_both\"`, `\"stretch_width\"`, or an explicit `width`/`height`): the `Overlay` takes that size and `base` is stretched to fill it -- this is the full-bleed map/plot case used at the top of this page.\n",
     "\n",
-    "Mixing the two the wrong way round -- a responsively sized `Overlay` around a fixed-size `base` -- leaves the panels anchored to empty space beyond the smaller base, so pick whichever of the two matches how `base` itself is sized."
+    "Mixing the two the wrong way round -- a responsively sized `Overlay` around a fixed-size `base` -- leaves the panels anchored to empty space beyond the smaller base, so pick whichever of the two matches how `base` itself is sized.\n",
+    "\n",
+    "To avoid having to declare the same `sizing_mode` (and `margin`) twice, `Overlay` picks both up from `base` automatically whenever you don't set them yourself -- set `sizing_mode` (and, if needed, `margin`) once on `base` and the `Overlay` follows suit:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "responsive_base = pn.pane.HTML(\n",
+    "    '<div style=\"width:100%;height:100%;\"></div>',\n",
+    "    styles={'background': '#0f172a'},\n",
+    "    sizing_mode='stretch_both', margin=0,\n",
+    ")\n",
+    "\n",
+    "# No sizing_mode/margin passed to Overlay itself -- both are picked up\n",
+    "# from responsive_base (shown here rather than displayed inline, since\n",
+    "# a bare stretch_both component doesn't preview meaningfully in a\n",
+    "# notebook cell with no definite height to fill).\n",
+    "responsive_overlay = pn.layout.Overlay(\n",
+    "    ('top-left', panel_box('Live', '#22c55e')),\n",
+    "    base=responsive_base,\n",
+    ")\n",
+    "responsive_overlay.sizing_mode, responsive_overlay.margin"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Passing `sizing_mode` (or `margin`) to `Overlay` explicitly always wins over whatever `base` declares, and once you've set one -- either up front or by assigning it later -- swapping `base` for something with a different `sizing_mode` won't override your choice."
    ]
   },
   {

--- a/panel/__init__.py
+++ b/panel/__init__.py
@@ -64,7 +64,8 @@ from .io import (  # noqa
 )
 from .layout import (  # noqa
     Accordion, Card, Column, Feed, FlexBox, FloatPanel, GridBox, GridSpec,
-    GridStack, HSpacer, Modal, Row, Spacer, Swipe, Tabs, VSpacer, WidgetBox,
+    GridStack, HSpacer, Modal, Overlay, Row, Spacer, Swipe, Tabs, VSpacer,
+    WidgetBox,
 )
 from .pane import panel  # noqa
 from .param import Param, ReactiveExpr  # noqa
@@ -89,6 +90,7 @@ __all__ = (
     "GridStack",
     "HSpacer",
     "Modal",
+    "Overlay",
     "Param",
     "ReactiveExpr",
     "Row",

--- a/panel/layout/__init__.py
+++ b/panel/layout/__init__.py
@@ -39,21 +39,22 @@ from .float import FloatPanel  # noqa
 from .grid import GridBox, GridSpec  # noqa
 from .gridstack import GridStack  # noqa
 from .modal import Modal
-# NOTE: `overlay` must be imported last, after every other name in this
-# module is bound. It's the only layout module that reaches into
-# `..custom` (for `JSComponent`), which transitively imports `..pane`
-# (`panel.custom` -> `panel.pane.base` -> triggers all of
-# `panel/pane/__init__.py`, e.g. `pane.holoviews` needs `HSpacer`, `Row`,
-# etc. back from `panel.layout`). Since `panel/__init__.py`'s very first
-# import is `layout`, that reach-back hits a partially-initialized
-# `panel.layout` module, so importing `overlay` before `spacer` (which
-# defines `HSpacer`) raises a circular ImportError.
-from .overlay import Overlay  # noqa
 from .spacer import (  # noqa
     Divider, HSpacer, Spacer, VSpacer,
 )
 from .swipe import Swipe  # noqa
 from .tabs import Tabs  # noqa
+
+# NOTE: `overlay` must be imported last -- the `isort:skip` pins it here
+# (same pattern as `custom`/`chat` in panel/__init__.py) so `ruff --fix`
+# can't sort it back up. It's the only layout module that reaches into
+# `..custom` (for `JSComponent`), which transitively imports `..pane` ->
+# `pane.holoviews`, which reaches back into `panel.layout` for `HSpacer`,
+# `Row`, etc. Since `panel/__init__.py` imports `layout` before `pane`,
+# that reach-back hits a partially-initialized `panel.layout`; importing
+# `overlay` before `spacer` (which defines `HSpacer`) would raise a
+# circular ImportError.
+from .overlay import Overlay  # isort:skip # noqa
 
 __all__ = (
     "Accordion",

--- a/panel/layout/__init__.py
+++ b/panel/layout/__init__.py
@@ -39,12 +39,6 @@ from .float import FloatPanel  # noqa
 from .grid import GridBox, GridSpec  # noqa
 from .gridstack import GridStack  # noqa
 from .modal import Modal
-from .spacer import (  # noqa
-    Divider, HSpacer, Spacer, VSpacer,
-)
-from .swipe import Swipe  # noqa
-from .tabs import Tabs  # noqa
-
 # NOTE: `overlay` must be imported last. It's the only layout module
 # that reaches into `..custom` (for `JSComponent`), which transitively
 # imports `..pane` (`panel.custom` -> `panel.pane.base` -> triggers all
@@ -55,6 +49,11 @@ from .tabs import Tabs  # noqa
 # after every other name here is already bound avoids the circular
 # ImportError.
 from .overlay import Overlay  # noqa
+from .spacer import (  # noqa
+    Divider, HSpacer, Spacer, VSpacer,
+)
+from .swipe import Swipe  # noqa
+from .tabs import Tabs  # noqa
 
 __all__ = (
     "Accordion",

--- a/panel/layout/__init__.py
+++ b/panel/layout/__init__.py
@@ -39,12 +39,22 @@ from .float import FloatPanel  # noqa
 from .grid import GridBox, GridSpec  # noqa
 from .gridstack import GridStack  # noqa
 from .modal import Modal
-from .overlay import Overlay  # noqa
 from .spacer import (  # noqa
     Divider, HSpacer, Spacer, VSpacer,
 )
 from .swipe import Swipe  # noqa
 from .tabs import Tabs  # noqa
+
+# NOTE: `overlay` must be imported last. It's the only layout module
+# that reaches into `..custom` (for `JSComponent`), which transitively
+# imports `..pane` (`panel.custom` -> `panel.pane.base` -> triggers all
+# of `panel/pane/__init__.py`, e.g. `pane.holoviews` needs `HSpacer`,
+# `Row`, etc. back from `panel.layout`). Since `panel/__init__.py`'s
+# very first import is `layout`, that reach-back hits a
+# partially-initialized `panel.layout` module -- importing `overlay`
+# after every other name here is already bound avoids the circular
+# ImportError.
+from .overlay import Overlay  # noqa
 
 __all__ = (
     "Accordion",

--- a/panel/layout/__init__.py
+++ b/panel/layout/__init__.py
@@ -39,15 +39,15 @@ from .float import FloatPanel  # noqa
 from .grid import GridBox, GridSpec  # noqa
 from .gridstack import GridStack  # noqa
 from .modal import Modal
-# NOTE: `overlay` must be imported last. It's the only layout module
-# that reaches into `..custom` (for `JSComponent`), which transitively
-# imports `..pane` (`panel.custom` -> `panel.pane.base` -> triggers all
-# of `panel/pane/__init__.py`, e.g. `pane.holoviews` needs `HSpacer`,
-# `Row`, etc. back from `panel.layout`). Since `panel/__init__.py`'s
-# very first import is `layout`, that reach-back hits a
-# partially-initialized `panel.layout` module -- importing `overlay`
-# after every other name here is already bound avoids the circular
-# ImportError.
+# NOTE: `overlay` must be imported last, after every other name in this
+# module is bound. It's the only layout module that reaches into
+# `..custom` (for `JSComponent`), which transitively imports `..pane`
+# (`panel.custom` -> `panel.pane.base` -> triggers all of
+# `panel/pane/__init__.py`, e.g. `pane.holoviews` needs `HSpacer`, `Row`,
+# etc. back from `panel.layout`). Since `panel/__init__.py`'s very first
+# import is `layout`, that reach-back hits a partially-initialized
+# `panel.layout` module, so importing `overlay` before `spacer` (which
+# defines `HSpacer`) raises a circular ImportError.
 from .overlay import Overlay  # noqa
 from .spacer import (  # noqa
     Divider, HSpacer, Spacer, VSpacer,

--- a/panel/layout/__init__.py
+++ b/panel/layout/__init__.py
@@ -39,6 +39,7 @@ from .float import FloatPanel  # noqa
 from .grid import GridBox, GridSpec  # noqa
 from .gridstack import GridStack  # noqa
 from .modal import Modal
+from .overlay import Overlay  # noqa
 from .spacer import (  # noqa
     Divider, HSpacer, Spacer, VSpacer,
 )
@@ -60,6 +61,7 @@ __all__ = (
     "ListLike",
     "ListPanel",
     "Modal",
+    "Overlay",
     "Panel",
     "Row",
     "Spacer",

--- a/panel/layout/overlay.js
+++ b/panel/layout/overlay.js
@@ -25,6 +25,19 @@ export function render({ model }) {
   el.classList.add("overlay")
   Object.assign(el.style, {position: "relative"})
 
+  // Bokeh already stretches its own wrapper around `el` to 100%/100%
+  // whenever sizing_mode is definite, but that only gives `el` a
+  // definite WIDTH for free -- a block-level element's height doesn't
+  // inherit from its container the same way. Without this, `el` (and
+  // anything inside it sized via height:100%, like a stretch_both
+  // base) collapses to zero height even though the outer component
+  // correctly fills the page. Mirrors the same isDefinite check used
+  // for the base below.
+  if (isDefinite(model)) {
+    el.style.width = "100%"
+    el.style.height = "100%"
+  }
+
   let baseNode = null
   let panelBoxes = []
 

--- a/panel/layout/overlay.js
+++ b/panel/layout/overlay.js
@@ -1,0 +1,85 @@
+const ANCHORS = {
+  "top-left":      {top: 0, left: 0},
+  "top-center":    {top: 0, left: "50%", transform: "translateX(-50%)"},
+  "top-right":     {top: 0, right: 0},
+  "center-left":   {top: "50%", left: 0, transform: "translateY(-50%)"},
+  "center":        {top: "50%", left: "50%", transform: "translate(-50%,-50%)"},
+  "center-right":  {top: "50%", right: 0, transform: "translateY(-50%)"},
+  "bottom-left":   {bottom: 0, left: 0},
+  "bottom-center": {bottom: 0, left: "50%", transform: "translateX(-50%)"},
+  "bottom-right":  {bottom: 0, right: 0},
+}
+
+const coord = (v) => (typeof v === "number" ? `${v}px` : v)
+
+// Overlay has a definite size if a stretch/scale_both mode or explicit
+// dims are set; otherwise it hugs the natural size of `base`.
+const isDefinite = (model) => {
+  const sm = model.sizing_mode || ""
+  return sm.includes("stretch") || sm === "scale_both" ||
+         model.width != null || model.height != null
+}
+
+export function render({ model }) {
+  const el = document.createElement("div")
+  el.classList.add("overlay")
+  Object.assign(el.style, {position: "relative"})
+
+  let baseNode = null
+  let panelBoxes = []
+
+  const renderBase = () => {
+    if (baseNode) { baseNode.remove(); baseNode = null }
+    const base = model.get_child("base")
+    if (base) {
+      baseNode = base
+      // Only force the base to fill the container when the Overlay's
+      // own size is definite (stretch_* / scale_both / explicit
+      // width+height) -- otherwise a content-sized base would be
+      // forced to 100% of a container that hasn't sized itself yet
+      // and collapse to zero.
+      if (isDefinite(model) && baseNode.style) {
+        baseNode.style.width = "100%"
+        baseNode.style.height = "100%"
+      }
+      el.insertBefore(baseNode, el.firstChild)  // base sits beneath panels
+    }
+  }
+
+  const renderPanels = () => {
+    panelBoxes.forEach((b) => b.remove())
+    panelBoxes = []
+    const panels = model.get_child("objects")
+    const anchors = model._anchors || []
+    panels.forEach((child, i) => {
+      const where = anchors[i]
+      const box = document.createElement("div")
+      box.style.position = "absolute"
+      box.classList.add("overlay-panel")
+      Object.assign(
+        box.style,
+        Array.isArray(where)
+          ? {left: coord(where[0]), top: coord(where[1])}
+          : (ANCHORS[where] || ANCHORS["top-left"])
+      )
+      // Not part of the reactivity contract -- purely a convenience
+      // hook for styling/tests to select a panel by its anchor.
+      if (typeof where === "string") {
+        box.dataset.anchor = where
+      } else if (Array.isArray(where)) {
+        box.dataset.anchor = `${where[0]},${where[1]}`
+      }
+      box.appendChild(child)
+      el.appendChild(box)
+      panelBoxes.push(box)
+    })
+  }
+
+  renderBase()
+  renderPanels()
+  model.on("base", renderBase)
+  model.on("objects", renderPanels)
+  model.on("_anchors", renderPanels)
+
+  return el
+}

--- a/panel/layout/overlay.js
+++ b/panel/layout/overlay.js
@@ -22,7 +22,10 @@ const isDefinite = (model) => {
 
 export function render({ model }) {
   const el = document.createElement("div")
-  el.classList.add("overlay")
+  // NOTE: not "overlay" -- ReactiveESM already names the host container
+  // after the component's class_name ("Overlay" -> ".overlay"), so
+  // reusing it here would produce two nested `.overlay` elements.
+  el.classList.add("overlay-container")
   Object.assign(el.style, {position: "relative"})
 
   // Bokeh already stretches its own wrapper around `el` to 100%/100%

--- a/panel/layout/overlay.py
+++ b/panel/layout/overlay.py
@@ -1,0 +1,180 @@
+"""
+Defines the Overlay layout, which floats one or more panels at
+anchored positions on top of a base component without the panels
+consuming layout space or displacing the base.
+"""
+from __future__ import annotations
+
+import typing as t
+
+import param
+
+from .._param import Margin
+from ..custom import Child, JSComponent
+from .base import NamedListLike
+
+if t.TYPE_CHECKING:
+    from typing_extensions import Self
+
+    from ..viewable import Viewable
+
+ANCHORS = {
+    "top-left", "top-center", "top-right",
+    "center-left", "center", "center-right",
+    "bottom-left", "bottom-center", "bottom-right",
+}
+
+
+def _valid_where(where: t.Any) -> bool:
+    """
+    Whether `where` is a valid Overlay placement: one of the nine
+    named anchors or an (x, y) coordinate of ints, floats and/or
+    percentage strings.
+    """
+    if where in ANCHORS:
+        return True
+    return (
+        isinstance(where, (tuple, list)) and len(where) == 2 and
+        all(isinstance(v, (int, float, str)) for v in where)
+    )
+
+
+class Overlay(NamedListLike, JSComponent):
+    """
+    The `Overlay` layout floats one or more panels at anchored
+    positions on top of a `base` component (e.g. a map, plot, image
+    or video) without the panels consuming layout space or
+    displacing the base. Unlike a covering layer, each floating panel
+    is only as large as its own footprint, so the base remains
+    interactive (pan/zoom/click) everywhere else.
+
+    Each panel is declared as a `(where, obj)` tuple where `where` is
+    either a named anchor (one of the nine points of a 3x3 grid, e.g.
+    `"top-left"` or `"center"`) or an explicit `(x, y)` coordinate
+    (in pixels or as a percentage string) measured from the top-left
+    of `base`. To place more than one thing at a single anchor,
+    compose them first with `Row`, `Column` or `FlexBox`.
+
+    A named anchor may only be used once; reusing one raises a
+    `ValueError`. Coordinates may be reused freely. Every item must
+    declare a placement explicitly -- a bare object (with no `where`)
+    also raises a `ValueError`.
+
+    Reference: https://panel.holoviz.org/reference/layouts/Overlay.html
+
+    :Example:
+
+    >>> pn.layout.Overlay(
+    ...     ("top-left", legend),
+    ...     ("top-right", pn.Column(search, layers)),
+    ...     ("bottom-right", guide),
+    ...     base=deckgl_map,
+    ...     sizing_mode="stretch_both",
+    ... )
+    """
+
+    base = Child(default=None, doc="""
+        The underlay component that the panels float on top of.
+        Determines the size of the Overlay unless overridden by
+        sizing_mode, width and/or height.""")
+
+    margin = Margin(default=0, doc="""
+        Allows to create additional space around the component. May
+        be specified as a two-tuple of the form (vertical, horizontal)
+        or a four-tuple (top, right, bottom, left). Defaults to 0,
+        unlike most other layouts, so that a full-bleed base has no
+        stray outer gap.""")
+
+    # Index-aligned with `objects`. Mirrors each panel's anchor or
+    # coordinate so the frontend can position it; read (read-only)
+    # from Python via the `anchors` property.
+    _anchors = param.List(default=[], doc="""
+        Read-only, index-aligned with `objects`.""")
+
+    _esm = "overlay.js"
+
+    def __init__(self, *objects: t.Any, **params: t.Any):
+        super().__init__(*objects, **params)
+        # NamedListLike.__init__ sets the initial `_names` directly
+        # (bypassing the 'objects' watcher below), so the first sync
+        # has to happen explicitly here.
+        self._sync_anchors()
+
+    #----------------------------------------------------------------
+    # NamedListLike API
+    #----------------------------------------------------------------
+
+    def _to_object_and_name(self, item: t.Any) -> tuple[Viewable, t.Any]:
+        if not (isinstance(item, tuple) and len(item) == 2):
+            raise ValueError(
+                "Overlay items must be (anchor, object) tuples, e.g. "
+                "('top-left', widget) or ((x, y), widget); got "
+                f"{item!r}."
+            )
+        where, obj = item
+        if not _valid_where(where):
+            raise ValueError(f"invalid anchor: {where!r}")
+        from ..pane import panel
+        return panel(obj), where
+
+    def _update_names(self, event: param.parameterized.Event) -> None:
+        super()._update_names(event)
+        self._sync_anchors()
+
+    def _sync_anchors(self) -> None:
+        """
+        Validates the current `_names` (anchors, aligned with
+        `objects`) and mirrors them onto `_anchors` for the frontend.
+        Runs after every mutation, whether via the constructor, the
+        list-like methods (append/insert/extend/__setitem__), or a
+        direct assignment to `.objects`.
+        """
+        seen = set()
+        for where in self._names:
+            if not _valid_where(where):
+                raise ValueError(f"invalid anchor: {where!r}")
+            if where in ANCHORS:
+                if where in seen:
+                    raise ValueError(f"duplicate anchor: {where!r}")
+                seen.add(where)
+        self._anchors = list(self._names)
+
+    def clone(self, *objects: t.Any, **params: t.Any) -> Self:
+        """
+        Makes a copy of the Overlay sharing the same parameters.
+
+        Parameters
+        ----------
+        objects: (anchor, object) tuples to add to the cloned Overlay.
+        params: Keyword arguments override the parameters on the clone.
+
+        Returns
+        -------
+        Cloned Overlay object
+        """
+        if objects:
+            overrides = objects
+            if 'objects' in params:
+                raise ValueError(
+                    "Overlay objects should be supplied either as "
+                    "positional arguments or as a keyword, not both."
+                )
+        elif 'objects' in params:
+            overrides = params.pop('objects')
+        else:
+            overrides = tuple(zip(self._names, self.objects))
+        p = dict(self.param.values(), **params)
+        del p['objects']
+        return type(self)(*overrides, **p)
+
+    #----------------------------------------------------------------
+    # Public API
+    #----------------------------------------------------------------
+
+    @property
+    def anchors(self) -> list[t.Any]:
+        """
+        Read-only list of each panel's anchor or coordinate, aligned
+        with `objects`.
+        """
+        return list(self._anchors)

--- a/panel/layout/overlay.py
+++ b/panel/layout/overlay.py
@@ -186,7 +186,7 @@ class Overlay(NamedListLike, JSComponent):
         seen = set()
         for where in self._names:
             if not _valid_where(where):
-                raise ValueError(f"invalid anchor: {where!r}")
+                raise ValueError(f"invalid anchor: {where!r}; must be one of {sorted(ANCHORS)} or an (x, y) coordinate")
             if where in ANCHORS:
                 if where in seen:
                     raise ValueError(f"duplicate anchor: {where!r}")

--- a/panel/layout/overlay.py
+++ b/panel/layout/overlay.py
@@ -16,8 +16,6 @@ from .base import NamedListLike
 if t.TYPE_CHECKING:
     from typing_extensions import Self
 
-    from ..viewable import Viewable
-
 ANCHORS = {
     "top-left", "top-center", "top-right",
     "center-left", "center", "center-right",
@@ -37,6 +35,15 @@ def _valid_where(where: t.Any) -> bool:
         isinstance(where, (tuple, list)) and len(where) == 2 and
         all(isinstance(v, (int, float, str)) for v in where)
     )
+
+
+def _validate_where(where: t.Any) -> None:
+    """Raise a ValueError with guidance if `where` is not a valid placement."""
+    if not _valid_where(where):
+        raise ValueError(
+            f"invalid anchor: {where!r}; must be one of {sorted(ANCHORS)} "
+            "or an (x, y) coordinate"
+        )
 
 
 class Overlay(NamedListLike, JSComponent):
@@ -91,11 +98,10 @@ class Overlay(NamedListLike, JSComponent):
         stray outer gap -- unless `base` is set and declares its own
         margin, which then takes precedence over this default.""")
 
-    # Index-aligned with `objects`. Mirrors each panel's anchor or
-    # coordinate so the frontend can position it; read (read-only)
-    # from Python via the `anchors` property.
-    _anchors = param.List(default=[], doc="""
-        Read-only, index-aligned with `objects`.""")
+    # Mirrors each panel's anchor/coordinate onto the model so the
+    # frontend can position it; exposed read-only via the `anchors`
+    # property and kept index-aligned with `objects`.
+    _anchors = param.List(default=[])
 
     _esm = "overlay.js"
 
@@ -158,7 +164,7 @@ class Overlay(NamedListLike, JSComponent):
     # NamedListLike API
     #----------------------------------------------------------------
 
-    def _to_object_and_name(self, item: t.Any) -> tuple[Viewable, t.Any]:
+    def _to_object_and_name(self, item: t.Any):
         if not (isinstance(item, tuple) and len(item) == 2):
             raise ValueError(
                 "Overlay items must be (anchor, object) tuples, e.g. "
@@ -166,8 +172,7 @@ class Overlay(NamedListLike, JSComponent):
                 f"{item!r}."
             )
         where, obj = item
-        if not _valid_where(where):
-            raise ValueError(f"invalid anchor: {where!r}")
+        _validate_where(where)
         from ..pane import panel
         return panel(obj), where
 
@@ -185,8 +190,7 @@ class Overlay(NamedListLike, JSComponent):
         """
         seen = set()
         for where in self._names:
-            if not _valid_where(where):
-                raise ValueError(f"invalid anchor: {where!r}; must be one of {sorted(ANCHORS)} or an (x, y) coordinate")
+            _validate_where(where)
             if where in ANCHORS:
                 if where in seen:
                     raise ValueError(f"duplicate anchor: {where!r}")

--- a/panel/layout/overlay.py
+++ b/panel/layout/overlay.py
@@ -60,6 +60,11 @@ class Overlay(NamedListLike, JSComponent):
     declare a placement explicitly -- a bare object (with no `where`)
     also raises a `ValueError`.
 
+    `sizing_mode` and `margin` default to whatever `base` declares, so
+    a responsive `base` (e.g. `sizing_mode="stretch_both"`) makes the
+    Overlay responsive too without repeating yourself. Pass either
+    explicitly to opt out of the inheritance for that parameter.
+
     Reference: https://panel.holoviz.org/reference/layouts/Overlay.html
 
     :Example:
@@ -68,22 +73,23 @@ class Overlay(NamedListLike, JSComponent):
     ...     ("top-left", legend),
     ...     ("top-right", pn.Column(search, layers)),
     ...     ("bottom-right", guide),
-    ...     base=deckgl_map,
-    ...     sizing_mode="stretch_both",
+    ...     base=deckgl_map,  # e.g. sizing_mode="stretch_both"
     ... )
     """
 
     base = Child(default=None, doc="""
         The underlay component that the panels float on top of.
         Determines the size of the Overlay unless overridden by
-        sizing_mode, width and/or height.""")
+        sizing_mode, width and/or height. Unless explicitly set,
+        sizing_mode and margin are inherited from base.""")
 
     margin = Margin(default=0, doc="""
         Allows to create additional space around the component. May
         be specified as a two-tuple of the form (vertical, horizontal)
         or a four-tuple (top, right, bottom, left). Defaults to 0,
         unlike most other layouts, so that a full-bleed base has no
-        stray outer gap.""")
+        stray outer gap -- unless `base` is set and declares its own
+        margin, which then takes precedence over this default.""")
 
     # Index-aligned with `objects`. Mirrors each panel's anchor or
     # coordinate so the frontend can position it; read (read-only)
@@ -94,11 +100,59 @@ class Overlay(NamedListLike, JSComponent):
     _esm = "overlay.js"
 
     def __init__(self, *objects: t.Any, **params: t.Any):
+        # sizing_mode/margin default to whatever `base` declares,
+        # unless the caller passed them explicitly -- checked against
+        # the raw incoming kwargs, before any class defaults apply.
+        self._inherit_sizing_mode = 'sizing_mode' not in params
+        self._inherit_margin = 'margin' not in params
+        self._updating_from_base = False
+        base = params.get('base')
+        if base is not None:
+            if self._inherit_sizing_mode and base.sizing_mode is not None:
+                params['sizing_mode'] = base.sizing_mode
+            if self._inherit_margin:
+                params['margin'] = base.margin
         super().__init__(*objects, **params)
         # NamedListLike.__init__ sets the initial `_names` directly
         # (bypassing the 'objects' watcher below), so the first sync
         # has to happen explicitly here.
         self._sync_anchors()
+        self.param.watch(self._inherit_from_base, 'base')
+        self.param.watch(self._track_explicit_sizing, ['sizing_mode', 'margin'])
+
+    #----------------------------------------------------------------
+    # Sizing inheritance
+    #----------------------------------------------------------------
+
+    def _track_explicit_sizing(self, *events: param.parameterized.Event) -> None:
+        # Once the user sets sizing_mode/margin themselves -- whether
+        # at construction or later -- stop overriding that parameter
+        # on future base changes. Ignore changes we made ourselves in
+        # _inherit_from_base below.
+        if self._updating_from_base:
+            return
+        for event in events:
+            if event.name == 'sizing_mode':
+                self._inherit_sizing_mode = False
+            elif event.name == 'margin':
+                self._inherit_margin = False
+
+    def _inherit_from_base(self, event: param.parameterized.Event) -> None:
+        base = self.base
+        if base is None or not (self._inherit_sizing_mode or self._inherit_margin):
+            return
+        updates: dict[str, t.Any] = {}
+        if self._inherit_sizing_mode and base.sizing_mode is not None:
+            updates['sizing_mode'] = base.sizing_mode
+        if self._inherit_margin:
+            updates['margin'] = base.margin
+        if not updates:
+            return
+        self._updating_from_base = True
+        try:
+            self.param.update(**updates)
+        finally:
+            self._updating_from_base = False
 
     #----------------------------------------------------------------
     # NamedListLike API

--- a/panel/tests/layout/test_overlay.py
+++ b/panel/tests/layout/test_overlay.py
@@ -81,6 +81,80 @@ def test_overlay_wraps_bare_python_objects():
 
 
 #-----------------------------------------------------------------------------
+# sizing_mode/margin are inherited from `base` unless set explicitly
+#-----------------------------------------------------------------------------
+
+def test_overlay_inherits_sizing_mode_and_margin_from_base():
+    base = Markdown('Map', sizing_mode='stretch_both', margin=7)
+    overlay = Overlay(('top-left', Markdown('Legend')), base=base)
+
+    assert overlay.sizing_mode == 'stretch_both'
+    assert overlay.margin == 7
+
+
+def test_overlay_explicit_sizing_mode_and_margin_win_over_base():
+    base = Markdown('Map', sizing_mode='stretch_both', margin=7)
+    overlay = Overlay(
+        ('top-left', Markdown('Legend')), base=base,
+        sizing_mode='fixed', margin=3,
+    )
+
+    assert overlay.sizing_mode == 'fixed'
+    assert overlay.margin == 3
+
+
+def test_overlay_no_base_keeps_own_defaults():
+    overlay = Overlay(('top-left', Markdown('Legend')))
+
+    assert overlay.sizing_mode is None
+    assert overlay.margin == 0
+
+
+def test_overlay_base_sizing_mode_none_does_not_force_fixed():
+    # Only inherit an actual value -- a base with sizing_mode=None
+    # (the common case) shouldn't push the Overlay to some other mode.
+    base = Markdown('Map', margin=9)
+    overlay = Overlay(('top-left', Markdown('Legend')), base=base)
+
+    assert overlay.sizing_mode is None
+    assert overlay.margin == 9
+
+
+def test_overlay_base_swap_updates_uninherited_sizing():
+    base1 = Markdown('Map 1', sizing_mode='stretch_width', margin=2)
+    base2 = Markdown('Map 2', sizing_mode='stretch_height', margin=4)
+    overlay = Overlay(('top-left', Markdown('Legend')), base=base1)
+    assert overlay.sizing_mode == 'stretch_width'
+    assert overlay.margin == 2
+
+    overlay.base = base2
+
+    assert overlay.sizing_mode == 'stretch_height'
+    assert overlay.margin == 4
+
+
+def test_overlay_pinned_sizing_mode_survives_base_swap():
+    base1 = Markdown('Map 1', sizing_mode='stretch_width')
+    base2 = Markdown('Map 2', sizing_mode='stretch_height')
+    overlay = Overlay(('top-left', Markdown('Legend')), base=base1)
+
+    overlay.sizing_mode = 'fixed'  # user pins it explicitly
+    overlay.base = base2
+
+    assert overlay.sizing_mode == 'fixed'
+
+
+def test_overlay_pinned_margin_survives_base_swap():
+    base1 = Markdown('Map 1', margin=2)
+    base2 = Markdown('Map 2', margin=4)
+    overlay = Overlay(('top-left', Markdown('Legend')), base=base1, margin=1)
+
+    overlay.base = base2
+
+    assert overlay.margin == 1
+
+
+#-----------------------------------------------------------------------------
 # Validation
 #-----------------------------------------------------------------------------
 

--- a/panel/tests/layout/test_overlay.py
+++ b/panel/tests/layout/test_overlay.py
@@ -1,0 +1,339 @@
+import pytest
+
+from panel.layout import Overlay
+from panel.pane import Markdown
+
+
+@pytest.fixture
+def panels():
+    return Markdown('Legend'), Markdown('Controls'), Markdown('Guide')
+
+
+#-----------------------------------------------------------------------------
+# Construction
+#-----------------------------------------------------------------------------
+
+def test_overlay_empty():
+    overlay = Overlay()
+
+    assert overlay.objects == []
+    assert overlay.anchors == []
+    assert overlay.base is None
+
+
+def test_overlay_margin_default():
+    assert Overlay().margin == 0
+
+
+def test_overlay_named_anchor_construction(panels):
+    legend, controls, _ = panels
+    overlay = Overlay(('top-left', legend), ('top-right', controls))
+
+    assert [o.object for o in overlay.objects] == ['Legend', 'Controls']
+    assert overlay.anchors == ['top-left', 'top-right']
+
+
+def test_overlay_coordinate_construction(panels):
+    legend, _, _ = panels
+    overlay = Overlay(((24, 80), legend))
+
+    assert overlay.anchors == [(24, 80)]
+
+
+def test_overlay_percentage_coordinate_construction(panels):
+    legend, _, _ = panels
+    overlay = Overlay((("50%", "10%"), legend))
+
+    assert overlay.anchors == [("50%", "10%")]
+
+
+def test_overlay_mixed_coordinate_construction(panels):
+    legend, _, _ = panels
+    overlay = Overlay(((24, "10%"), legend))
+
+    assert overlay.anchors == [(24, "10%")]
+
+
+def test_overlay_mixed_construction(panels):
+    legend, controls, guide = panels
+    overlay = Overlay(
+        ('top-left', legend),
+        ((24, 80), controls),
+        ('bottom-right', guide),
+    )
+
+    assert overlay.anchors == ['top-left', (24, 80), 'bottom-right']
+
+
+def test_overlay_base_via_constructor(panels):
+    legend, _, _ = panels
+    base = Markdown('Map')
+    overlay = Overlay(('top-left', legend), base=base)
+
+    assert overlay.base is base
+
+
+def test_overlay_wraps_bare_python_objects():
+    overlay = Overlay(('top-left', 'Legend'))
+
+    assert overlay.objects[0].object == 'Legend'
+    assert overlay.anchors == ['top-left']
+
+
+#-----------------------------------------------------------------------------
+# Validation
+#-----------------------------------------------------------------------------
+
+def test_overlay_bare_object_raises(panels):
+    legend, _, _ = panels
+    with pytest.raises(ValueError, match=r'must be \(anchor, object\) tuples'):
+        Overlay(legend)
+
+
+def test_overlay_invalid_anchor_raises(panels):
+    legend, _, _ = panels
+    with pytest.raises(ValueError, match='invalid anchor'):
+        Overlay(('somewhere', legend))
+
+
+def test_overlay_invalid_coordinate_length_raises(panels):
+    legend, _, _ = panels
+    with pytest.raises(ValueError, match='invalid anchor'):
+        Overlay(((1, 2, 3), legend))
+
+
+def test_overlay_invalid_coordinate_type_raises(panels):
+    legend, _, _ = panels
+    with pytest.raises(ValueError, match='invalid anchor'):
+        Overlay(((legend, 2), legend))
+
+
+def test_overlay_duplicate_named_anchor_raises(panels):
+    legend, controls, _ = panels
+    with pytest.raises(ValueError, match="duplicate anchor: 'top-left'"):
+        Overlay(('top-left', legend), ('top-left', controls))
+
+
+def test_overlay_duplicate_coordinate_allowed(panels):
+    legend, controls, _ = panels
+    overlay = Overlay(((0, 0), legend), ((0, 0), controls))
+
+    assert overlay.anchors == [(0, 0), (0, 0)]
+
+
+def test_overlay_append_raises_on_duplicate_anchor(panels):
+    legend, controls, _ = panels
+    overlay = Overlay(('top-left', legend))
+
+    with pytest.raises(ValueError, match="duplicate anchor: 'top-left'"):
+        overlay.append(('top-left', controls))
+
+
+def test_overlay_objects_direct_assignment_requires_valid_anchor(panels):
+    # Bypassing the (anchor, obj) tuple API by setting `.objects`
+    # directly isn't supported -- there's no anchor to fall back to,
+    # so this is expected to raise rather than silently guess one.
+    legend, controls, _ = panels
+    overlay = Overlay(('top-left', legend))
+
+    with pytest.raises(ValueError, match='invalid anchor'):
+        overlay.objects = [legend, controls]
+
+
+#-----------------------------------------------------------------------------
+# List-like API keeps `.anchors` aligned with `.objects`
+#-----------------------------------------------------------------------------
+
+def test_overlay_append_keeps_anchors_aligned(panels):
+    legend, controls, _ = panels
+    overlay = Overlay(('top-left', legend))
+    overlay.append(('bottom-right', controls))
+
+    assert overlay.anchors == ['top-left', 'bottom-right']
+    assert [o.object for o in overlay.objects] == ['Legend', 'Controls']
+
+
+def test_overlay_insert_keeps_anchors_aligned(panels):
+    legend, controls, guide = panels
+    overlay = Overlay(('top-left', legend), ('bottom-right', guide))
+    overlay.insert(1, ('top-right', controls))
+
+    assert overlay.anchors == ['top-left', 'top-right', 'bottom-right']
+
+
+def test_overlay_extend_keeps_anchors_aligned(panels):
+    legend, controls, guide = panels
+    overlay = Overlay(('top-left', legend))
+    overlay.extend([('top-right', controls), ('bottom-right', guide)])
+
+    assert overlay.anchors == ['top-left', 'top-right', 'bottom-right']
+
+
+def test_overlay_setitem_updates_anchor(panels):
+    legend, _, _ = panels
+    overlay = Overlay(('top-left', legend))
+    overlay[0] = ('bottom-right', legend)
+
+    assert overlay.anchors == ['bottom-right']
+    assert overlay.objects[0].object == 'Legend'
+
+
+def test_overlay_setitem_slice_keeps_anchors_aligned(panels):
+    legend, controls, guide = panels
+    overlay = Overlay(('top-left', legend), ('top-right', controls))
+    overlay[0:2] = [('bottom-left', guide), ('bottom-right', legend)]
+
+    assert overlay.anchors == ['bottom-left', 'bottom-right']
+
+
+def test_overlay_pop_keeps_anchors_aligned(panels):
+    legend, controls, _ = panels
+    overlay = Overlay(('top-left', legend), ('top-right', controls))
+    overlay.pop(0)
+
+    assert overlay.anchors == ['top-right']
+    assert len(overlay.objects) == 1
+
+
+def test_overlay_remove_keeps_anchors_aligned(panels):
+    legend, controls, _ = panels
+    overlay = Overlay(('top-left', legend), ('top-right', controls))
+    overlay.remove(controls)
+
+    assert overlay.anchors == ['top-left']
+
+
+def test_overlay_reverse_keeps_anchors_aligned(panels):
+    legend, controls, _ = panels
+    overlay = Overlay(('top-left', legend), ('top-right', controls))
+    overlay.reverse()
+
+    assert overlay.anchors == ['top-right', 'top-left']
+
+
+def test_overlay_clear():
+    overlay = Overlay(('top-left', Markdown('Legend')))
+    overlay.clear()
+
+    assert overlay.objects == []
+    assert overlay.anchors == []
+
+
+def test_overlay_clone_preserves_params(panels):
+    legend, _, _ = panels
+    base = Markdown('Map')
+    overlay = Overlay(('top-left', legend), base=base, sizing_mode='stretch_both')
+    cloned = overlay.clone()
+
+    assert cloned is not overlay
+    assert cloned.base is base
+    assert cloned.sizing_mode == 'stretch_both'
+    assert cloned.anchors == ['top-left']
+
+
+def test_overlay_clone_with_new_objects(panels):
+    legend, controls, _ = panels
+    overlay = Overlay(('top-left', legend), base=Markdown('Map'))
+    cloned = overlay.clone(('bottom-right', controls))
+
+    assert cloned.anchors == ['bottom-right']
+    assert cloned.base is overlay.base
+
+
+def test_overlay_add_combines_anchors(panels):
+    legend, controls, _ = panels
+    overlay1 = Overlay(('top-left', legend))
+    overlay2 = Overlay(('top-right', controls))
+    combined = overlay1 + overlay2
+
+    assert combined.anchors == ['top-left', 'top-right']
+
+
+def test_overlay_iadd_combines_anchors(panels):
+    legend, controls, _ = panels
+    overlay = Overlay(('top-left', legend))
+    overlay += [('top-right', controls)]
+
+    assert overlay.anchors == ['top-left', 'top-right']
+
+
+#-----------------------------------------------------------------------------
+# Model / rendering
+#-----------------------------------------------------------------------------
+
+def test_overlay_get_root(document, comm):
+    from panel.models import ReactiveESM as BkReactiveESM
+
+    legend = Markdown('Legend')
+    base = Markdown('Map')
+    overlay = Overlay(('top-left', legend), base=base)
+
+    model = overlay.get_root(document, comm=comm)
+
+    assert isinstance(model, BkReactiveESM)
+    assert model.data._anchors == ['top-left']
+    assert len(model.data.objects) == 1
+    assert model.data.base is not None
+
+
+def test_overlay_get_root_no_base(document, comm):
+    overlay = Overlay(('top-left', Markdown('Legend')))
+
+    model = overlay.get_root(document, comm=comm)
+
+    assert model.data.base is None
+
+
+def test_overlay_get_root_no_objects(document, comm):
+    overlay = Overlay(base=Markdown('Map'))
+
+    model = overlay.get_root(document, comm=comm)
+
+    assert model.data.objects == []
+    assert model.data._anchors == []
+    assert model.data.base is not None
+
+
+def test_overlay_margin_is_top_level_model_property(document, comm):
+    overlay = Overlay()
+
+    model = overlay.get_root(document, comm=comm)
+
+    # margin must stay a genuine bokeh LayoutDOM property (applied by
+    # Bokeh's own layout/CSS machinery), not get rerouted into the
+    # ESM `data` submodel, or the full-bleed default would be inert.
+    assert model.margin == 0
+
+
+def test_overlay_reactive_anchor_update(document, comm):
+    legend = Markdown('Legend')
+    overlay = Overlay(('top-left', legend))
+    model = overlay.get_root(document, comm=comm)
+
+    overlay[0] = ('bottom-right', legend)
+
+    assert model.data._anchors == ['bottom-right']
+
+
+def test_overlay_reactive_base_swap(document, comm):
+    base1 = Markdown('Map 1')
+    base2 = Markdown('Map 2')
+    overlay = Overlay(base=base1)
+    model = overlay.get_root(document, comm=comm)
+    base1_model = model.data.base
+
+    overlay.base = base2
+
+    assert model.data.base is not base1_model
+
+
+def test_overlay_reactive_objects_append(document, comm):
+    legend = Markdown('Legend')
+    controls = Markdown('Controls')
+    overlay = Overlay(('top-left', legend))
+    model = overlay.get_root(document, comm=comm)
+
+    overlay.append(('top-right', controls))
+
+    assert len(model.data.objects) == 2
+    assert model.data._anchors == ['top-left', 'top-right']

--- a/panel/tests/ui/layout/test_overlay.py
+++ b/panel/tests/ui/layout/test_overlay.py
@@ -16,7 +16,7 @@ TOL = 3  # pixel tolerance for bounding-box comparisons
 
 def _box(css_class, **kwargs):
     return HTML(
-        f'<div style="width:100%;height:100%"></div>',
+        '<div style="width:100%;height:100%"></div>',
         css_classes=[css_class], width=40, height=20, margin=0, **kwargs
     )
 

--- a/panel/tests/ui/layout/test_overlay.py
+++ b/panel/tests/ui/layout/test_overlay.py
@@ -15,16 +15,17 @@ TOL = 3  # pixel tolerance for bounding-box comparisons
 
 
 def _box(css_class, **kwargs):
+    kwargs.setdefault('margin', 0)
     return HTML(
         '<div style="width:100%;height:100%"></div>',
-        css_classes=[css_class], width=40, height=20, margin=0, **kwargs
+        css_classes=[css_class], width=40, height=20, **kwargs
     )
 
 
 def _container_box(page):
-    # The Overlay's own root element -- the reference frame every
-    # panel is anchored against.
-    return page.locator('.overlay').bounding_box()
+    # The Overlay's inner element -- the reference frame every panel is
+    # anchored against (the outer host container is `.overlay`).
+    return page.locator('.overlay-container').bounding_box()
 
 
 def test_overlay_named_anchor_positions(page):
@@ -135,7 +136,7 @@ def test_overlay_panels_do_not_cover_base(page):
 
 def test_overlay_base_receives_clicks_outside_panels(page):
     clicks = []
-    base = Button(name='Base', sizing_mode='stretch_both')
+    base = Button(label='Base', sizing_mode='stretch_both')
     base.on_click(lambda e: clicks.append(e))
 
     overlay = Overlay(

--- a/panel/tests/ui/layout/test_overlay.py
+++ b/panel/tests/ui/layout/test_overlay.py
@@ -1,0 +1,223 @@
+import pytest
+
+pytest.importorskip("playwright")
+
+from playwright.sync_api import expect
+
+from panel.layout import Overlay
+from panel.pane import HTML
+from panel.tests.util import serve_component, wait_until
+from panel.widgets import Button
+
+pytestmark = pytest.mark.ui
+
+TOL = 3  # pixel tolerance for bounding-box comparisons
+
+
+def _box(css_class, **kwargs):
+    return HTML(
+        f'<div style="width:100%;height:100%"></div>',
+        css_classes=[css_class], width=40, height=20, margin=0, **kwargs
+    )
+
+
+def _container_box(page):
+    # The Overlay's own root element -- the reference frame every
+    # panel is anchored against.
+    return page.locator('.overlay').bounding_box()
+
+
+def test_overlay_named_anchor_positions(page):
+    base = HTML('<div style="width:100%;height:100%"></div>')
+    overlay = Overlay(
+        ('top-left', _box('tl')),
+        ('top-center', _box('tc')),
+        ('top-right', _box('tr')),
+        ('center-left', _box('cl')),
+        ('center', _box('cc')),
+        ('center-right', _box('cr')),
+        ('bottom-left', _box('bl')),
+        ('bottom-center', _box('bc')),
+        ('bottom-right', _box('br')),
+        base=base, width=400, height=300,
+    )
+    serve_component(page, overlay)
+
+    expect(page.locator('.overlay-panel')).to_have_count(9)
+
+    container = _container_box(page)
+
+    tl = page.locator('.tl').bounding_box()
+    assert abs(tl['x'] - container['x']) < TOL
+    assert abs(tl['y'] - container['y']) < TOL
+
+    tr = page.locator('.tr').bounding_box()
+    assert abs((tr['x'] + tr['width']) - (container['x'] + container['width'])) < TOL
+    assert abs(tr['y'] - container['y']) < TOL
+
+    bl = page.locator('.bl').bounding_box()
+    assert abs(bl['x'] - container['x']) < TOL
+    assert abs((bl['y'] + bl['height']) - (container['y'] + container['height'])) < TOL
+
+    br = page.locator('.br').bounding_box()
+    assert abs((br['x'] + br['width']) - (container['x'] + container['width'])) < TOL
+    assert abs((br['y'] + br['height']) - (container['y'] + container['height'])) < TOL
+
+    tc = page.locator('.tc').bounding_box()
+    assert abs((tc['x'] + tc['width'] / 2) - (container['x'] + container['width'] / 2)) < TOL
+    assert abs(tc['y'] - container['y']) < TOL
+
+    bc = page.locator('.bc').bounding_box()
+    assert abs((bc['x'] + bc['width'] / 2) - (container['x'] + container['width'] / 2)) < TOL
+    assert abs((bc['y'] + bc['height']) - (container['y'] + container['height'])) < TOL
+
+    cl = page.locator('.cl').bounding_box()
+    assert abs(cl['x'] - container['x']) < TOL
+    assert abs((cl['y'] + cl['height'] / 2) - (container['y'] + container['height'] / 2)) < TOL
+
+    cr = page.locator('.cr').bounding_box()
+    assert abs((cr['x'] + cr['width']) - (container['x'] + container['width'])) < TOL
+    assert abs((cr['y'] + cr['height'] / 2) - (container['y'] + container['height'] / 2)) < TOL
+
+    cc = page.locator('.cc').bounding_box()
+    assert abs((cc['x'] + cc['width'] / 2) - (container['x'] + container['width'] / 2)) < TOL
+    assert abs((cc['y'] + cc['height'] / 2) - (container['y'] + container['height'] / 2)) < TOL
+
+
+def test_overlay_pixel_coordinate_position(page):
+    base = HTML('<div style="width:100%;height:100%"></div>')
+    overlay = Overlay(
+        ((24, 80), _box('coord')),
+        base=base, width=400, height=300,
+    )
+    serve_component(page, overlay)
+
+    container = _container_box(page)
+    box = page.locator('.coord').bounding_box()
+
+    assert abs(box['x'] - (container['x'] + 24)) < TOL
+    assert abs(box['y'] - (container['y'] + 80)) < TOL
+
+
+def test_overlay_percentage_coordinate_position(page):
+    base = HTML('<div style="width:100%;height:100%"></div>')
+    overlay = Overlay(
+        (("25%", "75%"), _box('pct')),
+        base=base, width=400, height=300,
+    )
+    serve_component(page, overlay)
+
+    container = _container_box(page)
+    box = page.locator('.pct').bounding_box()
+
+    assert abs(box['x'] - (container['x'] + container['width'] * 0.25)) < TOL
+    assert abs(box['y'] - (container['y'] + container['height'] * 0.75)) < TOL
+
+
+def test_overlay_panels_do_not_cover_base(page):
+    # There is no full-size covering layer -- each panel is only as
+    # big as its own footprint -- so the base stays interactive
+    # everywhere else (see spec 7).
+    base = HTML('<div style="width:100%;height:100%"></div>')
+    overlay = Overlay(
+        ('top-left', _box('tl')),
+        ('bottom-right', _box('br')),
+        base=base, width=400, height=300,
+    )
+    serve_component(page, overlay)
+
+    container = _container_box(page)
+    for cls in ('tl', 'br'):
+        box = page.locator(f'.{cls}').bounding_box()
+        assert box['width'] < container['width'] / 2
+        assert box['height'] < container['height'] / 2
+
+
+def test_overlay_base_receives_clicks_outside_panels(page):
+    clicks = []
+    base = Button(name='Base', sizing_mode='stretch_both')
+    base.on_click(lambda e: clicks.append(e))
+
+    overlay = Overlay(
+        ('top-left', _box('tl')),
+        ('bottom-right', _box('br')),
+        base=base, width=400, height=300,
+    )
+    serve_component(page, overlay)
+
+    container = _container_box(page)
+    # Dead center of a 400x300 box is well clear of both 40x20 corner panels.
+    page.mouse.click(container['x'] + container['width'] / 2, container['y'] + container['height'] / 2)
+
+    wait_until(lambda: len(clicks) == 1, page)
+
+
+def test_overlay_margin_insets_panel_from_anchor(page):
+    base = HTML('<div style="width:100%;height:100%"></div>')
+    overlay = Overlay(
+        ('top-left', _box('inset', margin=30)),
+        base=base, width=400, height=300,
+    )
+    serve_component(page, overlay)
+
+    container = _container_box(page)
+    box = page.locator('.inset').bounding_box()
+
+    # Roughly inset by the margin -- generous tolerance since the
+    # exact box-model arithmetic (collapsing, wrapper sizing) isn't
+    # being pinned down here, only that margin clearly pushes the
+    # panel content away from the flush corner.
+    assert 10 < (box['x'] - container['x']) < 50
+    assert 10 < (box['y'] - container['y']) < 50
+
+
+def test_overlay_no_objects_renders_base_only(page):
+    base = HTML('<div class="base-only" style="width:100%;height:100%"></div>')
+    overlay = Overlay(base=base, width=400, height=300)
+    serve_component(page, overlay)
+
+    expect(page.locator('.overlay-panel')).to_have_count(0)
+    expect(page.locator('.base-only')).to_have_count(1)
+
+
+def test_overlay_reactive_anchor_change(page):
+    base = HTML('<div style="width:100%;height:100%"></div>')
+    panel = _box('moving')
+    overlay = Overlay(('top-left', panel), base=base, width=400, height=300)
+    serve_component(page, overlay)
+
+    container = _container_box(page)
+    overlay[0] = ('bottom-right', panel)
+
+    def _moved():
+        box = page.locator('.moving').bounding_box()
+        return abs((box['x'] + box['width']) - (container['x'] + container['width'])) < TOL
+
+    wait_until(_moved, page)
+
+
+def test_overlay_reactive_base_swap(page):
+    base1 = HTML('<div class="base1" style="width:100%;height:100%"></div>')
+    base2 = HTML('<div class="base2" style="width:100%;height:100%"></div>')
+    overlay = Overlay(base=base1, width=400, height=300)
+    serve_component(page, overlay)
+
+    expect(page.locator('.base1')).to_have_count(1)
+    expect(page.locator('.base2')).to_have_count(0)
+
+    overlay.base = base2
+
+    wait_until(lambda: page.locator('.base2').count() == 1, page)
+    expect(page.locator('.base1')).to_have_count(0)
+
+
+def test_overlay_reactive_append(page):
+    base = HTML('<div style="width:100%;height:100%"></div>')
+    overlay = Overlay(('top-left', _box('tl')), base=base, width=400, height=300)
+    serve_component(page, overlay)
+
+    expect(page.locator('.overlay-panel')).to_have_count(1)
+
+    overlay.append(('bottom-right', _box('br')))
+
+    wait_until(lambda: page.locator('.overlay-panel').count() == 2, page)


### PR DESCRIPTION
<!-- Using AI? READ FIRST: https://holoviz.org/contribute.html#ai-readme -->

## Description
<!-- Summarize the change and which issue is fixed. Be sure to include relevant motivation and context. Describe the tests run to verify these changes and how to reproduce them (copy-pastable minimal, reproducible example). Include visuals when possible (e.g. before/after screenshots). -->

Adds ability to overlay panel objects for wall to wall displays. I based it off `Tabs()` usage of tuples, but happy to consider dict as well. I also wondered if it should be in pmui, but decided to put in Panel since this is unrelated to MUI. I had this idea re-ignited by the idea of pmui Wrappers.

Fixes #5086

Examples:

```python
import panel as pn
png_pane = pn.pane.PNG('https://assets.holoviz.org/panel/samples/png_sample.png')
pn.Overlay(("top-left", "# Some dice"), ("bottom-left", pn.pane.Markdown("## Blue, red, green, yellow", margin=(150))), base=png_pane).show()
```

<img width="630" height="436" alt="image" src="https://github.com/user-attachments/assets/2f3f3743-2002-4876-9c48-073c59f77c1c" />

<img width="1751" height="930" alt="image" src="https://github.com/user-attachments/assets/a5e82b8e-e5db-4aa0-8645-eef2d9c07513" />

<img width="1753" height="934" alt="image" src="https://github.com/user-attachments/assets/2b480ce3-460c-46c6-b05b-2f51f52eaa17" />

## AI Disclosure
<!-- Delete this section if AI was not used, else specify the tool/model (e.g. Cursor + Sonnet 4.6, Claude Code + Opus 4.6, ChatGPT) and briefly describe how it was used. Failure to disclose AI usage may result in a ban. -->

Tool & Model: Opus 4.8
Usage: Design and implementation

- [x] I have tested all AI-generated content in my PR.
- [x] I take responsibility for all AI-generated content in my PR.


## Checklist
<!-- Remove the non relevant items. -->

- [ ] Tests added and are passing
- [x] Added documentation
