### PR TITLE
Clarify FileDropper upload progress indicator

### DIFF
--- a/examples/reference/widgets/FileDropper.ipynb
+++ b/examples/reference/widgets/FileDropper.ipynb
@@ -27,7 +27,7 @@
     "\n",
     "* **`accepted_filetypes`** (list): List of accepted file types. Can be mimetypes, file extensions or wild cards. For instance `['image/*']` will accept all images while `['.png', 'image/jpeg']` will only accepts PNGs and JPEGs.\n",
     "* **`chunk_size`** (int): Size in bytes per chunk transferred across the WebSocket (`default=10000000`, i.e. 10MB).\n",
-    "* **`layout`** (Literal[\"circle\", \"compact\", \"integrated\"] | None): Compact mode will remove padding, integrated mode is used to render FilePond as part of a bigger element (and should not be used with `multiple=True`. Circle mode adjusts the item position offsets so buttons and progress indicators don't fall outside of the circular shape.\n",
+    "* **`layout`** (Literal[\"circle\", \"compact\", \"integrated\"] | None): Compact mode removes padding. Integrated mode renders FilePond as part of a bigger element and should not be used with `multiple=True`. Circle mode keeps FilePond's per-file action buttons and upload progress indicator inside the circular drop area.\n",
     "* **`max_file_size`** (str): Maximum size of a file as a string with units given in KB or MB, e.g. 5MB or 750KB.\n",
     "* **`max_files`** (int): Maximum number of files that can be uploaded if `multiple=True`.\n",
     "* **`max_total_file_size`** (str): Maximum size of all uploaded files, as a string with units given in KB or MB, e.g. 5MB or 750KB.\n",

--- a/panel/widgets/input.py
+++ b/panel/widgets/input.py
@@ -344,10 +344,10 @@ class FileDropper(Widget):
 
     layout: t.Literal["circle", "compact", "integrated"] | None = param.Selector(
         default=None, objects=["circle", "compact", "integrated"], doc="""
-        Compact mode will remove padding, integrated mode is used to render
-        FilePond as part of a bigger element. Circle mode adjusts the item
-        position offsets so buttons and progress indicators don't fall outside
-        of the circular shape.""")  # type: ignore[assignment, ty:invalid-assignment]
+        Compact mode removes padding. Integrated mode renders FilePond as part
+        of a bigger element. Circle mode keeps FilePond's per-file action
+        buttons and upload progress indicator inside the circular drop
+        area.""")  # type: ignore[assignment, ty:invalid-assignment]
 
     max_file_size = param.String(default=None, doc="""
         Maximum size of a file as a string with units given in KB or MB,


### PR DESCRIPTION
## What this changes

Clarifies that the progress indicator mentioned by `FileDropper.layout` is FilePond's per-file upload progress UI. The revised description also explains what circle mode does with the action buttons and fixes the unmatched parenthesis in the reference notebook.

The parameter docstring and widget reference now use consistent wording.

Closes #7332.

## Validation

- `python3 -m json.tool examples/reference/widgets/FileDropper.ipynb`
- `pre-commit run --files panel/widgets/input.py examples/reference/widgets/FileDropper.ipynb`