### PR TITLE
Claim the Document thread before running app code

### DIFF
--- a/panel/io/application.py
+++ b/panel/io/application.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import threading
 import typing as t
 
 from functools import partial
@@ -165,6 +166,10 @@ class Application(BkApplication):
 
     def initialize_document(self, doc):
         logger.info(LOG_SESSION_LAUNCHING, id(doc))
+        # Claim the Document for the current thread before user code runs,
+        # so APIs that behave differently when invoked off the Document's
+        # thread (e.g. hold) can tell the two cases apart during the build.
+        state._thread_id_[doc] = threading.get_ident()
         self._set_session_prefix(doc)
         super().initialize_document(doc)
         if doc in state._templates and doc not in state._templates[doc]._documents:

--- a/panel/tests/io/test_document.py
+++ b/panel/tests/io/test_document.py
@@ -78,6 +78,27 @@ def test_hold_does_not_get_stuck_with_threaded_callbacks(threads):
     wait_until(lambda: not doc.callbacks.hold_value, timeout=5000)
 
 
+@pytest.mark.xdist_group(name="server")
+def test_hold_in_app_callable_does_not_leak_hold():
+    build = {}
+
+    def app():
+        with hold():
+            pass
+        # A hold leaked here defers the unhold past ServerSession
+        # construction, which registers this callback a second time
+        # when the queued SessionCallbackAdded event is replayed.
+        pn.state.add_periodic_callback(lambda: None, period=10000)
+        build['thread_id'] = state._thread_id
+        build['hold'] = state.curdoc.callbacks.hold_value
+        return IntSlider()
+
+    serve_and_request(app)
+
+    assert build['thread_id'] is not None
+    assert build['hold'] is None
+
+
 class _FakeProtocol:
     def create(self, msgtype, events):
         return object()


### PR DESCRIPTION
## Description

`state._thread_id` is only recorded in `init_doc()`, which runs *after* the app callable returns. While the app callable is running it is therefore `None`, and `hold()` decides whether it was called off the Document's thread with `threaded = state._current_thread != state._thread_id` — so it unconditionally concludes it is off-thread. Rather than unholding on exit it schedules `_unhold` as a next-tick callback and restores `_hold`, leaving the Document held for the rest of the build. Bokeh then constructs the `ServerSession`, whose `__init__` registers every session callback already on the Document, and the deferred unhold afterwards replays the queued `SessionCallbackAdded` event — registering the same callback a second time.

Every session opened by an app that registers a session callback after a `hold()` block therefore logs `ValueError: A callback of the same type has already been added with this ID`:

```python
import panel as pn

def app():
    with pn.io.hold():
        pass
    pn.state.add_periodic_callback(lambda: None, period=1000)
    return pn.pane.Markdown("hello")

pn.serve(app, port=5051, show=False)
```

Beyond the log noise, `DocumentCallbackManager.unhold()` dispatches in a plain loop, so the exception drops every event still queued behind the offending one. In the app where I hit this that was 38 of the 39 events queued during the initial render.

The Document's thread is knowable before user code runs, so `Application.initialize_document` now claims it. That writes the same value `init_doc` writes moments later — `init_doc` runs synchronously inside the same build — just early enough for the app callable to see it. `init_doc` keeps its own assignment, which still covers Panel objects embedded in a plain Bokeh `Application`.

The alternative I originally suggested on the issue, guarding the comparison with `state._thread_id is not None and ...`, resolves the ambiguity by guessing that an unset thread id means "on-thread". That guess also fires where the thread id is legitimately never set — notably notebooks, where `init_doc` returns early because there is no `session_context` — and would silently move `hold()` there onto a different path, so I went with making the thread id known instead.

Fixes #8691

### A question on #8619

This moves a build-time `hold()` from the `threaded` branch of the `finally` chain onto the `not state._connected` branch, which drops the hold policy but leaves `_held_events` populated for an unrelated later `unhold()` to flush. Build-time holds behaved exactly that way before #8619 reordered the chain, so this restores the older behaviour rather than introducing something new — but was that reordering meant to change what happens to events queued while the app is still being built? Raised separately in #8692, since the leftover events outlive this PR either way.

## AI Disclosure

Tool & Model: Claude Code + Opus 5

Usage: Claude Code diagnosed the root cause against the Panel and Bokeh sources, chose where the fix should live, wrote the fix and the regression test, and ran the verification — the reproducer above before and after, the regression test confirmed failing on the parent commit, and the full non-UI test suite compared against a baseline run (no new failures; the 18 pre-existing ones are missing JS bundles and `bokeh_fastapi` in my environment). I reported the original issue and reviewed the change.

- [x] I have tested all AI-generated content in my PR.
- [x] I take responsibility for all AI-generated content in my PR.

## Checklist

- [x] Tests added and are passing
