### PR TITLE
Drain held events once connected

### DIFF
--- a/panel/io/document.py
+++ b/panel/io/document.py
@@ -133,7 +133,8 @@ def _drain_unconnected_events(doc: Document, lock: threading.Lock) -> list[Docum
         doc.callbacks._held_events = []
         doc.callbacks._hold = None
 
-        dispatch, deferred = [], []
+        dispatch: list[DocumentChangedEvent] = []
+        deferred: list[DocumentChangedEvent] = []
         for event in events:
             if isinstance(event, SessionCallbackAdded | SessionCallbackRemoved):
                 dispatch.append(event)

--- a/panel/io/document.py
+++ b/panel/io/document.py
@@ -136,7 +136,7 @@ def _drain_unconnected_events(doc: Document, lock: threading.Lock) -> list[Docum
         dispatch: list[DocumentChangedEvent] = []
         deferred: list[DocumentChangedEvent] = []
         for event in events:
-            if isinstance(event, SessionCallbackAdded | SessionCallbackRemoved):
+            if isinstance(event, (SessionCallbackAdded, SessionCallbackRemoved)):
                 dispatch.append(event)
             elif not isinstance(event, DocumentPatchedEvent) or isinstance(event, MessageSentEvent):
                 deferred.append(event)

--- a/panel/io/document.py
+++ b/panel/io/document.py
@@ -19,7 +19,10 @@ from weakref import WeakKeyDictionary
 
 from bokeh.application.application import SessionContext
 from bokeh.document.document import Document
-from bokeh.document.events import DocumentChangedEvent, DocumentPatchedEvent
+from bokeh.document.events import (
+    DocumentChangedEvent, DocumentPatchedEvent, MessageSentEvent,
+    SessionCallbackAdded, SessionCallbackRemoved,
+)
 from bokeh.model.util import visit_immediate_value_references
 from bokeh.models import CustomJS
 
@@ -49,6 +52,7 @@ _HOLD_LOCK: WeakKeyDictionary[Document, threading.Lock] = WeakKeyDictionary()
 _WRITE_FUTURES: WeakKeyDictionary[Document, list[Future]] = WeakKeyDictionary()
 _WRITE_MSGS: WeakKeyDictionary[Document, dict[ServerConnection, list[Message]]] = WeakKeyDictionary()
 _WRITE_BLOCK: WeakKeyDictionary[Document, bool] = WeakKeyDictionary()
+_UNCONNECTED_EVENTS: WeakKeyDictionary[Document, list[DocumentChangedEvent]] = WeakKeyDictionary()
 
 _panel_last_cleanup = None
 _write_tasks: WeakKeyDictionary[Document, list[asyncio.Task]] = WeakKeyDictionary()
@@ -96,6 +100,63 @@ def _dispatch_events(doc: Document, events: list[DocumentChangedEvent]) -> None:
     """
     for event in events:
         doc.callbacks.trigger_on_change(event)
+
+def _drain_unconnected_events(doc: Document, lock: threading.Lock) -> list[DocumentChangedEvent]:
+    """
+    Drains events collected by a hold that exited before the session
+    connected, sorting them into three groups, and returns the events
+    that have to be dispatched immediately.
+
+    Session callback events must be dispatched, since they are how
+    ``add_next_tick_callback`` and friends register the callback on the
+    IOLoop. Dropping them means the callback never runs at all, which
+    for a scheduled ``Reactive._update_model`` silently loses the update.
+
+    Events that carry no model state cannot be dispatched yet, since
+    there are no subscribed connections to write them to, so they are
+    deferred until the session connects. This currently means
+    MessageSentEvent, i.e. custom events sent via ``Reactive._send_event``
+    and ipywidgets comm messages.
+
+    Everything else is dropped, since the Document is serialized in full
+    once the session connects. Model property changes, title changes,
+    root additions/removals and ColumnDataSource stream/patch events are
+    all applied to the model before the event is emitted, so the
+    serialization reproduces them.
+
+    The events are returned rather than dispatched here so the caller can
+    dispatch them after releasing ``lock``, since a change callback may
+    itself enter ``hold``.
+    """
+    with lock:
+        events = list(doc.callbacks._held_events or [])
+        doc.callbacks._held_events = []
+        doc.callbacks._hold = None
+
+        dispatch, deferred = [], []
+        for event in events:
+            if isinstance(event, SessionCallbackAdded | SessionCallbackRemoved):
+                dispatch.append(event)
+            elif not isinstance(event, DocumentPatchedEvent) or isinstance(event, MessageSentEvent):
+                deferred.append(event)
+        if deferred:
+            _UNCONNECTED_EVENTS.setdefault(doc, []).extend(deferred)
+    return dispatch
+
+def _dispatch_unconnected_events(doc: Document) -> None:
+    """
+    Dispatches events deferred by ``_drain_unconnected_events`` now
+    that the session has connected. Scheduled on the Document to ensure
+    the events are dispatched on the Document's thread while it holds
+    its lock, since ``_on_load`` may run on the thread pool.
+    """
+    events = _UNCONNECTED_EVENTS.pop(doc, None)
+    if not events:
+        return
+    if doc.session_context:
+        doc.add_next_tick_callback(partial(retrigger_events, doc, events))
+    else:
+        retrigger_events(doc, events)
 
 def _cleanup_doc(doc, destroy=True):
     for callback in doc.session_destroyed_callbacks:
@@ -251,6 +312,7 @@ def _destroy_document(self, session):
     # Cancel any pending write tasks for this document
     _WRITE_MSGS.pop(self, None)
     _WRITE_BLOCK.pop(self, None)
+    _UNCONNECTED_EVENTS.pop(self, None)
     for future in _WRITE_FUTURES.pop(self, []):
         future.cancel()
     for task in _write_tasks.pop(self, []):
@@ -617,20 +679,27 @@ def hold(
                 pass
             elif threaded:
                 if not held or we_held:
-                    def _unhold(lock=hold_lock, doc=doc):
-                        with lock:
-                            doc.unhold()
-                    with hold_lock:
-                        doc.callbacks._hold = None
-                        doc.add_next_tick_callback(_unhold)
-                        doc.callbacks._hold = policy
+                    if state._connected.get(doc):
+                        def _unhold(lock=hold_lock, doc=doc):
+                            with lock:
+                                doc.unhold()
+                        with hold_lock:
+                            # Clear the hold around scheduling the callback
+                            # so the SessionCallbackAdded event it emits is
+                            # dispatched rather than collected by the hold
+                            # it is releasing.
+                            doc.callbacks._hold = None
+                            doc.add_next_tick_callback(_unhold)
+                            doc.callbacks._hold = policy
+                    else:
+                        _dispatch_events(doc, _drain_unconnected_events(doc, hold_lock))
             elif held:
                 doc.callbacks._hold = held
             elif comm is not None:
                 from .notebook import push
                 push(doc, comm)
             elif not state._connected.get(doc):
-                doc.callbacks._hold = None
+                _dispatch_events(doc, _drain_unconnected_events(doc, hold_lock))
             else:
                 doc.unhold()
 

--- a/panel/io/state.py
+++ b/panel/io/state.py
@@ -452,6 +452,13 @@ class _state(param.Parameterized):
         if not doc:
             return
         self._connected[doc] = True
+
+        # Events held before the session connected which the full
+        # Document serialization cannot reproduce are dispatched now
+        # that there is a connection to write them to.
+        from .document import _dispatch_unconnected_events
+        _dispatch_unconnected_events(doc)
+
         if doc not in self._onload:
             self._loaded[doc] = True
             return

--- a/panel/tests/io/test_document.py
+++ b/panel/tests/io/test_document.py
@@ -1,5 +1,6 @@
 import asyncio
 import gc
+import threading
 import weakref
 
 from concurrent.futures import ThreadPoolExecutor
@@ -9,12 +10,13 @@ import pytest
 import tornado.locks
 
 from bokeh.document import Document
+from bokeh.document.events import MessageSentEvent
 
 import panel as pn
 
 from panel.io.document import (
-    _WRITE_BLOCK, _cleanup_doc, _destroy_document, _write_tasks,
-    extra_socket_handlers, hold, schedule_write_events, unlocked,
+    _UNCONNECTED_EVENTS, _WRITE_BLOCK, _cleanup_doc, _destroy_document,
+    _write_tasks, extra_socket_handlers, hold, schedule_write_events, unlocked,
 )
 from panel.io.state import _state, set_curdoc, state
 from panel.tests.util import serve_and_request, wait_until
@@ -76,6 +78,149 @@ def test_hold_does_not_get_stuck_with_threaded_callbacks(threads):
             f.result()
 
     wait_until(lambda: not doc.callbacks.hold_value, timeout=5000)
+
+
+def test_hold_before_connected_does_not_strand_events():
+    """
+    A hold exiting before the session connects must leave nothing queued
+    on the Document, and must not swallow the session callback events
+    that scheduled updates rely on to register on the IOLoop.
+    """
+    state_info, docs, ran = {}, [], []
+
+    def app():
+        md = pn.pane.Markdown("initial")
+        doc = state.curdoc
+        docs.append(doc)
+
+        def before_ready():
+            with hold(doc):
+                md.object = "changed"
+                doc.add_next_tick_callback(lambda: ran.append('scheduled'))
+            state_info['connected'] = state._connected.get(doc)
+            state_info['hold'] = doc.callbacks.hold_value
+            state_info['queued'] = list(doc.callbacks._held_events)
+
+        doc.add_next_tick_callback(before_ready)
+        return md
+
+    serve_and_request(app)
+    wait_until(lambda: 'queued' in state_info)
+
+    # The hold exited before the session was connected
+    assert state_info['connected'] is None
+    assert state_info['hold'] is None
+    # Nothing is left queued behind the hold
+    assert state_info['queued'] == []
+
+    doc = docs[0]
+    # The scheduled callback was registered and ran, so the model update
+    # that Reactive schedules pre-connect is not lost
+    wait_until(lambda: ran == ['scheduled'])
+    wait_until(lambda: docs[0].roots[0].text == '&lt;p&gt;changed&lt;/p&gt;\n')
+    assert not doc.callbacks._held_events
+
+
+def test_hold_before_connected_defers_message_sent():
+    """
+    MessageSentEvent carries a protocol message with no representation in
+    the model graph, so it cannot be dropped like a model change. It has
+    to be deferred until a connection exists to write it to.
+    """
+    docs, state_info = [], {}
+
+    def app():
+        doc = state.curdoc
+        docs.append(doc)
+
+        def before_ready():
+            with hold(doc):
+                doc.callbacks.trigger_on_change(
+                    MessageSentEvent(doc, "panel_test", "payload")
+                )
+            state_info['deferred'] = list(_UNCONNECTED_EVENTS.get(doc, []))
+            state_info['queued'] = list(doc.callbacks._held_events)
+
+        doc.add_next_tick_callback(before_ready)
+        return pn.pane.Markdown("initial")
+
+    serve_and_request(app)
+    wait_until(lambda: 'deferred' in state_info)
+
+    # Not dropped, and not left queued on the Document
+    assert len(state_info['deferred']) == 1
+    assert isinstance(state_info['deferred'][0], MessageSentEvent)
+    assert state_info['queued'] == []
+
+
+def test_hold_before_connected_drops_recoverable_events():
+    """
+    Model changes are dropped rather than deferred, since the Document is
+    serialized in full once the session connects.
+    """
+    docs, state_info = [], {}
+
+    def app():
+        doc = state.curdoc
+        docs.append(doc)
+        slider = IntSlider(value=1)
+        model = slider.get_root(doc)
+
+        def before_ready():
+            with hold(doc):
+                model.value = 3
+            state_info['deferred'] = list(_UNCONNECTED_EVENTS.get(doc, []))
+            state_info['queued'] = list(doc.callbacks._held_events)
+            state_info['value'] = model.value
+
+        doc.add_next_tick_callback(before_ready)
+        return slider
+
+    serve_and_request(app)
+    wait_until(lambda: 'queued' in state_info)
+
+    assert state_info['queued'] == []
+    assert state_info['deferred'] == []
+    # The change is on the model, so the full serialization reproduces it
+    assert state_info['value'] == 3
+
+
+def test_threaded_hold_before_connected_does_not_strand_events():
+    """
+    The threaded branch must apply the same policy as the non-threaded
+    one; previously it unconditionally scheduled an unhold, ignoring
+    whether the session was connected.
+    """
+    docs, state_info, ran = [], {}, []
+
+    def app():
+        md = pn.pane.Markdown("initial")
+        doc = state.curdoc
+        docs.append(doc)
+
+        def worker():
+            with hold(doc):
+                md.object = "changed"
+                doc.add_next_tick_callback(lambda: ran.append('scheduled'))
+            state_info['threaded'] = state._current_thread != state._thread_id
+            state_info['connected'] = state._connected.get(doc)
+            state_info['hold'] = doc.callbacks.hold_value
+            state_info['queued'] = list(doc.callbacks._held_events)
+
+        thread = threading.Thread(target=worker)
+        thread.start()
+        thread.join()
+        return md
+
+    serve_and_request(app)
+    wait_until(lambda: 'queued' in state_info)
+
+    # Confirm we exercised the threaded branch while unconnected
+    assert state_info['threaded']
+    assert state_info['connected'] is None
+    assert state_info['hold'] is None
+    assert state_info['queued'] == []
+    wait_until(lambda: ran == ['scheduled'])
 
 
 class _FakeProtocol:

--- a/pixi.toml
+++ b/pixi.toml
@@ -240,8 +240,12 @@ nbval = "*"
 # The playwright CLI installs the browser build that the playwright-python
 # client speaks to, so the two must stay on the same minor version. A newer
 # CLI downloads a Chromium the client cannot drive, which hangs tests
-# indefinitely rather than failing them.
+# indefinitely rather than failing them. conda-forge ships the driver
+# (playwright) and the bindings (playwright-python) as separate packages, so
+# both need pinning; a newer client against an older driver sends fields the
+# driver rejects, failing every test at BrowserType.launch.
 playwright = "1.61.*"
+playwright-python = "1.61.*"
 pytest-playwright = "*"
 pytest-asyncio = "*"
 jupyter_server = "*"


### PR DESCRIPTION
Fixes #8692.

## Background

When a `hold()` block exits while the Document is not yet connected, the `finally` chain in `panel/io/document.py` took:

```python
elif not state._connected.get(doc):
    doc.callbacks._hold = None
```

This clears the hold policy but leaves `doc.callbacks._held_events` populated. Bokeh's `unhold()` returns early when `_hold is None`, so nothing drains them there. The events sit on the Document until some later, unrelated `hold()`/`unhold()` pair flushes them.

The branch is deliberate. It arrived in #7972 to avoid dispatching events before the Document is fully initialized, which leads to the pending writes error. The intent was that these events be discarded rather than deferred: model changes occurring during startup don't need to be synced, because they are picked up anyway when the whole Document is serialized on connect.

## The problem

That premise only holds if the change actually reaches the model, and pre-connect it often doesn't.

`state._unblocked(doc)` is `False` before the session connects, so `Reactive._apply_update` takes its else branch and schedules the update via `state.execute(cb, schedule=True)`, which is `doc.add_next_tick_callback`. That emits a `SessionCallbackAdded`, which is not a `DocumentPatchedEvent` and so is neither dispatched nor recoverable from a full serialization. Stranding it means the callback is never registered on the IOLoop and the deferred `_update_model` never runs.

So the single `SessionCallbackAdded` in the issue's reproducer *is* the pane update. Instrumenting that reproducer to also read the model:

```
on exiting hold: {'connected': None, 'hold': None, 'queued': ['SessionCallbackAdded', 'SessionCallbackAdded']}
model text at end:  ['<p>initial</p>\n', None, None]     # never became "changed"
inner next-tick callbacks that ran: []
doc pending session callbacks: 2
```

This is not late or out-of-context dispatch. The server-side model is left stale, and the full serialization on connect then faithfully sends the stale state. The same applies to anything else that registers through `SessionCallbackAdded`: `add_next_tick_callback`, `add_periodic_callback`, `state.execute(schedule=True)` and the scheduled branch of `Reactive._send_event`.

Two further gaps in the same chain:

The `threaded` branch never consulted `_connected` at all. It unconditionally scheduled `doc.unhold()` on a next tick, so the discard policy was simply not implemented there, and the dispatch it did instead is the pending-writes hazard #7972 was avoiding, reached by a different door. With `config.nthreads` set this is a common path, since `_schedule_on_load` submits `_on_load` to the thread pool.

The non-threaded branch mutated `_hold` without taking `_HOLD_LOCK[doc]`, so it raced the threaded unhold.

## The fix

Resolve the events at hold exit rather than parking them, sorting into three groups instead of discarding wholesale:

- **Dispatched immediately** — `SessionCallbackAdded` / `SessionCallbackRemoved`. These are how callbacks get registered on the IOLoop; dropping them loses the work they represent. Dispatching pre-connect is safe because the Document lock is held at this point.
- **Deferred until connect** — `MessageSentEvent`. It is a `DocumentPatchedEvent`, but it carries protocol messages (custom events from `Reactive._send_event`, ipywidgets comm messages) with no representation in the model graph, so a full serialization cannot reproduce them. They cannot be dispatched at hold exit either, because there are no subscribed connections yet to write them to, so they are held in a `_UNCONNECTED_EVENTS` weak-keyed map and flushed from `_on_load` once `_connected` is set. The flush goes through a next-tick callback so it lands on the Document's thread with the lock held, since `_on_load` may run on the thread pool.
- **Dropped** — everything else. `ModelChangedEvent`, `TitleChangedEvent`, `RootAdded`/`RootRemovedEvent` and the `ColumnDataSource` stream/patch hints are all applied to the model before the event is emitted, so the serialization on connect reproduces them. Worth noting for the CDS case: `PropertyValueColumnData._stream` and `._patch` deliberately bypass the wrapped dict methods and write through to the underlying data, so `.data` is locally correct and the events are transport hints rather than the state itself.

The threaded branch now applies the same policy, so both agree on what happens pre-connect, and the drain takes `_HOLD_LOCK[doc]`. Events are collected under the lock but dispatched after releasing it, since the lock is not reentrant and a change callback may itself enter `hold()`.

`_UNCONNECTED_EVENTS` is cleared in `_destroy_document` alongside the other per-Document maps.

## Testing

Four tests in `panel/tests/io/test_document.py`:

- `test_hold_before_connected_does_not_strand_events` — nothing is left queued, and the scheduled callback runs so the model update lands.
- `test_hold_before_connected_defers_message_sent` — `MessageSentEvent` is neither dropped nor stranded.
- `test_hold_before_connected_drops_recoverable_events` — a model change is dropped, with the value present on the model.
- `test_threaded_hold_before_connected_does_not_strand_events` — the threaded branch leaves no hold in place while unconnected. Asserts it actually took the threaded path.

The first and last were confirmed to fail against the pre-fix code (`queued == ['SessionCallbackAdded']` and `hold_value == 'combine'` respectively), so they pin the regression rather than just passing.

`panel/tests/io/`, `panel/tests/test_server.py` and `panel/tests/test_reactive.py` show no regressions. Three `test_server_ico_handling*` failures and the `test_resources`/`test_reactive` stylesheet failures are present on `main` in this working tree and unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
