### PR TITLE
Ensure ESM component child views aren't created concurrently

### DIFF
--- a/panel/models/react_component.ts
+++ b/panel/models/react_component.ts
@@ -305,7 +305,7 @@ export class ReactComponentView extends ReactiveESMView {
     return created
   }
 
-  override async update_children(): Promise<void> {
+  protected override async _update_children_pass(): Promise<void> {
     const created_children = new Set(await this.build_child_views())
 
     const new_views = new Map()

--- a/panel/models/reactive_esm.ts
+++ b/panel/models/reactive_esm.ts
@@ -189,6 +189,7 @@ export class ReactiveESMView extends HTMLBoxView {
   _rendered: boolean = false
   _stale_children: boolean = false
   _mounted: Map<string, Set<string>> = new Map()
+  _update_children_chain: Promise<void> = Promise.resolve()
 
   override initialize(): void {
     super.initialize()
@@ -536,7 +537,24 @@ export class ReactiveESMView extends HTMLBoxView {
     return null
   }
 
+  /**
+   * A children property can trigger more than one update pass for the same
+   * change, e.g. the property change signal and the manual render policy path
+   * in `ReactiveESM.watch`. `build_child_views` is async, so two passes that
+   * overlap both create a view for the same model and only the last one is kept
+   * in `_child_views`; the other is dropped without `remove()`. An orphaned
+   * ReactComponent never mounts, so the promise it handed to `root._await_ready`
+   * is never settled and the root's ready chain stays pending for the rest of
+   * the session, which silently blocks anything waiting on it. Serializing the
+   * passes makes the later one a no-op instead of a competing build.
+   */
   override async update_children(): Promise<void> {
+    const run = this._update_children_chain.then(() => this._update_children_pass())
+    this._update_children_chain = run.then(() => undefined, () => undefined)
+    return run
+  }
+
+  protected async _update_children_pass(): Promise<void> {
     const created_children = new Set(await this.build_child_views())
 
     const all_views = this.child_views

--- a/panel/package-lock.json
+++ b/panel/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.9.4-rc.1",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@bokeh/bokehjs": "^3.9.0",
+        "@bokeh/bokehjs": "^3.9.2",
         "@types/debounce": "^1.2.0",
         "@types/gl-matrix": "^2.4.5",
         "ace-code": "^1.40.1",
@@ -43,9 +43,9 @@
       }
     },
     "node_modules/@bokeh/bokehjs": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/@bokeh/bokehjs/-/bokehjs-3.9.0.tgz",
-      "integrity": "sha512-nwVuRTRLuWqcPxIbG85N/u29Zh/41OmibbyAaj3AVbY0CvlQqVZH70HsD0RgutNe+tubBYdDOh12KjBg3R9uJg==",
+      "version": "3.9.2",
+      "resolved": "https://registry.npmjs.org/@bokeh/bokehjs/-/bokehjs-3.9.2.tgz",
+      "integrity": "sha512-Ine6G9Fdot3ZbhCzjOxAQ8hqzxqnRdhRol4cnEtV2qrmAHl2WPTpBQX+hdxazN28M0jkJSpkwpVP9J68AQcqhQ==",
       "license": "BSD-3-Clause",
       "workspaces": [
         "./make",
@@ -67,7 +67,7 @@
         "choices.js": "^10.2.0",
         "dompurify": "^3.3.0",
         "fflate": "^0.8.2",
-        "flatbush": "^4.5.0",
+        "flatbush": "^4.5.1",
         "flatpickr": "^4.6.13",
         "marked": "^17.0.1",
         "mathjax-full": "^3.2.2",
@@ -1186,12 +1186,12 @@
       }
     },
     "node_modules/flatbush": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/flatbush/-/flatbush-4.5.0.tgz",
-      "integrity": "sha512-K7JSilGr4lySRLdJqKY45fu0m/dIs6YAAu/ESqdMsnW3pI0m3gpa6oRc6NDXW161Ov9+rIQjsuyOt5ObdIfgwg==",
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/flatbush/-/flatbush-4.6.2.tgz",
+      "integrity": "sha512-nNT7MFJ58Q4IAm3aYsEg+zgZGpdRcmR1i4U+aa8c+r91jmYZg7FTQwNnIMC0FyBqVZTbClKdAnrJkKkfp1BOvw==",
       "license": "ISC",
       "dependencies": {
-        "flatqueue": "^3.0.0"
+        "flatqueue": "^3.1.0"
       }
     },
     "node_modules/flatpickr": {
@@ -1201,9 +1201,9 @@
       "license": "MIT"
     },
     "node_modules/flatqueue": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/flatqueue/-/flatqueue-3.0.0.tgz",
-      "integrity": "sha512-y1deYaVt+lIc/d2uIcWDNd0CrdQTO5xoCjeFdhX0kSXvm2Acm0o+3bAOiYklTEoRyzwio3sv3/IiBZdusbAe2Q==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/flatqueue/-/flatqueue-3.1.0.tgz",
+      "integrity": "sha512-Ia4qIYrrsEqIRx3c3XhkT+QDLQuUV5ovsr6ah1rIgKT5wclhoGK3lAMS1bWRAWxlx7wtlTBpV7QXB5d9fOSRxA==",
       "license": "ISC"
     },
     "node_modules/flatted": {

--- a/panel/tests/ui/test_custom.py
+++ b/panel/tests/ui/test_custom.py
@@ -1567,3 +1567,95 @@ def test_react_root_ready_after_children_append(page):
             return new Promise(r => setTimeout(() => r(resolved), 100))
         }
     """, timeout=10000)
+
+
+class ReactChildrenRace(ReactComponent):
+
+    views = Children()
+    editors = Children()
+
+    _esm = """
+    export function render({model}) {
+      return (
+        <div>
+          <div id="views">{model.get_child("views")}</div>
+          <div id="editors">{model.get_child("editors")}</div>
+        </div>
+      )
+    }"""
+
+
+# Wraps the host view instance (not the prototype) so only the host's own update
+# passes are counted and not the nested builds of its child views.
+COUNT_OVERLAPPING_BUILDS = """
+() => {
+    const find = (view) => {
+        if (view.model.type.startsWith('panel.models.esm.')) return view
+        for (const child of (view.child_views || [])) {
+            const found = find(child)
+            if (found) return found
+        }
+        return null
+    }
+    let host = null
+    for (const root of Object.values(Bokeh.index)) {
+        host = find(root)
+        if (host) break
+    }
+    if (host == null) throw new Error('no ESM view found')
+    window._overlaps = 0
+    window._completed = 0
+    let active = 0
+    const build = host.build_child_views.bind(host)
+    host.build_child_views = async () => {
+        active += 1
+        if (active > 1) window._overlaps += 1
+        try {
+            return await build()
+        } finally {
+            active -= 1
+            window._completed += 1
+        }
+    }
+}
+"""
+
+
+def test_children_updates_do_not_overlap(page):
+    example = ReactChildrenRace(
+        views=[Row(ReactChildInner(text="view-0"))],
+        editors=[ReactChildInner(text="editor-0")],
+    )
+
+    serve_component(page, example)
+
+    expect(page.locator('.inner')).to_have_count(2)
+
+    page.evaluate(COUNT_OVERLAPPING_BUILDS)
+
+    # Updating two children props in one event triggers one update pass each.
+    # Overlapping passes both build a view for the same model and only the last
+    # is kept, so the other is orphaned without `remove()` and never settles the
+    # promise it handed to `root._await_ready`.
+    example.param.update(
+        views=[*example.views, Row(ReactChildInner(text="view-1"))],
+        editors=[*example.editors, ReactChildInner(text="editor-1")],
+    )
+
+    expect(page.locator('.inner')).to_have_count(4)
+    expect(page.locator('#views .inner')).to_have_count(2)
+    expect(page.locator('#editors .inner')).to_have_count(2)
+
+    wait_until(lambda: page.evaluate('() => window._completed') >= 2, page)
+    assert page.evaluate('() => window._overlaps') == 0
+
+    page.wait_for_function("""
+        () => {
+            const views = Object.values(Bokeh.index)
+            if (views.length === 0) return false
+            const root = views[0].root
+            let resolved = false
+            root.ready.then(() => { resolved = true })
+            return new Promise(r => setTimeout(() => r(resolved), 100))
+        }
+    """, timeout=10000)


### PR DESCRIPTION
Since ESM components can have multiple properties that embed children and these may be changed concurrently it was possible that `_update_children` would be called multiple times concurrently as well. This would result in multiple views for the same child model to be created, in turn resulting in one (or more) copies of these to be orphaned. That in itself would result in a memory leak but not be catastrophic. However, because these orphans would never actually render they would also block the ready promise that tells Bokeh and anyone watching the promise whether everything has finished rendering. Some downstream libraries used that as a signal to "reveal" the content, e.g. by setting opacity from 0 to 1, meaning that if the promise didn't resolve they would be forever hidden.