### PR TITLE
docs: add ESM components card to explanation Components section

### DIFF
--- a/doc/explanation/index.md
+++ b/doc/explanation/index.md
@@ -133,6 +133,13 @@ Deepen your understanding about Panel's built in components.
 Deepen your understanding about custom `ReactiveHTML` components
 :::
 
+:::{grid-item-card} {octicon}`code;2.5em;sd-mr-1 sd-animate-grow50` ESM components
+:link: ../how_to/custom_components/index.html#esm-components
+:link-type: url
+
+Deepen your understanding about custom ESM components, written in JavaScript, React, or AnyWidget.
+:::
+
 ::::
 
 ## Architecture


### PR DESCRIPTION
## Summary

The `## Components` section in `doc/explanation/index.md` listed only the **Built in components** and **ReactiveHTML components** cards. This adds a third **ESM components** card, matching the existing card layout, linking to the ESM components how-to guide as requested in #8625.

## Details

- The card links to `how_to/custom_components/index.html#esm-components` — the exact anchor named in the issue. I used `:link-type: url` with a relative path so the `#esm-components` fragment is preserved: `myst_heading_anchors` / `autosectionlabel` aren't enabled in `doc/conf.py`, and `:link-type: doc` can't target a section anchor. Happy to switch to a `doc`/`ref` cross-reference instead if you'd prefer one (that would land on the top of the page rather than the ESM section).
- The description mirrors the neighbouring cards' "Deepen your understanding about ..." phrasing.

Closes #8625.

---

*AI disclosure: this PR was drafted with Claude Code (AI-assisted). It is a single documentation card; I verified the diff mirrors the two existing cards and that the link target section (`## ESM Components`) exists in `doc/how_to/custom_components/index.md`.*
