### PR TITLE
docs: Add config file for markdown and llms.txt generation

### DIFF
--- a/doc/how_to/extending_panel.md
+++ b/doc/how_to/extending_panel.md
@@ -1,6 +1,6 @@
 .. raw:: html
     <head>
-        <meta http-equiv='refresh' content='0; URL=./index.html#extending-panel>
+        <meta http-equiv='refresh' content='0; URL=./index.html#extending-panel'>
     </head>
 
 # Extending Panel

--- a/pixi.toml
+++ b/pixi.toml
@@ -314,6 +314,7 @@ depends-on = [
     '_docs-generate',
     '_docs-copy-panel-dist',
     '_docs-pyodide',
+    '_docs_markdown',
 ]
 
 [feature.doc.tasks.docs-build-parallel]
@@ -323,6 +324,7 @@ depends-on = [
     '_docs-generate-parallel',
     '_docs-copy-panel-dist',
     '_docs-pyodide',
+    '_docs_markdown',
 ]
 
 # =============================================

--- a/pixi.toml
+++ b/pixi.toml
@@ -291,17 +291,18 @@ SPHINX_APIDOC_OPTIONS = "members,show-inheritance"
 
 [feature.doc.dependencies]
 lxml = "*"
-nbsite = ">=0.9.0a20"
+nbsite = ">=0.10.0a0"
 selenium = "*"
 numpydoc = "*"
 pydeck = ">=0.8"  # Add back to examples, when it support ipywidgets 8.0
 sphinx = "<9"
 
 [feature.doc.tasks]
-_docs-refmanual = 'sphinx-apidoc -e -o doc/api/ panel/ --ext-autodoc --ext-intersphinx'
+_docs-refmanual = 'sphinx-apidoc -e -o doc/api/ panel/ panel/tests --ext-autodoc --ext-intersphinx'
 _docs-convert-gallery = 'python scripts/gallery/convert_gallery.py'
 _docs-generate = 'nbsite build --what=html --output=builtdocs --org holoviz --project-name panel --disable-parallel'
 _docs-generate-parallel = 'nbsite build --what=html --output=builtdocs --org holoviz --project-name panel'
+_docs_markdown = 'python -m nbsite build-llms --config scripts/llms_config.py'
 _docs-copy-panel-dist = 'cp -r ./panel/dist ./builtdocs/panel_dist'
 _docs-pyodide = 'panel convert examples/gallery/*.ipynb doc/how_to/*/examples/*.md --to pyodide-worker --out ./builtdocs/pyodide/ --pwa --index --requirements doc/pyodide_dependencies.json --exclude examples/gallery/vtk*.ipynb'
 docs-server = 'python -m http.server 5500 --directory ./builtdocs'

--- a/scripts/llms_config.py
+++ b/scripts/llms_config.py
@@ -9,62 +9,17 @@ from nbsite.scripts import LlmsBuildConfig, LlmsSection, MarkdownSource
 ROOT = Path(__file__).parent.parent
 DOC_DIR = ROOT / "doc"
 BUILTDOCS_DIR = ROOT / "builtdocs"
-MARKDOWN_DIR = BUILTDOCS_DIR / "markdown"
-MARKDOWN_BASE_URL = "/markdown"
+OUTPUT_DIR = BUILTDOCS_DIR / "markdown"
 
-PAGES = {
-    Path("index.md"),
-    Path("FAQ.md"),
-    Path("community.md"),
-    Path("upgrade.md"),
-    Path("getting_started/index.md"),
-    Path("getting_started/build_app.md"),
-    Path("getting_started/core_concepts.md"),
-    Path("getting_started/installation.md"),
-    Path("tutorials/index.md"),
-    Path("tutorials/basic/index.md"),
-    Path("tutorials/intermediate/index.md"),
-    Path("tutorials/expert/index.md"),
-    Path("how_to/index.md"),
-    Path("how_to/components/index.md"),
-    Path("how_to/layout/index.md"),
-    Path("how_to/styling/index.md"),
-    Path("how_to/interactivity/index.md"),
-    Path("how_to/templates/index.md"),
-    Path("how_to/custom_components/index.md"),
-    Path("how_to/state/index.md"),
-    Path("explanation/index.md"),
-    Path("explanation/api/index.md"),
-    Path("explanation/apis.md"),
-    Path("explanation/components.md"),
-    Path("explanation/dependencies.md"),
-    Path("explanation/develop_seamlessly.md"),
-    Path("gallery/index.md"),
-    Path("gallery/portfolio_analyzer.md"),
-    Path("gallery/webllm.md"),
-    Path("reference/index.md"),
-    Path("reference/chat/index.md"),
-    Path("reference/indicators/index.md"),
-    Path("reference/layouts/index.md"),
-    Path("reference/panes/index.md"),
-    Path("reference/templates/index.md"),
-    Path("reference/widgets/index.md"),
-    Path("api/index.md"),
-    Path("api/panel.chat.md"),
-    Path("api/panel.io.md"),
-    Path("api/panel.layout.md"),
-    Path("api/panel.pane.md"),
-    Path("api/panel.template.md"),
-    Path("about/index.md"),
-    Path("about/releases.md"),
-}
+_MD_PAGE = lambda p: p.suffix == ".md" and p.stem != "index"
 
-ROOT_PAGES = {
-    Path("index.md"),
-    Path("FAQ.md"),
+# Files that carry no LLM code-gen value and should be excluded from the build.
+EXCLUDE_FILES = (
+    Path("releases.md"),
+    Path("roadmap.md"),
+    Path("about.md"),
     Path("community.md"),
-    Path("upgrade.md"),
-}
+)
 
 
 def _label(path: Path) -> str:
@@ -77,82 +32,77 @@ CONFIG = LlmsBuildConfig(
     project_title="Panel",
     project_description=(
         "Panel is a Python library for building powerful interactive dashboards, apps, "
-        "and data tools entirely in Python. This file exposes the Panel docs as markdown "
-        "for LLM-friendly browsing."
+        "and data tools entirely in Python.\n"
+        "This file lists the most important documentation pages for LLM-assisted "
+        "development; not all generated doc links are shown."
     ),
-    markdown_root=MARKDOWN_DIR,
+    markdown_root=OUTPUT_DIR,
     llms_output_path=BUILTDOCS_DIR / "llms.txt",
-    markdown_base_url=MARKDOWN_BASE_URL,
+    markdown_base_url="/markdown",
     sources=(
         MarkdownSource(
             source_dir=DOC_DIR,
-            output_dir=MARKDOWN_DIR,
+            output_dir=OUTPUT_DIR,
             rendered_source_dir=BUILTDOCS_DIR,
+            exclude_dir_names=("about", ".ipynb_checkpoints", "developer_guide"),
+            exclude_files=EXCLUDE_FILES,
         ),
     ),
     sections=(
         LlmsSection(
-            title="Home",
-            description="Top-level pages and project overview.",
-            path_prefix=Path("."),
-            path_filter=lambda path: path in ROOT_PAGES,
-            label_builder=_label,
-        ),
-        LlmsSection(
-            title="Getting Started",
+            title="getting started",
             description="Install Panel and learn the core concepts.",
             path_prefix=Path("getting_started"),
-            path_filter=lambda path: path in PAGES,
+            path_filter=_MD_PAGE,
             label_builder=_label,
+            group="Documentation",
         ),
         LlmsSection(
-            title="Tutorials",
+            title="tutorials",
             description="Basic, intermediate, and expert learning paths.",
             path_prefix=Path("tutorials"),
-            path_filter=lambda path: path in PAGES,
-            label_builder=_label,
+            path_filter=_MD_PAGE,
+            url_pattern="/markdown/tutorials/{path}.md",
+            group="Documentation",
         ),
         LlmsSection(
-            title="How-to",
+            title="how-to",
             description="Practical recipes for common Panel tasks.",
             path_prefix=Path("how_to"),
-            path_filter=lambda path: path in PAGES,
-            label_builder=_label,
+            path_filter=_MD_PAGE,
+            url_pattern="/markdown/how_to/{path}.md",
+            group="Documentation",
         ),
         LlmsSection(
-            title="Concepts",
+            title="concepts",
             description="Background on APIs, dependencies, and components.",
             path_prefix=Path("explanation"),
-            path_filter=lambda path: path in PAGES,
-            label_builder=_label,
+            path_filter=_MD_PAGE,
+            url_pattern="/markdown/explanation/{path}.md",
+            group="Documentation",
         ),
         LlmsSection(
-            title="Gallery",
+            title="gallery",
             description="Representative example applications.",
             path_prefix=Path("gallery"),
-            path_filter=lambda path: path in PAGES,
-            label_builder=_label,
+            path_filter=_MD_PAGE,
+            url_pattern="/markdown/gallery/{stem}.md",
+            group="Documentation",
         ),
         LlmsSection(
-            title="Reference",
-            description="Component gallery landing pages.",
+            title="reference",
+            description="Detailed reference guides for panes, widgets, layouts, and other components.",
             path_prefix=Path("reference"),
-            path_filter=lambda path: path in PAGES,
-            label_builder=_label,
+            path_filter=_MD_PAGE,
+            url_pattern="/markdown/reference/{path}.md",
+            group="Documentation",
         ),
         LlmsSection(
             title="API Reference",
             description="Key API module reference pages.",
             path_prefix=Path("api"),
-            path_filter=lambda path: path in PAGES,
-            label_builder=_label,
-        ),
-        LlmsSection(
-            title="About",
-            description="Project background and roadmap pages.",
-            path_prefix=Path("about"),
-            path_filter=lambda path: path in PAGES,
-            label_builder=_label,
+            path_filter=_MD_PAGE,
+            url_pattern="/markdown/api/{stem}.md",
         ),
     ),
 )

--- a/scripts/llms_config.py
+++ b/scripts/llms_config.py
@@ -1,0 +1,158 @@
+"""Config for building Panel markdown docs and llms.txt."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from nbsite.scripts import LlmsBuildConfig, LlmsSection, MarkdownSource
+
+ROOT = Path(__file__).parent.parent
+DOC_DIR = ROOT / "doc"
+BUILTDOCS_DIR = ROOT / "builtdocs"
+MARKDOWN_DIR = BUILTDOCS_DIR / "markdown"
+MARKDOWN_BASE_URL = "/markdown"
+
+PAGES = {
+    Path("index.md"),
+    Path("FAQ.md"),
+    Path("community.md"),
+    Path("upgrade.md"),
+    Path("getting_started/index.md"),
+    Path("getting_started/build_app.md"),
+    Path("getting_started/core_concepts.md"),
+    Path("getting_started/installation.md"),
+    Path("tutorials/index.md"),
+    Path("tutorials/basic/index.md"),
+    Path("tutorials/intermediate/index.md"),
+    Path("tutorials/expert/index.md"),
+    Path("how_to/index.md"),
+    Path("how_to/components/index.md"),
+    Path("how_to/layout/index.md"),
+    Path("how_to/styling/index.md"),
+    Path("how_to/interactivity/index.md"),
+    Path("how_to/templates/index.md"),
+    Path("how_to/custom_components/index.md"),
+    Path("how_to/state/index.md"),
+    Path("explanation/index.md"),
+    Path("explanation/api/index.md"),
+    Path("explanation/apis.md"),
+    Path("explanation/components.md"),
+    Path("explanation/dependencies.md"),
+    Path("explanation/develop_seamlessly.md"),
+    Path("gallery/index.md"),
+    Path("gallery/portfolio_analyzer.md"),
+    Path("gallery/webllm.md"),
+    Path("reference/index.md"),
+    Path("reference/chat/index.md"),
+    Path("reference/indicators/index.md"),
+    Path("reference/layouts/index.md"),
+    Path("reference/panes/index.md"),
+    Path("reference/templates/index.md"),
+    Path("reference/widgets/index.md"),
+    Path("api/index.md"),
+    Path("api/panel.chat.md"),
+    Path("api/panel.io.md"),
+    Path("api/panel.layout.md"),
+    Path("api/panel.pane.md"),
+    Path("api/panel.template.md"),
+    Path("about/index.md"),
+    Path("about/releases.md"),
+}
+
+ROOT_PAGES = {
+    Path("index.md"),
+    Path("FAQ.md"),
+    Path("community.md"),
+    Path("upgrade.md"),
+}
+
+
+def _label(path: Path) -> str:
+    if path.stem == "index":
+        return "home" if path.parent == Path(".") else path.parent.name.replace("_", " ")
+    return path.stem.removeprefix("panel.").replace(".", " ").replace("_", " ")
+
+
+CONFIG = LlmsBuildConfig(
+    project_title="Panel",
+    project_description=(
+        "Panel is a Python library for building powerful interactive dashboards, apps, "
+        "and data tools entirely in Python. This file exposes the Panel docs as markdown "
+        "for LLM-friendly browsing."
+    ),
+    markdown_root=MARKDOWN_DIR,
+    llms_output_path=BUILTDOCS_DIR / "llms.txt",
+    markdown_base_url=MARKDOWN_BASE_URL,
+    sources=(
+        MarkdownSource(
+            source_dir=DOC_DIR,
+            output_dir=MARKDOWN_DIR,
+            rendered_source_dir=BUILTDOCS_DIR,
+        ),
+    ),
+    sections=(
+        LlmsSection(
+            title="Home",
+            description="Top-level pages and project overview.",
+            path_prefix=Path("."),
+            path_filter=lambda path: path in ROOT_PAGES,
+            label_builder=_label,
+        ),
+        LlmsSection(
+            title="Getting Started",
+            description="Install Panel and learn the core concepts.",
+            path_prefix=Path("getting_started"),
+            path_filter=lambda path: path in PAGES,
+            label_builder=_label,
+        ),
+        LlmsSection(
+            title="Tutorials",
+            description="Basic, intermediate, and expert learning paths.",
+            path_prefix=Path("tutorials"),
+            path_filter=lambda path: path in PAGES,
+            label_builder=_label,
+        ),
+        LlmsSection(
+            title="How-to",
+            description="Practical recipes for common Panel tasks.",
+            path_prefix=Path("how_to"),
+            path_filter=lambda path: path in PAGES,
+            label_builder=_label,
+        ),
+        LlmsSection(
+            title="Concepts",
+            description="Background on APIs, dependencies, and components.",
+            path_prefix=Path("explanation"),
+            path_filter=lambda path: path in PAGES,
+            label_builder=_label,
+        ),
+        LlmsSection(
+            title="Gallery",
+            description="Representative example applications.",
+            path_prefix=Path("gallery"),
+            path_filter=lambda path: path in PAGES,
+            label_builder=_label,
+        ),
+        LlmsSection(
+            title="Reference",
+            description="Component gallery landing pages.",
+            path_prefix=Path("reference"),
+            path_filter=lambda path: path in PAGES,
+            label_builder=_label,
+        ),
+        LlmsSection(
+            title="API Reference",
+            description="Key API module reference pages.",
+            path_prefix=Path("api"),
+            path_filter=lambda path: path in PAGES,
+            label_builder=_label,
+        ),
+        LlmsSection(
+            title="About",
+            description="Project background and roadmap pages.",
+            path_prefix=Path("about"),
+            path_filter=lambda path: path in PAGES,
+            label_builder=_label,
+        ),
+    ),
+)

--- a/scripts/llms_config.py
+++ b/scripts/llms_config.py
@@ -91,7 +91,11 @@ CONFIG = LlmsBuildConfig(
         ),
         LlmsSection(
             title="reference",
-            description="Detailed reference guides for panes, widgets, layouts, and other components.",
+            description=(
+                "Detailed reference galleries for every pane, widget, layout, template, "
+                "and other component.\n Each page documents construction and usage, all "
+                "available parameters, and how to customize appearance and behavior."
+            ),
             path_prefix=Path("reference"),
             path_filter=_MD_PAGE,
             url_pattern="/markdown/reference/{path}.md",


### PR DESCRIPTION
## Description
This PR adds a config file for generating the markdown docs and llms.txt file using nbsite. 

Fixed a little typo as well in `doc/how_to/extending_panel.md`

## AI Disclosure

Tool & Model: Kilo code - Auto balanced
Usage:

- [x] I have tested all AI-generated content in my PR.
- [x] I take responsibility for all AI-generated content in my PR.

## Others
- [x] Tests added and are passing

**llms.txt file**
[panel/builtdocs/llms.txt](https://github.com/user-attachments/files/31041185/llms.txt)

**Markdown docs**
[panel/builtdocs/markdown.zip](https://github.com/user-attachments/files/31041188/markdown.zip)
