### PR TITLE
Fix DatetimeSlider same-day bounds

### DIFF
--- a/panel/tests/widgets/test_slider.py
+++ b/panel/tests/widgets/test_slider.py
@@ -253,6 +253,18 @@ def test_datetime_slider(document, comm, value, start, end):
         assert widget.value == 1620777600000
 
 
+def test_datetime_slider_preserves_time_in_bounds(document, comm):
+    start = datetime(2026, 8, 21, 8, 45)
+    end = datetime(2026, 8, 21, 13, 30)
+    datetime_slider = DatetimeSlider(value=start, start=start, end=end)
+
+    widget = datetime_slider.get_root(document, comm=comm)
+
+    epoch = datetime(1970, 1, 1)
+    assert widget.start == (start - epoch).total_seconds() * 1000
+    assert widget.end == (end - epoch).total_seconds() * 1000
+
+
 def test_datetime_slider_np_datetime64(document, comm):
     start = np.datetime64('2018-09-01')
     end = np.datetime64('2018-09-10')

--- a/panel/widgets/slider.py
+++ b/panel/widgets/slider.py
@@ -306,11 +306,13 @@ class DateSlider(_SliderBase):
 
     def _process_param_change(self, params: dict[str, t.Any]) -> dict[str, t.Any]:
         props = super()._process_param_change(params)
-        if 'value' in props:
-            value = props['value']
+        for key in ('value', 'start', 'end'):
+            if key not in props:
+                continue
+            value = props[key]
             if isinstance(value, dt.datetime):
                 value = datetime_as_utctimestamp(value)
-            props['value'] = value
+            props[key] = value
         return props
 
     def _process_property_change(self, props: dict[str, t.Any]) -> dict[str, t.Any]:


### PR DESCRIPTION
## Description

Fixes #8742.

`DatetimeSlider` converted its value to a millisecond timestamp but left its
`start` and `end` bounds as Python datetimes. Bokeh's datetime property then
normalized same-day bounds to the same midnight value, producing an invalid
slider model with equal bounds.

This converts datetime-valued `start`, `end`, and `value` fields consistently
and adds a regression test for same-day bounds with non-midnight times.

## Validation

- `python3 -m ruff check panel/widgets/slider.py panel/tests/widgets/test_slider.py`
- `.venv312/bin/python -m pytest panel/tests/widgets/test_slider.py -q` (63 passed)
- `git diff --check`

## Limitations

The local in-app browser blocked capture of the localhost before/after page.
The regression test validates the underlying rendered Bokeh model values: the
two datetime bounds remain distinct millisecond timestamps instead of both
becoming midnight.

## AI Disclosure

- **Tool & Model:** AI coding assistant (GPT-5)
- **Usage:** Used to investigate the reported serialization path, implement the
  focused conversion change, and draft the regression test and PR text.
- [x] I tested the contribution and reviewed the resulting diff.
- [x] I take responsibility for the contribution.

## Checklist

- [x] The contribution is linked to an existing issue.
- [x] Tests cover the behavioral change.
- [x] No documentation change is needed for this bug fix.
- [x] No unrelated generated files are included.
