### PR TITLE
Fix tabulator row_content in pmui dynamic Tabs

### DIFF
--- a/panel/models/tabulator.ts
+++ b/panel/models/tabulator.ts
@@ -429,6 +429,13 @@ export class DataTabulatorView extends HTMLBoxView {
     this.on_change(children, () => this.renderChildren())
 
     this.on_change(expanded, () => {
+      // A view whose render() has not run, or which has been torn down, has no Tabulator
+      // instance. It can still be subscribed to the model, and throwing here aborts the whole
+      // emit chain, so a sibling view that *is* rendered never gets to draw the row content and
+      // the expand click appears to do nothing. Every other handler in this file guards this way.
+      if (this.tabulator == null) {
+        return
+      }
       // The first cell is the cell of the frozen _index column.
       for (const row of this.tabulator.rowManager.getRows()) {
         if (row.cells.length > 0) {


### PR DESCRIPTION
I noticed the row content wasn't expanding in pmui.Tabs(dyanmic=True) not in the first tab, but works when dynamic=False and pn.Tabs. 

```python
import pandas as pd
import panel as pn
import panel_material_ui as pmui

pn.extension("tabulator")

print(f"panel {pn.__version__} | panel-material-ui {pmui.__version__} | "
      f"bokeh {__import__('bokeh').__version__}")

df = pd.DataFrame({"task": ["sql", "routing"], "grade": ["PASS", "FAIL"]})


def app():
    # Built per session: a Viewable cannot be shared across two Bokeh documents, and every
    # reload opens a new session. Sharing one instance raises "Models must be owned by only a
    # single document" on the second session, which is noise unrelated to the bug above.
    table = pn.widgets.Tabulator(
        df, row_content=lambda row: pn.pane.Markdown(f"### {row['grade']}")
    )
    return pmui.Tabs(("First", "Switch to the Table tab, then click an expand arrow."),
                     ("Table", table), dynamic=True)


pn.serve(app, port=5008, show=False)
```

Before:

https://github.com/user-attachments/assets/b3a47360-0580-4b21-be41-9f388f1efb0c


After:

https://github.com/user-attachments/assets/9d1aef26-47ae-4da4-b9b8-1dd5fcf86567

