### PR TITLE
Ignore the NumPy 2.5 ndarray.shape deprecation from VTK

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -243,6 +243,10 @@ filterwarnings = [
     "ignore:'asyncio.iscoroutinefunction' is deprecated and slated for removal in Python 3.16::starlette",
     "ignore:'asyncio.iscoroutinefunction' is deprecated and slated for removal in Python 3.16::fastapi",
     "ignore:Implicitly cleaning up <_TemporaryFileWrapper:ResourceWarning",
+    # 2026-08: NumPy 2.5 deprecated assigning to ndarray.shape, which VTK still
+    # does in vtk_to_numpy. Scoped to that module so Panel's own code would
+    # still fail on it.
+    "ignore:Setting the shape on a NumPy array has been deprecated:DeprecationWarning:vtkmodules.util.numpy_support",
 ]
 
 [tool.coverage.run]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -244,7 +244,7 @@ filterwarnings = [
     "ignore:'asyncio.iscoroutinefunction' is deprecated and slated for removal in Python 3.16::fastapi",
     "ignore:Implicitly cleaning up <_TemporaryFileWrapper:ResourceWarning",
     # 2026-08
-    "ignore:Setting the shape on a NumPy array has been deprecated:DeprecationWarning:vtkmodules.util.numpy_support", # OK, Numpy 2.5
+    "ignore:Setting the shape on a NumPy array has been deprecated:DeprecationWarning:vtk.util.numpy_support", # https://gitlab.kitware.com/vtk/vtk/-/work_items/19900
 ]
 
 [tool.coverage.run]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -243,10 +243,8 @@ filterwarnings = [
     "ignore:'asyncio.iscoroutinefunction' is deprecated and slated for removal in Python 3.16::starlette",
     "ignore:'asyncio.iscoroutinefunction' is deprecated and slated for removal in Python 3.16::fastapi",
     "ignore:Implicitly cleaning up <_TemporaryFileWrapper:ResourceWarning",
-    # 2026-08: NumPy 2.5 deprecated assigning to ndarray.shape, which VTK still
-    # does in vtk_to_numpy. Scoped to that module so Panel's own code would
-    # still fail on it.
-    "ignore:Setting the shape on a NumPy array has been deprecated:DeprecationWarning:vtkmodules.util.numpy_support",
+    # 2026-08
+    "ignore:Setting the shape on a NumPy array has been deprecated:DeprecationWarning:vtkmodules.util.numpy_support", # OK, Numpy 2.5
 ]
 
 [tool.coverage.run]


### PR DESCRIPTION
NumPy 2.5 deprecated assigning to `ndarray.shape`, VTK still does it in `numpy_support.vtk_to_numpy`, and `filterwarnings = ["error", ...]` turns that into two failing VTK tests on every PR opened since yesterday. Panel never assigns to `.shape` itself, so this ignores the warning until VTK ships a change, the same way the existing entries handle websockets, plotly and starlette.

Fixes #8728