### PR TITLE
Document syncing Parameterized object lists

### DIFF
--- a/doc/how_to/state/url.md
+++ b/doc/how_to/state/url.md
@@ -69,6 +69,44 @@ Lets try to serve it as an app
 pn.Param(settings).servable()
 ```
 
+### Sync a list of Parameterized objects
+
+URL query parameters can only contain serializable values. To synchronize a
+list of `Parameterized` objects, define how the list parameter converts its
+items to and from plain Python values:
+
+```python
+class Curve(param.Parameterized):
+    product = param.String()
+
+
+class CurveList(param.List):
+    class_ = Curve
+
+    @classmethod
+    def serialize(cls, value):
+        return [{"product": curve.product} for curve in value]
+
+    @classmethod
+    def deserialize(cls, value):
+        return [Curve(**curve) for curve in value]
+
+
+class CurveCollection(param.Parameterized):
+    curves = CurveList(default=[])
+
+
+collection = CurveCollection(curves=[Curve(product="A")])
+pn.state.location.sync(collection, ["curves"])
+
+pn.Param(collection).servable()
+```
+
+Changing `collection.curves` now updates the URL with a JSON representation,
+and loading that URL reconstructs the `Curve` objects. Keep synchronized data
+small and non-sensitive because query strings have practical length limits and
+are commonly retained in browser history and server logs.
+
 <video muted controls loop poster="../../_static/images/location_example_app.png" style="max-height: 400px; max-width: 100%;">
     <source src="https://assets.holoviz.org/panel/how_to/state/sync_url.mp4" type="video/mp4">
     Your browser does not support the video tag.


### PR DESCRIPTION
Closes #5753.

This documents how to synchronize a list of `Parameterized` objects with the URL by defining a `param.List` subclass with explicit serialization and deserialization. The example round-trips each object through plain JSON data and also calls out URL length, browser-history, and server-log considerations.

Validation:

- Executed the example against the current `Location` implementation and verified both serialization and reconstruction
- `pre-commit run --files doc/how_to/state/url.md`
