### PR TITLE
Fix nested Plotly array loss across clients

### DIFF
--- a/panel/pane/plotly.py
+++ b/panel/pane/plotly.py
@@ -150,11 +150,13 @@ class Plotly(ModelPane):
                 array = json.pop(key)
                 data[full_path] = [array]
             elif isinstance(value, dict):
-                # Recurse into dictionaries:
-                Plotly._get_sources_for_trace(value, data=data, parent_path=full_path)
+                # Nested containers may still belong to the original figure.
+                json[key] = dict(value)
+                Plotly._get_sources_for_trace(json[key], data=data, parent_path=full_path)
             elif isinstance(value, list) and value and isinstance(value[0], dict):
                 # recurse into object arrays:
-                for i, element in enumerate(value):
+                json[key] = [dict(element) for element in value]
+                for i, element in enumerate(json[key]):
                     element_path = full_path + '.' + str(i)
                     Plotly._get_sources_for_trace(
                         element, data=data, parent_path=element_path

--- a/panel/tests/pane/test_plotly.py
+++ b/panel/tests/pane/test_plotly.py
@@ -23,6 +23,43 @@ from panel.pane import PaneBase, Plotly
 
 
 @plotly_available
+@pytest.mark.parametrize('backend', ['numpy', 'polars'])
+@pytest.mark.parametrize('trace_type', ['scatter', 'parcoords'])
+def test_plotly_shared_figure_keeps_nested_arrays(document, comm, backend, trace_type):
+    as_array = np.asarray if backend == 'numpy' else pytest.importorskip('polars').Series
+    if trace_type == 'scatter':
+        fig = go.Figure(go.Scatter(
+            x=[1, 2], y=[3, 4],
+            marker={'color': as_array(['red', 'blue']), 'angle': as_array([0, 90]), 'symbol': 'arrow'},
+        ))
+        expected = {'marker.color': ['red', 'blue'], 'marker.angle': [0, 90]}
+    else:
+        fig = go.Figure(go.Parcoords(dimensions=[
+            {'label': 'first', 'values': as_array([1, 2])},
+            {'label': 'second', 'values': as_array([3, 4])},
+        ]))
+        expected = {'dimensions.0.values': [1, 2], 'dimensions.1.values': [3, 4]}
+
+    panes = []
+    try:
+        for _ in range(2):
+            pane = Plotly(fig)
+            model = pane.get_root(document, comm)
+            panes.append((pane, model))
+            for key, values in expected.items():
+                np.testing.assert_array_equal(model.data_sources[0].data[key][0], values)
+        if trace_type == 'scatter':
+            np.testing.assert_array_equal(fig.data[0].marker.color, ['red', 'blue'])
+            np.testing.assert_array_equal(fig.data[0].marker.angle, [0, 90])
+        else:
+            np.testing.assert_array_equal(fig.data[0].dimensions[0].values, [1, 2])
+            np.testing.assert_array_equal(fig.data[0].dimensions[1].values, [3, 4])
+    finally:
+        for pane, model in panes:
+            pane._cleanup(model)
+
+
+@plotly_available
 def test_get_plotly_pane_type_from_figure():
     trace = go.Scatter(x=[0, 1], y=[2, 3])
     fig = go.Figure([trace])


### PR DESCRIPTION
Reusing a Plotly figure can drop nested array data from the second Panel client. Binary serialization removes arrays from shallow-copied trace dictionaries, which still share nested containers with the original figure.

Copy nested dictionary and object-list containers before extracting their arrays. The array buffers remain shared with the data sources. Four regression cases exercise two independent panes using NumPy and Polars inputs, covering marker color/angle and parallel-coordinate dimensions.

Fixes #8354. Thanks to DevilSpecial for identifying the shallow-copy mutation in the issue discussion.

Validation: all four new cases fail before the fix. All 18 Plotly pane tests and applicable pre-commit hooks pass with Plotly 6.9.0. On Plotly 7.0.0 the four new cases also pass; an existing trace-swap test fails because that version removed `figure_factory.create_distplot`.

## Post-Deploy Monitoring & Validation

Open a cached figure in two client sessions and check that both retain the same marker styling and dimension values. Regression tests inspect the Bokeh data sources; browser rendering was not separately exercised.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
