### PR TITLE
Ensure explicitly set sizing options are respected

### DIFF
--- a/doc/api/config.md
+++ b/doc/api/config.md
@@ -371,6 +371,17 @@ fully loaded.
 
 Default: '' | Type: String
 
+### `respect_explicit_sizing`
+
+When enabled, explicitly set sizing_mode/width_policy/height_policy on a
+layout are respected and never overridden by values inferred from the
+layout's children. When disabled (the default) the legacy behaviour is
+preserved: child-inferred values silently override explicit settings, but
+a warning is emitted whenever such an override would occur so that the
+incorrect specification can be corrected.
+
+Default: False | Type: Boolean
+
 ### `reuse_sessions`
 
 Whether to reuse a session for the initial request to speed up

--- a/doc/how_to/layout/size.md
+++ b/doc/how_to/layout/size.md
@@ -149,6 +149,118 @@ pn.Row(
 )
 ```
 
+(sizing-mode-inference)=
+## Sizing Mode Inference on Layouts
+
+Layouts do not only use their own `sizing_mode`; they also inspect their
+children and may upgrade themselves to be responsive along an axis where a
+child is responsive. This exists so that dropping a responsive component into a
+plain `Row` or `Column` does something sensible without having to set
+`sizing_mode` on every level of the layout hierarchy. The rules are:
+
+- If any child is responsive in width, the layout becomes width-responsive,
+  unless the layout has a fixed `width`.
+- If a vertical layout (e.g. a `Column`) has any height-responsive child, the
+  layout becomes height-responsive, unless the layout has a fixed `height`.
+- If a horizontal layout (e.g. a `Row`) has children that are *all*
+  height-responsive, the layout becomes height-responsive. This is
+  asymmetrical with width because there is not always vertical space to expand
+  into, and matching the height of the other children is usually preferable.
+- Any children with a fixed `width` or `height` contribute a `min_width` or
+  `min_height` to the layout so sufficient space is allocated.
+
+`FlexBox` is an exception: it picks a `sizing_mode` from its `flex_direction`
+instead of inspecting its children, so these rules do not apply to it.
+
+In the example below the `Column` was never given a `sizing_mode`, but its
+background fills the available width because it inherited `stretch_width` from
+its child:
+
+```{pyodide}
+pn.Column(
+    pn.pane.Markdown('Responsive child', sizing_mode='stretch_width'),
+    styles={'background': '#f0f0f0'},
+)
+```
+
+The inferred value is applied when the layout is rendered, so it is not
+reflected in the layout's `sizing_mode` parameter, which stays at whatever you
+set it to (or `None`).
+
+### When inference overrides an explicit setting
+
+Because inference looks at children, it can end up contradicting a
+`sizing_mode` you set on the layout yourself. If a layout is declared
+`sizing_mode='stretch_height'` but contains a width-responsive child, the
+inferred `'stretch_width'` wins and your setting is dropped. Panel warns when
+this happens:
+
+```python
+pn.Column(
+    pn.pane.Markdown('...', sizing_mode='stretch_width'),
+    sizing_mode='stretch_height',
+)
+# WARNING: sizing_mode='stretch_height' on Column is being overridden to
+# 'stretch_width' by a child's sizing.
+```
+
+The warning means the layout is not sized the way the code says it is, which is
+usually a bug in the sizing specification rather than something to silence. The
+two ways to resolve it are to correct the `sizing_mode` so it matches what the
+children need, or to pin the axis with a policy as described below.
+
+Note that inference never *reduces* responsiveness. A layout declared
+`sizing_mode='stretch_both'` whose children only expand in width stays
+`stretch_both`, because the explicit setting already covers the inferred one.
+
+### Pinning an axis with a policy
+
+Since `width_policy` and `height_policy` take precedence over `sizing_mode`,
+setting a policy on an axis keeps that axis under your control regardless of
+what the children ask for, and never produces an override warning. In the
+example below the layout still reports an inferred `stretch_width`, but
+`width_policy='min'` is what actually governs the horizontal axis, so the
+column shrinks to its contents:
+
+```{pyodide}
+pn.Column(
+    pn.pane.Markdown('Responsive child', sizing_mode='stretch_width'),
+    styles={'background': '#f0f0f0'},
+    width_policy='min',
+)
+```
+
+Setting a fixed `width` or `height` on the layout also suppresses inference on
+that axis, since a fixed size is unambiguous:
+
+```{pyodide}
+pn.Column(
+    pn.pane.Markdown('Responsive child', sizing_mode='stretch_width'),
+    styles={'background': '#f0f0f0'},
+    width=300,
+)
+```
+
+### Disabling inference entirely
+
+To make explicitly set sizing parameters authoritative everywhere, enable
+`respect_explicit_sizing`:
+
+```python
+pn.extension(respect_explicit_sizing=True)
+# OR
+pn.config.respect_explicit_sizing = True
+```
+
+With this enabled, a `sizing_mode`, `width_policy`, or `height_policy` you set
+on a layout is never overridden by its children, and no override warnings are
+emitted. Layouts that were not given an explicit setting still infer one from
+their children, so responsive content continues to work without annotating
+every container.
+
+This defaults to `False` to preserve the pre-existing behavior, since apps that
+relied on inference winning would otherwise change layout.
+
 ---
 
 ## Related Resources

--- a/doc/how_to/layout/size.md
+++ b/doc/how_to/layout/size.md
@@ -142,8 +142,8 @@ space, while `max_width` prevents it from becoming wider than 600 pixels:
 
 ```{pyodide}
 pn.Row(
-    pn.widgets.TextInput(name="Name", width_policy="max"),
-    pn.widgets.Button(name="Submit"),
+    pn.widgets.TextInput(label="Name", width_policy="max"),
+    pn.widgets.Button(label="Submit"),
     width_policy="max",
     max_width=600,
 )

--- a/doc/upgrade.md
+++ b/doc/upgrade.md
@@ -47,6 +47,18 @@ Let us walk through an example. Below we declare a responsive `Image` and a fixe
 To maintain backward compatibility Panel will still try to infer the appropriate sizing mode by inspecting the children of a container. It is, however, always best to be explicit.
 :::
 
+:::{admonition} Current behavior
+:class: important
+
+The rules above describe the behavior as of Panel 1.0 and have since been
+refined, e.g. `FlexBox` now derives its `sizing_mode` from its `flex_direction`
+rather than from its children. Panel also now warns when child inference
+overrides a `sizing_mode` you set on a layout yourself, and offers the
+`respect_explicit_sizing` config option to disable inference for explicitly
+sized layouts. See {ref}`sizing-mode-inference` for the current rules and how
+to opt out.
+:::
+
 #### Ambiguous configurations
 
 In the past, Panel would happily accept ambiguous layout configurations, e.g., providing a fixed width while also setting a responsive `sizing_mode` along the same dimension. As an example, take the following:

--- a/panel/config.py
+++ b/panel/config.py
@@ -234,6 +234,14 @@ class _config(_base_config):
         'scale_width', 'scale_height', 'scale_both', None], doc="""
         Specify the default sizing mode behavior of panels.""")  # type: ignore[assignment, ty:invalid-assignment]
 
+    respect_explicit_sizing = param.Boolean(default=False, doc="""
+        When enabled, explicitly set sizing_mode/width_policy/height_policy on a
+        layout are respected and never overridden by values inferred from the
+        layout's children. When disabled (the default) the legacy behaviour is
+        preserved: child-inferred values silently override explicit settings, but
+        a warning is emitted whenever such an override would occur so that the
+        incorrect specification can be corrected.""")
+
     template: str = param.Selector(default=None, doc="""
         The default template to render served applications into.""")  # type: ignore[assignment, ty:invalid-assignment]
 

--- a/panel/io/document.py
+++ b/panel/io/document.py
@@ -310,7 +310,7 @@ def write_events(
     if state._unblocked(doc):
         _dispatch_write_task(doc, _run_write_futures, doc)
     else:
-        doc.add_next_tick_callback(partial(_run_write_futures, doc))
+        doc.add_next_tick_callback(partial(_run_write_futures, doc))  # type: ignore[arg-type]
 
 def schedule_write_events(
     doc: Document,

--- a/panel/io/server.py
+++ b/panel/io/server.py
@@ -254,7 +254,7 @@ def async_execute(func: Callable[..., None]) -> None:
                 state._handle_exception(e)
     if unlock:
         wrapped.nolock = True # type: ignore
-    state.curdoc.add_next_tick_callback(wrapped)
+    state.curdoc.add_next_tick_callback(wrapped)  # type: ignore[arg-type]
 
 param.parameterized.async_executor = async_execute
 

--- a/panel/layout/base.py
+++ b/panel/layout/base.py
@@ -99,8 +99,14 @@ class SizingModeMixin:
 
             width_expanded = smode in ('stretch_width', 'stretch_both', 'scale_width', 'scale_both')
             height_expanded = smode in ('stretch_height', 'stretch_both', 'scale_height', 'scale_both')
-            expand_width |= width_expanded
-            expand_height |= height_expanded
+            # Only inherit a child's responsiveness along an axis if the
+            # corresponding policy was not explicitly set to a non-max
+            # value. An explicit width_policy/height_policy of "max"
+            # already forces expansion via the initializer above.
+            if not getattr(self, '_explicit_width_policy', False):
+                expand_width |= width_expanded
+            if not getattr(self, '_explicit_height_policy', False):
+                expand_height |= height_expanded
             if width_expanded:
                 width = child.min_width
             else:
@@ -135,14 +141,18 @@ class SizingModeMixin:
                     height += margin*2
                 heights.append(height)
 
-        # Infer new sizing mode based on children
+        # Infer new sizing mode based on children unless the user
+        # explicitly supplied a sizing_mode, in which case that setting is
+        # honored rather than inherited from the children.
         mode = 'scale' if scale else 'stretch'
         if self._direction == 'horizontal':
             allow_height_scale = all_expand_height
         else:
             allow_height_scale = True
 
-        if expand_width and expand_height and not self.width and not self.height:
+        if getattr(self, '_explicit_sizing_mode', False):
+            pass
+        elif expand_width and expand_height and not self.width and not self.height:
             if allow_height_scale or 'both' in (sizing_mode or ''):
                 sizing_mode = f'{mode}_both'
             else:

--- a/panel/layout/base.py
+++ b/panel/layout/base.py
@@ -16,6 +16,7 @@ import param
 from bokeh.models import Row as BkRow
 from param.parameterized import iscoroutinefunction, resolve_ref
 
+from ..config import config
 from ..io.document import freeze_doc, hold
 from ..io.resources import CDN_DIST
 from ..models.layout import Column as PnColumn, ScrollToEvent
@@ -92,6 +93,8 @@ class SizingModeMixin:
         heights, widths = [], []
         all_expand_height, expand_width, expand_height, scale = True, self.width_policy=="max", self.height_policy=="max", False
 
+        explicit_width = getattr(self, '_explicit_width_policy', False)
+        explicit_height = getattr(self, '_explicit_height_policy', False)
         for child in children:
             smode = child.sizing_mode
             if smode and 'scale' in smode:
@@ -99,13 +102,29 @@ class SizingModeMixin:
 
             width_expanded = smode in ('stretch_width', 'stretch_both', 'scale_width', 'scale_both')
             height_expanded = smode in ('stretch_height', 'stretch_both', 'scale_height', 'scale_both')
-            # Only inherit a child's responsiveness along an axis if the
-            # corresponding policy was not explicitly set to a non-max
-            # value. An explicit width_policy/height_policy of "max"
-            # already forces expansion via the initializer above.
-            if not getattr(self, '_explicit_width_policy', False):
+            if explicit_width and width_expanded:
+                if config.respect_explicit_sizing:
+                    pass
+                else:
+                    self.param.warning(
+                        f"width_policy={self.width_policy!r} on {type(self).__name__} is "
+                        "being overridden by a child's sizing. Set "
+                        "pn.config.respect_explicit_sizing=True to prevent this."
+                    )
+                    expand_width |= width_expanded
+            else:
                 expand_width |= width_expanded
-            if not getattr(self, '_explicit_height_policy', False):
+            if explicit_height and height_expanded:
+                if config.respect_explicit_sizing:
+                    pass
+                else:
+                    self.param.warning(
+                        f"height_policy={self.height_policy!r} on {type(self).__name__} is "
+                        "being overridden by a child's sizing. Set "
+                        "pn.config.respect_explicit_sizing=True to prevent this."
+                    )
+                    expand_height |= height_expanded
+            else:
                 expand_height |= height_expanded
             if width_expanded:
                 width = child.min_width
@@ -150,17 +169,31 @@ class SizingModeMixin:
         else:
             allow_height_scale = True
 
-        if getattr(self, '_explicit_sizing_mode', False):
-            pass
-        elif expand_width and expand_height and not self.width and not self.height:
+        # Infer what sizing_mode the children demand.
+        inferred_mode = None
+        if expand_width and expand_height and not self.width and not self.height:
             if allow_height_scale or 'both' in (sizing_mode or ''):
-                sizing_mode = f'{mode}_both'
+                inferred_mode = f'{mode}_both'
             else:
-                sizing_mode = f'{mode}_width'
+                inferred_mode = f'{mode}_width'
         elif expand_width and not self.width:
-            sizing_mode = f'{mode}_width'
+            inferred_mode = f'{mode}_width'
         elif expand_height and not self.height and allow_height_scale:
-            sizing_mode = f'{mode}_height'
+            inferred_mode = f'{mode}_height'
+
+        explicit_sizing = getattr(self, '_explicit_sizing_mode', False)
+        if explicit_sizing and inferred_mode and inferred_mode != sizing_mode:
+            if config.respect_explicit_sizing:
+                inferred_mode = None
+            else:
+                self.param.warning(
+                    f"sizing_mode={sizing_mode!r} on {type(self).__name__} is being "
+                    f"overridden to {inferred_mode!r} by a child's sizing. Set "
+                    "pn.config.respect_explicit_sizing=True to prevent this."
+                )
+
+        if inferred_mode:
+            sizing_mode = inferred_mode
         if sizing_mode is None:
             return {'sizing_mode': props.get('sizing_mode')}
 

--- a/panel/layout/base.py
+++ b/panel/layout/base.py
@@ -102,7 +102,9 @@ class SizingModeMixin:
 
             width_expanded = smode in ('stretch_width', 'stretch_both', 'scale_width', 'scale_both')
             height_expanded = smode in ('stretch_height', 'stretch_both', 'scale_height', 'scale_both')
-            if explicit_width and width_expanded:
+            # 'max' already requests expansion so a child expanding the same
+            # axis is not a conflict. Only warn/block for restrictive policies.
+            if explicit_width and width_expanded and self.width_policy != 'max':
                 if config.respect_explicit_sizing:
                     pass
                 else:

--- a/panel/layout/base.py
+++ b/panel/layout/base.py
@@ -102,32 +102,8 @@ class SizingModeMixin:
 
             width_expanded = smode in ('stretch_width', 'stretch_both', 'scale_width', 'scale_both')
             height_expanded = smode in ('stretch_height', 'stretch_both', 'scale_height', 'scale_both')
-            # 'max' already requests expansion so a child expanding the same
-            # axis is not a conflict. Only warn/block for restrictive policies.
-            if explicit_width and width_expanded and self.width_policy != 'max':
-                if config.respect_explicit_sizing:
-                    pass
-                else:
-                    self.param.warning(
-                        f"width_policy={self.width_policy!r} on {type(self).__name__} is "
-                        "being overridden by a child's sizing. Set "
-                        "pn.config.respect_explicit_sizing=True to prevent this."
-                    )
-                    expand_width |= width_expanded
-            else:
-                expand_width |= width_expanded
-            if explicit_height and height_expanded and self.height_policy != 'max':
-                if config.respect_explicit_sizing:
-                    pass
-                else:
-                    self.param.warning(
-                        f"height_policy={self.height_policy!r} on {type(self).__name__} is "
-                        "being overridden by a child's sizing. Set "
-                        "pn.config.respect_explicit_sizing=True to prevent this."
-                    )
-                    expand_height |= height_expanded
-            else:
-                expand_height |= height_expanded
+            expand_width |= width_expanded
+            expand_height |= height_expanded
             if width_expanded:
                 width = child.min_width
             else:
@@ -162,6 +138,17 @@ class SizingModeMixin:
                     height += margin*2
                 heights.append(height)
 
+        # An explicitly set width_policy/height_policy takes precedence over
+        # sizing_mode, so inferring expansion on that axis cannot change the
+        # rendered behavior. In strict mode we skip the inference entirely so
+        # the reported sizing_mode reflects what the user asked for; in either
+        # mode this is not a conflict and so is never warned about.
+        if config.respect_explicit_sizing:
+            if explicit_width and self.width_policy != 'max':
+                expand_width = False
+            if explicit_height and self.height_policy != 'max':
+                expand_height = False
+
         # Infer new sizing mode based on children unless the user
         # explicitly supplied a sizing_mode, in which case that setting is
         # honored rather than inherited from the children.
@@ -185,19 +172,24 @@ class SizingModeMixin:
 
         explicit_sizing = getattr(self, '_explicit_sizing_mode', False)
         if explicit_sizing and inferred_mode and inferred_mode != sizing_mode:
-            explicit_axes = set()
-            if sizing_mode and ('width' in sizing_mode or 'both' in sizing_mode):
-                explicit_axes.add('width')
-            if sizing_mode and ('height' in sizing_mode or 'both' in sizing_mode):
-                explicit_axes.add('height')
-            inferred_axes = set()
-            if 'width' in inferred_mode or 'both' in inferred_mode:
-                inferred_axes.add('width')
-            if 'height' in inferred_mode or 'both' in inferred_mode:
-                inferred_axes.add('height')
-            # Only a conflict when inference adds axes the explicit mode didn't request.
-            # If inference would downgrade (fewer axes), suppress it silently.
-            if not inferred_axes.issubset(explicit_axes):
+            explicit_axes = {
+                axis for axis in ('width', 'height')
+                if sizing_mode and (axis in sizing_mode or 'both' in sizing_mode)
+            }
+            inferred_axes = {
+                axis for axis in ('width', 'height')
+                if axis in inferred_mode or 'both' in inferred_mode
+            }
+            # Inference only conflicts on axes it adds on top of the explicit
+            # sizing_mode. width_policy/height_policy take precedence over
+            # sizing_mode, so an axis with an explicit policy stays under the
+            # user's control and is not being overridden.
+            conflicting_axes = inferred_axes - explicit_axes
+            if explicit_width:
+                conflicting_axes.discard('width')
+            if explicit_height:
+                conflicting_axes.discard('height')
+            if conflicting_axes:
                 if config.respect_explicit_sizing:
                     inferred_mode = None
                 else:
@@ -206,7 +198,9 @@ class SizingModeMixin:
                         f"overridden to {inferred_mode!r} by a child's sizing. Set "
                         "pn.config.respect_explicit_sizing=True to prevent this."
                     )
-            else:
+            elif inferred_axes.issubset(explicit_axes):
+                # Inference would downgrade the explicit sizing_mode; the
+                # explicit setting is a superset so it should win.
                 inferred_mode = None
 
         if inferred_mode:

--- a/panel/layout/base.py
+++ b/panel/layout/base.py
@@ -116,7 +116,7 @@ class SizingModeMixin:
                     expand_width |= width_expanded
             else:
                 expand_width |= width_expanded
-            if explicit_height and height_expanded:
+            if explicit_height and height_expanded and self.height_policy != 'max':
                 if config.respect_explicit_sizing:
                     pass
                 else:
@@ -185,14 +185,29 @@ class SizingModeMixin:
 
         explicit_sizing = getattr(self, '_explicit_sizing_mode', False)
         if explicit_sizing and inferred_mode and inferred_mode != sizing_mode:
-            if config.respect_explicit_sizing:
-                inferred_mode = None
+            explicit_axes = set()
+            if sizing_mode and ('width' in sizing_mode or 'both' in sizing_mode):
+                explicit_axes.add('width')
+            if sizing_mode and ('height' in sizing_mode or 'both' in sizing_mode):
+                explicit_axes.add('height')
+            inferred_axes = set()
+            if 'width' in inferred_mode or 'both' in inferred_mode:
+                inferred_axes.add('width')
+            if 'height' in inferred_mode or 'both' in inferred_mode:
+                inferred_axes.add('height')
+            # Only a conflict when inference adds axes the explicit mode didn't request.
+            # If inference would downgrade (fewer axes), suppress it silently.
+            if not inferred_axes.issubset(explicit_axes):
+                if config.respect_explicit_sizing:
+                    inferred_mode = None
+                else:
+                    self.param.warning(
+                        f"sizing_mode={sizing_mode!r} on {type(self).__name__} is being "
+                        f"overridden to {inferred_mode!r} by a child's sizing. Set "
+                        "pn.config.respect_explicit_sizing=True to prevent this."
+                    )
             else:
-                self.param.warning(
-                    f"sizing_mode={sizing_mode!r} on {type(self).__name__} is being "
-                    f"overridden to {inferred_mode!r} by a child's sizing. Set "
-                    "pn.config.respect_explicit_sizing=True to prevent this."
-                )
+                inferred_mode = None
 
         if inferred_mode:
             sizing_mode = inferred_mode

--- a/panel/tests/layout/test_base.py
+++ b/panel/tests/layout/test_base.py
@@ -681,3 +681,55 @@ def test_compute_sizing_mode_stretch_margin_four_tuple(dim, document, comm):
     new_props = col._compute_sizing_mode(root.children, {'margin': margin})
 
     assert new_props == {f'min_{dim}': 115, 'sizing_mode': f'stretch_{dim}'}
+
+def test_compute_sizing_mode_explicit_sizing_mode_not_inherited(document, comm):
+    md = Markdown('foo', sizing_mode='stretch_width')
+    col = Column(md, sizing_mode='fixed')
+
+    root = col.get_root(document, comm=comm)
+
+    assert root.sizing_mode == 'fixed'
+
+def test_compute_sizing_mode_explicit_width_policy_max_still_inherited(document, comm):
+    md = Markdown('foo', sizing_mode='stretch_width')
+    col = Column(md, width_policy='max')
+
+    root = col.get_root(document, comm=comm)
+
+    assert root.sizing_mode == 'stretch_width'
+    assert root.width_policy == 'max'
+
+def test_compute_sizing_mode_explicit_width_policy_not_max_not_inherited(document, comm):
+    md = Markdown('foo', sizing_mode='stretch_width')
+    col = Column(md, width_policy='fixed')
+
+    root = col.get_root(document, comm=comm)
+
+    assert root.sizing_mode is None
+    assert root.width_policy == 'fixed'
+
+def test_compute_sizing_mode_explicit_height_policy_not_max_not_inherited(document, comm):
+    md = Markdown('foo', sizing_mode='stretch_height')
+    col = Column(md, height_policy='fixed')
+
+    root = col.get_root(document, comm=comm)
+
+    assert root.sizing_mode is None
+    assert root.height_policy == 'fixed'
+
+def test_compute_sizing_mode_inherited_without_explicit_sizing(document, comm):
+    md = Markdown('foo', sizing_mode='stretch_width')
+    col = Column(md)
+
+    root = col.get_root(document, comm=comm)
+
+    assert root.sizing_mode == 'stretch_width'
+
+def test_compute_sizing_mode_dynamic_sizing_mode_not_inherited(document, comm):
+    md = Markdown('foo', sizing_mode='stretch_width')
+    col = Column(md)
+    col.sizing_mode = 'fixed'
+
+    root = col.get_root(document, comm=comm)
+
+    assert root.sizing_mode == 'fixed'

--- a/panel/tests/layout/test_base.py
+++ b/panel/tests/layout/test_base.py
@@ -738,3 +738,65 @@ def test_compute_sizing_mode_dynamic_sizing_mode_not_inherited(document, comm):
     root = col.get_root(document, comm=comm)
 
     assert root.sizing_mode == 'fixed'
+
+def test_compute_sizing_mode_explicit_sizing_mode_override_warns(document, comm, caplog):
+    md = Markdown('foo', sizing_mode='stretch_width')
+    col = Column(md, sizing_mode='stretch_height')
+
+    root = col.get_root(document, comm=comm)
+
+    assert root.sizing_mode == 'stretch_width'
+    assert "sizing_mode='stretch_height' on Column is being overridden" in caplog.text
+
+@pytest.mark.parametrize('policy', ['fixed', 'min', 'max'])
+def test_compute_sizing_mode_explicit_width_policy_does_not_warn(policy, document, comm, caplog):
+    # width_policy takes precedence over sizing_mode so an inferred
+    # sizing_mode is not overriding the user's setting.
+    md = Markdown('foo', sizing_mode='stretch_width')
+    col = Column(md, width_policy=policy)
+
+    col.get_root(document, comm=comm)
+
+    assert 'being overridden' not in caplog.text
+
+@pytest.mark.parametrize('policy', ['fixed', 'min', 'max'])
+def test_compute_sizing_mode_explicit_height_policy_does_not_warn(policy, document, comm, caplog):
+    md = Markdown('foo', sizing_mode='stretch_height')
+    col = Column(md, height_policy=policy)
+
+    col.get_root(document, comm=comm)
+
+    assert 'being overridden' not in caplog.text
+
+def test_compute_sizing_mode_explicit_policy_suppresses_sizing_mode_warning(document, comm, caplog):
+    # The conflicting axis (width) is governed by the explicit width_policy,
+    # so the sizing_mode override is not reported as a conflict.
+    md = Markdown('foo', sizing_mode='stretch_width')
+    col = Column(md, sizing_mode='stretch_height', width_policy='fixed')
+
+    root = col.get_root(document, comm=comm)
+
+    assert root.width_policy == 'fixed'
+    assert 'being overridden' not in caplog.text
+
+def test_compute_sizing_mode_explicit_policy_respected_with_strict_config(document, comm, caplog):
+    md = Markdown('foo', sizing_mode='stretch_width')
+    col = Column(md, sizing_mode='stretch_height', width_policy='fixed')
+
+    with config.set(respect_explicit_sizing=True):
+        root = col.get_root(document, comm=comm)
+
+    assert root.sizing_mode == 'stretch_height'
+    assert root.width_policy == 'fixed'
+    assert 'being overridden' not in caplog.text
+
+def test_compute_sizing_mode_inference_downgrade_does_not_warn(document, comm, caplog):
+    # Children only expand width, which is narrower than the explicit
+    # stretch_both, so the explicit setting wins silently.
+    md = Markdown('foo', sizing_mode='stretch_width')
+    col = Column(md, sizing_mode='stretch_both')
+
+    root = col.get_root(document, comm=comm)
+
+    assert root.sizing_mode == 'stretch_both'
+    assert 'being overridden' not in caplog.text

--- a/panel/tests/layout/test_base.py
+++ b/panel/tests/layout/test_base.py
@@ -7,6 +7,7 @@ import pytest
 from bokeh.models import Column as BkColumn, Div, Row as BkRow
 
 from panel.chat import ChatInterface
+from panel.config import config
 from panel.layout import (
     Accordion, Card, Column, FlexBox, Row, Spacer, Tabs, WidgetBox,
 )
@@ -686,7 +687,8 @@ def test_compute_sizing_mode_explicit_sizing_mode_not_inherited(document, comm):
     md = Markdown('foo', sizing_mode='stretch_width')
     col = Column(md, sizing_mode='fixed')
 
-    root = col.get_root(document, comm=comm)
+    with config.set(respect_explicit_sizing=True):
+        root = col.get_root(document, comm=comm)
 
     assert root.sizing_mode == 'fixed'
 
@@ -694,7 +696,8 @@ def test_compute_sizing_mode_explicit_width_policy_max_still_inherited(document,
     md = Markdown('foo', sizing_mode='stretch_width')
     col = Column(md, width_policy='max')
 
-    root = col.get_root(document, comm=comm)
+    with config.set(respect_explicit_sizing=True):
+        root = col.get_root(document, comm=comm)
 
     assert root.sizing_mode == 'stretch_width'
     assert root.width_policy == 'max'
@@ -703,7 +706,8 @@ def test_compute_sizing_mode_explicit_width_policy_not_max_not_inherited(documen
     md = Markdown('foo', sizing_mode='stretch_width')
     col = Column(md, width_policy='fixed')
 
-    root = col.get_root(document, comm=comm)
+    with config.set(respect_explicit_sizing=True):
+        root = col.get_root(document, comm=comm)
 
     assert root.sizing_mode is None
     assert root.width_policy == 'fixed'
@@ -712,7 +716,8 @@ def test_compute_sizing_mode_explicit_height_policy_not_max_not_inherited(docume
     md = Markdown('foo', sizing_mode='stretch_height')
     col = Column(md, height_policy='fixed')
 
-    root = col.get_root(document, comm=comm)
+    with config.set(respect_explicit_sizing=True):
+        root = col.get_root(document, comm=comm)
 
     assert root.sizing_mode is None
     assert root.height_policy == 'fixed'

--- a/panel/tests/test_interact.py
+++ b/panel/tests/test_interact.py
@@ -233,7 +233,7 @@ def test_interact_replaces_model(document, comm):
     assert new_pane._models[column.ref['id']][0] is new_div
 
     interact_pane._cleanup(column)
-    assert len(interact_pane._internal_callbacks) == 5
+    assert len(interact_pane._internal_callbacks) == 6
 
 
 def test_interact_throttled():

--- a/panel/viewable.py
+++ b/panel/viewable.py
@@ -262,6 +262,13 @@ class Layoutable(param.Parameterized):
     __abstract = True
 
     def __init__(self, **params):
+        # Track which sizing parameters were explicitly supplied by the
+        # user (as opposed to their defaults or values inferred from
+        # children). This is computed before the config driven defaults
+        # below are applied so config defaults are not treated as explicit.
+        self._explicit_sizing_mode = params.get('sizing_mode') is not None
+        self._explicit_width_policy = params.get('width_policy') not in (None, 'auto')
+        self._explicit_height_policy = params.get('height_policy') not in (None, 'auto')
         sizing_mode = params.get('sizing_mode')
         if (sizing_mode in ('stretch_width', 'scale_width', 'stretch_both', 'scale_both') and
             params.get('width') is not None):
@@ -313,6 +320,17 @@ class Layoutable(param.Parameterized):
         if 'design' not in params and self.param.design.default is None:
             params['design'] = config.design
         super().__init__(**params)
+
+    # Track dynamic (post-init) updates to the sizing parameters so that
+    # explicitly set values are honored rather than being overridden by
+    # values inferred from a layout's children. Child inference writes to
+    # the underlying model rather than the parameter, so it does not
+    # trigger this watcher.
+    @param.depends('sizing_mode', 'width_policy', 'height_policy', watch=True)
+    def _update_explicit_sizing(self):
+        self._explicit_sizing_mode = self.sizing_mode is not None
+        self._explicit_width_policy = self.width_policy != 'auto'
+        self._explicit_height_policy = self.height_policy != 'auto'
 
 
 class ServableMixin:

--- a/panel/viewable.py
+++ b/panel/viewable.py
@@ -320,17 +320,23 @@ class Layoutable(param.Parameterized):
         if 'design' not in params and self.param.design.default is None:
             params['design'] = config.design
         super().__init__(**params)
+        # Track dynamic (post-init) updates to the sizing parameters so
+        # that explicitly set values are honored rather than being
+        # overridden by values inferred from a layout's children. Child
+        # inference writes to the underlying model rather than the
+        # parameter, so it does not trigger this watcher.
+        watcher = self.param.watch(
+            self._update_explicit_sizing,
+            ['sizing_mode', 'width_policy', 'height_policy']
+        )
+        if not hasattr(self, '_internal_callbacks'):
+            self._internal_callbacks = []
+        self._internal_callbacks.append(watcher)
 
-    # Track dynamic (post-init) updates to the sizing parameters so that
-    # explicitly set values are honored rather than being overridden by
-    # values inferred from a layout's children. Child inference writes to
-    # the underlying model rather than the parameter, so it does not
-    # trigger this watcher.
-    @param.depends('sizing_mode', 'width_policy', 'height_policy', watch=True)
-    def _update_explicit_sizing(self):
-        self._explicit_sizing_mode = self.sizing_mode is not None
-        self._explicit_width_policy = self.width_policy != 'auto'
-        self._explicit_height_policy = self.height_policy != 'auto'
+    def _update_explicit_sizing(self, *events):
+        for event in events:
+            explicit = event.new is not None if event.name == 'sizing_mode' else event.new != 'auto'
+            setattr(self, f'_explicit_{event.name}', explicit)
 
 
 class ServableMixin:

--- a/panel/viewable.py
+++ b/panel/viewable.py
@@ -269,6 +269,7 @@ class Layoutable(param.Parameterized):
         self._explicit_sizing_mode = params.get('sizing_mode') is not None
         self._explicit_width_policy = params.get('width_policy') not in (None, 'auto')
         self._explicit_height_policy = params.get('height_policy') not in (None, 'auto')
+        self._sizing_initializing = True
         sizing_mode = params.get('sizing_mode')
         if (sizing_mode in ('stretch_width', 'scale_width', 'stretch_both', 'scale_both') and
             params.get('width') is not None):
@@ -320,6 +321,7 @@ class Layoutable(param.Parameterized):
         if 'design' not in params and self.param.design.default is None:
             params['design'] = config.design
         super().__init__(**params)
+        self._sizing_initializing = False
         # Track dynamic (post-init) updates to the sizing parameters so
         # that explicitly set values are honored rather than being
         # overridden by values inferred from a layout's children. Child
@@ -334,6 +336,8 @@ class Layoutable(param.Parameterized):
         self._internal_callbacks.append(watcher)
 
     def _update_explicit_sizing(self, *events):
+        if self._sizing_initializing:
+            return
         for event in events:
             explicit = event.new is not None if event.name == 'sizing_mode' else event.new != 'auto'
             setattr(self, f'_explicit_{event.name}', explicit)


### PR DESCRIPTION
## Summary

Layouts in Panel infer a `sizing_mode` for themselves by inspecting their children: if a child expands along an axis, the parent layout is upgraded to expand along that axis too. This is useful default behavior, but it means that an explicitly set `sizing_mode`, `width_policy`, or `height_policy` on a layout can be silently overridden by a child, which is surprising and hard to debug.

This PR fixes that, while preserving backwards compatibility via a new config flag and actionable warnings.

## Changes

### `panel/viewable.py` — fix init-time watcher regression

The `_explicit_sizing_mode`, `_explicit_width_policy`, and `_explicit_height_policy` flags (introduced to track user-supplied sizing params) were being incorrectly set to `True` during `__init__` by a `param.watch` callback. The callback fired when `super().__init__()` processed the `config.sizing_mode` value that had been injected into `params` just beforehand, making every component built in an app with a non-default `config.sizing_mode` believe its sizing was explicitly set by the user.

Fixed by setting a `_sizing_initializing` guard before `super().__init__()` and clearing it after, causing `_update_explicit_sizing` to skip all events fired during initialisation.

### `panel/layout/base.py` — guarded override with warnings

`SizingModeMixin._compute_sizing_mode` is updated to distinguish three cases when a child's sizing would change the parent's effective sizing mode:

- **Genuine conflict (explicit restricts, child expands):** In legacy mode (`config.respect_explicit_sizing=False`, the default), the child-inferred value still wins but a `param.warning` is emitted telling the user which setting is being overridden and how to fix it. With `config.respect_explicit_sizing=True` the explicit setting is honoured and child inference is suppressed.

- **No conflict (`width_policy='max'`, child also expands width):** `'max'` already requests full expansion, so a child that also expands is not overriding anything. No warning is emitted.

- **Inference would downgrade (explicit is a superset of inferred):** If the layout has `sizing_mode='stretch_both'` but children only expand width, the inferred `'stretch_width'` is narrower than what was set. The override is suppressed silently in both modes — there is no conflict, and the explicit setting should win.

### `panel/config.py` — new `respect_explicit_sizing` flag

```python
pn.config.respect_explicit_sizing = True  # opt in to strict behaviour
```

Defaults to `False` to preserve backwards compatibility. When `True`, explicitly set sizing parameters on layouts are never overridden by child inference. The warnings emitted in the default mode direct users to either correct their sizing specification or enable this flag.