### PR TITLE
Fix conda build issue

### DIFF
--- a/scripts/conda/build.sh
+++ b/scripts/conda/build.sh
@@ -9,16 +9,26 @@ python -m build --sdist .
 VERSION=$(python -c "import $PACKAGE; print($PACKAGE._version.__version__)")
 export VERSION
 
-BK_CHANNEL=$(python -c "
+# Prereleases depend on prereleases of other HoloViz packages, which are only
+# published to pyviz/label/dev, so the build and test envs need that channel.
+CHANNELS=$(python -c "
+import os
+
 import bokeh
 from packaging.version import Version
 
+channels = []
+if Version(os.environ['VERSION']).is_prerelease:
+    channels.append('pyviz/label/dev')
 if Version(bokeh.__version__).is_prerelease:
-    print('bokeh/label/rc')
+    channels.append('bokeh/label/rc')
 else:
-    print('bokeh')
+    channels.append('bokeh')
+channels.append('conda-forge')
+print(' '.join(f'-c {channel}' for channel in channels))
 ")
+read -ra CHANNEL_ARGS <<<"$CHANNELS"
 
-conda build scripts/conda/recipe --no-anaconda-upload --no-verify -c "$BK_CHANNEL" -c conda-forge --package-format 2
+conda build scripts/conda/recipe --no-anaconda-upload --no-verify "${CHANNEL_ARGS[@]}" --package-format 2
 
 mv "$CONDA_PREFIX/conda-bld/noarch/$PACKAGE-$VERSION-py_0.conda" dist

--- a/scripts/conda/recipe/meta.yaml
+++ b/scripts/conda/recipe/meta.yaml
@@ -31,22 +31,21 @@ requirements:
     - {{ dep }}
     {% endfor %}
 
-# TODO: Add back when we have release panel-core 1.10.0 on conda-forge
-# test:
-#   imports:
-#     - panel
-#     - panel.io
-#   requires:
-#     - pip
-#     - pytest-asyncio
-#     - pytest-rerunfailures <16
-#     - pytest-xdist
-#     - esbuild
-#     - python-gil
-#   commands:
-#     - pip check
-#     - panel --help
-#     - pytest --pyargs panel.tests -n logical --dist loadgroup
+test:
+  imports:
+    - panel
+    - panel.io
+  requires:
+    - pip
+    - pytest-asyncio
+    - pytest-rerunfailures <16
+    - pytest-xdist
+    - esbuild
+    - python-gil
+  commands:
+    - pip check
+    - panel --help
+    - pytest --pyargs panel.tests -n logical --dist loadgroup
 
 about:
   home: {{ project['urls']['Homepage'] }}


### PR DESCRIPTION
For making dev releases the conda build test step may need packages from the `pyviz/label/dev` channel. This ensures that during a dev release the channel is added.