### PR TITLE
Fix reactive row count in interactivity tutorial

### DIFF
--- a/doc/tutorials/intermediate/interactivity.md
+++ b/doc/tutorials/intermediate/interactivity.md
@@ -343,7 +343,9 @@ class DataExplorer(Viewer):
             & dfrx.p_cap.between(p_cap_min, p_cap_max)
         ][self.param.columns]
 
-        self.number_of_rows = pn.rx("Rows: {len_df}").format(len_df=pn.rx(len)(dfrx))
+        self.number_of_rows = pn.rx("Rows: {len_df}").format(
+            len_df=pn.rx(len)(self.filtered_data)
+        )
 
     def __panel__(self):
         return pn.Column(


### PR DESCRIPTION
## What this changes

Updates the class-based `pn.rx` example so `number_of_rows` derives from `self.filtered_data` instead of the unfiltered `dfrx`. The displayed count now reacts when the year or capacity filters change.

Closes #7528.

## Validation

- Ran a minimal version of the tutorial class with three rows and verified the label changes from `Rows: 3` to `Rows: 2` after narrowing the year range.
- `pre-commit run --files doc/tutorials/intermediate/interactivity.md`