### PR TITLE
Various ESM component robustness fixes

### DIFF
--- a/panel/models/layout.ts
+++ b/panel/models/layout.ts
@@ -8,6 +8,36 @@ import {LayoutDOM, LayoutDOMView} from "@bokehjs/models/layouts/layout_dom"
 import type {UIElement} from "@bokehjs/models/ui/ui_element"
 import type * as p from "@bokehjs/core/properties"
 
+/**
+ * Re-renders a view, including its layout.
+ *
+ * Bokeh's own `rerender` runs the whole render walk before `update_layout`,
+ * which is wrong for anything that is positioned by the layout: `render`
+ * re-parents annotation elements into the canvas layers and it is
+ * `update_layout` that moves them into their side panels. Measuring in
+ * between therefore caches a bbox for the container the element is about to
+ * leave, e.g. a legend measuring the full canvas width instead of its side
+ * panel. `compute_layout` then sizes the panel from that stale bbox and can
+ * squeeze the frame to zero, which poisons everything derived from it (for
+ * tile-based plots, a division by zero width puts NaN into the ranges with no
+ * recovery path). Updating the layout first means `after_render` measures
+ * elements where they will actually live.
+ */
+export function rerender_view(view: DOMView): void {
+  if (view instanceof LayoutDOMView) {
+    view.render()
+    view.update_layout()
+    view.r_after_render()
+    view.compute_layout()
+  } else if (view.rerender) {
+    // Can be removed when Bokeh>3.7 (see https://github.com/holoviz/panel/pull/7815)
+    view.rerender()
+  } else {
+    view.render()
+    view.r_after_render()
+  }
+}
+
 export class PanelMarkupView extends WidgetView {
   declare model: Markup
 
@@ -52,7 +82,10 @@ export class PanelMarkupView extends WidgetView {
       // @ts-expect-error: 'el' is protected
       const style_el = stylesheet.el
       if (style_el instanceof HTMLLinkElement) {
-        this._initialized_stylesheets.set(style_el.href, false)
+        // A link served from cache may already have loaded, and `load` does
+        // not fire again for it, so seed from `sheet` instead of assuming
+        // every stylesheet is still pending.
+        this._initialized_stylesheets.set(style_el.href, style_el.sheet != null)
         const settled = () => {
           this._initialized_stylesheets.set(style_el.href, true)
           if ([...this._initialized_stylesheets.values()].every((v) => v)) {
@@ -63,7 +96,7 @@ export class PanelMarkupView extends WidgetView {
         style_el.addEventListener("error", settled, {signal})
       }
     }
-    if (this._initialized_stylesheets.size == 0) {
+    if ([...this._initialized_stylesheets.values()].every((v) => v)) {
       this.style_redraw()
     }
   }
@@ -82,14 +115,7 @@ export class PanelMarkupView extends WidgetView {
   }
 
   rerender_(view: DOMView | null = null): void {
-    // Can be removed when Bokeh>3.7 (see https://github.com/holoviz/panel/pull/7815)
-    view = view == null ? this : view
-    if (view.rerender) {
-      view.rerender()
-    } else {
-      view.render()
-      view.r_after_render()
-    }
+    rerender_view(view == null ? this : view)
   }
 
   style_redraw(): void {}
@@ -211,14 +237,7 @@ export abstract class HTMLBoxView extends LayoutDOMView {
   }
 
   rerender_(view: DOMView | null = null): void {
-    // Can be removed when Bokeh>3.7 (see https://github.com/holoviz/panel/pull/7815)
-    view = view == null ? this : view
-    if (view.rerender) {
-      view.rerender()
-    } else {
-      view.render()
-      view.r_after_render()
-    }
+    rerender_view(view == null ? this : view)
   }
 
   watch_stylesheets(): void {

--- a/panel/models/react_component.ts
+++ b/panel/models/react_component.ts
@@ -114,7 +114,7 @@ export class ReactComponentView extends ReactiveESMView {
   }
 
   override render_esm(): void {
-    if (this.model.compiled === null || this.model.render_module === null) {
+    if (this.model.compiled === null || this.model.render_module === null || this.container == null) {
       return
     }
     this._rendered = false
@@ -135,9 +135,38 @@ export class ReactComponentView extends ReactiveESMView {
       this._mounted_resolve = resolve
     })
     this.model.render_module.then((mod: any) => {
+      if (this.container == null) {
+        // Nothing will mount, so the ready promise has to be settled here or
+        // the view never finishes and the document never goes idle.
+        this._resolve_mounted()
+        return
+      }
       this.react_root = mod.default.render(this.model.id)
+    }).catch((e: unknown) => {
+      this._resolve_mounted()
+      throw e
     })
     this._await_ready(mounted_promise)
+  }
+
+  override render_error(error: SyntaxError): void {
+    // A component that errored will never mount and so never settles its
+    // promise via `after_rendered`.
+    this._resolve_mounted()
+    super.render_error(error)
+  }
+
+  /**
+   * Settles the promise handed to `_await_ready` by `render_esm`. Safe to call
+   * more than once; only the first call has an effect.
+   */
+  _resolve_mounted(): void {
+    const resolve = this._mounted_resolve
+    if (resolve == null) {
+      return
+    }
+    this._mounted_resolve = null
+    resolve()
   }
 
   on_force_update(cb: () => void): void {
@@ -153,11 +182,13 @@ export class ReactComponentView extends ReactiveESMView {
   override remove(): void {
     this._force_update_callbacks = []
     this.mounted = false
+    // A view removed before it mounted still owes a resolution to the promise
+    // handed to `_await_ready`, otherwise the root never reaches idle.
+    this._resolve_mounted()
     if (this.react_root && this.use_shadow_dom) {
       super.remove()
       this.react_root.then((root: any) => root && root.unmount())
-      for (const view of this._scheduled_removals) { view.remove() }
-      this._scheduled_removals = []
+      this.flush_scheduled_removals()
     } else {
       this._applied_stylesheets.forEach((stylesheet) => stylesheet.uninstall())
       for (const cb of (this._lifecycle_handlers.get("remove") || [])) {
@@ -167,6 +198,7 @@ export class ReactComponentView extends ReactiveESMView {
       this._child_rendered.clear()
       this._mounted.clear()
     }
+    this.react_root = null
   }
 
   get root_view(): ReactComponentView {
@@ -206,6 +238,9 @@ export class ReactComponentView extends ReactiveESMView {
     }
     this._force_update_callbacks = []
     this.mounted = false
+    // `super.render()` calls `render_esm`, which installs a fresh promise, so
+    // settle any promise the previous render left outstanding first.
+    this._resolve_mounted()
     super.render()
   }
 
@@ -282,6 +317,20 @@ export class ReactComponentView extends ReactiveESMView {
       }
     }
     this._update_children()
+    // Removals are normally drained by the replacement child once it mounts,
+    // but a child that never mounts would leak the old views, so flush any
+    // that are still pending after React has had a chance to commit.
+    setTimeout(() => this.flush_scheduled_removals(), 0)
+  }
+
+  flush_scheduled_removals(): void {
+    const removals = this._scheduled_removals
+    this._scheduled_removals = []
+    for (const view of removals) {
+      if (!view.is_destroyed) {
+        view.remove()
+      }
+    }
   }
 
   override _on_mounted(): void {
@@ -312,16 +361,14 @@ export class ReactComponentView extends ReactiveESMView {
     }
     this._rendered = true
     if (this._mounted_resolve) {
-      const resolve = this._mounted_resolve
-      this._mounted_resolve = null
       const child_ready: Promise<void>[] = []
       for (const child_view of this.child_views) {
         child_ready.push(child_view.ready)
       }
       if (child_ready.length > 0) {
-        Promise.all(child_ready).then(() => resolve())
+        Promise.all(child_ready).then(() => this._resolve_mounted())
       } else {
-        resolve()
+        this._resolve_mounted()
       }
     }
     this.finish()
@@ -447,15 +494,13 @@ async function render(id) {
         }
         this.updateElement()
         if (this.use_shadow_dom) {
-          for (const view of this.props.parent._scheduled_removals) { view.remove() }
-          this.props.parent._scheduled_removals = []
+          this.props.parent.flush_scheduled_removals()
           this.props.parent.rerender_(view)
           this.props.parent._child_rendered.set(view, true)
         } else {
           view.patch_container(this.containerRef.current)
           view.model.render_module.then(async (mod) => {
-            for (const view of this.props.parent._scheduled_removals) { view.remove() }
-            this.props.parent._scheduled_removals = []
+            this.props.parent.flush_scheduled_removals()
             this.setState(
               {rendered: await mod.default.render(view.model.id)},
               () => {
@@ -469,8 +514,7 @@ async function render(id) {
       }
       this.props.parent.on_child_render(this.props.name, this.render_callback)
       if (view == null) { return }
-      for (const rview of this.props.parent._scheduled_removals) { rview.remove() }
-      this.props.parent._scheduled_removals = []
+      this.props.parent.flush_scheduled_removals()
       if (this.use_shadow_dom) {
         this.updateElement()
         this.props.parent.rerender_(view)
@@ -495,8 +539,11 @@ async function render(id) {
       if (this.render_callback) {
         this.props.parent.remove_on_child_render(this.props.name, this.render_callback)
       }
-      if (!this.use_shadow_dom && this.view._mounted.has(this.props.name)) {
-        this.view._mounted.get(this.props.name).delete(this.props.id)
+      // The mount bookkeeping lives on the parent, and the view may already be
+      // gone by the time React unmounts us, so fall back to the model id prop.
+      const id = this.view?.model.id ?? this.props.id
+      if (id != null) {
+        this.props.parent.notify_mount(this.props.name, id, true)
       }
     }
 
@@ -666,6 +713,9 @@ async function render(id) {
         container.id = view.model.root_node.replace("#", "")
         document.body.append(container)
       }
+    } else if (view.container == null) {
+      view._resolve_mounted()
+      return null
     } else {
       container = view.container
     }
@@ -673,6 +723,7 @@ async function render(id) {
     try {
       root.render(rendered)
     } catch(e) {
+      view._resolve_mounted()
       view.render_error(e)
     }
     return root

--- a/panel/models/react_component.ts
+++ b/panel/models/react_component.ts
@@ -214,21 +214,39 @@ export class ReactComponentView extends ReactiveESMView {
 
   protected override _apply_stylesheets(stylesheets: StyleSheetLike[]): void {
     const resolved_stylesheets = stylesheets.map((style) => isString(style) ? new InlineStyleSheet(style) : style)
-    const styles = this.root_view.shadow_el.querySelectorAll("style")
-    const links = this.root_view.shadow_el.querySelectorAll("link")
+    const root_view = this.root_view
+    const target = root_view.shadow_el
+    // When shadow DOM is disabled every component in the tree installs its
+    // stylesheets into the same root, so the existing CSS is indexed once and
+    // looked up by value. Scanning the root per stylesheet made this quadratic
+    // in the number of components times the number of stylesheets each.
+    const installed_css = new Set<string | null>()
+    const installed_hrefs = new Set<string>()
+    if (!this.use_shadow_dom) {
+      for (const style of target.querySelectorAll("style")) {
+        installed_css.add(style.textContent)
+      }
+      for (const link of target.querySelectorAll("link")) {
+        installed_hrefs.add(link.href)
+      }
+    }
     resolved_stylesheets.forEach((stylesheet) => {
       if (!this.use_shadow_dom) {
-        if (stylesheet instanceof InlineStyleSheet &&
-            Array.from(styles).some(style => style.innerHTML === stylesheet.css)) {
-          return
-        }
-        if (stylesheet instanceof ImportedStyleSheet &&
-            Array.from(links).some(link => link.href === (stylesheet as any).el.href)) {
-          return
+        if (stylesheet instanceof InlineStyleSheet) {
+          if (installed_css.has(stylesheet.css)) {
+            return
+          }
+          installed_css.add(stylesheet.css)
+        } else if (stylesheet instanceof ImportedStyleSheet) {
+          const {href} = (stylesheet as any).el
+          if (installed_hrefs.has(href)) {
+            return
+          }
+          installed_hrefs.add(href)
         }
       }
       this._applied_stylesheets.push(stylesheet)
-      stylesheet.install(this.root_view.shadow_el)
+      stylesheet.install(target)
     })
   }
 

--- a/panel/models/react_component.ts
+++ b/panel/models/react_component.ts
@@ -459,6 +459,18 @@ async function render(id) {
       super(props)
       this.render_callback = null
       this.containerRef = React.createRef()
+      // Registers the child as tracked but not yet rendered. React's render
+      // phase has to stay free of side effects, since a render may be
+      // discarded without ever committing, so the flag is only ever flipped
+      // here and from getSnapshotBeforeUpdate.
+      this._mark_stale()
+    }
+
+    _mark_stale() {
+      const view = this.view
+      if (view) {
+        this.props.parent._child_rendered.set(view, false)
+      }
     }
 
     updateElement() {
@@ -547,6 +559,14 @@ async function render(id) {
       }
     }
 
+    getSnapshotBeforeUpdate() {
+      // Commit-phase equivalent of the constructor's registration: the view
+      // this Child renders may have been swapped out, so the incoming one is
+      // registered as stale here rather than during render.
+      this._mark_stale()
+      return null
+    }
+
     componentDidUpdate() {
       if (this.use_shadow_dom) {
         this.updateElement()
@@ -555,9 +575,6 @@ async function render(id) {
 
     render() {
       const child = this.state.rendered
-      if  (this.view) {
-        this.props.parent._child_rendered.set(this.view, false)
-      }
       const class_name = (this.use_shadow_dom ?
         "child-wrapper" : this.view.model.class_name.replace(/([a-z])([A-Z])/g, "$1-$2").toLowerCase()
       )

--- a/panel/models/reactive_esm.ts
+++ b/panel/models/reactive_esm.ts
@@ -5,6 +5,7 @@ import {ModelEvent, server_event} from "@bokehjs/core/bokeh_events"
 import {div} from "@bokehjs/core/dom"
 import type {StyleSheetLike} from "@bokehjs/core/dom"
 import {ImportedStyleSheet} from "@bokehjs/core/dom"
+import {DOMView} from "@bokehjs/core/dom_view"
 import {Enum} from "@bokehjs/core/kinds"
 import type * as p from "@bokehjs/core/properties"
 import type {Attrs} from "@bokehjs/core/types"
@@ -251,7 +252,38 @@ export class ReactiveESMView extends HTMLBoxView {
 
   _on_mounted(): void {}
 
-  notify_mount(child: string, id: string, remove: boolean): void {
+  /**
+   * Bokeh walks the whole view tree from `r_after_render`, but ESM components
+   * do not render their children themselves: the children are mounted later,
+   * by the component, once it commits. Recursing into a child that has not
+   * been mounted yet would run `after_render` (and with it style updates,
+   * measurement and layout) on a view that is still detached and therefore
+   * measures 0x0, which permanently poisons anything latching onto its first
+   * measurement. Such children are skipped here and walked when they mount.
+   */
+  override r_after_render(): void {
+    for (const child_view of this.children_views()) {
+      if (child_view instanceof DOMView && this._is_mountable(child_view)) {
+        child_view.r_after_render()
+      }
+    }
+    this.after_render();
+    (this as any)._was_built = true
+  }
+
+  /**
+   * Whether Bokeh's render walk may descend into a child view. Views this
+   * component owns are only walkable once mounted; anything else (e.g. a
+   * context menu) is not ours to defer.
+   */
+  protected _is_mountable(child_view: DOMView): boolean {
+    if (!this._child_views.has(child_view.model as UIElement)) {
+      return true
+    }
+    return child_view.el.isConnected
+  }
+
+  notify_mount(child: string, id: string, remove: boolean = false): void {
     if (!this._mounted.has(child)) {
       this._mounted.set(child, new Set())
     }


### PR DESCRIPTION
Applies two fixes to improve the robustness of rendering ESM and React components.

`r_after_render()` recurses children_views() unconditionally, but an ESM view never renders its children in render(); they're mounted later by the component. Since `children_views()` is already populated from `lazy_initialize`, every child was getting a full `after_render()` while still detached and measuring 0×0, and then rendering a second time when `Child.componentDidMount` fired `rerender_`. The override now skips children this component owns until `el.isConnected`, and walks them when they mount. Views it doesn't own (context menus, etc.) still recurse normally.

Settling the ready promise on every path that can't reach after_rendered. `render_esm`'s early
return when `container == null`, its rejection handler, `render_error`, a `remove()` before mount, and a `re-render()` that installs a fresh promise all now call a new idempotent `_resolve_mounted()`. Previously any of those left the view unfinished and the document never reached idle. Alongside that: `_scheduled_removals` draining is consolidated into `flush_scheduled_removals()` (all four sites, including the three inside the `_render_code()` template) with a post-commit `setTimeout` flush in `update_children`, so a replacement child that never mounts no longer leaks the old views; and `componentWillUnmount` was reading `this.view._mounted` (the child's map, where the bookkeeping actually lives on the parent) and dereferencing `this.view` unguarded, so it now falls back to `this.props.id`.

Verified effects: detached `r_after_render` passes went 2 → 0, Figure `after_render` count 2 → 1, and the document still reaches `idle`.