### PR TITLE
Clean up GridSpec children when deleting cells

### DIFF
--- a/panel/layout/grid.py
+++ b/panel/layout/grid.py
@@ -466,10 +466,10 @@ class GridSpec(Panel):
             deleted = dict([list(o)[0] for o in subgrid.flatten()])
         else:
             deleted = [list(subgrid)[0][0]]
-        new_objects = dict(self.objects)
-        for key in deleted:
-            del new_objects[key]
-        self.objects = new_objects
+        self.objects = {
+            k: v for k, v in self.objects.items()
+            if k not in deleted
+        }
 
     def __getitem__(self, index):
         if isinstance(index, tuple):

--- a/panel/layout/grid.py
+++ b/panel/layout/grid.py
@@ -466,9 +466,10 @@ class GridSpec(Panel):
             deleted = dict([list(o)[0] for o in subgrid.flatten()])
         else:
             deleted = [list(subgrid)[0][0]]
+        new_objects = dict(self.objects)
         for key in deleted:
-            del self.objects[key]
-        self.param.trigger('objects')
+            del new_objects[key]
+        self.objects = new_objects
 
     def __getitem__(self, index):
         if isinstance(index, tuple):

--- a/panel/tests/layout/test_grid.py
+++ b/panel/tests/layout/test_grid.py
@@ -23,6 +23,20 @@ def test_gridspec_cleanup(document, comm):
     assert ref not in spacer._models
 
 
+def test_gridspec_delete_cleans_up_removed_pane(document, comm):
+    spacer = Spacer()
+    gspec = GridSpec()
+    gspec[0, 0] = spacer
+
+    model = gspec.get_root(document, comm)
+    ref = model.ref['id']
+
+    del gspec[0, 0]
+
+    assert ref not in spacer._models
+    assert model.children == []
+
+
 def test_gridspec_integer_setitem():
     div = Div()
     gspec = GridSpec()


### PR DESCRIPTION
## Summary

`GridSpec.__delitem__` now assigns a copied `objects` mapping instead of mutating the current mapping in place. The parameter event therefore retains the old children, allowing the existing diff logic to clean up removed pane models.

The replacement path on current `main` already assigns a new mapping; this closes the corresponding deletion path and adds a regression test for model cleanup.

Fixes #8710

## Testing

- `pytest panel/tests/layout/test_grid.py -q` — 22 passed
- `ruff check panel/layout/grid.py panel/tests/layout/test_grid.py`
- `isort --check-only panel/layout/grid.py panel/tests/layout/test_grid.py`