### PR TITLE
Fix UI tests

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -251,7 +251,7 @@ PLAYWRIGHT_BROWSERS_PATH = ".pixi/playwright-browsers"
 _install-ui = 'playwright install chromium'
 
 [feature.test-ui.tasks.test-ui]
-cmd = 'pytest panel/tests/ui --ui --browser chromium -n logical --dist loadgroup'
+cmd = 'pytest panel/tests/ui --ui --browser chromium -n logical --dist loadgroup -v'
 depends-on = ["_install-ui"]
 
 # =============================================

--- a/pixi.toml
+++ b/pixi.toml
@@ -237,7 +237,11 @@ test-example = 'pytest -n logical --dist loadscope --nbval-lax examples'
 nbval = "*"
 
 [feature.test-ui.dependencies]
-playwright = "*"
+# The playwright CLI installs the browser build that the playwright-python
+# client speaks to, so the two must stay on the same minor version. A newer
+# CLI downloads a Chromium the client cannot drive, which hangs tests
+# indefinitely rather than failing them.
+playwright = "1.61.*"
 pytest-playwright = "*"
 pytest-asyncio = "*"
 jupyter_server = "*"


### PR DESCRIPTION
Pins playwright to avoid divergence of playwright versions leading to the UI tests stalling.