### PR TITLE
Update value_throttled when a slider value is set from Python (closes #2675)

### DIFF
--- a/panel/tests/widgets/test_slider.py
+++ b/panel/tests/widgets/test_slider.py
@@ -10,9 +10,9 @@ from bokeh.models import (
 
 from panel import config
 from panel.widgets import (
-    DateRangeSlider, DateSlider, DatetimeRangeSlider, DatetimeSlider,
-    DiscreteSlider, EditableFloatSlider, EditableIntSlider,
-    EditableRangeSlider, FloatSlider, IntSlider, RangeSlider, StaticText,
+    DateRangeSlider, DateSlider, DatetimeRangeSlider, DatetimeSlider, DiscretePlayer,
+    DiscreteSlider, EditableFloatSlider, EditableIntSlider, EditableRangeSlider, FloatInput,
+    FloatSlider, IntInput, IntSlider, Player, RangeSlider, StaticText,
 )
 
 
@@ -1011,3 +1011,18 @@ def test_slider_value_throttled_not_updated_while_dragging(document, comm):
 
     slider._process_events({'value_throttled': 4.0})
     assert slider.value_throttled == 4.0
+
+
+@pytest.mark.parametrize('widget, kwargs, new', [
+    (Player, dict(start=0, end=10, value=1), 4),
+    (DiscretePlayer, dict(options=[1, 2, 3], value=1), 3),
+    (IntInput, dict(value=1), 7),
+    (FloatInput, dict(value=1.0), 7.0),
+])
+def test_non_slider_value_throttled_follows_programmatic_value(widget, kwargs, new):
+    # PlayerBase and _SpinnerBase seed value_throttled from value in __init__ the
+    # same way _SliderBase does, so they had the same stale-forever bug. The sync
+    # lives on Widget so every family that declares value_throttled gets it.
+    w = widget(**kwargs)
+    w.value = new
+    assert w.value_throttled == new

--- a/panel/tests/widgets/test_slider.py
+++ b/panel/tests/widgets/test_slider.py
@@ -10,9 +10,10 @@ from bokeh.models import (
 
 from panel import config
 from panel.widgets import (
-    DateRangeSlider, DateSlider, DatetimeRangeSlider, DatetimeSlider, DiscretePlayer,
-    DiscreteSlider, EditableFloatSlider, EditableIntSlider, EditableRangeSlider, FloatInput,
-    FloatSlider, IntInput, IntSlider, Player, RangeSlider, StaticText,
+    DateRangeSlider, DateSlider, DatetimeRangeSlider, DatetimeSlider,
+    DiscretePlayer, DiscreteSlider, EditableFloatSlider, EditableIntSlider,
+    EditableRangeSlider, FloatInput, FloatSlider, IntInput, IntSlider, Player,
+    RangeSlider, StaticText,
 )
 
 

--- a/panel/tests/widgets/test_slider.py
+++ b/panel/tests/widgets/test_slider.py
@@ -1027,3 +1027,73 @@ def test_non_slider_value_throttled_follows_programmatic_value(widget, kwargs, n
     w = widget(**kwargs)
     w.value = new
     assert w.value_throttled == new
+
+
+@pytest.mark.parametrize('widget, kwargs, new', [
+    (DiscreteSlider, dict(options=[1, 2, 3, 4, 5], value=1), 4),
+    (EditableFloatSlider, dict(start=0, end=10, value=1.0), 7.0),
+    (EditableIntSlider, dict(start=0, end=10, value=1), 7),
+    (EditableRangeSlider, dict(start=0, end=10, value=(1.0, 2.0)), (3.0, 4.0)),
+])
+def test_composite_slider_value_throttled_follows_programmatic_value(widget, kwargs, new):
+    # CompositeWidget subclasses relay value_throttled from their sub-widgets
+    # rather than deriving it generically, but a programmatic set of `value`
+    # must still be reflected in `value_throttled` immediately.
+    w = widget(**kwargs)
+    w.value = new
+    assert w.value_throttled == new
+
+
+@pytest.mark.parametrize('widget, kwargs, drag_value, released_value', [
+    (DiscreteSlider, dict(options=[1, 2, 3, 4, 5], value=1), 3, 4),
+    (EditableFloatSlider, dict(start=0, end=10, value=1.0), 5.0, 5.0),
+    (EditableIntSlider, dict(start=0, end=10, value=1), 5, 5),
+])
+def test_composite_slider_value_throttled_not_updated_while_dragging(
+    widget, kwargs, drag_value, released_value
+):
+    # Dragging the inner slider must not leak into the composite's own
+    # `value_throttled` until the drag is released, otherwise composite
+    # widgets like DiscreteSlider lose the point of the parameter for
+    # exactly the callbacks (e.g. DynamicMap redraws) it exists to protect.
+    w = widget(**kwargs)
+    initial_throttled = w.value_throttled
+
+    w._slider._process_events({'value': drag_value})
+    assert w.value_throttled == initial_throttled
+
+    w._slider._process_events({'value_throttled': drag_value})
+    assert w.value_throttled == released_value
+
+
+def test_editable_range_slider_value_throttled_not_updated_while_dragging():
+    w = EditableRangeSlider(start=0, end=10, value=(1.0, 2.0))
+
+    w._slider._process_events({'value': (1.0, 5.0)})
+    assert w.value == (1.0, 5.0)
+    assert w.value_throttled == (1.0, 2.0)
+
+    w._slider._process_events({'value_throttled': (1.0, 5.0)})
+    assert w.value_throttled == (1.0, 5.0)
+
+
+@pytest.mark.parametrize('widget, kwargs, sub_widget, drag_value, released_value, updated_value', [
+    (EditableFloatSlider, dict(start=0, end=10, value=1.0), '_value_edit', 3.0, 3.0, 3.0),
+    (EditableRangeSlider, dict(start=0, end=10, value=(1.0, 5.0)), '_start_edit', 2.0, 2.0, (2.0, 5.0)),
+])
+def test_editable_slider_value_throttled_not_updated_while_dragging_edit(
+    widget, kwargs, sub_widget, drag_value, released_value, updated_value
+):
+    # Dragging the numeric slider reflects `value` down into the text-input
+    # sub-widget for display, and vice versa; that reflection must not be
+    # mistaken by the *other* sub-widget for a fresh user-driven set of its
+    # own value, which would corrupt the composite's `value_throttled`.
+    w = widget(**kwargs)
+    initial_throttled = w.value_throttled
+    edit = getattr(w, sub_widget)
+
+    edit._process_events({'value': drag_value})
+    assert w.value_throttled == initial_throttled
+
+    edit._process_events({'value_throttled': released_value})
+    assert w.value_throttled == updated_value

--- a/panel/tests/widgets/test_slider.py
+++ b/panel/tests/widgets/test_slider.py
@@ -969,3 +969,45 @@ def test_date_range_slider_start_end_explicit_conversion(document, comm):
     assert widget.end == expected_end_ms
     assert widget.start == widget.value[0]
     assert widget.end == widget.value[1]
+
+
+@pytest.mark.parametrize('widget, initial, new', [
+    (FloatSlider, 0.1, 0.4),
+    (IntSlider, 1, 4),
+    (RangeSlider, (0, 1), (2, 3)),
+])
+def test_slider_value_throttled_follows_programmatic_value(widget, initial, new):
+    # Assigning value from Python is not a drag, so there is nothing to
+    # throttle and value_throttled must follow, the way __init__ already
+    # seeds it. See https://github.com/holoviz/panel/issues/2675.
+    slider = widget(start=0, end=10, value=initial)
+    assert slider.value_throttled == initial
+
+    slider.value = new
+    assert slider.value_throttled == new
+
+
+def test_slider_value_throttled_notifies_watchers():
+    # A callback bound to value_throttled never fired on a programmatic set.
+    seen = []
+    slider = IntSlider(start=0, end=10, value=0)
+    slider.param.watch(lambda event: seen.append(event.new), 'value_throttled')
+
+    slider.value = 7
+
+    assert seen == [7]
+
+
+def test_slider_value_throttled_not_updated_while_dragging(document, comm):
+    # The frontend sends `value` during a drag and `value_throttled` on
+    # release. Only the release may move value_throttled, otherwise the
+    # parameter would lose its purpose.
+    slider = FloatSlider(start=0, end=10, value=0)
+    slider.get_root(document, comm=comm)
+
+    slider._process_events({'value': 4.0})
+    assert slider.value == 4.0
+    assert slider.value_throttled == 0
+
+    slider._process_events({'value_throttled': 4.0})
+    assert slider.value_throttled == 4.0

--- a/panel/widgets/base.py
+++ b/panel/widgets/base.py
@@ -170,6 +170,9 @@ class Widget(Reactive, WidgetBase):
     # Declares the Bokeh model type of the widget
     _widget_type: t.ClassVar[type[Model] | None] = None
 
+    # Whether `value_throttled` should be auto-synced from `value`
+    _auto_sync_value_throttled: t.ClassVar[bool] = True
+
     __abstract = True
 
     def __init__(self, **params: t.Any):
@@ -184,7 +187,7 @@ class Widget(Reactive, WidgetBase):
             self.param.watch(self._sync__label, ['name']),
             self.param.watch(self._sync__name, ['label'])
         ])
-        if 'value_throttled' in self.param:
+        if 'value_throttled' in self.param and self._auto_sync_value_throttled:
             self._internal_callbacks.append(
                 self.param.watch(self._sync_value_throttled, 'value')
             )
@@ -297,6 +300,8 @@ class CompositeWidget(Widget):
     _composite_type: t.ClassVar[type[ListLike] | type[NamedListLike]] = Row
 
     _linked_properties: tuple[str, ...] = ()
+
+    _auto_sync_value_throttled: t.ClassVar[bool] = False
 
     __abstract = True
 

--- a/panel/widgets/base.py
+++ b/panel/widgets/base.py
@@ -184,6 +184,22 @@ class Widget(Reactive, WidgetBase):
             self.param.watch(self._sync__label, ['name']),
             self.param.watch(self._sync__name, ['label'])
         ])
+        if 'value_throttled' in self.param:
+            self._internal_callbacks.append(
+                self.param.watch(self._sync_value_throttled, 'value')
+            )
+
+    def _sync_value_throttled(self, event):
+        # Assigning `value` from Python is not a drag, so there is nothing to
+        # throttle and `value_throttled` should follow, the same way the sliders,
+        # players and spinners already seed it from `value` in their __init__.
+        # Changes driven by the frontend arrive inside param's `_syncing` context,
+        # and those must leave `value_throttled` pinned until the interaction
+        # finishes, which is the point of the parameter.
+        if 'value' in self._param__private.syncing:
+            return
+        with edit_readonly(self):
+            self.value_throttled = event.new
 
     def _sync__label(self, event):
         if self.label != self.name:

--- a/panel/widgets/slider.py
+++ b/panel/widgets/slider.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 import datetime as dt
 import typing as t
 
+from contextlib import nullcontext
+
 import numpy as np
 import param
 
@@ -20,7 +22,7 @@ from bokeh.models.widgets import (
     RangeSlider as _BkRangeSlider, Slider as _BkSlider,
 )
 from bokeh.models.widgets.sliders import NumericalSlider as _BkNumericalSlider
-from param.parameterized import resolve_value
+from param.parameterized import _syncing, resolve_value
 
 from ..config import config
 from ..io import state
@@ -530,13 +532,15 @@ class DiscreteSlider(CompositeWidget, _SliderBase):
         This will update the DiscreteSlider (front)
         based on changes to the IntSlider (behind the scene).
 
-        _syncing options is to avoid infinite loop.
+        The infinite loop with `_update_value` is already broken by
+        `_update_value`'s own `_syncing` guard, so this method must not
+        also bail out on `_syncing` - doing so would drop the relay of a
+        `value_throttled` update that originates from `_update_value`
+        pushing a programmatic `value` set down into the IntSlider.
 
         event.name is either value or value_throttled.
         """
         if event.name not in ('value', 'value_throttled'):
-            return
-        if self._syncing:
             return
         try:
             self._syncing = True
@@ -864,6 +868,7 @@ class _EditableContinuousSlider(CompositeWidget):
     __abstract = True
 
     def __init__(self, **params):
+        self._syncing = False
         if 'width' not in params and 'sizing_mode' not in params:
             params['width'] = 300
         self._validate_init_bounds(params)
@@ -974,15 +979,25 @@ class _EditableContinuousSlider(CompositeWidget):
 
     @param.depends('value', watch=True)
     def _update_value(self):
-        if self.value is not None:
-            self._slider.value = self.value
-        self._value_edit.value = self.value
+        # Ensure that child widget does not treat this as user update and sync value_throttled
+        slider_ctx = _syncing(self._slider, ['value']) if self._syncing else nullcontext()
+        edit_ctx = _syncing(self._value_edit, ['value']) if self._syncing else nullcontext()
+        with slider_ctx, edit_ctx:
+            if self.value is not None:
+                self._slider.value = self.value
+            self._value_edit.value = self.value
 
     def _sync_value(self, event):
         if event.name not in ('value', 'value_throttled'):
             return
-        with param.edit_constant(self):
-            self.param.update(**{event.name: event.new})
+        if self._syncing:
+            return
+        try:
+            self._syncing = True
+            with param.edit_constant(self):
+                self.param.update(**{event.name: event.new})
+        finally:
+            self._syncing = False
 
     @param.depends("start", "end", "fixed_start", "fixed_end", watch=True)
     def _update_bounds(self):
@@ -1098,6 +1113,7 @@ class EditableRangeSlider(CompositeWidget, _SliderBase):
     _composite_type: t.ClassVar[type[ListLike] | type[NamedListLike]] = Column
 
     def __init__(self, **params):
+        self._syncing = False
         if 'width' not in params and 'sizing_mode' not in params:
             params['width'] = 300
         self._validate_init_bounds(params)
@@ -1237,39 +1253,62 @@ class EditableRangeSlider(CompositeWidget, _SliderBase):
 
     @param.depends('value', watch=True)
     def _update_value(self):
-        self._slider.value = self.value
-        self._start_edit.value = self.value[0]
-        self._end_edit.value = self.value[1]
+        # Ensure that child widget does not treat this as user update and sync value_throttled
+        slider_ctx = _syncing(self._slider, ['value']) if self._syncing else nullcontext()
+        start_ctx = _syncing(self._start_edit, ['value']) if self._syncing else nullcontext()
+        end_ctx = _syncing(self._end_edit, ['value']) if self._syncing else nullcontext()
+        with slider_ctx, start_ctx, end_ctx:
+            self._slider.value = self.value
+            self._start_edit.value = self.value[0]
+            self._end_edit.value = self.value[1]
 
     def _sync_value(self, event):
         if event.name not in ('value', 'value_throttled'):
             return
-        with param.edit_constant(self):
-            self.param.update(**{event.name: event.new})
+        if self._syncing:
+            return
+        try:
+            self._syncing = True
+            with param.edit_constant(self):
+                self.param.update(**{event.name: event.new})
+        finally:
+            self._syncing = False
 
     def _sync_start_value(self, event):
         if event.name not in ('value', 'value_throttled'):
+            return
+        if self._syncing:
             return
         if event.name == 'value':
             end = self.value[1] if self.value else self.end
         else:
             end = self.value_throttled[1] if self.value_throttled else self.end
-        with param.edit_constant(self):
-            self.param.update(
-                **{event.name: (event.new, end)}
-            )
+        try:
+            self._syncing = True
+            with param.edit_constant(self):
+                self.param.update(
+                    **{event.name: (event.new, end)}
+                )
+        finally:
+            self._syncing = False
 
     def _sync_end_value(self, event):
         if event.name not in ('value', 'value_throttled'):
+            return
+        if self._syncing:
             return
         if event.name == 'value':
             start = self.value[0] if self.value else self.start
         else:
             start = self.value_throttled[0] if self.value_throttled else self.start
-        with param.edit_constant(self):
-            self.param.update(
-                **{event.name: (start, event.new)}
-            )
+        try:
+            self._syncing = True
+            with param.edit_constant(self):
+                self.param.update(
+                    **{event.name: (start, event.new)}
+                )
+        finally:
+            self._syncing = False
 
     @param.depends("start", "end", "fixed_start", "fixed_end", watch=True)
     def _update_bounds(self):

--- a/panel/widgets/slider.py
+++ b/panel/widgets/slider.py
@@ -78,6 +78,21 @@ class _SliderBase(Widget):
         if 'orientation' == 'vertical':
             params['height'] = self.param.width.default
         super().__init__(**params)
+        if 'value_throttled' in self.param:
+            self._internal_callbacks.append(
+                self.param.watch(self._sync_value_throttled, 'value')
+            )
+
+    def _sync_value_throttled(self, event: param.parameterized.Event) -> None:
+        # Assigning `value` from Python is not a drag, so there is nothing to
+        # throttle and `value_throttled` should follow, the same way __init__
+        # already seeds it from `value`. Changes driven by the frontend arrive
+        # inside `_syncing`, and those must leave `value_throttled` pinned until
+        # the handle is released, which is the point of the parameter.
+        if 'value' in self._param__private.syncing:
+            return
+        with edit_readonly(self):
+            self.value_throttled = event.new
 
     def __repr__(self, depth=0):
         return '{cls}({params})'.format(cls=type(self).__name__,

--- a/panel/widgets/slider.py
+++ b/panel/widgets/slider.py
@@ -78,21 +78,6 @@ class _SliderBase(Widget):
         if 'orientation' == 'vertical':
             params['height'] = self.param.width.default
         super().__init__(**params)
-        if 'value_throttled' in self.param:
-            self._internal_callbacks.append(
-                self.param.watch(self._sync_value_throttled, 'value')
-            )
-
-    def _sync_value_throttled(self, event: param.parameterized.Event) -> None:
-        # Assigning `value` from Python is not a drag, so there is nothing to
-        # throttle and `value_throttled` should follow, the same way __init__
-        # already seeds it from `value`. Changes driven by the frontend arrive
-        # inside `_syncing`, and those must leave `value_throttled` pinned until
-        # the handle is released, which is the point of the parameter.
-        if 'value' in self._param__private.syncing:
-            return
-        with edit_readonly(self):
-            self.value_throttled = event.new
 
     def __repr__(self, depth=0):
         return '{cls}({params})'.format(cls=type(self).__name__,


### PR DESCRIPTION
Closes #2675.

### The bug

Setting a slider's `value` from Python leaves `value_throttled` stale forever, so
the two attributes disagree and every callback bound to `param.value_throttled`
silently never fires.

```python
s = pn.widgets.FloatSlider(start=0, end=1, value=0, step=0.1)
s.value = 1
s.value, s.value_throttled          # (1, 0)

seen = []
s2 = pn.widgets.IntSlider(start=0, end=10, value=0)
pn.bind(lambda v: seen.append(v), s2.param.value_throttled, watch=True)
s2.value = 7
seen                                # []   expected [7]
```

Verified on panel 1.8.7 across all four families: `FloatSlider`, `IntSlider`,
`DiscreteSlider` (3 -> throttled 1) and `RangeSlider` ((2, 5) -> throttled (0, 1)).

The reporter's case is a `DynamicMap` driven by `value_throttled` that quietly
renders against the previous value. There is no error, so it looks like it works.

### Why this is a bug and not the intended contract

`_SliderBase.__init__` already does this:

```python
if 'value' in params and 'value_throttled' in self.param:
    params['value_throttled'] = params['value']
```

So the invariant "value_throttled tracks value unless a drag is in progress" is
already established at construction. A later programmatic assignment just fails
to maintain it. Nothing is being throttled when Python sets the value, because
there is no handle being dragged.

### The fix

A watcher on `value` that syncs `value_throttled`, skipping changes that came
from the frontend. Panel applies frontend property changes inside param's
`_syncing` context (`reactive.py`, `_process_events`), so `_param__private.syncing`
distinguishes the two cases. A drag still leaves `value_throttled` pinned until
the handle is released.

The watcher is appended to `_internal_callbacks`, matching `input.py` and
`codeeditor.py`. Without that, `test_widget_untracked_watchers` fails for eight
slider types. I hit exactly that and it is why the registration is explicit.

### One thing I would like your call on

The guard reads `self._param__private.syncing`, which is param-internal. Panel
already imports `param.parameterized._syncing` in `reactive.py` and `custom.py`,
so this is consistent with existing usage, but if you would rather I set an
explicit flag on the widget in `_process_events` instead, say so and I will
change it.

### Verification

- `panel/tests/widgets/test_slider.py`: 67 passed.
- `panel/tests/widgets/`: 3 failed, 890 passed, identical to an unmodified
  checkout. The 3 pre-existing failures are async tests that need a plugin the
  local environment lacks.
- Four of the five new tests fail on `main`. The fifth,
  `test_slider_value_throttled_not_updated_while_dragging`, passes both before
  and after by design: it pins the drag behaviour that must not change.
