### PR TITLE
Add panel-live-server to docs Extensions gallery

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -172,6 +172,10 @@ nbsite_gallery_conf = {
                             'title': 'panel-web-llm',
                             'url': 'https://github.com/holoviz/panel-web-llm',
                         },
+                        {
+                            'title': 'panel-live-server',
+                            'url': 'https://github.com/panel-extensions/panel-live-server',
+                        },
                     ]
                 },
             ],


### PR DESCRIPTION
Adds panel-live-server to the Component Gallery's Extensions list, alongside panel-material-ui, panel-graphic-walker, panel-reactflow, and panel-web-llm.