### PR TITLE
Ensure explicitly set sizing options are respected

### DIFF
--- a/panel/io/document.py
+++ b/panel/io/document.py
@@ -310,7 +310,7 @@ def write_events(
     if state._unblocked(doc):
         _dispatch_write_task(doc, _run_write_futures, doc)
     else:
-        doc.add_next_tick_callback(partial(_run_write_futures, doc))
+        doc.add_next_tick_callback(partial(_run_write_futures, doc))  # type: ignore[arg-type]
 
 def schedule_write_events(
     doc: Document,

--- a/panel/io/server.py
+++ b/panel/io/server.py
@@ -254,7 +254,7 @@ def async_execute(func: Callable[..., None]) -> None:
                 state._handle_exception(e)
     if unlock:
         wrapped.nolock = True # type: ignore
-    state.curdoc.add_next_tick_callback(wrapped)
+    state.curdoc.add_next_tick_callback(wrapped)  # type: ignore[arg-type]
 
 param.parameterized.async_executor = async_execute
 

--- a/panel/layout/base.py
+++ b/panel/layout/base.py
@@ -99,8 +99,14 @@ class SizingModeMixin:
 
             width_expanded = smode in ('stretch_width', 'stretch_both', 'scale_width', 'scale_both')
             height_expanded = smode in ('stretch_height', 'stretch_both', 'scale_height', 'scale_both')
-            expand_width |= width_expanded
-            expand_height |= height_expanded
+            # Only inherit a child's responsiveness along an axis if the
+            # corresponding policy was not explicitly set to a non-max
+            # value. An explicit width_policy/height_policy of "max"
+            # already forces expansion via the initializer above.
+            if not getattr(self, '_explicit_width_policy', False):
+                expand_width |= width_expanded
+            if not getattr(self, '_explicit_height_policy', False):
+                expand_height |= height_expanded
             if width_expanded:
                 width = child.min_width
             else:
@@ -135,14 +141,18 @@ class SizingModeMixin:
                     height += margin*2
                 heights.append(height)
 
-        # Infer new sizing mode based on children
+        # Infer new sizing mode based on children unless the user
+        # explicitly supplied a sizing_mode, in which case that setting is
+        # honored rather than inherited from the children.
         mode = 'scale' if scale else 'stretch'
         if self._direction == 'horizontal':
             allow_height_scale = all_expand_height
         else:
             allow_height_scale = True
 
-        if expand_width and expand_height and not self.width and not self.height:
+        if getattr(self, '_explicit_sizing_mode', False):
+            pass
+        elif expand_width and expand_height and not self.width and not self.height:
             if allow_height_scale or 'both' in (sizing_mode or ''):
                 sizing_mode = f'{mode}_both'
             else:

--- a/panel/tests/layout/test_base.py
+++ b/panel/tests/layout/test_base.py
@@ -681,3 +681,55 @@ def test_compute_sizing_mode_stretch_margin_four_tuple(dim, document, comm):
     new_props = col._compute_sizing_mode(root.children, {'margin': margin})
 
     assert new_props == {f'min_{dim}': 115, 'sizing_mode': f'stretch_{dim}'}
+
+def test_compute_sizing_mode_explicit_sizing_mode_not_inherited(document, comm):
+    md = Markdown('foo', sizing_mode='stretch_width')
+    col = Column(md, sizing_mode='fixed')
+
+    root = col.get_root(document, comm=comm)
+
+    assert root.sizing_mode == 'fixed'
+
+def test_compute_sizing_mode_explicit_width_policy_max_still_inherited(document, comm):
+    md = Markdown('foo', sizing_mode='stretch_width')
+    col = Column(md, width_policy='max')
+
+    root = col.get_root(document, comm=comm)
+
+    assert root.sizing_mode == 'stretch_width'
+    assert root.width_policy == 'max'
+
+def test_compute_sizing_mode_explicit_width_policy_not_max_not_inherited(document, comm):
+    md = Markdown('foo', sizing_mode='stretch_width')
+    col = Column(md, width_policy='fixed')
+
+    root = col.get_root(document, comm=comm)
+
+    assert root.sizing_mode is None
+    assert root.width_policy == 'fixed'
+
+def test_compute_sizing_mode_explicit_height_policy_not_max_not_inherited(document, comm):
+    md = Markdown('foo', sizing_mode='stretch_height')
+    col = Column(md, height_policy='fixed')
+
+    root = col.get_root(document, comm=comm)
+
+    assert root.sizing_mode is None
+    assert root.height_policy == 'fixed'
+
+def test_compute_sizing_mode_inherited_without_explicit_sizing(document, comm):
+    md = Markdown('foo', sizing_mode='stretch_width')
+    col = Column(md)
+
+    root = col.get_root(document, comm=comm)
+
+    assert root.sizing_mode == 'stretch_width'
+
+def test_compute_sizing_mode_dynamic_sizing_mode_not_inherited(document, comm):
+    md = Markdown('foo', sizing_mode='stretch_width')
+    col = Column(md)
+    col.sizing_mode = 'fixed'
+
+    root = col.get_root(document, comm=comm)
+
+    assert root.sizing_mode == 'fixed'

--- a/panel/tests/test_interact.py
+++ b/panel/tests/test_interact.py
@@ -233,7 +233,7 @@ def test_interact_replaces_model(document, comm):
     assert new_pane._models[column.ref['id']][0] is new_div
 
     interact_pane._cleanup(column)
-    assert len(interact_pane._internal_callbacks) == 5
+    assert len(interact_pane._internal_callbacks) == 6
 
 
 def test_interact_throttled():

--- a/panel/viewable.py
+++ b/panel/viewable.py
@@ -262,6 +262,13 @@ class Layoutable(param.Parameterized):
     __abstract = True
 
     def __init__(self, **params):
+        # Track which sizing parameters were explicitly supplied by the
+        # user (as opposed to their defaults or values inferred from
+        # children). This is computed before the config driven defaults
+        # below are applied so config defaults are not treated as explicit.
+        self._explicit_sizing_mode = params.get('sizing_mode') is not None
+        self._explicit_width_policy = params.get('width_policy') not in (None, 'auto')
+        self._explicit_height_policy = params.get('height_policy') not in (None, 'auto')
         sizing_mode = params.get('sizing_mode')
         if (sizing_mode in ('stretch_width', 'scale_width', 'stretch_both', 'scale_both') and
             params.get('width') is not None):
@@ -313,6 +320,17 @@ class Layoutable(param.Parameterized):
         if 'design' not in params and self.param.design.default is None:
             params['design'] = config.design
         super().__init__(**params)
+
+    # Track dynamic (post-init) updates to the sizing parameters so that
+    # explicitly set values are honored rather than being overridden by
+    # values inferred from a layout's children. Child inference writes to
+    # the underlying model rather than the parameter, so it does not
+    # trigger this watcher.
+    @param.depends('sizing_mode', 'width_policy', 'height_policy', watch=True)
+    def _update_explicit_sizing(self):
+        self._explicit_sizing_mode = self.sizing_mode is not None
+        self._explicit_width_policy = self.width_policy != 'auto'
+        self._explicit_height_policy = self.height_policy != 'auto'
 
 
 class ServableMixin:

--- a/panel/viewable.py
+++ b/panel/viewable.py
@@ -320,17 +320,23 @@ class Layoutable(param.Parameterized):
         if 'design' not in params and self.param.design.default is None:
             params['design'] = config.design
         super().__init__(**params)
+        # Track dynamic (post-init) updates to the sizing parameters so
+        # that explicitly set values are honored rather than being
+        # overridden by values inferred from a layout's children. Child
+        # inference writes to the underlying model rather than the
+        # parameter, so it does not trigger this watcher.
+        watcher = self.param.watch(
+            self._update_explicit_sizing,
+            ['sizing_mode', 'width_policy', 'height_policy']
+        )
+        if not hasattr(self, '_internal_callbacks'):
+            self._internal_callbacks = []
+        self._internal_callbacks.append(watcher)
 
-    # Track dynamic (post-init) updates to the sizing parameters so that
-    # explicitly set values are honored rather than being overridden by
-    # values inferred from a layout's children. Child inference writes to
-    # the underlying model rather than the parameter, so it does not
-    # trigger this watcher.
-    @param.depends('sizing_mode', 'width_policy', 'height_policy', watch=True)
-    def _update_explicit_sizing(self):
-        self._explicit_sizing_mode = self.sizing_mode is not None
-        self._explicit_width_policy = self.width_policy != 'auto'
-        self._explicit_height_policy = self.height_policy != 'auto'
+    def _update_explicit_sizing(self, *events):
+        for event in events:
+            explicit = event.new is not None if event.name == 'sizing_mode' else event.new != 'auto'
+            setattr(self, f'_explicit_{event.name}', explicit)
 
 
 class ServableMixin:


### PR DESCRIPTION
During the last bokeh layout changes we added `sizing_mode` inference from a layout component's children. This achieved backward compatibility but meant that explicitly set sizing options were not always respected. This addresses this problem by tracking which options were set explicitly.