### PR TITLE
Keep the count and timeout budgets across a period change

### DIFF
--- a/panel/io/callbacks.py
+++ b/panel/io/callbacks.py
@@ -80,8 +80,14 @@ class PeriodicCallback(param.Parameterized):
     @param.depends('period', watch=True)
     def _update_period(self):
         if self._cb:
+            # stop() zeroes the counter and start() re-stamps the start time,
+            # so both are carried across the restart.
+            counter, start_time = self.counter, self._start_time
             self.stop()
             self.start()
+            with param.discard_events(self):
+                self.counter = counter
+            self._start_time = start_time
 
     def _exec_callback(self, post=False, busy_event_id=None):
         try:

--- a/panel/tests/io/test_callbacks.py
+++ b/panel/tests/io/test_callbacks.py
@@ -63,6 +63,50 @@ async def test_overrunning_callback_still_yields_to_the_loop():
     assert turns >= frames
 
 
+async def _run_until_stopped(cb, limit=400):
+    for _ in range(limit):
+        if not cb.running:
+            return
+        await asyncio.sleep(0.01)
+
+
+async def test_period_change_keeps_the_count_budget():
+    calls = 0
+
+    def body():
+        nonlocal calls
+        calls += 1
+
+    cb = PeriodicCallback(callback=body, period=20, count=6)
+    cb.start()
+    try:
+        while calls < 3:
+            await asyncio.sleep(0.005)
+        cb.period = 21
+        await _run_until_stopped(cb)
+    finally:
+        cb.stop()
+
+    assert calls == 6
+
+
+async def test_period_change_keeps_the_timeout_deadline():
+    cb = PeriodicCallback(callback=lambda: None, period=10, timeout=500)
+    start = time.monotonic()
+    cb.start()
+    try:
+        await asyncio.sleep(0.3)
+        cb.period = 11
+        await _run_until_stopped(cb)
+        elapsed = time.monotonic() - start
+    finally:
+        cb.stop()
+
+    # The deadline is 500 ms from start(); restarting it at the period change
+    # would push the last run out past 800 ms.
+    assert elapsed < 0.7
+
+
 async def test_callback_inside_its_period_still_waits():
     start = time.monotonic()
     calls, _ = await _drive(period=50, frames=2, body=lambda: None)


### PR DESCRIPTION
<!-- Using AI? READ FIRST: https://holoviz.org/contribute.html#ai-readme -->

## Description

Fixes #8756

`_update_period` restarts the callback to pick up the new interval, and `stop()`/`start()` also reset the two budgets on the way through: `stop()` zeroes `counter`, `start()` re-stamps `_start_time`. So a period change gives a `count=6` callback six more runs and pushes a `timeout` out by however long it had already been running.

The reset in `stop()` is wanted when you actually stop, so I carried `counter` and `_start_time` across the internal restart instead of changing `stop()`. `counter` is restored under `param.discard_events` so watchers do not see it bounce.

Repro is in the issue. Two tests in `panel/tests/io/test_callbacks.py`, one per budget; both fail on main (`assert 9 == 6` and `assert 0.815 < 0.7`) and pass here. `panel/tests/io` goes 304 to 306 passing with no new failures.

The timeout test asserts on elapsed wall time with a 200 ms margin either side, so tell me if you would rather it did not sit in the matrix.

## AI Disclosure

Tool & Model: Claude Code + Opus 5
Usage: helped locate the reset, draft the patch and write the two tests. I reproduced the fault and ran the tests myself.

- [x] I have tested all AI-generated content in my PR.
- [x] I take responsibility for all AI-generated content in my PR.

## Checklist

- [x] Tests added and are passing
