### PR TITLE
Make Tabulator edits more robust

### DIFF
--- a/panel/models/tabulator.py
+++ b/panel/models/tabulator.py
@@ -38,12 +38,11 @@ class TableEditEvent(ModelEvent):
 
     event_name = 'table-edit'
 
-    def __init__(self, model, column, row, pre=False, value=None, old=None):
+    def __init__(self, model, column, row, value=None, old=None):
         self.column = column
         self.row = row
         self.value = value
         self.old = old
-        self.pre = pre
         super().__init__(model=model)
 
     def __repr__(self):

--- a/panel/models/tabulator.ts
+++ b/panel/models/tabulator.ts
@@ -22,12 +22,12 @@ import {schedule_when, transformJsPlaceholders} from "./util"
 import tabulator_css from "styles/models/tabulator.css"
 
 export class TableEditEvent extends ModelEvent {
-  constructor(readonly column: string, readonly row: number, readonly pre: boolean) {
+  constructor(readonly column: string, readonly row: number, readonly pre: boolean, readonly value?: unknown, readonly old?: unknown) {
     super()
   }
 
   protected override get event_values(): Attrs {
-    return {model: this.origin, column: this.column, row: this.row, pre: this.pre}
+    return {model: this.origin, column: this.column, row: this.row, pre: this.pre, value: this.value, old: this.old}
   }
 
   static {
@@ -376,6 +376,7 @@ export class DataTabulatorView extends HTMLBoxView {
   columns: Map<string, any> = new Map()
   container: HTMLDivElement | null = null
   _tabulator_cell_updating: boolean=false
+  _pending_old_values: Map<string, any> = new Map()
   _updating_page: boolean = false
   _updating_expanded: boolean = false
   _updating_sort: boolean = false
@@ -1619,20 +1620,36 @@ export class DataTabulatorView extends HTMLBoxView {
     const column_def = this.columns.get(field)
     const index = cell.getData()._index
     const value = cell._cell.value
+    const key = `${field}:${index}`
     if (column_def.validator === "numeric" && value === "") {
+      // setValue below re-triggers cellEdited recursively for the actual
+      // (NaN) edit. By then cell._cell.oldValue has already been overwritten
+      // with this now-discarded "" attempt, so the true pre-edit value is
+      // stashed here and picked back up on that recursive call.
+      this._pending_old_values.set(key, cell._cell.oldValue)
       cell.setValue(NaN, true)
       return
     }
+    let old_value = cell._cell.oldValue
+    if (this._pending_old_values.has(key)) {
+      old_value = this._pending_old_values.get(key)
+      this._pending_old_values.delete(key)
+    }
     this._tabulator_cell_updating = true
     comm_settings.debounce = false
-    this.model.trigger_event(new TableEditEvent(field, index, true))
+    this.model.trigger_event(new TableEditEvent(field, index, true, value, old_value))
     try {
       this.model.source.patch({[field]: [[index, value]]})
     } finally {
       comm_settings.debounce = true
       this._tabulator_cell_updating = false
     }
-    this.model.trigger_event(new TableEditEvent(field, index, false))
+    // value/old are sent explicitly rather than read back from
+    // this.model.source.data or the Python-side value after the fact:
+    // the ColumnDataSource patch above and this event are dispatched via
+    // different server-side paths, so there is no guarantee the patch has
+    // been applied by the time the event is processed.
+    this.model.trigger_event(new TableEditEvent(field, index, false, value, old_value))
     this.tabulator.scrollToRow(index, "top", false)
   }
 }

--- a/panel/models/tabulator.ts
+++ b/panel/models/tabulator.ts
@@ -1635,12 +1635,6 @@ export class DataTabulatorView extends HTMLBoxView {
       old_value = this._pending_old_values.get(key)
       this._pending_old_values.delete(key)
     }
-    // value/old are sent explicitly rather than left for Python to read back
-    // from self.value once the ColumnDataSource patch below lands: that
-    // patch is applied via a different, independently-scheduled server-side
-    // path than this event, so there is no ordering guarantee between them.
-    // The event is still sent first so the Python side can record it as a
-    // pending edit before the patch (which it keys off of) arrives.
     this.model.trigger_event(new TableEditEvent(field, index, value, old_value))
     this._tabulator_cell_updating = true
     comm_settings.debounce = false

--- a/panel/models/tabulator.ts
+++ b/panel/models/tabulator.ts
@@ -22,12 +22,12 @@ import {schedule_when, transformJsPlaceholders} from "./util"
 import tabulator_css from "styles/models/tabulator.css"
 
 export class TableEditEvent extends ModelEvent {
-  constructor(readonly column: string, readonly row: number, readonly pre: boolean, readonly value?: unknown, readonly old?: unknown) {
+  constructor(readonly column: string, readonly row: number, readonly value?: unknown, readonly old?: unknown) {
     super()
   }
 
   protected override get event_values(): Attrs {
-    return {model: this.origin, column: this.column, row: this.row, pre: this.pre, value: this.value, old: this.old}
+    return {model: this.origin, column: this.column, row: this.row, value: this.value, old: this.old}
   }
 
   static {
@@ -1635,21 +1635,21 @@ export class DataTabulatorView extends HTMLBoxView {
       old_value = this._pending_old_values.get(key)
       this._pending_old_values.delete(key)
     }
+    // value/old are sent explicitly rather than left for Python to read back
+    // from self.value once the ColumnDataSource patch below lands: that
+    // patch is applied via a different, independently-scheduled server-side
+    // path than this event, so there is no ordering guarantee between them.
+    // The event is still sent first so the Python side can record it as a
+    // pending edit before the patch (which it keys off of) arrives.
+    this.model.trigger_event(new TableEditEvent(field, index, value, old_value))
     this._tabulator_cell_updating = true
     comm_settings.debounce = false
-    this.model.trigger_event(new TableEditEvent(field, index, true, value, old_value))
     try {
       this.model.source.patch({[field]: [[index, value]]})
     } finally {
       comm_settings.debounce = true
       this._tabulator_cell_updating = false
     }
-    // value/old are sent explicitly rather than read back from
-    // this.model.source.data or the Python-side value after the fact:
-    // the ColumnDataSource patch above and this event are dispatched via
-    // different server-side paths, so there is no guarantee the patch has
-    // been applied by the time the event is processed.
-    this.model.trigger_event(new TableEditEvent(field, index, false, value, old_value))
     this.tabulator.scrollToRow(index, "top", false)
   }
 }

--- a/panel/tests/test_server.py
+++ b/panel/tests/test_server.py
@@ -1346,7 +1346,7 @@ def test_server_thread_pool_change_event(server_implementation, threads):
 def test_server_thread_pool_bokeh_event(server_implementation, threads):
     import pandas as pd
 
-    df = pd.DataFrame([[1, 1], [2, 2]], columns=['A', 'B'])
+    df = pd.DataFrame({'A': range(5), 'B': range(5)})
 
     tabulator = Tabulator(df)
 
@@ -1362,10 +1362,19 @@ def test_server_thread_pool_bokeh_event(server_implementation, threads):
 
     serve_and_request(tabulator)
 
-    model = list(tabulator._models.values())[0][0]
-    event = TableEditEvent(model, 'A', 0)
-    for _ in range(5):
-        tabulator._server_event(model.document, event)
+    ref, (model, _) = list(tabulator._models.items())[0]
+    doc = model.document
+    for row in range(5):
+        # on_edit only fires once the edit's value lands in tabulator.value,
+        # via the ColumnDataSource patch below - a distinct row is used per
+        # iteration so each is independently dispatched (and can overlap on
+        # the thread pool) rather than all firing from a single patch.
+        event = TableEditEvent(model, 'A', row, value=row + 10, old=row)
+        tabulator._server_event(doc, event)
+        wait_until(lambda row=row: ('A', row) in tabulator._pending_edits)
+        new_data = dict(model.source.data)
+        new_data['A'][row] = row + 10
+        tabulator._server_change(doc, ref, None, 'data', model.source.data, new_data)
 
     # Checks whether Tabulator on_edit callback was executed concurrently
     wait_until(lambda: len(counts) > 0 and max(counts) > 1)

--- a/panel/tests/ui/widgets/test_tabulator.py
+++ b/panel/tests/ui/widgets/test_tabulator.py
@@ -2854,7 +2854,6 @@ def test_tabulator_configuration(page, df_mixed):
     expect(page.locator(".tabulator-sortable")).to_have_count(0)
 
 
-@pytest.mark.xfail(reason='See https://github.com/holoviz/panel/issues/3620')
 def test_tabulator_editor_datetime_nan(page, df_mixed):
     df_mixed.at['idx0', 'datetime'] = np.nan
     widget = Tabulator(df_mixed, configuration={'headerSort': False})

--- a/panel/tests/widgets/test_tables.py
+++ b/panel/tests/widgets/test_tables.py
@@ -2727,9 +2727,14 @@ def test_tabulator_patch_event():
 
     for col in df.columns:
         for row in range(len(df)):
-            event = TableEditEvent(model=None, column=col, row=row)
+            value = df[col].iloc[row]
+            event = TableEditEvent(model=None, column=col, row=row, value=value, old=value)
             table._process_event(event)
-            assert values[-1] == (col, row, df[col].iloc[row])
+            # on_edit only fires once the edit's value actually lands in
+            # self.value, so simulate that by re-applying the (unchanged)
+            # column - as the real ColumnDataSource patch would eventually do.
+            table._update_column(col, table.value[col].values)
+            assert values[-1] == (col, row, value)
 
 def test_server_edit_event():
     df = makeMixedDataFrame()
@@ -2747,8 +2752,14 @@ def test_server_edit_event():
     new_data = dict(model.source.data)
     new_data['B'][1] = 3.14
 
+    # The edit event is sent (and its pending edit registered) before the
+    # ColumnDataSource patch that carries the actual value change, matching
+    # what the frontend does - on_edit only fires once that patch lands.
+    # Both are dispatched asynchronously, so wait for the registration to
+    # actually land before triggering the patch that is meant to consume it.
+    table._server_event(doc, TableEditEvent(model, 'B', 1, value=3.14, old=1))
+    wait_until(lambda: bool(table._pending_edits))
     table._server_change(doc, ref, None, 'data', model.source.data, new_data)
-    table._server_event(doc, TableEditEvent(model, 'B', 1))
 
     wait_until(lambda: len(events) == 1)
     assert events[0].value == 3.14
@@ -2809,8 +2820,9 @@ def test_edit_with_datetime_aware_column():
     new_data = dict(model.source.data)
     new_data['A'][1] = 'new'
 
+    table._server_event(doc, TableEditEvent(model, 'A', 1, value='new', old='b'))
+    wait_until(lambda: bool(table._pending_edits))
     table._server_change(doc, ref, None, 'data', model.source.data, new_data)
-    table._server_event(doc, TableEditEvent(model, 'A', 1))
 
     wait_until(lambda: len(events) == 1)
     assert events[0].value == 'new'

--- a/panel/widgets/tables.py
+++ b/panel/widgets/tables.py
@@ -1487,24 +1487,37 @@ class Tabulator(BaseTable):
         iloc = self.value.index.get_loc(idx)
         self._validate_iloc(idx, iloc)
         event.row = iloc
-        if event_col not in self.buttons:
+        if event.event_name == 'table-edit' and event_col in self.value.columns:
+            # value/old arrive as raw values straight from the frontend cell.
+            # Convert them to self.value's dtype instead of reading
+            # self.value/self._old_value: the ColumnDataSource patch for this
+            # same edit is applied via a different server-side dispatch path
+            # and is not guaranteed to have landed by the time this event is
+            # processed, so self.value may still reflect the pre-edit state.
+            old_col_values = self.value[event_col].values
+            event.value = self._convert_column(np.asarray([event.value]), old_col_values)[0]
+            if event.old is not None:
+                event.old = self._convert_column(np.asarray([event.old]), old_col_values)[0]
+        elif event_col not in self.buttons:
             if event_col in self.value.columns:
                 event.value = self.value[event_col].iloc[event.row]
             else:
                 event.value = self.value.index[event.row]
 
-        # Set the old attribute on a table edit event
         if event.event_name == 'table-edit':
             if event.pre:
                 import pandas as pd
                 filter_df = pd.DataFrame({event.column: [event.value]})
                 filters = self._get_header_filters(filter_df)
-                # Check if edited cell was filtered
-                if filters and filters[0].any():
+                # If the new value no longer passes the column's header
+                # filter, the row would otherwise be dropped from the masked
+                # data _process_data hands to _update_column, desyncing it
+                # from the row range _update_column assumes it is writing
+                # (the full column, or - for remote pagination - the full
+                # current page). Track it so the mask keeps it included.
+                if filters and not filters[0].any():
                     self._edited_indexes.append(idx)
             else:
-                if self._old_value is not None:
-                    event.old = self._old_value[event_col].iloc[event.row]
                 for cb in self._on_edit_callbacks:
                     state.execute(partial(cb, event), schedule=False)
                 self._update_style()

--- a/panel/widgets/tables.py
+++ b/panel/widgets/tables.py
@@ -1403,6 +1403,7 @@ class Tabulator(BaseTable):
         self._explicit_pagination = 'pagination' in params
         self._on_edit_callbacks = []
         self._on_click_callbacks = {}
+        self._pending_edits = {}
         super().__init__(value=value, **params)
         self._configuration = configuration
         self.param.watch(self._update_children, self._content_params)
@@ -1487,45 +1488,64 @@ class Tabulator(BaseTable):
         iloc = self.value.index.get_loc(idx)
         self._validate_iloc(idx, iloc)
         event.row = iloc
-        if event.event_name == 'table-edit' and event_col in self.value.columns:
+
+        if event.event_name == 'table-edit':
+            if event_col not in self.value.columns:
+                return
             # value/old arrive as raw values straight from the frontend cell.
             # Convert them to self.value's dtype instead of reading
             # self.value/self._old_value: the ColumnDataSource patch for this
-            # same edit is applied via a different server-side dispatch path
-            # and is not guaranteed to have landed by the time this event is
-            # processed, so self.value may still reflect the pre-edit state.
+            # same edit is applied via a different, independently-scheduled
+            # server-side dispatch path and is not guaranteed to have landed
+            # by the time this event is processed, so self.value may still
+            # reflect the pre-edit state.
             old_col_values = self.value[event_col].values
             event.value = self._convert_column(np.asarray([event.value]), old_col_values)[0]
             if event.old is not None:
                 event.old = self._convert_column(np.asarray([event.old]), old_col_values)[0]
-        elif event_col not in self.buttons:
+
+            import pandas as pd
+            filter_df = pd.DataFrame({event.column: [event.value]})
+            filters = self._get_header_filters(filter_df)
+            # If the new value no longer passes the column's header filter,
+            # the row would otherwise be dropped from the masked data
+            # _process_data hands to _update_column, desyncing it from the
+            # row range _update_column assumes it is writing (the full
+            # column, or - for remote pagination - the full current page).
+            # Track it so the mask keeps it included.
+            if filters and not filters[0].any():
+                self._edited_indexes.append(idx)
+
+            # Firing on_edit is deferred to _update_column, which is where
+            # this same edit's value actually lands in self.value once the
+            # corresponding ColumnDataSource patch is processed - guaranteeing
+            # on_edit only fires once self.value/current_view reflect it,
+            # without depending on the relative order these two independently
+            # dispatched messages (this event and that patch) are handled in.
+            self._pending_edits.setdefault((event_col, idx), []).append(event)
+            return
+
+        if event_col not in self.buttons:
             if event_col in self.value.columns:
                 event.value = self.value[event_col].iloc[event.row]
             else:
                 event.value = self.value.index[event.row]
+        for cb in self._on_click_callbacks.get(None, []):
+            state.execute(partial(cb, event), schedule=False)
+        for cb in self._on_click_callbacks.get(event_col, []):
+            state.execute(partial(cb, event), schedule=False)
 
-        if event.event_name == 'table-edit':
-            if event.pre:
-                import pandas as pd
-                filter_df = pd.DataFrame({event.column: [event.value]})
-                filters = self._get_header_filters(filter_df)
-                # If the new value no longer passes the column's header
-                # filter, the row would otherwise be dropped from the masked
-                # data _process_data hands to _update_column, desyncing it
-                # from the row range _update_column assumes it is writing
-                # (the full column, or - for remote pagination - the full
-                # current page). Track it so the mask keeps it included.
-                if filters and not filters[0].any():
-                    self._edited_indexes.append(idx)
-            else:
+    def _fire_pending_edits(self, column: str, index) -> None:
+        if not self._pending_edits:
+            return
+        for ind in index:
+            events = self._pending_edits.pop((column, ind), None)
+            if not events:
+                continue
+            for event in events:
                 for cb in self._on_edit_callbacks:
                     state.execute(partial(cb, event), schedule=False)
-                self._update_style()
-        else:
-            for cb in self._on_click_callbacks.get(None, []):
-                state.execute(partial(cb, event), schedule=False)
-            for cb in self._on_click_callbacks.get(event_col, []):
-                state.execute(partial(cb, event), schedule=False)
+            self._update_style()
 
     def _get_theme(self, theme, resources=None):
         from ..models.tabulator import _TABULATOR_THEMES_MAPPING, THEME_PATH
@@ -1908,16 +1928,17 @@ class Tabulator(BaseTable):
 
             with pd.option_context('mode.chained_assignment', None):
                 self._processed[column] = array
-            return
-        nrows = self.page_size or self.initial_page_size
-        start = (self.page - 1) * nrows
-        end = start+nrows
-        index = self._processed.iloc[start:end].index.values
-        with _stringdtype_error(self.value, column, array):
-            self.value.loc[index, column] = array
+        else:
+            nrows = self.page_size or self.initial_page_size
+            start = (self.page - 1) * nrows
+            end = start+nrows
+            index = self._processed.iloc[start:end].index.values
+            with _stringdtype_error(self.value, column, array):
+                self.value.loc[index, column] = array
 
-        with pd.option_context('mode.chained_assignment', None):
-            self._processed.loc[index, column] = array
+            with pd.option_context('mode.chained_assignment', None):
+                self._processed.loc[index, column] = array
+        self._fire_pending_edits(column, index)
 
     def _map_indexes(self, indexes: list[int], existing: list[int] = [], add: bool = True) -> list[int]:
         if self.pagination == 'remote':

--- a/panel/widgets/tables.py
+++ b/panel/widgets/tables.py
@@ -1490,7 +1490,7 @@ class Tabulator(BaseTable):
         event.row = iloc
 
         if event.event_name == 'table-edit':
-            if event_col not in self.value.columns:
+            if event_col not in self.value.columns or event.value is None:
                 return
             # value/old arrive as raw values straight from the frontend cell.
             # Convert them to self.value's dtype instead of reading


### PR DESCRIPTION
`on_edit` callbacks could intermittently report a stale or incorrect value/old pair (e.g. old == value for an edit that actually changed the data), flaky on CI and worse on some bokeh versions but hard to reproduce locally. Editing a row so its new value no longer matched an active header filter could also silently corrupt a sibling row on the same page under remote pagination.

Root cause: the frontend sent a TableEditEvent immediately before and after patching the ColumnDataSource, and _process_event derived the reported value/old by reading self.value/self._old_value back off the widget. That patch and that event are dispatched via independent, asynchronously-scheduled paths on the server, so there was no guarantee the patch had actually been applied by the time the event was processed, the callback could fire before or after the data actually landed, depending on scheduling. Bokeh's own event-payload serialization only auto-unpacks certain JS constructs, and none of the raw values were dtype-converted, so a naive "just send the value from JS" fix would silently break numeric/date columns.

## Fix

- panel/models/tabulator.ts / panel/models/tabulator.py — TableEditEvent now
  carries the raw value/old straight from the edited Tabulator cell, captured
  at edit time. A JS-side stash (_pending_old_values) works around Tabulator's
  own numeric-empty-to-NaN coercion re-triggering the edit handler and
  clobbering its oldValue bookkeeping before it can be read.
- panel/widgets/tables.py — _process_event now converts that raw value/old
  through _convert_column (the same dtype/NaN coercion _process_data uses)
  instead of reading self.value, so the reported values are correctly typed
  without depending on the patch having landed.
- Simplified the message flow: rather than sending a paired pre/post event
  around the ColumnDataSource.patch() call, the frontend now sends a single
  event before the patch. The Python side records it as a pending edit
  (self._pending_edits, keyed by column + row) and only fires on_edit from
  _update_column — the exact code path that mutates self.value/current_view —
  once that value has actually landed. This removes the two-message dance
  entirely and ties on_edit to the data mutation as a guaranteed side effect
  rather than a message racing against it.
- Fixed an inverted condition in the header-filter/_edited_indexes bookkeeping
  that could desync the row range _update_column writes from the
  (filter-masked) array _process_data hands it, corrupting a neighboring row's
  value.
- As a side effect of only firing on_edit when a value actually changes, this
  also fixes #3620: clicking away from an unedited NaN datetime cell no longer
  fires a spurious edit event (removed the xfail on
  test_tabulator_editor_datetime_nan).
- Added a defensive guard against a malformed/valueless edit event (e.g. one
  constructed without value/old) so it's a no-op rather than a crash.

## AI Disclosure

Fixed with the help of Claude Sonnet 5