### PR TITLE
Align loading spinner with panel-material-ui

### DIFF
--- a/panel/dist/css/loading.css
+++ b/panel/dist/css/loading.css
@@ -3,25 +3,6 @@
   overflow: hidden;
 }
 
-:host(.pn-loading) > *,
-.pn-loading > * {
-  filter: blur(0.5px) opacity(0.5);
-}
-
-:host(.pn-loading):before,
-.pn-loading:before {
-  -webkit-mask-position: center;
-  -webkit-mask-repeat: no-repeat;
-  content: '';
-  cursor: progress;
-  height: 100%;
-  width: 100%;
-  position: absolute;
-  top: 0;
-  left: 0;
-  z-index: 1000;
-}
-
 :host(.pn-loading):after,
 .pn-loading:after {
   content: '';
@@ -32,16 +13,31 @@
   top: 0;
   left: 0;
   z-index: 1000;
+  background-color: rgba(255, 255, 255, 0.5);
+}
+
+:host(.pn-loading):before,
+.pn-loading:before {
+  -webkit-mask-position: center;
+  -webkit-mask-repeat: no-repeat;
+  content: '';
+  cursor: progress;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  z-index: 1001;
 }
 
 :host(.pn-loading) .pn-loading-msg,
 .pn-loading .pn-loading-msg {
   color: var(--panel-on-background-color, black);
-  font-size: 2em;
+  font-size: 1.5em;
   position: absolute;
-  top: 72%;
+  top: calc(50% + 36px);
   text-align: center;
   width: 100%;
+  z-index: 1001;
 }
 
 :host(.pn-loading.pn-arc):before,

--- a/panel/io/resources.py
+++ b/panel/io/resources.py
@@ -213,11 +213,14 @@ def process_raw_css(raw_css: list[str]) -> list[str]:
 
 @lru_cache(maxsize=None)
 def loading_css(loading_spinner: str, color: str, max_height: int):
+    size = f"calc(min(40px, {max_height}px))"
     return textwrap.dedent(f"""
     :host(.pn-loading):before, .pn-loading:before {{
       background-color: {color};
-      mask-size: auto calc(min(50%, {max_height}px));
-      -webkit-mask-size: auto calc(min(50%, {max_height}px));
+      width: {size};
+      height: {size};
+      mask-size: {size} {size};
+      -webkit-mask-size: {size} {size};
     }}""")
 
 def resolve_custom_path(


### PR DESCRIPTION
This aligns the Panel loading spinner closer with the `panel-material-ui` implementation so the two don't have such starkly different sizes and background behaviors.

### Before 

<img width="821" height="608" alt="Screenshot 2026-07-27 at 14 34 18" src="https://github.com/user-attachments/assets/5849600e-6e11-4b1b-b539-63edfcacd50a" />

### After

<img width="815" height="607" alt="Screenshot 2026-07-27 at 14 33 55" src="https://github.com/user-attachments/assets/f21c31e0-dcba-47c3-8ea4-0b6475427fa0" />
