### PR TITLE
fix: Prevent Tabulator page reset when clicking Last on a shrunk container

### DIFF
--- a/panel/models/tabulator.ts
+++ b/panel/models/tabulator.ts
@@ -827,10 +827,20 @@ export class DataTabulatorView extends HTMLBoxView {
     if (!this.model.pagination || (this.model.page_size !== null && !this._automatic_page_size) || this._initializing || !this.tabulator) {
       return
     }
-    this._automatic_page_size = true
-    const responsive = this.model.sizing_mode && (this.model.sizing_mode.includes("height") || this.model.sizing_mode.includes("both"))
     const holder = this.shadow_el.querySelector(".tabulator-tableholder")
     const table = this.shadow_el.querySelector(".tabulator-table")
+    if (
+      this.model.page_size != null &&
+      this.model.page >= this.model.max_page &&
+      table != null &&
+      table.children.length < this.model.page_size
+    ) {
+      // Partial page: holder has shrunk to fit it, so its height doesn't
+      // reflect full-page capacity. See https://github.com/holoviz/panel/issues/8737
+      return
+    }
+    this._automatic_page_size = true
+    const responsive = this.model.sizing_mode && (this.model.sizing_mode.includes("height") || this.model.sizing_mode.includes("both"))
     if (table != null && holder != null) {
       const table_height = holder.clientHeight
       let height = 0

--- a/panel/tests/ui/widgets/test_tabulator.py
+++ b/panel/tests/ui/widgets/test_tabulator.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import datetime as dt
+import typing as t
 
 from contextlib import contextmanager
 
@@ -3988,6 +3989,29 @@ def test_tabulator_local_pagination_page_size_preserved_on_value_none(page, df_m
     widget.value = df_mixed
     page.wait_for_timeout(200)
     expect(page.locator('.tabulator-row')).to_have_count(4)
+
+
+def test_tabulator_local_pagination_auto_page_size_last_button(page):
+    # https://github.com/holoviz/panel/issues/8737
+    df = pd.DataFrame({'value': range(6401)})
+    widget = Tabulator(df, max_height=500, show_index=True)
+
+    serve_component(page, widget)
+
+    expect(page.locator('.tabulator-table')).to_have_count(1)
+
+    wait_until(lambda: bool(widget.page_size), page)
+    initial_page_size = t.cast("int", widget.page_size)
+    counts = count_per_page(len(df), initial_page_size)
+    last_page = len(counts)
+
+    page.locator('text="Last"').click()
+    page.wait_for_timeout(1000)
+
+    assert widget.page_size == initial_page_size
+    assert widget.page == last_page
+    expect(page.locator('.tabulator-row')).to_have_count(counts[-1])
+    expect(page.locator('.tabulator-row').last).to_contain_text(str(df['value'].iloc[-1]))
 
 
 @pytest.mark.parametrize('pagination', ['local', 'remote', None])


### PR DESCRIPTION

## Description
<!-- Summarize the change and which issue is fixed. Be sure to include relevant motivation and context. Describe the tests run to verify these changes and how to reproduce them (copy-pastable minimal, reproducible example). Include visuals when possible (e.g. before/after screenshots). -->

Fixes #8737

`recompute_page_size()` measured `holder.clientHeight` to auto-size page_size, but on a partial (e.g. last) page with `max_height` set the holder shrinks to fit the fewer rows shown, so the measurement undercounts capacity. The resulting bogus `page_size` then reset page back to 1, discarding navigation.

``` python
import pandas as pd
import panel as pn

pn.extension("tabulator")

df = pd.DataFrame({"value": range(6401)})
table = pn.widgets.Tabulator(df, max_height=500, show_index=True)
tabs = pn.Tabs(("Table", table))
tabs.servable()
```


<details><summary>mre + playwright</summary>
<p>

``` python
"""
Playwright reproducer for GitHub issue #8737:
Tabulator breaks after Last button is pressed

https://github.com/holoviz/panel/issues/8737

Run with: python reproduce_8737.py

The bug: A Tabulator with a large DataFrame (>200 rows, so pagination is
automatically switched to "local") that lives inside a pn.Tabs and has
max_height set (so page_size is auto-computed to fit the available height)
breaks after clicking the "Last" pagination button: the number of displayed
rows collapses (e.g. from 11 to 2), the "First"/"Prev" buttons become
disabled, and the rows shown are actually the FIRST rows of the data (0, 1)
rather than the last ones.

Suspected root cause: panel/models/tabulator.ts `recompute_page_size()` is
re-triggered (via a resize/redraw) after navigating to a page that renders
fewer/virtualized DOM rows than a full page. It then computes a bogus
page_size from `table.children.length`, which is pushed back to Python,
`page_size` changes, `max_page` gets recomputed, and `page` gets clamped -
producing the observed collapse back to page 1 with the wrong row count.
"""

import time
from pathlib import Path

import pandas as pd
import panel as pn
from playwright.sync_api import sync_playwright

pn.extension("tabulator")

SCREENSHOT_DIR = Path(__file__).parent

N_ROWS = 6401

GET_STATE_JS = """() => {
    const doc = window.Bokeh?.documents?.[0];
    if (!doc) return {error: 'No Bokeh document'};
    for (const model of doc._all_models.values()) {
        if (model.type === 'panel.models.tabulator.DataTabulator') {
            return {
                page: model.page,
                page_size: model.page_size,
                pagination: model.pagination,
                max_page: model.max_page,
            };
        }
    }
    return {error: 'No DataTabulator model found'};
}"""


def create_app():
    df = pd.DataFrame({"value": range(N_ROWS)})

    table = pn.widgets.Tabulator(df, max_height=500, show_index=True)
    tabs = pn.Tabs(("Table", table))

    return tabs, table


def serve_app(app, port=5006):
    return pn.serve(app, port=port, show=False, threaded=True)


def get_state(page):
    result = page.evaluate(GET_STATE_JS)
    if "error" in result:
        print(f"  Warning: {result['error']}")
        return None
    return result


def get_visible_row_count(page):
    return page.locator(".tabulator-row").count()


def get_visible_first_value(page):
    cell = page.locator(".tabulator-row .tabulator-cell[tabulator-field='value']").first
    if cell.count() == 0:
        return None
    return cell.text_content()


def main():
    print("=" * 60)
    print(f"Reproducer for GitHub issue #8737 ({N_ROWS} rows)")
    print("Tabulator breaks after Last button is pressed")
    print("=" * 60)

    app, table = create_app()
    port = 5006
    server = serve_app(app, port)
    time.sleep(2)

    try:
        with sync_playwright() as p:
            browser = p.chromium.launch(headless=True, slow_mo=100)
            page = browser.new_page()
            page.goto(f"http://localhost:{port}")

            page.locator(".tabulator").wait_for(state="visible", timeout=15000)
            time.sleep(2)

            # === STEP 1: Initial state ===
            print("\n--- Step 1: Initial state ---")
            initial_state = get_state(page)
            initial_rows = get_visible_row_count(page)
            print(f"  model state: {initial_state}")
            print(f"  visible rows: {initial_rows}")
            page.screenshot(path=str(SCREENSHOT_DIR / "step1_initial.png"))

            # === STEP 2: Click the "Last" pagination button ===
            print("\n--- Step 2: Click 'Last' button ---")
            last_button = page.locator(".tabulator-page[data-page='last']")
            last_button.wait_for(state="visible", timeout=10000)
            last_button.click()
            time.sleep(2)
            page.screenshot(path=str(SCREENSHOT_DIR / "step2_after_last.png"))

            after_last_state = get_state(page)
            after_last_rows = get_visible_row_count(page)
            after_last_first_value = get_visible_first_value(page)
            print(f"  model state: {after_last_state}")
            print(f"  visible rows: {after_last_rows}")
            print(f"  first visible row 'value': {after_last_first_value}")

            first_disabled = last_button.locator(
                "xpath=../button[@data-page='first']"
            ).get_attribute("disabled")
            prev_disabled = last_button.locator(
                "xpath=../button[@data-page='prev']"
            ).get_attribute("disabled")
            print(f"  First button disabled: {first_disabled is not None}")
            print(f"  Prev button disabled: {prev_disabled is not None}")

            # Give any deferred resize/redraw a chance to fire and settle.
            time.sleep(2)
            page.screenshot(path=str(SCREENSHOT_DIR / "step3_settled.png"))
            settled_state = get_state(page)
            settled_rows = get_visible_row_count(page)
            settled_first_value = get_visible_first_value(page)
            print("\n--- Step 3: After settling ---")
            print(f"  model state: {settled_state}")
            print(f"  visible rows: {settled_rows}")
            print(f"  first visible row 'value': {settled_first_value}")

            bug_detected = check_for_bug(
                initial_state, initial_rows, settled_state, settled_rows, settled_first_value
            )

            print("\n" + "=" * 60)
            if bug_detected:
                print("BUG CONFIRMED!")
                print(
                    f"  - row count collapsed from {initial_rows} to {settled_rows} "
                    "after clicking Last"
                )
                print(
                    f"  - page_size went from {initial_state['page_size']} to "
                    f"{settled_state['page_size']}"
                )
                print(f"  - model.page after Last: {settled_state['page']}")
                print(f"  - first visible row value: {settled_first_value} (expected a value near {N_ROWS - 1})")
            else:
                print("Bug not detected (may be fixed)")
            print("=" * 60)

            print(f"\nScreenshots saved in: {SCREENSHOT_DIR}")
            time.sleep(1)
            browser.close()
    finally:
        server.stop()

    print("\nDone.")


def check_for_bug(initial_state, initial_rows, settled_state, settled_rows, settled_first_value):
    """Return True if the bug is present.

    The bug manifests as: the number of rendered rows drops sharply after
    clicking Last, and/or the first visible row's value is near 0 (i.e. we
    are actually looking at page 1 data) instead of near N_ROWS - 1.
    """
    if settled_state is None or initial_state is None:
        return False
    row_collapse = settled_rows < initial_rows / 2
    try:
        wrong_data = settled_first_value is not None and int(settled_first_value) < N_ROWS / 2
    except ValueError:
        wrong_data = False
    return row_collapse or wrong_data


if __name__ == "__main__":
    main()


```

</p>
</details> 

## AI Disclosure
<!-- Delete this section if AI was not used, else specify the tool/model (e.g. Cursor + Sonnet 4.6, Claude Code + Opus 4.6, ChatGPT) and briefly describe how it was used. Failure to disclose AI usage may result in a ban. -->

Tool & Model: Claude Code:claude-sonnet-5
Usage: Asked to create an MRE, create a UI test and then fix it.

- [x] I have tested all AI-generated content in my PR.
- [x] I take responsibility for all AI-generated content in my PR.


## Checklist
<!-- Remove the non relevant items. -->

- [x] Tests added and are passing
