### PR TITLE
Reveal markup panes when their stylesheets fail to load or are replaced

### DIFF
--- a/panel/models/layout.ts
+++ b/panel/models/layout.ts
@@ -13,6 +13,7 @@ export class PanelMarkupView extends WidgetView {
 
   container: HTMLDivElement
   protected _initialized_stylesheets: Map<string, boolean>
+  protected _stylesheets_watcher: AbortController | null = null
 
   override connect_signals(): void {
     super.connect_signals()
@@ -35,23 +36,48 @@ export class PanelMarkupView extends WidgetView {
     }
   }
 
+  /**
+   * Schedules `style_redraw` for when all applied stylesheets have settled.
+   *
+   * A stylesheet counts as settled once it has loaded *or* failed: views
+   * reveal their container from `style_redraw`, so a stylesheet that never
+   * arrives must not hide them forever. Listeners registered by a previous
+   * call are cancelled, since the elements they watch have been discarded.
+   */
   watch_stylesheets(): void {
+    this._stylesheets_watcher?.abort()
+    const {signal} = this._stylesheets_watcher = new AbortController()
     this._initialized_stylesheets = new Map()
     for (const stylesheet of this._applied_stylesheets) {
       // @ts-expect-error: 'el' is protected
       const style_el = stylesheet.el
       if (style_el instanceof HTMLLinkElement) {
         this._initialized_stylesheets.set(style_el.href, false)
-        style_el.addEventListener("load", () => {
+        const settled = () => {
           this._initialized_stylesheets.set(style_el.href, true)
           if ([...this._initialized_stylesheets.values()].every((v) => v)) {
             requestAnimationFrame(() => this.style_redraw())
           }
-        })
+        }
+        style_el.addEventListener("load", settled, {signal})
+        style_el.addEventListener("error", settled, {signal})
       }
     }
     if (this._initialized_stylesheets.size == 0) {
       this.style_redraw()
+    }
+  }
+
+  /**
+   * Bokeh recreates the stylesheet elements on every update, discarding the
+   * ones `watch_stylesheets` listens on, so the watcher has to be re-armed.
+   * Skipped until the view has armed it itself, as the update triggered from
+   * `super.render()` precedes the creation of `this.container`.
+   */
+  protected override _update_stylesheets(): void {
+    super._update_stylesheets()
+    if (this._stylesheets_watcher != null) {
+      this.watch_stylesheets()
     }
   }
 
@@ -210,9 +236,9 @@ export abstract class HTMLBoxView extends LayoutDOMView {
         })
       }
     }
-    if (Object.keys(this._initialized_stylesheets).length === 0) {
-      requestAnimationFrame(() => this.style_redraw())
-    }
+    // Unconditional: subclasses redraw (and reveal themselves) here even when
+    // the stylesheets never load, so this is their only guaranteed redraw.
+    requestAnimationFrame(() => this.style_redraw())
   }
 
   style_redraw(): void {}

--- a/panel/tests/ui/pane/test_markup.py
+++ b/panel/tests/ui/pane/test_markup.py
@@ -6,10 +6,11 @@ pytest.importorskip("playwright")
 
 from playwright.sync_api import expect
 
-from panel.layout import Row
+from panel.layout import Column, Row
 from panel.models import HTML
 from panel.pane import Markdown
 from panel.tests.util import serve_component, wait_until
+from panel.widgets import Button
 
 pytestmark = pytest.mark.ui
 
@@ -153,3 +154,47 @@ def test_anchor_scroll_on_init(page):
 
     expect(page.locator('#tag1')).not_to_be_in_viewport()
     expect(page.locator('#tag3')).to_be_in_viewport()
+
+
+def test_markdown_pane_visible_when_stylesheet_fails_to_load(page):
+    # Markup panes hide themselves until their stylesheets have loaded, so a
+    # stylesheet that never arrives must not hide them forever.
+    md = Markdown('Initial', stylesheets=['missing.css'])
+
+    serve_component(page, md)
+
+    expect(page.locator(".markdown").locator("div")).to_be_visible()
+
+
+def test_markdown_pane_visible_after_stylesheet_url_patched(page):
+    # A pane rendered after page load is handed CDN stylesheet URLs, which
+    # Panel patches to the locally served ones as soon as the model is
+    # attached. The patch recreates the <link> elements, discarding the load
+    # events the pane waits on before revealing itself (holoviz/panel#8696).
+    # Never answered, so the pane is still waiting when the URL is patched
+    page.route("**/pending.css", lambda route: None)
+
+    md = Markdown('Added', stylesheets=['pending.css'])
+
+    def app():
+        column = Column()
+        button = Button(label='Add')
+        button.on_click(lambda event: column.append(md))
+        return Column(column, button)
+
+    serve_component(page, app)
+
+    page.get_by_role("button", name="Add").click()
+
+    expect(page.locator(".markdown")).to_have_count(1)
+    expect(page.locator(".markdown").locator("div")).not_to_be_visible()
+
+    page.evaluate("""() => {  // Mimic Panel patching the stylesheet URLs
+      for (const model of Bokeh.documents[0].all_models) {
+        if (String(model.url).includes("pending.css")) {
+          model.url = "patched.css"
+        }
+      }
+    }""")
+
+    expect(page.locator(".markdown").locator("div")).to_be_visible()


### PR DESCRIPTION
<!-- Using AI? READ FIRST: https://holoviz.org/contribute.html#ai-readme -->

## Description

> **Read this first: the cause given in #8696 is out of date.** The race described there — a pane rendered after page load gets CDN stylesheet URLs, Panel patches them to the locally served ones, and the `<link>` elements are recreated while the reveal is still pending — no longer reproduces on `main`. Panes added to a live layout now reach the browser with local URLs already in place, so nothing is patched afterwards. That is most likely a side effect of #8693, which claims the Document thread at session build and thereby changes which dispatch path `hold`/`unlocked` take, i.e. whether a new model is serialized before or after its stylesheet URLs are patched; #8698 touches the same timing. I have not confirmed this by bisecting, since the churn does not reproduce in my environment on any version, including the 1.9.3 the issue was filed against.
>
> The issue's *symptom* does still reproduce on `main`, through the other trigger: a stylesheet the browser cannot fetch. That is what this PR fixes and what the screenshots below show.

A markup pane (`HTML`, `Markdown`, `Str`) appended to an already rendered layout inside a template can stay invisible forever: its Bokeh model, text and layout are all correct, but the pane's content container keeps `visibility: hidden` until the page is reloaded. I hit this in a dashboard where status pills are appended to a live layout, and it looked intermittent and data-dependent from the outside, which is what made it worth chasing rather than working around.

Markup panes hide their container on render and reveal it once every applied `<link>` stylesheet has fired `load`. That is the whole mechanism — there is no failure path. A stylesheet that 404s, is blocked by a proxy, or simply cannot be reached hides the pane permanently, and the pane that suffers is exactly the one added after page load, because that is the one handed the design's stylesheets. This is the same end state as #7594, which was fixed trigger-side in #7627 by correcting the URL rather than by making the reveal robust; the mechanism stayed one bad URL away from the symptom.

So a stylesheet now counts as settled once it has loaded *or* failed. The watcher is also re-armed whenever the applied stylesheets change, because Bokeh recreates the `<link>` elements on every stylesheet update and the pending `load` events then belong to elements that no longer exist — this is the JS approach @philippjfr picked in #8696.

`HTMLBoxView` is deliberately left on its unconditional next-frame redraw. Its guard, `Object.keys(this._initialized_stylesheets).length === 0`, is always true because `_initialized_stylesheets` is a `Map`, and `QuillInputView`, `DataTabulatorView` and `PlotlyView` rely on that accidental unconditional call to reveal themselves — correcting the check without also making those views robust would pull them into this bug.

### Reproducer

The added pane carries a stylesheet that 404s, which makes the failure deterministic; in the wild the same thing happens to the design's own CDN stylesheet whenever the browser cannot fetch it. The clock is there so the screenshots cannot be mistaken for a race: it is driven by the same periodic callback that appends the pill.

```python
import panel as pn

pn.extension()

PILL = '<span style="background:#dde;padding:0 8px;border-radius:10px">{}</span>'


def app():
    clock = pn.pane.HTML(PILL.format("clock: 0s"))
    column = pn.Column(clock, pn.pane.HTML(PILL.format("rendered at page load")))
    elapsed = [0]

    def tick():
        elapsed[0] += 1
        clock.object = PILL.format(f"clock: {elapsed[0]}s")
        if elapsed[0] == 3:
            column.append(pn.pane.HTML(PILL.format("added after page load, at 3s"),
                                       stylesheets=['missing.css']))

    pn.state.add_periodic_callback(tick, period=1000)
    return pn.template.MaterialTemplate(title="repro", main=[column])


pn.serve(app, port=5006, show=False)
```

Before — twelve seconds after the append, the pane is laid out in the right place with the right text, but invisible:

<img width="900" height="300" alt="before" src="https://github.com/user-attachments/assets/d1046376-9229-4686-8cf8-0657bb924705" />

After:

<img width="900" height="300" alt="after" src="https://github.com/user-attachments/assets/980df49e-9f61-4efa-bf55-b729e98709b1" />
Both UI tests added here fail on a build from `main` and pass with this change. Running `panel/tests/ui/pane` and `panel/tests/ui/layout` against both builds gives an identical set of failures (all of them unrelated to this change and caused by my sandbox having no outbound network), the only difference being the two new tests.

Fixes #8696

## AI Disclosure

Tool & Model: Claude Code + Opus 5

Usage: investigating the reveal mechanism, writing the change and the two UI tests, and verifying them against builds with and without the change.

- [x] I have tested all AI-generated content in my PR.
- [x] I take responsibility for all AI-generated content in my PR.

## Checklist

- [x] Tests added and are passing
