### PR TITLE
Yield to the event loop when a periodic callback overruns its period

### DIFF
--- a/panel/io/callbacks.py
+++ b/panel/io/callbacks.py
@@ -151,8 +151,9 @@ class PeriodicCallback(param.Parameterized):
             start = time.monotonic()
             await func()
             timeout = (self.period/1000.) - (time.monotonic()-start)
-            if timeout > 0:
-                await asyncio.sleep(timeout)
+            # sleep(0) still yields, so an overrunning callback runs again
+            # immediately without holding the loop for the next iteration.
+            await asyncio.sleep(max(timeout, 0))
 
     def _cleanup(self, session_context):
         self.stop()

--- a/panel/tests/io/test_callbacks.py
+++ b/panel/tests/io/test_callbacks.py
@@ -1,0 +1,72 @@
+"""Tests for PeriodicCallback's loop-driven path.
+
+`_async_repeat` is the branch `start()` takes when there is a running event loop but
+no bokeh session: Pyodide and WASM, notebooks, and scripts. Session-scoped callbacks
+go to `doc.add_periodic_callback` instead and are covered in `panel/tests/test_server.py`.
+"""
+
+import asyncio
+import time
+
+import pytest
+
+from panel.io.callbacks import PeriodicCallback
+
+
+class _Stop(Exception):
+    """Raised by a test callback to end the otherwise infinite `_async_repeat` loop."""
+
+
+async def _drive(period, frames, body):
+    """Run `_async_repeat` for `frames` iterations of `body`, counting loop turns.
+
+    Returns (number of callback invocations, number of times a competing task ran).
+    A competing task can only advance when `_async_repeat` suspends, so the second
+    number is how many times the loop handed control back to the scheduler.
+    """
+    turns = 0
+
+    async def competing():
+        nonlocal turns
+        while True:
+            turns += 1
+            await asyncio.sleep(0)
+
+    calls = 0
+
+    async def callback():
+        nonlocal calls
+        calls += 1
+        body()
+        if calls >= frames:
+            raise _Stop
+
+    competitor = asyncio.create_task(competing())
+    await asyncio.sleep(0)
+
+    cb = PeriodicCallback(callback=callback, period=period)
+    try:
+        with pytest.raises(_Stop):
+            await cb._async_repeat(callback)
+    finally:
+        competitor.cancel()
+    return calls, turns
+
+
+async def test_overrunning_callback_still_yields_to_the_loop():
+    frames = 5
+    # 5 ms of work against a 1 ms period, so every frame overruns and the remaining
+    # sleep budget is negative.
+    calls, turns = await _drive(period=1, frames=frames, body=lambda: time.sleep(0.005))
+
+    assert calls == frames
+    assert turns >= frames
+
+
+async def test_callback_inside_its_period_still_waits():
+    start = time.monotonic()
+    calls, _ = await _drive(period=50, frames=2, body=lambda: None)
+    elapsed = time.monotonic() - start
+
+    assert calls == 2
+    assert elapsed >= 0.03


### PR DESCRIPTION
`asyncio.sleep(0)` is still a yield, so dropping the conditional keeps the documented "run again immediately" behaviour and gives the loop a turn on every iteration:

```python
timeout = (self.period/1000.) - (time.monotonic()-start)
await asyncio.sleep(max(timeout, 0))
```

`asyncio.sleep` already routes `delay <= 0` to a bare yield, so the old `if timeout > 0` guard was not avoiding a sleep, it was only removing the yield.

One scope note: this is the `_async_repeat` branch only. Session-scoped callbacks in a served app go to `doc.add_periodic_callback` instead, and I have not checked whether that path behaves the same way.

Your measure() script goes from 1 to 20 other-task runs on the 50 ms frame for me. Added two tests in `panel/tests/io/test_callbacks.py`; the overrunning one fails on main.

Closes #8751
