### PR TITLE
Fix Tabulator 'starts' and 'ends' header filters

### DIFF
--- a/panel/tests/widgets/test_tables.py
+++ b/panel/tests/widgets/test_tables.py
@@ -3072,6 +3072,47 @@ def test_header_filters_categorial_dtype():
     widget.filters = [{'field': 'model', 'type': 'like', 'value': 'A'}]
     assert widget.current_view.size == 1
 
+
+@pytest.fixture
+def df_words():
+    return pd.DataFrame({'word': ['alpha', 'alphabet', 'beta', 'Alphanumeric']})
+
+
+@pytest.mark.parametrize('pagination', ['local', 'remote', None])
+def test_header_filter_starts(df_words, pagination):
+    widget = Tabulator(df_words, header_filters=True, pagination=pagination)
+
+    widget.filters = [{'field': 'word', 'type': 'starts', 'value': 'bet'}]
+
+    assert list(widget.current_view['word']) == ['beta']
+
+
+@pytest.mark.parametrize('pagination', ['local', 'remote', None])
+def test_header_filter_starts_is_case_insensitive(df_words, pagination):
+    widget = Tabulator(df_words, header_filters=True, pagination=pagination)
+
+    widget.filters = [{'field': 'word', 'type': 'starts', 'value': 'ALPHA'}]
+
+    assert list(widget.current_view['word']) == ['alpha', 'alphabet', 'Alphanumeric']
+
+
+@pytest.mark.parametrize('pagination', ['local', 'remote', None])
+def test_header_filter_ends(df_words, pagination):
+    widget = Tabulator(df_words, header_filters=True, pagination=pagination)
+
+    widget.filters = [{'field': 'word', 'type': 'ends', 'value': 'a'}]
+
+    assert list(widget.current_view['word']) == ['alpha', 'beta']
+
+
+@pytest.mark.parametrize('pagination', ['local', 'remote', None])
+def test_header_filter_ends_is_case_insensitive(df_words, pagination):
+    widget = Tabulator(df_words, header_filters=True, pagination=pagination)
+
+    widget.filters = [{'field': 'word', 'type': 'ends', 'value': 'IC'}]
+
+    assert list(widget.current_view['word']) == ['Alphanumeric']
+
 @pytest.mark.parametrize('aggs', [{}, {'Country': 'sum'}, {'Country': {'Int': 'sum', 'Float': 'mean'}}])
 def test_tabulator_aggregators(document, comm, df_agg, aggs):
     tabulator = Tabulator(df_agg, hierarchical=True, aggregators=aggs)

--- a/panel/tests/widgets/test_tables.py
+++ b/panel/tests/widgets/test_tables.py
@@ -3073,14 +3073,10 @@ def test_header_filters_categorial_dtype():
     assert widget.current_view.size == 1
 
 
-@pytest.fixture
-def df_words():
-    return pd.DataFrame({'word': ['alpha', 'alphabet', 'beta', 'Alphanumeric']})
-
-
 @pytest.mark.parametrize('pagination', ['local', 'remote', None])
-def test_header_filter_starts(df_words, pagination):
-    widget = Tabulator(df_words, header_filters=True, pagination=pagination)
+def test_header_filter_starts(pagination):
+    df = pd.DataFrame({'word': ['alpha', 'alphabet', 'beta', 'Alphanumeric']})
+    widget = Tabulator(df, header_filters=True, pagination=pagination)
 
     widget.filters = [{'field': 'word', 'type': 'starts', 'value': 'bet'}]
 
@@ -3088,8 +3084,9 @@ def test_header_filter_starts(df_words, pagination):
 
 
 @pytest.mark.parametrize('pagination', ['local', 'remote', None])
-def test_header_filter_starts_is_case_insensitive(df_words, pagination):
-    widget = Tabulator(df_words, header_filters=True, pagination=pagination)
+def test_header_filter_starts_is_case_insensitive(pagination):
+    df = pd.DataFrame({'word': ['alpha', 'alphabet', 'beta', 'Alphanumeric']})
+    widget = Tabulator(df, header_filters=True, pagination=pagination)
 
     widget.filters = [{'field': 'word', 'type': 'starts', 'value': 'ALPHA'}]
 
@@ -3097,8 +3094,9 @@ def test_header_filter_starts_is_case_insensitive(df_words, pagination):
 
 
 @pytest.mark.parametrize('pagination', ['local', 'remote', None])
-def test_header_filter_ends(df_words, pagination):
-    widget = Tabulator(df_words, header_filters=True, pagination=pagination)
+def test_header_filter_ends(pagination):
+    df = pd.DataFrame({'word': ['alpha', 'alphabet', 'beta', 'Alphanumeric']})
+    widget = Tabulator(df, header_filters=True, pagination=pagination)
 
     widget.filters = [{'field': 'word', 'type': 'ends', 'value': 'a'}]
 
@@ -3106,8 +3104,9 @@ def test_header_filter_ends(df_words, pagination):
 
 
 @pytest.mark.parametrize('pagination', ['local', 'remote', None])
-def test_header_filter_ends_is_case_insensitive(df_words, pagination):
-    widget = Tabulator(df_words, header_filters=True, pagination=pagination)
+def test_header_filter_ends_is_case_insensitive(pagination):
+    df = pd.DataFrame({'word': ['alpha', 'alphabet', 'beta', 'Alphanumeric']})
+    widget = Tabulator(df, header_filters=True, pagination=pagination)
 
     widget.filters = [{'field': 'word', 'type': 'ends', 'value': 'IC'}]
 

--- a/panel/tests/widgets/test_tables.py
+++ b/panel/tests/widgets/test_tables.py
@@ -3113,6 +3113,23 @@ def test_header_filter_ends_is_case_insensitive(df_words, pagination):
 
     assert list(widget.current_view['word']) == ['Alphanumeric']
 
+
+@pytest.mark.parametrize(('op', 'value', 'expected'), [
+    ('=', 2, [2]),
+    ('!=', 2, [1, 3, 4]),
+    ('<', 3, [1, 2]),
+    ('<=', 2, [1, 2]),
+    ('>', 2, [3, 4]),
+    ('>=', 3, [3, 4]),
+    ('in', [1, 3], [1, 3]),
+])
+def test_header_filter_comparison_operators(op, value, expected):
+    widget = Tabulator(pd.DataFrame({'n': [1, 2, 3, 4]}), header_filters=True)
+
+    widget.filters = [{'field': 'n', 'type': op, 'value': value}]
+
+    assert list(widget.current_view['n']) == expected
+
 @pytest.mark.parametrize('aggs', [{}, {'Country': 'sum'}, {'Country': {'Int': 'sum', 'Float': 'mean'}}])
 def test_tabulator_aggregators(document, comm, df_agg, aggs):
     tabulator = Tabulator(df_agg, hierarchical=True, aggregators=aggs)

--- a/panel/widgets/tables.py
+++ b/panel/widgets/tables.py
@@ -608,9 +608,9 @@ class BaseTable(ReactiveData, Widget):
             elif op == 'like':
                 filters.append(col.str.contains(val, case=False, regex=False))
             elif op == 'starts':
-                filters.append(col.str.startsWith(val))
+                filters.append(col.str.lower().str.startswith(val.lower()))
             elif op == 'ends':
-                filters.append(col.str.endsWith(val))
+                filters.append(col.str.lower().str.endswith(val.lower()))
             elif op == 'keywords':
                 match_all = filt_def.get(col_name, {}).get('matchAll', False)
                 sep = filt_def.get(col_name, {}).get('separator', ' ')


### PR DESCRIPTION
The `starts` and `ends` header filters called `col.str.startsWith` and `col.str.endsWith`, which are JavaScript names, so both raised `AttributeError` for every value. Now using the pandas spelling, matched case insensitively to mirror Tabulator's own client side filters so local and remote pagination agree.

Fixes #8717