### PR TITLE
fix(fast): resolve invisible slider title font color in light theme

### DIFF
--- a/panel/theme/css/fast.css
+++ b/panel/theme/css/fast.css
@@ -15,7 +15,7 @@
   --font-size: var(--type-ramp-base-font-size);
   --switch-size: 12px;
   --container-background: var(--panel-surface-color);
-  color: var(--neutral-foreground-rest);
+  color: var(--panel-on-surface-color, inherit);
   --panel-primary-color: var(--accent-foreground-rest);
   --panel-on-primary-color: var(--foreground-on-accent-rest);
 }


### PR DESCRIPTION
### Description
Fixes an issue where the slider title text (`.bk-slider-title`) becomes invisible when the Fast design theme is applied due to white font color inheritance on light backgrounds.

### Changes
Updated the `:host` rule in `panel/theme/css/fast.css` to use `inherit` for proper text color contrast.

Fixes #8571

