### PR TITLE
fix: report the pre-edit value on Tabulator value events

### DIFF
--- a/examples/reference/widgets/Tabulator.ipynb
+++ b/examples/reference/widgets/Tabulator.ipynb
@@ -289,7 +289,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "When editing a cell the data stored on the `Tabulator.value` is updated and you can listen to any changes using the usual `.param.watch(callback, 'value')` mechanism. However if you need to know precisely which cell was changed you may also attach an `on_edit` callback which will be passed a `TableEditEvent` containing the:\n",
+    "When editing a cell the data stored on the `Tabulator.value` is updated and you can listen to any changes using the usual `.param.watch(callback, 'value')` mechanism. Since the DataFrame is edited in place, the `old` value on that event is a copy of the table as it was before the edit while the `new` value is the DataFrame you passed in. However if you need to know precisely which cell was changed you may also attach an `on_edit` callback which will be passed a `TableEditEvent` containing the:\n",
     "\n",
     "- `column`: Name of the edited column\n",
     "- `row`: Integer index of the edited row of the `value` DataFrame\n",

--- a/panel/param.py
+++ b/panel/param.py
@@ -46,7 +46,7 @@ from .layout import (
 from .layout.base import ListLike, NamedListLike
 from .pane import DataFrame as DataFramePane
 from .pane.base import Pane, ReplacementPane
-from .reactive import Reactive
+from .reactive import Reactive, ReactiveData
 from .util import (
     abbreviated_repr, flatten, full_groupby, fullpath, is_parameterized,
     param_name, recursive_parameterized, to_async_gen,
@@ -578,6 +578,13 @@ class Param(Pane):
                     reset = True
             try:
                 updating.append(p_key)
+                if isinstance(widget, ReactiveData) and getattr(parameterized, p_name) is new:
+                    # Data widgets such as Tabulator edit the value in place,
+                    # so the Parameterized already holds the mutated object and
+                    # param would report old is new. Restore the pre-edit value
+                    # silently to ensure a correct event is emitted.
+                    with discard_events(parameterized):
+                        parameterized.param.update(**{p_name: change.old})
                 parameterized.param.update(**{p_name: new})
             finally:
                 updating.remove(p_key)

--- a/panel/reactive.py
+++ b/panel/reactive.py
@@ -1033,6 +1033,7 @@ class SyncableData(Reactive):
         super().__init__(**params)
         self._data = None
         self._processed = None
+        self._old_value = None
         callbacks = [self.param.watch(self._validate, self._data_params)]
         if self._data_params:
             callbacks.append(
@@ -1439,7 +1440,13 @@ class ReactiveData(SyncableData):
             return
         # Get old data to compare to
         old_raw, old_data = self._get_data()
+        # The pre-edit state reported on the value event and on Tabulator's
+        # table-edit event must be the unprocessed data, so a separate snapshot
+        # is only needed when old_raw was filtered, sorted or paginated.
+        value = getattr(self, self._data_params[0])
+        raw_is_value = old_raw is value
         old_raw = old_raw.copy()
+        self._old_value = old_value = old_raw if raw_is_value else value.copy()
         if hasattr(old_raw, 'columns'):
             columns = list(old_raw.columns) # type: ignore
         else:
@@ -1481,7 +1488,7 @@ class ReactiveData(SyncableData):
             if old_data is self.value: # type: ignore
                 with _syncing(self, ['value']):
                     with param.discard_events(self):
-                        self.value = old_raw
+                        self.value = old_value
                     self.value = old_data
             else:
                 self.param.trigger('value')

--- a/panel/tests/widgets/test_tables.py
+++ b/panel/tests/widgets/test_tables.py
@@ -2663,6 +2663,61 @@ def test_tabulator_download_menu_custom_kwargs():
     assert filename.label == 'Enter filename'
     assert button.label == 'Download table'
 
+def test_tabulator_value_event_old_preserves_inplace(dataframe):
+    df = dataframe.copy()
+    table = Tabulator(df)
+
+    events = []
+    table.param.watch(events.append, 'value')
+
+    table._process_events({'data': {'int': [5, 7, 9]}})
+
+    # The value is edited in place, i.e. the DataFrame the user passed in
+    # is mutated and remains the object held by the widget.
+    assert table.value is df
+    assert list(df['int']) == [5, 7, 9]
+
+    assert len(events) == 1
+    assert events[0].new is df
+    assert events[0].old is not df
+    assert list(events[0].old['int']) == [1, 2, 3]
+
+
+def test_tabulator_from_param_value_event_old(dataframe):
+    class Test(param.Parameterized):
+
+        df = param.DataFrame()
+
+    obj = Test(df=dataframe.copy())
+    table = Tabulator.from_param(obj.param.df)
+
+    events = []
+    obj.param.watch(events.append, 'df')
+
+    table._process_events({'data': {'int': [5, 7, 9]}})
+
+    assert len(events) == 1
+    assert events[0].old is not events[0].new
+    assert list(events[0].old['int']) == [1, 2, 3]
+    assert list(events[0].new['int']) == [5, 7, 9]
+
+
+def test_tabulator_value_event_old_with_filter(dataframe):
+    table = Tabulator(dataframe.copy())
+    table.add_filter('A', 'str')
+    assert len(table._processed) == 1
+
+    events = []
+    table.param.watch(events.append, 'value')
+
+    table._process_events({'data': {'int': [5]}})
+
+    assert len(events) == 1
+    # The old value must be the full pre-edit table, not the filtered view
+    pd.testing.assert_frame_equal(events[0].old, dataframe)
+    assert list(events[0].new['int']) == [5, 2, 3]
+
+
 def test_tabulator_patch_event():
     df = makeMixedDataFrame()
     table = Tabulator(df)
@@ -2698,6 +2753,34 @@ def test_server_edit_event():
     wait_until(lambda: len(events) == 1)
     assert events[0].value == 3.14
     assert events[0].old == 1
+
+
+def test_server_edit_event_from_param():
+    class Test(param.Parameterized):
+
+        df = param.DataFrame()
+
+    obj = Test(df=makeMixedDataFrame())
+    table = Tabulator.from_param(obj.param.df)
+
+    serve_and_request(table)
+
+    wait_until(lambda: bool(table._models))
+    ref, (model, _) = list(table._models.items())[0]
+    doc = list(table._documents.keys())[0]
+
+    events = []
+    obj.param.watch(events.append, 'df')
+
+    new_data = dict(model.source.data)
+    new_data['B'][1] = 3.14
+
+    table._server_change(doc, ref, None, 'data', model.source.data, new_data)
+
+    wait_until(lambda: len(events) == 1)
+    assert events[0].old is not events[0].new
+    assert events[0].old['B'].iloc[1] == 1
+    assert events[0].new['B'].iloc[1] == 3.14
 
 
 def test_edit_with_datetime_aware_column():

--- a/panel/widgets/tables.py
+++ b/panel/widgets/tables.py
@@ -1403,7 +1403,6 @@ class Tabulator(BaseTable):
         self._explicit_pagination = 'pagination' in params
         self._on_edit_callbacks = []
         self._on_click_callbacks = {}
-        self._old_value = None
         super().__init__(value=value, **params)
         self._configuration = configuration
         self.param.watch(self._update_children, self._content_params)
@@ -1542,10 +1541,6 @@ class Tabulator(BaseTable):
         # the new data and old data wrong. This extension replicates the
         # front-end filtering - if need be - to be able to correctly make the
         # comparison and update the data held by the backend.
-
-        # It also makes a copy of the value dataframe, to use it to obtain
-        # the old value in a table-edit event.
-        self._old_value = self.value.copy()
 
         import pandas as pd
         df = pd.DataFrame(data)


### PR DESCRIPTION
Tabulator edits its `value` DataFrame in place, so a `Parameterized` bound with `from_param` already holds the mutated frame and param reports `old is new`. I restore the pre-edit value before syncing, and take the event's `old` from the unprocessed data rather than the filtered or paginated view.

Fixes #8062