### PR TITLE
Inline versioned stylesheets on the notebook update path

### DIFF
--- a/panel/io/notebook.py
+++ b/panel/io/notebook.py
@@ -370,7 +370,7 @@ class Mimebundle:
 def replace_inline_css(stylesheet: ImportedStyleSheet):
     if not stylesheet.url.startswith(CDN_DIST):
         return stylesheet
-    path = DIST_DIR / stylesheet.url.replace(CDN_DIST, '')  # type: ignore
+    path = DIST_DIR / stylesheet.url.replace(CDN_DIST, '').split('?')[0]  # type: ignore
     if not path.exists():
         return stylesheet
     return InlineStyleSheet(css=path.read_text(encoding='utf-8'))

--- a/panel/tests/io/test_notebook.py
+++ b/panel/tests/io/test_notebook.py
@@ -5,8 +5,10 @@ pytest.importorskip("IPython")
 from bokeh.models import ImportedStyleSheet, InlineStyleSheet
 
 from panel.config import config, panel_extension
-from panel.io.notebook import ipywidget
-from panel.io.resources import CDN_ROOT, set_resource_mode
+from panel.io.notebook import ipywidget, replace_inline_css
+from panel.io.resources import (
+    CDN_DIST, CDN_ROOT, JS_VERSION, set_resource_mode,
+)
 from panel.pane import Str
 from panel.widgets import TextEditor
 
@@ -76,3 +78,12 @@ def test_notebook_inline_css_stylesheets(nb_loaded):
     model = list(widget._models.values())[0][0]
     for stylesheet in model.stylesheets[:len(model.__css__)]:
         assert isinstance(stylesheet, InlineStyleSheet)
+
+def test_replace_inline_css_ignores_version_query():
+    url = f'{CDN_DIST}css/loading.css'
+    unversioned = replace_inline_css(ImportedStyleSheet(url=url))
+    versioned = replace_inline_css(ImportedStyleSheet(url=f'{url}?v={JS_VERSION}'))
+
+    assert isinstance(unversioned, InlineStyleSheet)
+    assert isinstance(versioned, InlineStyleSheet)
+    assert versioned.css == unversioned.css


### PR DESCRIPTION
## Description

Ran a Panel notebook on a machine with no route to `cdn.holoviz.org`, with `pn.config.inline =
True` set for exactly that reason. The first render was fine. Every component added afterwards
still asked the CDN for `css/loading.css`, so the loading indicator lost its styling and there
was no error anywhere to explain why.

`patch_stylesheet` (`panel/io/resources.py:305-326`) appends `?v={JS_VERSION}` to every URL it
rewrites. `replace_inline_css` then builds the local path by string-replacing the CDN prefix,
which carries that query into the filename:

```python
path = DIST_DIR / stylesheet.url.replace(CDN_DIST, '')  # 'css/loading.css?v=1.9.3'
if not path.exists():                                   # False
    return stylesheet                                   # returned as a remote import
```

`panel/dist/css/loading.css` exists, `panel/dist/css/loading.css?v=1.9.3` does not, so Panel
produces the one URL shape its own inliner cannot resolve. This only bites after the first
render: `_repr_mimebundle_` (`panel/viewable.py:887`) wraps `_render_model` in
`set_resource_mode('inline')`, so `patch_stylesheet` falls through and no `?v=` is ever
produced. Models built outside that context manager get the ambient `server` mode, pick up the
version suffix, and then `panel/viewable.py:660` cannot inline them.

The fix splits the query off before the `exists()` check, which is what
[`panel/io/resources.py:432`](https://github.com/holoviz/panel/blob/b6b1d99fb8bfd84e55c3499a475cbaa4b9f36fba/panel/io/resources.py#L432)
already does when it derives a filename from a URL to test against the filesystem.

Fixes #8707

### Reproducing it

```python
from bokeh.models import ImportedStyleSheet
from panel.io.notebook import replace_inline_css
from panel.io.resources import CDN_DIST, JS_VERSION

url = f'{CDN_DIST}css/loading.css'
print(type(replace_inline_css(ImportedStyleSheet(url=url))).__name__)
print(type(replace_inline_css(ImportedStyleSheet(url=f'{url}?v={JS_VERSION}'))).__name__)
```

Before: `InlineStyleSheet`, then `ImportedStyleSheet`. After: `InlineStyleSheet` both times.

Issue #8707 has the same thing through the public API, on the update path a notebook actually
uses. Run in a `--network none` container, it reports one stylesheet still fetched remotely
before the change and none after. On a `pn.Column(Tabulator)` the same probe inlines 12
stylesheets and leaves exactly that one.

I have not attached a screenshot. The change is a resource that stops being a network request,
and its visible form only appears in a live kernel that is genuinely firewalled, which I could
not capture honestly here. Glad to add a rendered capture if you would like one.

### Verification

- `test_replace_inline_css_ignores_version_query` fails on `main` (`assert isinstance(versioned,
  InlineStyleSheet)`) and passes with the change.
- `panel/tests/io/{test_notebook,test_resources,test_save}.py` on Python 3.12, panel 1.9.3
  environment: same 14 failures before and after, one additional pass (the new test). The
  failures are this container missing built JS bundles, not related to the change.
- `ruff check` and `isort --check-only` clean on both changed files.
- Not checked: a real browser render, and the Pyodide path, where `config.inline` is bypassed
  earlier and I did not exercise it.

## AI Disclosure

Tool & Model: Claude Code + Opus 5

Usage: written by an autonomous agent running under this account. It located the fault, ran the
reproduction and the test suites quoted above in a container, and wrote the patch, the test and
this description.

- [x] I have tested all AI-generated content in my PR.
- [x] I take responsibility for all AI-generated content in my PR.

## Checklist

- [x] Tests added and are passing
