### PR TITLE
Raise a clear type error for unsupported Perspective objects

### DIFF
--- a/panel/pane/perspective.py
+++ b/panel/pane/perspective.py
@@ -363,6 +363,11 @@ class Perspective(ModelPane, ReactiveData):
     def _get_data(self):
         if self.object is None:
             return {}, {}
+        # ReactiveData builds the data during super().__init__, before PaneBase
+        # gets to validate the object, so the type check has to happen here to
+        # cover both construction and later assignment to .object.
+        if self.applies(self.object) is False:
+            self._type_error(self.object)
         if isinstance(self.object, dict):
             ncols = len(self.object)
             df = data = self.object

--- a/panel/tests/pane/test_perspective.py
+++ b/panel/tests/pane/test_perspective.py
@@ -1,3 +1,5 @@
+import pytest
+
 from panel.pane import Perspective
 
 data = {
@@ -8,6 +10,18 @@ data = {
         '1981 01 01 04    72    39 10196 -9999     0     0     0 -9999'],
     'year': [1981, 1981, 1981, 1981, 1981],
  }
+
+
+def test_perspective_rejects_unsupported_object():
+    with pytest.raises(ValueError, match='does not support objects of type'):
+        Perspective('not tabular')
+
+
+def test_perspective_rejects_unsupported_object_on_assignment():
+    psp = Perspective(data)
+
+    with pytest.raises(ValueError, match='does not support objects of type'):
+        psp.object = 'not tabular'
 
 
 def test_perspective_int_cols(document, comm):


### PR DESCRIPTION
`Perspective` mixes in `ReactiveData`, which builds the data inside `super().__init__()`, before `PaneBase` reaches its `applies()` check, so an unsupported object crashed with an `AttributeError` instead of the standard "does not support objects of type" error. Guard added in `_get_data`, which both the construction and the `.object` assignment paths go through.

Fixes #8718